### PR TITLE
refactor: extract shared validation utilities and expand agent frontmatter support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,12 +4,9 @@ import path from 'node:path'
 import * as agents from './lib/agents.js'
 import * as commands from './lib/commands.js'
 import { getConfigPaths } from './lib/config.js'
-import {
-  type AgentMode,
-  type ContentType,
-  convertContent,
-} from './lib/converter.js'
+import { type ContentType, convertContent } from './lib/converter.js'
 import * as skills from './lib/skills.js'
+import type { AgentMode } from './lib/validation.js'
 
 const VERSION = '0.1.0'
 

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -1,10 +1,37 @@
-import { parseFrontmatter, stripFrontmatter } from './frontmatter.js'
+import { parseFrontmatter } from './frontmatter.js'
+import {
+  isAgentMode,
+  isToolsMap,
+  normalizePermission,
+  type PermissionConfig,
+} from './validation.js'
 import { walkDir } from './walk-dir.js'
 
 export interface AgentFrontmatter {
+  /** Name of the agent */
   name: string
+  /** Description of the agent's purpose */
   description: string
+  /** The system prompt for the agent */
   prompt: string
+  /** Model to use (provider/model format) */
+  model?: string
+  /** Temperature for generation */
+  temperature?: number
+  /** Top-p sampling */
+  top_p?: number
+  /** Tool whitelist/blacklist */
+  tools?: Record<string, boolean>
+  /** Disable this agent */
+  disable?: boolean
+  /** Agent mode */
+  mode?: 'subagent' | 'primary' | 'all'
+  /** Hex color code */
+  color?: string
+  /** Max agentic iterations */
+  maxSteps?: number
+  /** Permission settings */
+  permission?: PermissionConfig
 }
 
 export interface AgentInfo {
@@ -26,18 +53,51 @@ export function findAgentsInDir(dir: string, maxDepth = 2): AgentInfo[] {
   }))
 }
 
