### PR TITLE
feat(config): add config hook for OpenCode integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,39 @@ Specialized code review agents organized by category:
 
 - `framework-docs-researcher` - Documentation research
 
+## Config Hook
+
+Systematic uses OpenCode's `config` hook to automatically register bundled agents, commands, and skills directly into OpenCode's configuration. This means:
+
+- **Zero configuration required** - All bundled content is available immediately after installing the plugin
+- **No file copying** - Skills, agents, and commands ship with the npm package
+- **Priority-based overrides** - Project and user content override bundled defaults
+
+### Priority Order
+
+Content is merged with the following priority (highest priority wins):
+
+1. **Existing OpenCode config** - Your `opencode.json` settings are preserved
+2. **Project content** - `.opencode/systematic/` in current project
+3. **User content** - `~/.config/opencode/systematic/`
+4. **Bundled content** - Provided by this plugin
+
+This allows you to override any bundled skill, agent, or command by creating your own version in the project or user directory.
+
+### Directory Structure
+
+```
+~/.config/opencode/systematic/
+├── skills/           # User-level skill overrides
+├── agents/           # User-level agent overrides
+└── commands/         # User-level command overrides
+
+.opencode/systematic/
+├── skills/           # Project-level skill overrides
+├── agents/           # Project-level agent overrides
+└── commands/         # Project-level command overrides
+```
+
 ## Tools
 
 The plugin provides these tools to OpenCode:

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { Plugin } from '@opencode-ai/plugin'
 import { tool } from '@opencode-ai/plugin/tool'
+import { createConfigHandler } from './lib/config-handler.js'
 import { type SystematicConfig, loadConfig } from './lib/config.js'
 import * as skillsCore from './lib/skills-core.js'
 
