### PR TITLE
refactor(skills): extract skill loading into dedicated module

### DIFF
--- a/src/lib/skill-loader.ts
+++ b/src/lib/skill-loader.ts
@@ -1,0 +1,75 @@
+import path from 'node:path'
+import { convertFileWithCache } from './converter.js'
+import { stripFrontmatter } from './frontmatter.js'
+import type { SkillInfo } from './skills.js'
+
+const SKILL_PREFIX = 'systematic:'
+const SKILL_DESCRIPTION_PREFIX = '(systematic - Skill) '
+
+export interface LoadedSkill {
+  name: string
+  prefixedName: string
+  description: string
+  path: string
+  skillFile: string
+  wrappedTemplate: string
+}
+
+export function formatSkillCommandName(name: string): string {
+  if (name.startsWith(SKILL_PREFIX)) {
+    return name
+  }
+  return `${SKILL_PREFIX}${name}`
+}
+
+export function formatSkillDescription(
+  description: string,
+  fallbackName: string,
+): string {
+  const desc = description || `${fallbackName} skill`
+  if (desc.startsWith(SKILL_DESCRIPTION_PREFIX)) {
+    return desc
+  }
+  return `${SKILL_DESCRIPTION_PREFIX}${desc}`
+}
+
+export function wrapSkillTemplate(skillPath: string, body: string): string {
+  const skillDir = path.dirname(skillPath)
+  return `<skill-instruction>
+Base directory for this skill: ${skillDir}/
+File references (@path) in this skill are relative to this directory.
+
+${body.trim()}
+</skill-instruction>`
+}
+
+export function extractSkillBody(wrappedTemplate: string): string {
+  const match = wrappedTemplate.match(
+    /<skill-instruction>([\s\S]*?)<\/skill-instruction>/,
+  )
+  return match ? match[1].trim() : wrappedTemplate
+}
+
+export function loadSkill(skillInfo: SkillInfo): LoadedSkill | null {
+  try {
+    const converted = convertFileWithCache(skillInfo.skillFile, 'skill', {
+      source: 'bundled',
+    })
+    const body = stripFrontmatter(converted)
+    const wrappedTemplate = wrapSkillTemplate(skillInfo.skillFile, body)
+
+    return {
+      name: skillInfo.name,
+      prefixedName: formatSkillCommandName(skillInfo.name),
+      description: formatSkillDescription(
+        skillInfo.description,
+        skillInfo.name,
+      ),
+      path: skillInfo.path,
+      skillFile: skillInfo.skillFile,
+      wrappedTemplate,
+    }
+  } catch {
+    return null
+  }
+}