+function extractString(
+  data: Record<string, unknown>,
+  key: string,
+  fallback = '',
+): string {
+  const value = data[key]
+  return typeof value === 'string' ? value : fallback
+}
+
+function extractNumber(
+  data: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = data[key]
+  return typeof value === 'number' ? value : undefined
+}
+
+function extractBoolean(
+  data: Record<string, unknown>,
+  key: string,
+): boolean | undefined {
+  const value = data[key]
+  return typeof value === 'boolean' ? value : undefined
+}
+
 export function extractAgentFrontmatter(content: string): AgentFrontmatter {
-  const { data, parseError } = parseFrontmatter<{
-    name?: string
-    description?: string
-  }>(content)
+  const { data, parseError, body } =
+    parseFrontmatter<Record<string, unknown>>(content)
+
+  if (parseError) {
+    return { name: '', description: '', prompt: body.trim() }
+  }
 
   return {
-    name: !parseError && typeof data.name === 'string' ? data.name : '',
-    description:
-      !parseError && typeof data.description === 'string'
-        ? data.description
-        : '',
-    prompt: stripFrontmatter(content),
+    name: extractString(data, 'name'),
+    description: extractString(data, 'description'),
+    prompt: body.trim(),
+    model: extractString(data, 'model') || undefined,
+    temperature: extractNumber(data, 'temperature'),
+    top_p: extractNumber(data, 'top_p'),
+    tools: isToolsMap(data.tools) ? data.tools : undefined,
+    disable: extractBoolean(data, 'disable'),
+    mode: isAgentMode(data.mode) ? data.mode : undefined,
+    color: extractString(data, 'color') || undefined,
+    maxSteps: extractNumber(data, 'maxSteps'),
+    permission: normalizePermission(data.permission),
   }
 }

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import type { SystematicConfig } from './config.js'
-import { stripFrontmatter } from './frontmatter.js'
+import { parseFrontmatter } from './frontmatter.js'
 
 export interface BootstrapDeps {
   bundledSkillsDir: string
@@ -53,7 +53,8 @@ export function getBootstrapContent(
   if (!fs.existsSync(usingSystematicPath)) return null
 
   const fullContent = fs.readFileSync(usingSystematicPath, 'utf8')
-  const content = stripFrontmatter(fullContent)
+  const { body } = parseFrontmatter(fullContent)
+  const content = body.trim()
   const toolMapping = getToolMappingTemplate(bundledSkillsDir)
 
   return `<SYSTEMATIC_WORKFLOWS>

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -59,6 +59,10 @@ export function formatFrontmatter(data: Record<string, unknown>): string {
   return ['---', yamlContent, '---'].join('\n')
 }
 
+/**
+ * Removes YAML frontmatter from content and returns the body.
+ * Convenience wrapper around parseFrontmatter.
+ */
 export function stripFrontmatter(content: string): string {
   const { body, hadFrontmatter } = parseFrontmatter(content)
   return hadFrontmatter ? body.trim() : content.trim()

--- a/src/lib/skill-loader.ts
+++ b/src/lib/skill-loader.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import { convertFileWithCache } from './converter.js'
-import { stripFrontmatter } from './frontmatter.js'
+import { parseFrontmatter } from './frontmatter.js'
 import type { SkillInfo } from './skills.js'
 
 const SKILL_PREFIX = 'systematic:'
@@ -59,7 +59,7 @@ export function loadSkill(skillInfo: SkillInfo): LoadedSkill | null {
     const converted = convertFileWithCache(skillInfo.skillFile, 'skill', {
       source: 'bundled',
     })
-    const body = stripFrontmatter(converted)
+    const { body } = parseFrontmatter(converted)
     const wrappedTemplate = wrapSkillTemplate(skillInfo.skillFile, body)
 
     return {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,108 @@
+/**
+ * Shared type guards and validation utilities for agent/skill/command frontmatter.
+ */
+
+export type AgentMode = 'subagent' | 'primary' | 'all'
+
+export type PermissionSetting = 'ask' | 'allow' | 'deny'
+
+export interface PermissionConfig {
+  edit?: PermissionSetting
+  bash?: PermissionSetting | Record<string, PermissionSetting>
+  webfetch?: PermissionSetting
+  doom_loop?: PermissionSetting
+  external_directory?: PermissionSetting
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function isPermissionSetting(
+  value: unknown,
+): value is PermissionSetting {
+  return value === 'ask' || value === 'allow' || value === 'deny'
+}
+
+export function isToolsMap(value: unknown): value is Record<string, boolean> {
+  if (!isRecord(value)) return false
+  return Object.values(value).every((entry) => typeof entry === 'boolean')
+}
+
+export function isAgentMode(value: unknown): value is AgentMode {
+  return value === 'subagent' || value === 'primary' || value === 'all'
+}
+
+function extractSimplePermission(
+  data: Record<string, unknown>,
+  key: keyof PermissionConfig,
+): PermissionSetting | null | undefined {
+  if (!(key in data)) return undefined
+  const value = data[key]
+  return isPermissionSetting(value) ? value : null
+}
+
+function extractBashPermission(
+  data: Record<string, unknown>,
+): PermissionConfig['bash'] | null | undefined {
+  if (!('bash' in data)) return undefined
+
+  const bash = data.bash
+  if (isPermissionSetting(bash)) return bash
+
+  if (isRecord(bash)) {
+    const entries = Object.entries(bash)
+    if (entries.every(([, setting]) => isPermissionSetting(setting))) {
+      return Object.fromEntries(entries) as Record<string, PermissionSetting>
+    }
+  }
+  return null
+}
+
+function buildPermissionObject(
+  edit: PermissionSetting | null | undefined,
+  bash: PermissionConfig['bash'] | null | undefined,
+  webfetch: PermissionSetting | null | undefined,
+  doom_loop: PermissionSetting | null | undefined,
+  external_directory: PermissionSetting | null | undefined,
+): PermissionConfig | undefined {
+  const permission: PermissionConfig = {}
+  if (edit) permission.edit = edit
+  if (bash) permission.bash = bash
+  if (webfetch) permission.webfetch = webfetch
+  if (doom_loop) permission.doom_loop = doom_loop
+  if (external_directory) permission.external_directory = external_directory
+  return Object.keys(permission).length > 0 ? permission : undefined
+}
+
+export function normalizePermission(
+  value: unknown,
+): PermissionConfig | undefined {
+  if (!isRecord(value)) return undefined
+
+  const bash = extractBashPermission(value)
+  if (bash === null) return undefined
+
+  const edit = extractSimplePermission(value, 'edit')
+  if (edit === null) return undefined
+
+  const webfetch = extractSimplePermission(value, 'webfetch')
+  if (webfetch === null) return undefined
+
+  const doom_loop = extractSimplePermission(value, 'doom_loop')
+  if (doom_loop === null) return undefined
+
+  const external_directory = extractSimplePermission(
+    value,
+    'external_directory',
+  )
+  if (external_directory === null) return undefined
+
+  return buildPermissionObject(
+    edit,
+    bash,
+    webfetch,
+    doom_loop,
+    external_directory,
+  )
+}

--- a/tests/unit/agents.test.ts
+++ b/tests/unit/agents.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from 'bun:test'
+import { extractAgentFrontmatter } from '../../src/lib/agents.js'
+
+describe('extractAgentFrontmatter', () => {
+  test('extracts name from frontmatter', () => {
+    const content = `---
+name: security-sentinel
+description: Security review agent
+---
+Be a security expert.`
+    const result = extractAgentFrontmatter(content)
+    expect(result.name).toBe('security-sentinel')
+  })
+
+  test('extracts description from frontmatter', () => {
+    const content = `---
+name: security-sentinel
+description: Security review agent
+---
+Be a security expert.`
+    const result = extractAgentFrontmatter(content)
+    expect(result.description).toBe('Security review agent')
+  })
+
+  test('extracts prompt (body content)', () => {
+    const content = `---
+name: security-sentinel
+description: Security review agent
+---
+Be a security expert.`
+    const result = extractAgentFrontmatter(content)
+    expect(result.prompt.trim()).toBe('Be a security expert.')
+  })
+
+  test('handles missing frontmatter gracefully', () => {
+    const content = 'Be a security expert.'
+    const result = extractAgentFrontmatter(content)
+    expect(result.name).toBe('')
+    expect(result.description).toBe('')
+    expect(result.prompt.trim()).toBe('Be a security expert.')
+  })
+
+  test('handles empty/malformed frontmatter', () => {
+    const content = `---
+malformed
+---
+Be a security expert.`
+    const result = extractAgentFrontmatter(content)
+    expect(result.name).toBe('')
+    expect(result.description).toBe('')
+    expect(result.prompt.trim()).toBe('Be a security expert.')
+  })
+
+  describe('new fields (Task 3)', () => {
+    test('extracts model', () => {
+      const content = '---\nmodel: gpt-4o\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.model).toBe('gpt-4o')
+    })
+
+    test('extracts temperature', () => {
+      const content = '---\ntemperature: 0.7\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.temperature).toBe(0.7)
+    })
+
+    test('extracts top_p', () => {
+      const content = '---\ntop_p: 0.9\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.top_p).toBe(0.9)
+    })
+
+    test('extracts tools', () => {
+      const content = '---\ntools:\n  bash: true\n  read: false\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.tools).toEqual({ bash: true, read: false })
+    })
+
+    test('ignores tools with non-boolean values', () => {
+      const content = '---\ntools:\n  bash: true\n  read: "yes"\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.tools).toBeUndefined()
+    })
+
+    test('extracts disable', () => {
+      const content = '---\ndisable: true\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.disable).toBe(true)
+    })
+
+    test('extracts mode', () => {
+      const content = '---\nmode: subagent\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.mode).toBe('subagent')
+    })
+
+    test('extracts color', () => {
+      const content = '---\ncolor: "#ff0000"\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.color).toBe('#ff0000')
+    })
+
+    test('extracts maxSteps', () => {
+      const content = '---\nmaxSteps: 10\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.maxSteps).toBe(10)
+    })
+
+    test('extracts permission', () => {
+      const content =
+        '---\npermission:\n  edit: allow\n  bash: ask\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.permission).toEqual({ edit: 'allow', bash: 'ask' })
+    })
+
+    test('extracts per-command bash permission', () => {
+      const content = '---\npermission:\n  bash:\n    rm: deny\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.permission).toEqual({ bash: { rm: 'deny' } })
+    })
+
+    test('ignores permission with invalid settings', () => {
+      const content = '---\npermission:\n  edit: maybe\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.permission).toBeUndefined()
+    })
+
+    test('ignores permission with invalid bash map values', () => {
+      const content = '---\npermission:\n  bash:\n    rm: maybe\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.permission).toBeUndefined()
+    })
+
+    test('extracts mode: all', () => {
+      const content = '---\nmode: all\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.mode).toBe('all')
+    })
+
+    test('extracts mode: primary', () => {
+      const content = '---\nmode: primary\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.mode).toBe('primary')
+    })
+
+    test('ignores invalid mode values', () => {
+      const content = '---\nmode: invalid\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.mode).toBeUndefined()
+    })
+
+    test('extracts all permission fields', () => {
+      const content = `---
+permission:
+  edit: allow
+  bash: deny
+  webfetch: ask
+  doom_loop: allow
+  external_directory: deny
+---
+Prompt`
+      const result = extractAgentFrontmatter(content)
+      expect(result.permission).toEqual({
+        edit: 'allow',
+        bash: 'deny',
+        webfetch: 'ask',
+        doom_loop: 'allow',
+        external_directory: 'deny',
+      })
+    })
+
+    test('returns undefined permission for empty permission object', () => {
+      const content = '---\npermission: {}\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.permission).toBeUndefined()
+    })
+
+    test('ignores unknown permission keys', () => {
+      const content =
+        '---\npermission:\n  edit: allow\n  unknown: maybe\n---\nPrompt'
+      const result = extractAgentFrontmatter(content)
+      expect(result.permission).toEqual({ edit: 'allow' })
+    })
+  })
+})


### PR DESCRIPTION
- Create validation.ts module with shared type guards and utilities
  - Add PermissionConfig interface and related type guards (isRecord, isPermissionSetting, isToolsMap, isAgentMode)
  - Extract normalizePermission with helper functions to reduce complexity
  - Support AgentMode type ('subagent' | 'primary' | 'all')

- Expand AgentFrontmatter interface with 10+ optional fields
  - Add model, temperature, top_p, tools, disable, mode, color, maxSteps, permission
  - Implement extraction with type-safe helper functions (extractString, extractNumber, extractBoolean)
  - Add early return for parse errors

- Update agent conversion logic
  - Add addOptionalFields helper to reduce complexity
  - Support preserving explicit frontmatter mode over CLI options
  - Extract all optional fields to OpenCode config in config-handler

- Replace stripFrontmatter with parseFrontmatter().body.trim()
  - Update bootstrap.ts, config-handler.ts, skill-loader.ts
  - Add JSDoc to stripFrontmatter clarifying it's a convenience wrapper

- Refactor CLI to import AgentMode from validation.ts

- Add comprehensive test coverage
  - 24 tests for agent frontmatter extraction (agents.test.ts)
  - 6 new tests for config handler field extraction
  - 10 new tests for converter frontmatter transformation
  - Tests for edge cases: mode: all, invalid values, empty permissions

All 151 tests passing. Complexity reduced below Biome limit (15).