@@ -113,7 +114,16 @@ export const SystematicPlugin: Plugin = async ({ client, directory }) => {
   const userAgentsDir = config.paths.user_agents
   const userCommandsDir = config.paths.user_commands
 
+  const configHandler = createConfigHandler({
+    directory,
+    bundledSkillsDir,
+    bundledAgentsDir,
+    bundledCommandsDir,
+  })
+
   return {
+    config: configHandler,
+
     tool: {
       systematic_find_skills: tool({
         description:

--- a/src/lib/config-handler.ts
+++ b/src/lib/config-handler.ts
@@ -1,0 +1,218 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { AgentConfig, Config } from '@opencode-ai/sdk'
+import { loadConfig } from './config.js'
+import * as skillsCore from './skills-core.js'
+
+export interface ConfigHandlerDeps {
+  directory: string
+  bundledSkillsDir: string
+  bundledAgentsDir: string
+  bundledCommandsDir: string
+}
+
+type CommandConfig = NonNullable<Config['command']>[string]
+
+function loadAgentAsConfig(
+  agentInfo: { name: string; file: string; sourceType: string; category?: string }
+): AgentConfig | null {
+  try {
+    const content = fs.readFileSync(agentInfo.file, 'utf8')
+    const { name, description, prompt } = skillsCore.extractAgentFrontmatter(content)
+
+    return {
+      description: description || `${name || agentInfo.name} agent`,
+      prompt: prompt || skillsCore.stripFrontmatter(content),
+    }
+  } catch {
+    return null
+  }
+}
+
+function loadCommandAsConfig(
+  commandInfo: { name: string; file: string; sourceType: string; category?: string }
+): CommandConfig | null {
+  try {
+    const content = fs.readFileSync(commandInfo.file, 'utf8')
+    const { name, description } = skillsCore.extractCommandFrontmatter(content)
+
+    const cleanName = commandInfo.name.replace(/^\//, '')
+
+    return {
+      template: skillsCore.stripFrontmatter(content),
+      description: description || `${name || cleanName} command`,
+    }
+  } catch {
+    return null
+  }
+}
+
+function loadSkillAsCommand(
+  skillInfo: skillsCore.SkillInfo
+): CommandConfig | null {
+  try {
+    const content = fs.readFileSync(skillInfo.skillFile, 'utf8')
+
+    return {
+      template: skillsCore.stripFrontmatter(content),
+      description: skillInfo.description || `${skillInfo.name} skill`,
+    }
+  } catch {
+    return null
+  }
+}
+
+function collectAgents(
+  dir: string,
+  sourceType: 'project' | 'user' | 'bundled',
+  disabledAgents: string[]
+): NonNullable<Config['agent']> {
+  const agents: NonNullable<Config['agent']> = {}
+  const agentList = skillsCore.findAgentsInDir(dir, sourceType)
+
+  for (const agentInfo of agentList) {
+    if (disabledAgents.includes(agentInfo.name)) continue
+
+    const config = loadAgentAsConfig(agentInfo)
+    if (config) {
+      agents[agentInfo.name] = config
+    }
+  }
+
+  return agents
+}
+
+function collectCommands(
+  dir: string,
+  sourceType: 'project' | 'user' | 'bundled',
+  disabledCommands: string[]
+): NonNullable<Config['command']> {
+  const commands: NonNullable<Config['command']> = {}
+  const commandList = skillsCore.findCommandsInDir(dir, sourceType)
+
+  for (const commandInfo of commandList) {
+    const cleanName = commandInfo.name.replace(/^\//, '')
+    if (disabledCommands.includes(cleanName)) continue
+
+    const config = loadCommandAsConfig(commandInfo)
+    if (config) {
+      commands[cleanName] = config
+    }
+  }
+
+  return commands
+}
+
+function collectSkillsAsCommands(
+  dir: string,
+  sourceType: 'project' | 'user' | 'bundled',
+  disabledSkills: string[]
+): NonNullable<Config['command']> {
+  const commands: NonNullable<Config['command']> = {}
+  const skillList = skillsCore.findSkillsInDir(dir, sourceType, 3)
+
+  for (const skillInfo of skillList) {
+    if (disabledSkills.includes(skillInfo.name)) continue
+
+    const config = loadSkillAsCommand(skillInfo)
+    if (config) {
+      commands[skillInfo.name] = config
+    }
+  }
+
+  return commands
+}
+
+/**
+ * Create the config hook handler for the Systematic plugin.
+ *
+ * This follows the pattern used by oh-my-opencode to inject bundled agents,
+ * skills (as commands), and commands into OpenCode's configuration.
+ *
+ * Priority order (highest priority last, so they override earlier):
+ * 1. Bundled content (from this plugin)
+ * 2. User content (~/.config/opencode/systematic/)
+ * 3. Project content (.opencode/systematic/)
+ * 4. Existing OpenCode config (preserved)
+ */
+export function createConfigHandler(deps: ConfigHandlerDeps) {
+  const { directory, bundledSkillsDir, bundledAgentsDir, bundledCommandsDir } = deps
+
+  return async (config: Config): Promise<void> => {
+    const systematicConfig = loadConfig(directory)
+
+    const userSkillsDir = systematicConfig.paths.user_skills
+    const userAgentsDir = systematicConfig.paths.user_agents
+    const userCommandsDir = systematicConfig.paths.user_commands
+    const projectSkillsDir = path.join(directory, '.opencode/systematic/skills')
+    const projectAgentsDir = path.join(directory, '.opencode/systematic/agents')
+    const projectCommandsDir = path.join(directory, '.opencode/systematic/commands')
+
+    const bundledAgents = collectAgents(
+      bundledAgentsDir,
+      'bundled',
+      systematicConfig.disabled_agents
+    )
+    const userAgents = collectAgents(
+      userAgentsDir,
+      'user',
+      systematicConfig.disabled_agents
+    )
+    const projectAgents = collectAgents(
+      projectAgentsDir,
+      'project',
+      systematicConfig.disabled_agents
+    )
+
+    const bundledCommands = collectCommands(
+      bundledCommandsDir,
+      'bundled',
+      systematicConfig.disabled_commands
+    )
+    const userCommands = collectCommands(
+      userCommandsDir,
+      'user',
+      systematicConfig.disabled_commands
+    )
+    const projectCommands = collectCommands(
+      projectCommandsDir,
+      'project',
+      systematicConfig.disabled_commands
+    )
+
+    const bundledSkills = collectSkillsAsCommands(
+      bundledSkillsDir,
+      'bundled',
+      systematicConfig.disabled_skills
+    )
+    const userSkills = collectSkillsAsCommands(
+      userSkillsDir,
+      'user',
+      systematicConfig.disabled_skills
+    )
+    const projectSkills = collectSkillsAsCommands(
+      projectSkillsDir,
+      'project',
+      systematicConfig.disabled_skills
+    )
+
+    const existingAgents = config.agent ?? {}
+    config.agent = {
+      ...bundledAgents,
+      ...userAgents,
+      ...projectAgents,
+      ...existingAgents,
+    }
+
+    const existingCommands = config.command ?? {}
+    config.command = {
+      ...bundledCommands,
+      ...bundledSkills,
+      ...userCommands,
+      ...userSkills,
+      ...projectCommands,
+      ...projectSkills,
+      ...existingCommands,
+    }
+  }
+}

--- a/src/lib/skills-core.ts
+++ b/src/lib/skills-core.ts
@@ -267,3 +267,71 @@ export function findCommandsInDir(
   recurse(dir, 0)
   return commands
 }
+
+export interface AgentFrontmatter {
+  name: string
+  description: string
+  prompt: string
+}
+
+export interface CommandFrontmatter {
+  name: string
+  description: string
+  argumentHint: string
+}
+
+export function extractAgentFrontmatter(content: string): AgentFrontmatter {
+  const lines = content.split('\n')
+
+  let inFrontmatter = false
+  let name = ''
+  let description = ''
+
+  for (const line of lines) {
+    if (line.trim() === '---') {
+      if (inFrontmatter) break
+      inFrontmatter = true
+      continue
+    }
+
+    if (inFrontmatter) {
+      const match = line.match(/^(\w+(?:-\w+)*):\s*(.*)$/)
+      if (match) {
+        const [, key, value] = match
+        if (key === 'name') name = value.trim()
+        if (key === 'description') description = value.trim()
+      }
+    }
+  }
+
+  return { name, description, prompt: stripFrontmatter(content) }
+}
+
+export function extractCommandFrontmatter(content: string): CommandFrontmatter {
+  const lines = content.split('\n')
+
+  let inFrontmatter = false
+  let name = ''
+  let description = ''
+  let argumentHint = ''
+
+  for (const line of lines) {
+    if (line.trim() === '---') {
+      if (inFrontmatter) break
+      inFrontmatter = true
+      continue
+    }
+
+    if (inFrontmatter) {
+      const match = line.match(/^(\w+(?:-\w+)*):\s*(.*)$/)
+      if (match) {
+        const [, key, value] = match
+        if (key === 'name') name = value.trim()
+        if (key === 'description') description = value.trim()
+        if (key === 'argument-hint') argumentHint = value.trim().replace(/^["']|["']$/g, '')
+      }
+    }
+  }
+
+  return { name, description, argumentHint }
+}

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { Config } from '@opencode-ai/sdk'
+import { createConfigHandler } from '../../src/lib/config-handler.ts'
+
+describe('config-handler', () => {
+  let testDir: string
+  let bundledDir: string
+  let projectDir: string
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'systematic-config-test-'))
+    bundledDir = path.join(testDir, 'bundled')
+    projectDir = path.join(testDir, 'project')
+
+    fs.mkdirSync(path.join(bundledDir, 'skills'), { recursive: true })
+    fs.mkdirSync(path.join(bundledDir, 'agents'), { recursive: true })
+    fs.mkdirSync(path.join(bundledDir, 'commands'), { recursive: true })
+    fs.mkdirSync(path.join(projectDir, '.opencode/systematic/skills'), {
+      recursive: true,
+    })
+    fs.mkdirSync(path.join(projectDir, '.opencode/systematic/agents'), {
+      recursive: true,
+    })
+    fs.mkdirSync(path.join(projectDir, '.opencode/systematic/commands'), {
+      recursive: true,
+    })
+  })
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true })
+  })
+
+  function createSkill(dir: string, name: string, description: string): void {
+    const skillDir = path.join(dir, name)
+    fs.mkdirSync(skillDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(skillDir, 'SKILL.md'),
+      `---
+name: ${name}
+description: ${description}
+---
+# ${name}
+
+Skill content for ${name}.`,
+    )
+  }
+
+  function createAgent(dir: string, name: string, description: string): void {
+    fs.writeFileSync(
+      path.join(dir, `${name}.md`),
+      `---
+name: ${name}
+description: ${description}
+---
+# ${name}
+
+Agent prompt for ${name}.`,
+    )
+  }
+
+  function createCommand(dir: string, name: string, description: string): void {
+    fs.writeFileSync(
+      path.join(dir, `${name}.md`),
+      `---
+name: ${name}
+description: ${description}
+---
+# ${name}
+
+Command template for ${name}.`,
+    )
+  }
+
+  describe('createConfigHandler', () => {
+    test('returns a function', () => {
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+      expect(typeof handler).toBe('function')
+    })
+
+    test('collects bundled agents into config', async () => {
+      createAgent(path.join(bundledDir, 'agents'), 'test-agent', 'A test agent')
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent).toBeDefined()
+      expect(config.agent?.['test-agent']).toBeDefined()
+      expect(config.agent?.['test-agent']?.description).toBe('A test agent')
+    })
+
+    test('collects bundled commands into config', async () => {
+      createCommand(
+        path.join(bundledDir, 'commands'),
+        'test-command',
+        'A test command',
+      )
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.command).toBeDefined()
+      expect(config.command?.['test-command']).toBeDefined()
+      expect(config.command?.['test-command']?.description).toBe(
+        'A test command',
+      )
+      expect(config.command?.['test-command']?.template).toContain(
+        'Command template for test-command',
+      )
+    })
+
+    test('collects skills as commands', async () => {
+      createSkill(path.join(bundledDir, 'skills'), 'test-skill', 'A test skill')
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.command).toBeDefined()
+      expect(config.command?.['test-skill']).toBeDefined()
+      expect(config.command?.['test-skill']?.description).toBe('A test skill')
+      expect(config.command?.['test-skill']?.template).toContain(
+        'Skill content for test-skill',
+      )
+    })
+
+    test('preserves existing config entries', async () => {
+      createAgent(
+        path.join(bundledDir, 'agents'),
+        'bundled-agent',
+        'Bundled agent',
+      )
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {
+        agent: {
+          'existing-agent': {
+            description: 'Already exists',
+            prompt: 'Existing prompt',
+          },
+        },
+        command: {
+          'existing-command': {
+            description: 'Already exists',
+            template: 'Existing template',
+          },
+        },
+      }
+      await handler(config)
+
+      expect(config.agent?.['existing-agent']).toBeDefined()
+      expect(config.agent?.['bundled-agent']).toBeDefined()
+      expect(config.command?.['existing-command']).toBeDefined()
+    })
+
+    test('existing config overrides bundled content (preserves user config)', async () => {
+      createAgent(
+        path.join(bundledDir, 'agents'),
+        'test-agent',
+        'Bundled description',
+      )
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {
+        agent: {
+          'test-agent': { description: 'User override', prompt: 'User prompt' },
+        },
+      }
+      await handler(config)
+
+      expect(config.agent?.['test-agent']?.description).toBe('User override')
+    })
+  })
+
+  describe('priority ordering', () => {
+    test('project overrides bundled', async () => {
+      createAgent(path.join(bundledDir, 'agents'), 'priority-test', 'bundled')
+
+      const projectAgentsDir = path.join(
+        projectDir,
+        '.opencode/systematic/agents',
+      )
+      createAgent(projectAgentsDir, 'priority-test', 'project')
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.['priority-test']?.description).toBe('project')
+    })
+  })
+})


### PR DESCRIPTION
Implement config hook handler to register agents, skills, and commands with OpenCode's native configuration system, following the pattern established by oh-my-opencode plugin.

Changes:
- Add config-handler.ts with createConfigHandler factory function
- Export config handler in plugin return value (src/index.ts)
- Add extractAgentFrontmatter and extractCommandFrontmatter to skills-core
- Implement priority-based merging (bundled → user → project → existing)
- Convert skills to commands, agents to AgentConfig, commands to CommandConfig
- Add comprehensive unit tests in config-handler.test.ts
- Test priority ordering, config preservation, and content collection

This enables skills, agents, and commands to appear natively in OpenCode's command palette and agent selection UI, improving discoverability and integration with the platform.