### PR TITLE
feat: add Claude Code field compatibility to skills system

### DIFF
--- a/docs/CONVERSION-GUIDE.md
+++ b/docs/CONVERSION-GUIDE.md
@@ -47,6 +47,14 @@
 | `compatibility` | `compatibility` | **Keep** (optional) |
 | `metadata` | `metadata` | **Keep** (optional) |
 
+**Systematic compatibility note:** Systematic reads skill frontmatter directly for its own tooling. CC-only fields are still accepted for bundled skills to power **systematic_skill** and **skills-as-commands** behavior, but they are not emitted into OpenCode's native skill definitions.
+
+- `disable-model-invocation`: hides skills from the Systematic skill tool list.
+- `user-invocable`: controls whether a skill is exposed as a command (skills-as-commands only).
+- `context: fork`: maps to `subtask` when a skill is exposed as a command.
+- `agent` / `model`: routed through when a skill is exposed as a command.
+- `allowed-tools`: reserved for future use (stored but not enforced).
+
 #### Example Transformation
 
 **Before (Claude Code):**

--- a/src/lib/config-handler.ts
+++ b/src/lib/config-handler.ts
@@ -92,10 +92,16 @@ function loadCommandAsConfig(commandInfo: {
 }
 
 function loadSkillAsCommand(loaded: LoadedSkill): CommandConfig {
-  return {
+  const config: CommandConfig = {
     template: loaded.wrappedTemplate,
     description: loaded.description,
   }
+
+  if (loaded.agent !== undefined) config.agent = loaded.agent
+  if (loaded.model !== undefined) config.model = loaded.model
+  if (loaded.subtask !== undefined) config.subtask = loaded.subtask
+
+  return config
 }
 
 function collectAgents(
@@ -149,6 +155,8 @@ function collectSkillsAsCommands(
 
     const loaded = loadSkill(skillInfo)
     if (loaded) {
+      if (loaded.userInvocable === false) continue
+
       commands[loaded.prefixedName] = loadSkillAsCommand(loaded)
     }
   }

--- a/src/lib/skill-loader.ts
+++ b/src/lib/skill-loader.ts
@@ -13,6 +13,12 @@ export interface LoadedSkill {
   path: string
   skillFile: string
   wrappedTemplate: string
+  disableModelInvocation?: boolean
+  userInvocable?: boolean
+  subtask?: boolean
+  agent?: string
+  model?: string
+  argumentHint?: string
 }
 
 export function formatSkillCommandName(name: string): string {
@@ -72,6 +78,12 @@ export function loadSkill(skillInfo: SkillInfo): LoadedSkill | null {
       path: skillInfo.path,
       skillFile: skillInfo.skillFile,
       wrappedTemplate,
+      disableModelInvocation: skillInfo.disableModelInvocation,
+      userInvocable: skillInfo.userInvocable,
+      subtask: skillInfo.subtask,
+      agent: skillInfo.agent,
+      model: skillInfo.model,
+      argumentHint: skillInfo.argumentHint,
     }
   } catch {
     return null

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -1,11 +1,29 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { parseFrontmatter } from './frontmatter.js'
+import {
+  extractBoolean,
+  extractNonEmptyString,
+  extractString,
+  isRecord,
+} from './validation.js'
 import { walkDir } from './walk-dir.js'
 
 export interface SkillFrontmatter {
   name: string
   description: string
+  // OpenCode SDK fields
+  license?: string
+  compatibility?: string
+  metadata?: Record<string, string>
+  // Claude Code converted fields
+  disableModelInvocation?: boolean // from YAML key: disable-model-invocation
+  userInvocable?: boolean // from YAML key: user-invocable
+  subtask?: boolean // derived from context: "fork"
+  agent?: string // from YAML key: agent
+  model?: string // from YAML key: model
+  argumentHint?: string // from YAML key: argument-hint
+  allowedTools?: string // from YAML key: allowed-tools
 }
 
 export interface SkillInfo {
@@ -13,23 +31,56 @@ export interface SkillInfo {
   skillFile: string
   name: string
   description: string
+  // OpenCode SDK fields
+  license?: string
+  compatibility?: string
+  metadata?: Record<string, string>
+  // Claude Code converted fields
+  disableModelInvocation?: boolean
+  userInvocable?: boolean
+  subtask?: boolean
+  agent?: string
+  model?: string
+  argumentHint?: string
+  allowedTools?: string
 }
 
 export function extractFrontmatter(filePath: string): SkillFrontmatter {
   try {
     const content = fs.readFileSync(filePath, 'utf8')
-    const { data, parseError } = parseFrontmatter<{
-      name?: string
-      description?: string
-    }>(content)
+    const { data, parseError } =
+      parseFrontmatter<Record<string, unknown>>(content)
 
     if (parseError) {
       return { name: '', description: '' }
     }
 
+    const metadataRaw = data.metadata
+    let metadata: Record<string, string> | undefined
+    if (isRecord(metadataRaw)) {
+      const entries = Object.entries(metadataRaw)
+      if (entries.every(([, v]) => typeof v === 'string')) {
+        metadata = Object.fromEntries(entries) as Record<string, string>
+      }
+    }
+
+    const argumentHintRaw = extractNonEmptyString(data, 'argument-hint')
+    const argumentHint =
+      argumentHintRaw?.replace(/^["']|["']$/g, '') || undefined
+
     return {
-      name: typeof data.name === 'string' ? data.name : '',
-      description: typeof data.description === 'string' ? data.description : '',
+      name: extractString(data, 'name'),
+      description: extractString(data, 'description'),
+      license: extractNonEmptyString(data, 'license'),
+      compatibility: extractNonEmptyString(data, 'compatibility'),
+      metadata,
+      disableModelInvocation: extractBoolean(data, 'disable-model-invocation'),
+      userInvocable: extractBoolean(data, 'user-invocable'),
+      subtask: data.context === 'fork' ? true : undefined,
+      agent: extractNonEmptyString(data, 'agent'),
+      model: extractNonEmptyString(data, 'model'),
+      argumentHint: argumentHint !== '' ? argumentHint : undefined,
+      allowedTools: extractNonEmptyString(data, 'allowed-tools'),
     }
   } catch {
     return { name: '', description: '' }
@@ -47,33 +98,25 @@ export function findSkillsInDir(dir: string, maxDepth = 3): SkillInfo[] {
   for (const entry of entries) {
     const skillFile = path.join(entry.path, 'SKILL.md')
     if (fs.existsSync(skillFile)) {
-      const { name, description } = extractFrontmatter(skillFile)
+      const frontmatter = extractFrontmatter(skillFile)
       skills.push({
         path: entry.path,
         skillFile,
-        name: name || entry.name,
-        description: description || '',
+        name: frontmatter.name || entry.name,
+        description: frontmatter.description || '',
+        license: frontmatter.license,
+        compatibility: frontmatter.compatibility,
+        metadata: frontmatter.metadata,
+        disableModelInvocation: frontmatter.disableModelInvocation,
+        userInvocable: frontmatter.userInvocable,
+        subtask: frontmatter.subtask,
+        agent: frontmatter.agent,
+        model: frontmatter.model,
+        argumentHint: frontmatter.argumentHint,
+        allowedTools: frontmatter.allowedTools,
       })
     }
   }
 
   return skills
-}
-
-export function formatSkillsXml(skills: SkillInfo[]): string {
-  if (skills.length === 0) return ''
-
-  const skillsXml = skills
-    .map((skill) => {
-      const lines = [
-        '  <skill>',
-        `    <name>systematic:${skill.name}</name>`,
-        `    <description>${skill.description}</description>`,
-      ]
-      lines.push('  </skill>')
-      return lines.join('\n')
-    })
-    .join('\n')
-
-  return `<available_skills>\n${skillsXml}\n</available_skills>`
 }

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -466,5 +466,85 @@ Full command template.`,
       expect(command?.subtask).toBe(true)
       expect(command?.template).toContain('Full command template')
     })
+
+    test('skills with userInvocable: false are not loaded as commands', async () => {
+      const skillDir = path.join(bundledDir, 'skills', 'hidden-skill')
+      fs.mkdirSync(skillDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(skillDir, 'SKILL.md'),
+        `---
+name: hidden-skill
+description: A hidden skill
+user-invocable: false
+---
+# Hidden Skill Content`,
+      )
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.command?.['systematic:hidden-skill']).toBeUndefined()
+    })
+
+    test('skills include subtask field in command config', async () => {
+      const skillDir = path.join(bundledDir, 'skills', 'forked-skill')
+      fs.mkdirSync(skillDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(skillDir, 'SKILL.md'),
+        `---
+name: forked-skill
+description: A forked skill
+context: fork
+---
+# Forked Skill Content`,
+      )
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.command?.['systematic:forked-skill']?.subtask).toBe(true)
+    })
+
+    test('skills include agent and model fields in command config', async () => {
+      const skillDir = path.join(bundledDir, 'skills', 'routed-skill')
+      fs.mkdirSync(skillDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(skillDir, 'SKILL.md'),
+        `---
+name: routed-skill
+description: A routed skill
+agent: oracle
+model: gpt-4
+---
+# Routed Skill Content`,
+      )
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.command?.['systematic:routed-skill']?.agent).toBe('oracle')
+      expect(config.command?.['systematic:routed-skill']?.model).toBe('gpt-4')
+    })
   })
 })

