### PR TITLE
refactor(frontmatter): unify YAML parsing with js-yaml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,14 @@
 # AGENTS.md - Coding Agent Guidelines for Systematic
 
+**Generated:** 2026-01-28 | **Commit:** d4bfa75 | **Branch:** main
+
 ## Project Overview
 
-OpenCode plugin providing systematic engineering workflows. Converts and adapts Claude Code agents, skills, and commands from Compound Engineering Plugin (CEP) to OpenCode. Includes skills, agents, and commands for structured AI-assisted development.
+OpenCode plugin providing systematic engineering workflows. Converts/adapts Claude Code agents, skills, and commands from Compound Engineering Plugin (CEP) to OpenCode.
+
+**Key insight:** This repo has two distinct parts:
+1. **TypeScript source** (`src/`) - Plugin logic, tools, config handling
+2. **Bundled assets** (`skills/`, `agents/`, `commands/`) - OpenCode Markdown content shipped with npm package
 
 ## Build & Test Commands
 
@@ -175,21 +181,28 @@ describe('module-name', () => {
 ```
 systematic/
 ├── src/
-│   ├── index.ts          # Plugin entry point
-│   ├── cli.ts            # CLI entry point
+│   ├── index.ts              # Plugin entry point (SystematicPlugin)
+│   ├── cli.ts                # CLI entry point
 │   └── lib/
-│       ├── config.ts     # Configuration loading
-│       ├── converter.ts  # CEP to OpenCode conversion
-│       └── skills-core.ts # Skill discovery/resolution
+│       ├── agents.ts         # Agent discovery + frontmatter parsing
+│       ├── bootstrap.ts      # System prompt injection
+│       ├── commands.ts       # Command discovery + frontmatter parsing
+│       ├── config.ts         # JSONC config loading (project > user)
+│       ├── config-handler.ts # OpenCode config hook (merges bundled → existing)
+│       ├── converter.ts      # CEP to OpenCode conversion
+│       ├── frontmatter.ts    # YAML frontmatter utilities
+│       ├── skill-tool.ts     # `systematic_skill` tool implementation
+│       ├── skills.ts         # Skill discovery + frontmatter parsing
+│       └── walk-dir.ts       # Recursive directory traversal
 ├── tests/
-│   ├── unit/             # Unit tests (bun test tests/unit)
-│   └── integration/      # Integration tests
-├── skills/               # Bundled skill definitions
-├── agents/               # Bundled agent definitions
-├── commands/             # Bundled command definitions
-├── dist/                 # Build output (git-ignored)
-├── biome.json            # Linter/formatter config
-├── tsconfig.json         # TypeScript config
+│   ├── unit/                 # Unit tests (bun test tests/unit)
+│   └── integration/          # Integration tests
+├── skills/                   # Bundled OpenCode skill definitions (SKILL.md)
+├── agents/                   # Bundled OpenCode agent definitions (Markdown)
+├── commands/                 # Bundled OpenCode command definitions (Markdown)
+├── dist/                     # Build output (git-ignored)
+├── biome.json                # Biome linter/formatter config
+├── tsconfig.json             # TypeScript config
 └── package.json
 ```
 

--- a/biome.json
+++ b/biome.json
@@ -28,7 +28,6 @@
     "includes": [
       "**",
       "!**/dist",
-      "!**/lib",
       "!**/.opencode",
       "!**/node_modules",
       "!**/*.md"

--- a/bun.lock
+++ b/bun.lock
@@ -5,12 +5,14 @@
     "": {
       "name": "@fro.bot/systematic",
       "dependencies": {
+        "js-yaml": "^4.1.1",
         "jsonc-parser": "^3.3.0",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.0.0",
         "@opencode-ai/plugin": "^1.1.30",
         "@types/bun": "latest",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.0.0",
         "conventional-changelog-conventionalcommits": "^9.0.0",
         "markdownlint-cli": "^0.47.0",
@@ -114,6 +116,8 @@
     "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
+
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
     "@types/katex": ["@types/katex@0.16.8", "", {}, "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg=="],
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@biomejs/biome": "^2.0.0",
     "@opencode-ai/plugin": "^1.1.30",
     "@types/bun": "latest",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
     "conventional-changelog-conventionalcommits": "^9.0.0",
     "markdownlint-cli": "^0.47.0",
@@ -63,6 +64,7 @@
     "typescript": "^5.7.0"
   },
   "dependencies": {
+    "js-yaml": "^4.1.1",
     "jsonc-parser": "^3.3.0"
   },
   "publishConfig": {

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -1,5 +1,5 @@
+import { parseFrontmatter, stripFrontmatter } from './frontmatter.js'
 import { walkDir } from './walk-dir.js'
-import { stripFrontmatter } from './frontmatter.js'
 
 export interface AgentFrontmatter {
   name: string
@@ -27,28 +27,17 @@ export function findAgentsInDir(dir: string, maxDepth = 2): AgentInfo[] {
 }
 
 export function extractAgentFrontmatter(content: string): AgentFrontmatter {
-  const lines = content.split('\n')
+  const { data, parseError } = parseFrontmatter<{
+    name?: string
+    description?: string
+  }>(content)
 
-  let inFrontmatter = false
-  let name = ''
-  let description = ''
-
-  for (const line of lines) {
-    if (line.trim() === '---') {
-      if (inFrontmatter) break
-      inFrontmatter = true
-      continue
-    }
-
-    if (inFrontmatter) {
-      const match = line.match(/^(\w+(?:-\w+)*):\s*(.*)$/)
-      if (match) {
-        const [, key, value] = match
-        if (key === 'name') name = value.trim()
-        if (key === 'description') description = value.trim()
-      }
-    }
+  return {
+    name: !parseError && typeof data.name === 'string' ? data.name : '',
+    description:
+      !parseError && typeof data.description === 'string'
+        ? data.description
+        : '',
+    prompt: stripFrontmatter(content),
   }
-
-  return { name, description, prompt: stripFrontmatter(content) }
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
-import path from 'node:path'
 import os from 'node:os'
+import path from 'node:path'
 import { parse as parseJsonc } from 'jsonc-parser'
 
 export interface BootstrapConfig {
@@ -34,40 +34,14 @@ function loadJsoncFile<T>(filePath: string): T | null {
   }
 }
 
-function mergeArraysUnique<T>(arr1: T[] | undefined, arr2: T[] | undefined): T[] {
+function mergeArraysUnique<T>(
+  arr1: T[] | undefined,
+  arr2: T[] | undefined,
+): T[] {
   const set = new Set<T>()
-  if (arr1) arr1.forEach((item) => set.add(item))
-  if (arr2) arr2.forEach((item) => set.add(item))
+  if (arr1) for (const item of arr1) set.add(item)
+  if (arr2) for (const item of arr2) set.add(item)
   return Array.from(set)
-}
-
-function deepMerge<T extends Record<string, unknown>>(
-  base: T,
-  ...overrides: Array<Partial<T> | null>
-): T {
-  const result = { ...base }
-
-  for (const override of overrides) {
-    if (!override) continue
-    for (const [key, value] of Object.entries(override)) {
-      if (
-        typeof value === 'object' &&
-        value !== null &&
-        !Array.isArray(value) &&
-        typeof result[key] === 'object' &&
-        result[key] !== null
-      ) {
-        ;(result as Record<string, unknown>)[key] = deepMerge(
-          result[key] as Record<string, unknown>,
-          value as Record<string, unknown>
-        )
-      } else if (value !== undefined) {
-        ;(result as Record<string, unknown>)[key] = value
-      }
-    }
-  }
-
-  return result
 }
 
 export function loadConfig(projectDir: string): SystematicConfig {
@@ -76,20 +50,30 @@ export function loadConfig(projectDir: string): SystematicConfig {
   const projectConfigPath = path.join(projectDir, '.opencode/systematic.json')
 
   const userConfig = loadJsoncFile<Partial<SystematicConfig>>(userConfigPath)
-  const projectConfig = loadJsoncFile<Partial<SystematicConfig>>(projectConfigPath)
+  const projectConfig =
+    loadJsoncFile<Partial<SystematicConfig>>(projectConfigPath)
 
   const result: SystematicConfig = {
     disabled_skills: mergeArraysUnique(
-      mergeArraysUnique(DEFAULT_CONFIG.disabled_skills, userConfig?.disabled_skills),
-      projectConfig?.disabled_skills
+      mergeArraysUnique(
+        DEFAULT_CONFIG.disabled_skills,
+        userConfig?.disabled_skills,
+      ),
+      projectConfig?.disabled_skills,
     ),
     disabled_agents: mergeArraysUnique(
-      mergeArraysUnique(DEFAULT_CONFIG.disabled_agents, userConfig?.disabled_agents),
-      projectConfig?.disabled_agents
+      mergeArraysUnique(
+        DEFAULT_CONFIG.disabled_agents,
+        userConfig?.disabled_agents,
+      ),
+      projectConfig?.disabled_agents,
     ),
     disabled_commands: mergeArraysUnique(
-      mergeArraysUnique(DEFAULT_CONFIG.disabled_commands, userConfig?.disabled_commands),
-      projectConfig?.disabled_commands
+      mergeArraysUnique(
+        DEFAULT_CONFIG.disabled_commands,
+        userConfig?.disabled_commands,
+      ),
+      projectConfig?.disabled_commands,
     ),
     bootstrap: {
       ...DEFAULT_CONFIG.bootstrap,

--- a/src/lib/converter.ts
+++ b/src/lib/converter.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs'
-import { parseFrontmatter, formatFrontmatter, type ParsedFrontmatter } from './frontmatter.js'
+import { formatFrontmatter, parseFrontmatter } from './frontmatter.js'
 
 export type ContentType = 'skill' | 'agent' | 'command'
 export type SourceType = 'bundled' | 'external'
@@ -19,10 +19,16 @@ const cache = new Map<string, CacheEntry>()
 
 function inferTemperature(name: string, description?: string): number {
   const sample = `${name} ${description ?? ''}`.toLowerCase()
-  if (/(review|audit|security|sentinel|oracle|lint|verification|guardian)/.test(sample)) {
+  if (
+    /(review|audit|security|sentinel|oracle|lint|verification|guardian)/.test(
+      sample,
+    )
+  ) {
     return 0.1
   }
-  if (/(plan|planning|architecture|strategist|analysis|research)/.test(sample)) {
+  if (
+    /(plan|planning|architecture|strategist|analysis|research)/.test(sample)
+  ) {
     return 0.2
   }
   if (/(doc|readme|changelog|editor|writer)/.test(sample)) {
@@ -45,10 +51,11 @@ function normalizeModel(model: string): string {
 
 function transformAgentFrontmatter(
   data: Record<string, string | number | boolean>,
-  agentMode: AgentMode
+  agentMode: AgentMode,
 ): Record<string, string | number | boolean> {
   const name = typeof data.name === 'string' ? data.name : ''
-  const description = typeof data.description === 'string' ? data.description : ''
+  const description =
+    typeof data.description === 'string' ? data.description : ''
 
   const newData: Record<string, string | number | boolean> = {
     description: description || `${name} agent`,
@@ -71,14 +78,14 @@ function transformAgentFrontmatter(
 export function convertContent(
   content: string,
   type: ContentType,
-  options: ConvertOptions = {}
+  options: ConvertOptions = {},
 ): string {
   if (content === '') return ''
 
-  const { data, body, raw } = parseFrontmatter(content)
-  const hasFrontmatter = raw !== ''
+  const { data, body, hadFrontmatter } =
+    parseFrontmatter<Record<string, string | number | boolean>>(content)
 
-  if (!hasFrontmatter) {
+  if (!hadFrontmatter) {
     return content
   }
 
@@ -94,7 +101,7 @@ export function convertContent(
 export function convertFileWithCache(
   filePath: string,
   type: ContentType,
-  options: ConvertOptions = {}
+  options: ConvertOptions = {},
 ): string {
   const fd = fs.openSync(filePath, 'r')
   try {

--- a/src/lib/skill-tool.ts
+++ b/src/lib/skill-tool.ts
@@ -7,7 +7,6 @@ import { stripFrontmatter } from './frontmatter.js'
 import type { SkillInfo } from './skills.js'
 import { findSkillsInDir, formatSkillsXml } from './skills.js'
 
-
 function wrapSkillContent(skillPath: string, content: string): string {
   const skillDir = path.dirname(skillPath)
   const converted = convertContent(content, 'skill', { source: 'bundled' })
@@ -60,7 +59,7 @@ Use this when a task matches an available skill's description.`
       name: tool.schema
         .string()
         .describe(
-          "The skill identifier from available_skills (e.g., 'systematic:brainstorming')"
+          "The skill identifier from available_skills (e.g., 'systematic:brainstorming')",
         ),
     },
     async execute(args: { name: string }): Promise<string> {
@@ -87,14 +86,14 @@ ${wrapped}`
           const errorMessage =
             error instanceof Error ? error.message : String(error)
           throw new Error(
-            `Failed to load skill "${requestedName}": ${errorMessage}`
+            `Failed to load skill "${requestedName}": ${errorMessage}`,
           )
         }
       }
 
       const availableSystematic = skills.map((s) => `systematic:${s.name}`)
       throw new Error(
-        `Skill "${requestedName}" not found. Available systematic skills: ${availableSystematic.join(', ')}`
+        `Skill "${requestedName}" not found. Available systematic skills: ${availableSystematic.join(', ')}`,
       )
     },
   })

--- a/src/lib/walk-dir.ts
+++ b/src/lib/walk-dir.ts
@@ -14,7 +14,10 @@ export interface WalkOptions {
   filter?: (entry: WalkEntry) => boolean
 }
 
-export function walkDir(rootDir: string, options: WalkOptions = {}): WalkEntry[] {
+export function walkDir(
+  rootDir: string,
+  options: WalkOptions = {},
+): WalkEntry[] {
   const { maxDepth = 3, filter } = options
   const results: WalkEntry[] = []
 

--- a/tests/unit/frontmatter.test.ts
+++ b/tests/unit/frontmatter.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  formatFrontmatter,
+  parseFrontmatter,
+  stripFrontmatter,
+} from '../../src/lib/frontmatter.ts'
+
+describe('frontmatter', () => {
+  describe('parseFrontmatter', () => {
+    describe('valid frontmatter', () => {
+      test('parses simple key-value pairs', () => {
+        const content = `---
+name: test-skill
+description: A test skill
+---
+# Content`
+        const result = parseFrontmatter(content)
+        expect(result.hadFrontmatter).toBe(true)
+        expect(result.parseError).toBe(false)
+        expect(result.data).toEqual({
+          name: 'test-skill',
+          description: 'A test skill',
+        })
+        expect(result.body).toBe('# Content')
+      })
+
+      test('parses hyphenated keys', () => {
+        const content = `---
+argument-hint: "[file path]"
+allowed-tools: Read, Write
+---
+Body`
+        const result = parseFrontmatter<{
+          'argument-hint': string
+          'allowed-tools': string
+        }>(content)
+        expect(result.hadFrontmatter).toBe(true)
+        expect(result.parseError).toBe(false)
+        expect(result.data['argument-hint']).toBe('[file path]')
+        expect(result.data['allowed-tools']).toBe('Read, Write')
+      })
+
+      test('parses boolean values', () => {
+        const content = `---
+enabled: true
+disabled: false
+---
+Body`
+        const result = parseFrontmatter<{
+          enabled: boolean
+          disabled: boolean
+        }>(content)
+        expect(result.data.enabled).toBe(true)
+        expect(result.data.disabled).toBe(false)
+      })
+
+      test('parses numeric values', () => {
+        const content = `---
+temperature: 0.7
+count: 42
+---
+Body`
+        const result = parseFrontmatter<{ temperature: number; count: number }>(
+          content,
+        )
+        expect(result.data.temperature).toBe(0.7)
+        expect(result.data.count).toBe(42)
+      })
+
+      test('parses quoted strings', () => {
+        const content = `---
+name: "quoted value"
+description: 'single quoted'
+---
+Body`
+        const result = parseFrontmatter(content)
+        expect(result.data).toEqual({
+          name: 'quoted value',
+          description: 'single quoted',
+        })
+      })
+
+      test('preserves body content exactly', () => {
+        const content = `---
+name: test
+---
+Line 1
+Line 2
+
+Line 4`
+        const result = parseFrontmatter(content)
+        expect(result.body).toBe('Line 1\nLine 2\n\nLine 4')
+      })
+
+      test('handles Windows line endings', () => {
+        const content = '---\r\nname: test\r\n---\r\nBody content'
+        const result = parseFrontmatter(content)
+        expect(result.hadFrontmatter).toBe(true)
+        expect(result.data).toEqual({ name: 'test' })
+        expect(result.body).toBe('Body content')
+      })
+    })
+
+    describe('edge cases', () => {
+      test('returns hadFrontmatter: false when no delimiters', () => {
+        const content = '# Just a heading\nSome content'
+        const result = parseFrontmatter(content)
+        expect(result.hadFrontmatter).toBe(false)
+        expect(result.parseError).toBe(false)
+        expect(result.body).toBe(content)
+        expect(result.data).toEqual({})
+      })
+
+      test('returns hadFrontmatter: false when only opening delimiter', () => {
+        const content = '---\nname: test\n# No closing delimiter'
+        const result = parseFrontmatter(content)
+        expect(result.hadFrontmatter).toBe(false)
+        expect(result.body).toBe(content)
+      })
+
+      test('handles empty frontmatter', () => {
+        const content = `---
+---
+# Content`
+        const result = parseFrontmatter(content)
+        expect(result.hadFrontmatter).toBe(true)
+        expect(result.parseError).toBe(false)
+        expect(result.data).toEqual({})
+      })
+
+      test('handles empty content', () => {
+        const result = parseFrontmatter('')
+        expect(result.hadFrontmatter).toBe(false)
+        expect(result.body).toBe('')
+        expect(result.data).toEqual({})
+      })
+
+      test('handles frontmatter with only newline before closing', () => {
+        const content = `---
+name: test
+---
+Body`
+        const result = parseFrontmatter(content)
+        expect(result.hadFrontmatter).toBe(true)
+        expect(result.data).toEqual({ name: 'test' })
+      })
+    })
+
+    describe('error handling', () => {
+      test('sets parseError: true for malformed YAML', () => {
+        const content = `---
+key: value
+  invalid: indentation
+---
+Body`
+        const result = parseFrontmatter(content)
+        expect(result.hadFrontmatter).toBe(true)
+        expect(result.parseError).toBe(true)
+        expect(result.data).toEqual({})
+      })
+
+      test('returns empty data on parse error', () => {
+        const content = `---
+[invalid yaml
+---
+Body`
+        const result = parseFrontmatter(content)
+        expect(result.parseError).toBe(true)
+        expect(result.data).toEqual({})
+        expect(result.body).toBe('Body')
+      })
+    })
+
+    describe('generic type support', () => {
+      interface SkillFrontmatter {
+        name: string
+        description: string
+      }
+
+      test('supports typed frontmatter extraction', () => {
+        const content = `---
+name: my-skill
+description: A skill description
+---
+Body`
+        const result = parseFrontmatter<SkillFrontmatter>(content)
+        expect(result.data.name).toBe('my-skill')
+        expect(result.data.description).toBe('A skill description')
+      })
+    })
+  })
+
+  describe('formatFrontmatter', () => {
+    test('formats key-value pairs', () => {
+      const data = { name: 'test', count: 5, enabled: true }
+      const result = formatFrontmatter(data)
+      expect(result).toBe('---\nname: test\ncount: 5\nenabled: true\n---')
+    })
+
+    test('handles empty data', () => {
+      const result = formatFrontmatter({})
+      expect(result).toBe('---\n---')
+    })
+  })
+
+  describe('stripFrontmatter', () => {
+    test('removes frontmatter from content', () => {
+      const content = `---
+name: test
+---
+# Content Here`
+      const result = stripFrontmatter(content)
+      expect(result).toBe('# Content Here')
+    })
+
+    test('returns content unchanged if no frontmatter', () => {
+      const content = '# No frontmatter'
+      const result = stripFrontmatter(content)
+      expect(result).toBe('# No frontmatter')
+    })
+
+    test('trims whitespace from body', () => {
+      const content = `---
+name: test
+---
+
+Content with leading newline`
+      const result = stripFrontmatter(content)
+      expect(result).toBe('Content with leading newline')
+    })
+  })
+})


### PR DESCRIPTION
Replace manual frontmatter parsers with robust js-yaml implementation. Add FrontmatterResult<T> interface with generic type support. Refactor agents, commands, and skills modules to use new parser. Add comprehensive unit tests covering edge cases and error handling.

Benefits: hyphenated keys support, proper type parsing (bool/number), CRLF handling, type safety, security via JSON_SCHEMA.