### PR TITLE
docs(readme): update command names with systematic namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ Commands are slash-invokable shortcuts that trigger workflows or actions.
 
 | Command | Description |
 |---------|-------------|
-| `/lfg` | "Let's go" — start working immediately |
-| `/create-agent-skill` | Create a new skill with guidance |
-| `/deepen-plan` | Add detail to existing plans |
-| `/agent-native-audit` | Audit code for agent-native patterns |
+| `/systematic:lfg` | "Let's go" — start working immediately |
+| `/systematic:create-agent-skill` | Create a new skill with guidance |
+| `/systematic:deepen-plan` | Add detail to existing plans |
+| `/systematic:agent-native-audit` | Audit code for agent-native patterns |
 
 ## Configuration
 
@@ -218,6 +218,7 @@ For non-Systematic skills (project or user-level), use OpenCode's native `skill`
 Systematic uses three OpenCode plugin hooks:
 
 ```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1a1a2e', 'primaryTextColor': '#fff', 'primaryBorderColor': '#4FD1C5', 'lineColor': '#4FD1C5', 'secondaryColor': '#16213e', 'tertiaryColor': '#0f0f23'}}}%%
 flowchart TB
     A[Plugin Loaded] --> B[config hook]
     A --> C[tool hook]
@@ -227,10 +228,13 @@ flowchart TB
     C --> F[Register systematic_skill tool]
     D --> G[Inject bootstrap prompt into every conversation]
 
-    style A fill:#e1f5fe
-    style E fill:#f1f8e9
-    style F fill:#fff3e0
-    style G fill:#fce4ec
+    style A fill:#1a1a2e,stroke:#4FD1C5,color:#fff
+    style B fill:#16213e,stroke:#4FD1C5,color:#4FD1C5
+    style C fill:#16213e,stroke:#E91E8C,color:#E91E8C
+    style D fill:#16213e,stroke:#F5A623,color:#F5A623
+    style E fill:#0f0f23,stroke:#4FD1C5,color:#B2F5EA
+    style F fill:#0f0f23,stroke:#E91E8C,color:#B2F5EA
+    style G fill:#0f0f23,stroke:#F5A623,color:#B2F5EA
 ```
 
 1. **`config` hook** — Merges bundled assets into your OpenCode configuration

--- a/src/lib/config-handler.ts
+++ b/src/lib/config-handler.ts
@@ -76,9 +76,11 @@ function loadCommandAsConfig(commandInfo: {
 
     const cleanName = commandInfo.name.replace(/^\//, '')
 
+    const baseDescription = description || `${name || cleanName} command`
+
     const config: CommandConfig = {
       template: body.trim(),
-      description: description || `${name || cleanName} command`,
+      description: `(systematic) ${baseDescription}`,
     }
 
     if (agent !== undefined) config.agent = agent
@@ -136,7 +138,11 @@ function collectCommands(
 
     const config = loadCommandAsConfig(commandInfo)
     if (config) {
-      commands[cleanName] = config
+      // Prefix commands without a colon with 'systematic:'
+      const prefixedName = cleanName.includes(':')
+        ? cleanName
+        : `systematic:${cleanName}`
+      commands[prefixedName] = config
     }
   }
 

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -125,11 +125,11 @@ Command template for ${name}.`,
       await handler(config)
 
       expect(config.command).toBeDefined()
-      expect(config.command?.['test-command']).toBeDefined()
-      expect(config.command?.['test-command']?.description).toBe(
-        'A test command',
+      expect(config.command?.['systematic:test-command']).toBeDefined()
+      expect(config.command?.['systematic:test-command']?.description).toBe(
+        '(systematic) A test command',
       )
-      expect(config.command?.['test-command']?.template).toContain(
+      expect(config.command?.['systematic:test-command']?.template).toContain(
         'Command template for test-command',
       )
     })
@@ -384,7 +384,7 @@ Use oracle for this task.`,
       const config: Config = {}
       await handler(config)
 
-      expect(config.command?.routed?.agent).toBe('oracle')
+      expect(config.command?.['systematic:routed']?.agent).toBe('oracle')
     })
 
     test('includes model field in command config', async () => {
@@ -408,7 +408,7 @@ Use gpt-4 for this task.`,
       const config: Config = {}
       await handler(config)
 
-      expect(config.command?.modeled?.model).toBe('openai/gpt-4')
+      expect(config.command?.['systematic:modeled']?.model).toBe('openai/gpt-4')
     })
 
     test('includes subtask field in command config', async () => {
@@ -432,7 +432,7 @@ Run as subtask.`,
       const config: Config = {}
       await handler(config)
 
-      expect(config.command?.subtasked?.subtask).toBe(true)
+      expect(config.command?.['systematic:subtasked']?.subtask).toBe(true)
     })
 
     test('extracts all command frontmatter fields into config', async () => {
@@ -458,9 +458,9 @@ Full command template.`,
       const config: Config = {}
       await handler(config)
 
-      const command = config.command?.['full-command']
+      const command = config.command?.['systematic:full-command']
       expect(command).toBeDefined()
-      expect(command?.description).toBe('A full command')
+      expect(command?.description).toBe('(systematic) A full command')
       expect(command?.agent).toBe('oracle')
       expect(command?.model).toBe('openai/gpt-4')
       expect(command?.subtask).toBe(true)


### PR DESCRIPTION
Update README.md to reflect new systematic: prefix for bundled commands. All utility commands now include the namespace to prevent conflicts.

Changes:
- Update command references from /lfg to /systematic:lfg
- Update command references from /create-agent-skill to /systematic:create-agent-skill
- Update command references from /deepen-plan to /systematic:deepen-plan
- Update command references from /agent-native-audit to /systematic:agent-native-audit
- Enhance mermaid diagram styling with dark theme colors