--- a/tests/integration/opencode.test.ts
+++ b/tests/integration/opencode.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import type { Config } from '@opencode-ai/sdk'
+import { createConfigHandler } from '../../src/lib/config-handler.ts'
 
 const OPENCODE_AVAILABLE = (() => {
   const result = Bun.spawnSync(['which', 'opencode'])
@@ -118,12 +120,124 @@ describe.skipIf(!OPENCODE_AVAILABLE)('opencode integration', () => {
         'What skills are available? List the systematic skills you can load.',
       )
 
-      expect(result.stdout).toMatch(
-        /systematic:brainstorming|systematic:.*|available.*skills/i,
-      )
+      expect(result.stdout).toMatch(/brainstorming|systematic.*skills/i)
     },
     TIMEOUT_MS * MAX_RETRIES,
   )
+})
+
+describe('config handler integration', () => {
+  let testEnv: {
+    tempDir: string
+    bundledDir: string
+    projectDir: string
+  }
+
+  beforeEach(() => {
+    const tempBase = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'systematic-config-integration-'),
+    )
+
+    testEnv = {
+      tempDir: tempBase,
+      bundledDir: path.join(tempBase, 'bundled'),
+      projectDir: path.join(tempBase, 'project'),
+    }
+
+    fs.mkdirSync(path.join(testEnv.bundledDir, 'skills', 'test-skill'), {
+      recursive: true,
+    })
+    fs.mkdirSync(path.join(testEnv.bundledDir, 'agents'), { recursive: true })
+    fs.mkdirSync(path.join(testEnv.bundledDir, 'commands'), { recursive: true })
+    fs.mkdirSync(testEnv.projectDir, { recursive: true })
+
+    fs.writeFileSync(
+      path.join(testEnv.bundledDir, 'skills', 'test-skill', 'SKILL.md'),
+      `---
+name: test-skill
+description: A skill for integration testing
+---
+# Test Skill
+
+Integration test content.`,
+    )
+  })
+
+  afterEach(() => {
+    if (testEnv.tempDir) {
+      fs.rmSync(testEnv.tempDir, { recursive: true, force: true })
+    }
+  })
+
+  test('registers skills with systematic: prefix in command name', async () => {
+    const handler = createConfigHandler({
+      directory: testEnv.projectDir,
+      bundledSkillsDir: path.join(testEnv.bundledDir, 'skills'),
+      bundledAgentsDir: path.join(testEnv.bundledDir, 'agents'),
+      bundledCommandsDir: path.join(testEnv.bundledDir, 'commands'),
+    })
+
+    const config: Config = {}
+    await handler(config)
+
+    const commandNames = Object.keys(config.command || {})
+    expect(commandNames).toContain('systematic:test-skill')
+    expect(commandNames).not.toContain('test-skill')
+  })
+
+  test('adds (systematic - Skill) prefix to skill descriptions', async () => {
+    const handler = createConfigHandler({
+      directory: testEnv.projectDir,
+      bundledSkillsDir: path.join(testEnv.bundledDir, 'skills'),
+      bundledAgentsDir: path.join(testEnv.bundledDir, 'agents'),
+      bundledCommandsDir: path.join(testEnv.bundledDir, 'commands'),
+    })
+
+    const config: Config = {}
+    await handler(config)
+
+    const skillCommand = config.command?.['systematic:test-skill']
+    expect(skillCommand?.description).toMatch(/^\(systematic - Skill\) /)
+    expect(skillCommand?.description).toBe(
+      '(systematic - Skill) A skill for integration testing',
+    )
+  })
+
+  test('wraps skill template in <skill-instruction> tags', async () => {
+    const handler = createConfigHandler({
+      directory: testEnv.projectDir,
+      bundledSkillsDir: path.join(testEnv.bundledDir, 'skills'),
+      bundledAgentsDir: path.join(testEnv.bundledDir, 'agents'),
+      bundledCommandsDir: path.join(testEnv.bundledDir, 'commands'),
+    })
+
+    const config: Config = {}
+    await handler(config)
+
+    const skillCommand = config.command?.['systematic:test-skill']
+    expect(skillCommand?.template).toContain('<skill-instruction>')
+    expect(skillCommand?.template).toContain('</skill-instruction>')
+    expect(skillCommand?.template).toContain('Base directory for this skill:')
+    expect(skillCommand?.template).toContain('Integration test content.')
+  })
+
+  test('skill template does not contain frontmatter', async () => {
+    const handler = createConfigHandler({
+      directory: testEnv.projectDir,
+      bundledSkillsDir: path.join(testEnv.bundledDir, 'skills'),
+      bundledAgentsDir: path.join(testEnv.bundledDir, 'agents'),
+      bundledCommandsDir: path.join(testEnv.bundledDir, 'commands'),
+    })
+
+    const config: Config = {}
+    await handler(config)
+
+    const skillCommand = config.command?.['systematic:test-skill']
+    expect(skillCommand?.template).not.toContain('name: test-skill')
+    expect(skillCommand?.template).not.toContain(
+      'description: A skill for integration testing',
+    )
+  })
 })
 
 describe('opencode availability check', () => {

--- a/tests/unit/skill-loader.test.ts
+++ b/tests/unit/skill-loader.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  extractSkillBody,
+  formatSkillCommandName,
+  formatSkillDescription,
+  loadSkill,
+  wrapSkillTemplate,
+} from '../../src/lib/skill-loader.ts'
+import type { SkillInfo } from '../../src/lib/skills.ts'
+
+describe('skill-loader', () => {
+  describe('formatSkillCommandName', () => {
+    test('adds systematic: prefix to plain name', () => {
+      expect(formatSkillCommandName('brainstorming')).toBe(
+        'systematic:brainstorming',
+      )
+    })
+
+    test('does not double-prefix already prefixed name', () => {
+      expect(formatSkillCommandName('systematic:brainstorming')).toBe(
+        'systematic:brainstorming',
+      )
+    })
+
+    test('handles empty string', () => {
+      expect(formatSkillCommandName('')).toBe('systematic:')
+    })
+  })
+
+  describe('formatSkillDescription', () => {
+    test('adds (systematic - Skill) prefix to description', () => {
+      expect(formatSkillDescription('A test skill', 'test')).toBe(
+        '(systematic - Skill) A test skill',
+      )
+    })
+
+    test('does not double-prefix already prefixed description', () => {
+      expect(
+        formatSkillDescription('(systematic - Skill) A test skill', 'test'),
+      ).toBe('(systematic - Skill) A test skill')
+    })
+
+    test('uses fallback name when description is empty', () => {
+      expect(formatSkillDescription('', 'my-skill')).toBe(
+        '(systematic - Skill) my-skill skill',
+      )
+    })
+  })
+
+  describe('wrapSkillTemplate', () => {
+    test('wraps content in skill-instruction tags', () => {
+      const result = wrapSkillTemplate(
+        '/path/to/skill/SKILL.md',
+        '# Skill Body',
+      )
+      expect(result).toContain('<skill-instruction>')
+      expect(result).toContain('</skill-instruction>')
+      expect(result).toContain('# Skill Body')
+    })
+
+    test('includes base directory from skill path', () => {
+      const result = wrapSkillTemplate(
+        '/bundled/skills/brainstorming/SKILL.md',
+        '# Content',
+      )
+      expect(result).toContain(
+        'Base directory for this skill: /bundled/skills/brainstorming/',
+      )
+    })
+
+    test('includes file reference note', () => {
+      const result = wrapSkillTemplate('/path/to/skill/SKILL.md', '# Content')
+      expect(result).toContain(
+        'File references (@path) in this skill are relative to this directory',
+      )
+    })
+
+    test('trims body content', () => {
+      const result = wrapSkillTemplate(
+        '/path/to/skill/SKILL.md',
+        '  \n# Skill Body\n  ',
+      )
+      expect(result).toContain('# Skill Body')
+      expect(result).not.toMatch(/\n\s+\n<\/skill-instruction>/)
+    })
+  })
+
+  describe('extractSkillBody', () => {
+    test('extracts body from wrapped template', () => {
+      const wrapped = `<skill-instruction>
+Base directory for this skill: /path/to/skill/
+File references (@path) in this skill are relative to this directory.
+
+# Skill Body
+
+Some content here.
+</skill-instruction>`
+
+      const result = extractSkillBody(wrapped)
+      expect(result).toContain('# Skill Body')
+      expect(result).toContain('Some content here.')
+      expect(result).not.toContain('<skill-instruction>')
+      expect(result).not.toContain('</skill-instruction>')
+    })
+
+    test('returns original content if no wrapper tags', () => {
+      const unwrapped = '# Just raw content'
+      expect(extractSkillBody(unwrapped)).toBe('# Just raw content')
+    })
+
+    test('trims extracted body', () => {
+      const wrapped = `<skill-instruction>
+
+  # Body
+
+</skill-instruction>`
+
+      const result = extractSkillBody(wrapped)
+      expect(result).toBe('# Body')
+    })
+  })
+
+  describe('loadSkill', () => {
+    let testDir: string
+
+    beforeEach(() => {
+      testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-loader-test-'))
+      fs.mkdirSync(path.join(testDir, 'test-skill'), { recursive: true })
+    })
+
+    afterEach(() => {
+      fs.rmSync(testDir, { recursive: true, force: true })
+    })
+
+    test('loads skill with all properties', () => {
+      const skillFile = path.join(testDir, 'test-skill', 'SKILL.md')
+      fs.writeFileSync(
+        skillFile,
+        `---
+name: test-skill
+description: A test skill
+---
+# Test Content`,
+      )
+
+      const skillInfo: SkillInfo = {
+        name: 'test-skill',
+        description: 'A test skill',
+        path: path.join(testDir, 'test-skill'),
+        skillFile,
+      }
+
+      const loaded = loadSkill(skillInfo)
+
+      expect(loaded).not.toBeNull()
+      expect(loaded!.name).toBe('test-skill')
+      expect(loaded!.prefixedName).toBe('systematic:test-skill')
+      expect(loaded!.description).toBe('(systematic - Skill) A test skill')
+      expect(loaded!.wrappedTemplate).toContain('<skill-instruction>')
+      expect(loaded!.wrappedTemplate).toContain('# Test Content')
+    })
+
+    test('returns null for non-existent file', () => {
+      const skillInfo: SkillInfo = {
+        name: 'missing',
+        description: '',
+        path: path.join(testDir, 'missing'),
+        skillFile: path.join(testDir, 'missing', 'SKILL.md'),
+      }
+
+      expect(loadSkill(skillInfo)).toBeNull()
+    })
+
+    test('wraps and extracts consistently (roundtrip)', () => {
+      const skillFile = path.join(testDir, 'test-skill', 'SKILL.md')
+      fs.writeFileSync(
+        skillFile,
+        `---
+name: test-skill
+description: A test skill
+---
+# Original Body
+
+Content here.`,
+      )
+
+      const skillInfo: SkillInfo = {
+        name: 'test-skill',
+        description: 'A test skill',
+        path: path.join(testDir, 'test-skill'),
+        skillFile,
+      }
+
+      const loaded = loadSkill(skillInfo)
+      const extracted = extractSkillBody(loaded!.wrappedTemplate)
+
+      expect(extracted).toContain('# Original Body')
+      expect(extracted).toContain('Content here.')
+      expect(extracted).not.toContain('name: test-skill')
+    })
+  })
+})

--- a/tests/unit/skill-tool.test.ts
+++ b/tests/unit/skill-tool.test.ts
@@ -99,9 +99,9 @@ This is the skill content.`,
       )
 
       expect(result).toContain('systematic:load-test')
-      expect(result).toContain('<skill-instruction>')
       expect(result).toContain('# Load Test Skill')
       expect(result).toContain('This is the skill content.')
+      expect(result).not.toContain('<skill-instruction>')
     })
 
     test('loads systematic skill without prefix', async () => {
@@ -166,7 +166,7 @@ No frontmatter visible here.`,
       expect(result).toContain('# Actual Content')
     })
 