--- a/tests/unit/skills.test.ts
+++ b/tests/unit/skills.test.ts
@@ -54,6 +54,113 @@ description: A test skill
       expect(result.name).toBe('')
       expect(result.description).toBe('')
     })
+
+    test('extracts OpenCode SDK fields', () => {
+      const filePath = path.join(testDir, 'test.md')
+      fs.writeFileSync(
+        filePath,
+        `---
+name: test-skill
+description: A test skill
+license: MIT
+compatibility: opencode
+---
+# Skill Content`,
+      )
+      const result = skills.extractFrontmatter(filePath)
+      expect(result.license).toBe('MIT')
+      expect(result.compatibility).toBe('opencode')
+    })
+
+    test('extracts metadata object with string values', () => {
+      const filePath = path.join(testDir, 'test.md')
+      fs.writeFileSync(
+        filePath,
+        `---
+name: test-skill
+description: A test skill
+metadata:
+  author: Test Author
+  version: '1.0.0'
+---
+# Skill Content`,
+      )
+      const result = skills.extractFrontmatter(filePath)
+      expect(result.metadata).toEqual({
+        author: 'Test Author',
+        version: '1.0.0',
+      })
+    })
+
+    test('extracts Claude Code converted fields', () => {
+      const filePath = path.join(testDir, 'test.md')
+      fs.writeFileSync(
+        filePath,
+        `---
+name: test-skill
+description: A test skill
+disable-model-invocation: true
+user-invocable: false
+agent: oracle
+model: gpt-4
+argument-hint: "[file]"
+allowed-tools: read,write
+---
+# Skill Content`,
+      )
+      const result = skills.extractFrontmatter(filePath)
+      expect(result.disableModelInvocation).toBe(true)
+      expect(result.userInvocable).toBe(false)
+      expect(result.agent).toBe('oracle')
+      expect(result.model).toBe('gpt-4')
+      expect(result.argumentHint).toBe('[file]')
+      expect(result.allowedTools).toBe('read,write')
+    })
+
+    test('derives subtask from context: fork', () => {
+      const filePath = path.join(testDir, 'test.md')
+      fs.writeFileSync(
+        filePath,
+        `---
+name: test-skill
+description: A test skill
+context: fork
+---
+# Skill Content`,
+      )
+      const result = skills.extractFrontmatter(filePath)
+      expect(result.subtask).toBe(true)
+    })
+
+    test('subtask is undefined when context is not fork', () => {
+      const filePath = path.join(testDir, 'test.md')
+      fs.writeFileSync(
+        filePath,
+        `---
+name: test-skill
+description: A test skill
+context: other
+---
+# Skill Content`,
+      )
+      const result = skills.extractFrontmatter(filePath)
+      expect(result.subtask).toBeUndefined()
+    })
+
+    test('strips quotes from argument-hint', () => {
+      const filePath = path.join(testDir, 'test.md')
+      fs.writeFileSync(
+        filePath,
+        `---
+name: test-skill
+description: A test skill
+argument-hint: '"[pattern]"'
+---
+# Skill Content`,
+      )
+      const result = skills.extractFrontmatter(filePath)
+      expect(result.argumentHint).toBe('[pattern]')
+    })
   })
 
   describe('findSkillsInDir', () => {


### PR DESCRIPTION
Extends skill frontmatter extraction to support Claude Code-specific fields alongside OpenCode SDK fields, enabling skills-as-commands functionality.

- Add support for Claude Code converted fields in skill frontmatter:
  * disable-model-invocation: hide skills from tool list
  * user-invocable: control command exposure (skills-as-commands)
  * context: fork → subtask mapping for forked execution
  * agent/model routing for command delegation
  * argument-hint for CLI/autocomplete hints
  * allowed-tools for future permission system

- Update skill-tool to filter skills based on disableModelInvocation flag
- Add permission request and metadata emission in skill tool execution
- Enhance config-handler to route agent/model/subtask fields when loading
  skills as commands
- Move formatSkillsXml from skills.ts to skill-tool.ts (better cohesion)
- Add validation helpers for extracting typed frontmatter fields
- Document CC-to-OC field compatibility in CONVERSION-GUIDE.md

This enables bundled skills to preserve Claude Code semantics while working in OpenCode's native environment without breaking changes.