-    test('wraps content with skill-instruction tags', async () => {
+    test('extracts body from wrapped template (matches OMO pattern)', async () => {
       const skillDir = path.join(testDir, 'wrap-test')
       fs.mkdirSync(skillDir)
       fs.writeFileSync(
@@ -185,9 +185,11 @@ description: Test wrapper
 
       const result = await tool.execute({ name: 'wrap-test' }, mockContext)
 
-      expect(result).toContain('<skill-instruction>')
-      expect(result).toContain('</skill-instruction>')
-      expect(result).toContain('Base directory for this skill:')
+      expect(result).toContain('## Skill: systematic:wrap-test')
+      expect(result).toContain('**Base directory**:')
+      expect(result).toContain('# Wrapped Content')
+      expect(result).not.toContain('<skill-instruction>')
+      expect(result).not.toContain('</skill-instruction>')
     })
   })
 })


### PR DESCRIPTION
- Add skill-loader.ts module centralizing skill loading logic
- Prefix skill command names with 'systematic:' for namespacing
- Prefix skill descriptions with '(systematic - Skill)' for clarity
- Wrap skill templates in <skill-instruction> tags with base directory
- Extract body from wrapped template when displaying via tool
- Fix double-prefix bug in formatSkillsXml integration
- Refactor config-handler to use new loadSkill function
- Refactor skill-tool to use centralized loading utilities
- Add comprehensive unit tests for skill-loader module
- Add integration tests for config handler skill registration
- Update existing tests to verify new prefixing behavior