### PR TITLE
feat(config): standardize Systematic branding in descriptions

### DIFF
--- a/src/lib/config-handler.ts
+++ b/src/lib/config-handler.ts
@@ -16,6 +16,29 @@ export interface ConfigHandlerDeps {
 
 type CommandConfig = NonNullable<Config['command']>[string]
 
+export function toTitleCase(name: string): string {
+  return name
+    .split('-')
+    .map((segment) =>
+      segment.length > 0
+        ? segment.charAt(0).toUpperCase() + segment.slice(1)
+        : segment,
+    )
+    .join('-')
+}
+
+export function formatAgentDescription(
+  name: string,
+  description: string | undefined,
+): string {
+  const baseDescription = description || `${name} agent`
+  const suffix = `(${toTitleCase(name)} - Systematic)`
+  if (baseDescription.endsWith(suffix)) {
+    return baseDescription
+  }
+  return `${baseDescription} ${suffix}`
+}
+
 function loadAgentAsConfig(agentInfo: {
   name: string
   file: string
@@ -41,7 +64,7 @@ function loadAgentAsConfig(agentInfo: {
     } = extractAgentFrontmatter(converted)
 
     const config: AgentConfig = {
-      description: description || `${agentInfo.name} agent`,
+      description: formatAgentDescription(agentInfo.name, description),
       prompt,
     }
 
@@ -80,7 +103,7 @@ function loadCommandAsConfig(commandInfo: {
 
     const config: CommandConfig = {
       template: body.trim(),
-      description: `(systematic) ${baseDescription}`,
+      description: `(Systematic) ${baseDescription}`,
     }
 
     if (agent !== undefined) config.agent = agent

--- a/src/lib/skill-loader.ts
+++ b/src/lib/skill-loader.ts
@@ -4,7 +4,7 @@ import { parseFrontmatter } from './frontmatter.js'
 import type { SkillInfo } from './skills.js'
 
 const SKILL_PREFIX = 'systematic:'
-const SKILL_DESCRIPTION_PREFIX = '(systematic - Skill) '
+const SKILL_DESCRIPTION_PREFIX = '(Systematic - Skill) '
 
 export interface LoadedSkill {
   name: string

--- a/tests/integration/opencode.test.ts
+++ b/tests/integration/opencode.test.ts
@@ -185,7 +185,7 @@ Integration test content.`,
     expect(commandNames).not.toContain('test-skill')
   })
 
-  test('adds (systematic - Skill) prefix to skill descriptions', async () => {
+  test('adds (Systematic - Skill) prefix to skill descriptions', async () => {
     const handler = createConfigHandler({
       directory: testEnv.projectDir,
       bundledSkillsDir: path.join(testEnv.bundledDir, 'skills'),
@@ -197,9 +197,9 @@ Integration test content.`,
     await handler(config)
 
     const skillCommand = config.command?.['systematic:test-skill']
-    expect(skillCommand?.description).toMatch(/^\(systematic - Skill\) /)
+    expect(skillCommand?.description).toMatch(/^\(Systematic - Skill\) /)
     expect(skillCommand?.description).toBe(
-      '(systematic - Skill) A skill for integration testing',
+      '(Systematic - Skill) A skill for integration testing',
     )
   })
 

--- a/tests/unit/skill-loader.test.ts
+++ b/tests/unit/skill-loader.test.ts
@@ -31,21 +31,21 @@ describe('skill-loader', () => {
   })
 
   describe('formatSkillDescription', () => {
-    test('adds (systematic - Skill) prefix to description', () => {
+    test('adds (Systematic - Skill) prefix to description', () => {
       expect(formatSkillDescription('A test skill', 'test')).toBe(
-        '(systematic - Skill) A test skill',
+        '(Systematic - Skill) A test skill',
       )
     })
 
     test('does not double-prefix already prefixed description', () => {
       expect(
-        formatSkillDescription('(systematic - Skill) A test skill', 'test'),
-      ).toBe('(systematic - Skill) A test skill')
+        formatSkillDescription('(Systematic - Skill) A test skill', 'test'),
+      ).toBe('(Systematic - Skill) A test skill')
     })
 
     test('uses fallback name when description is empty', () => {
       expect(formatSkillDescription('', 'my-skill')).toBe(
-        '(systematic - Skill) my-skill skill',
+        '(Systematic - Skill) my-skill skill',
       )
     })
   })
@@ -162,7 +162,7 @@ description: A test skill
 
       expect(loaded.name).toBe('test-skill')
       expect(loaded.prefixedName).toBe('systematic:test-skill')
-      expect(loaded.description).toBe('(systematic - Skill) A test skill')
+      expect(loaded.description).toBe('(Systematic - Skill) A test skill')
       expect(loaded.wrappedTemplate).toContain('<skill-instruction>')
       expect(loaded.wrappedTemplate).toContain('# Test Content')
     })


### PR DESCRIPTION
Add toTitleCase() and formatAgentDescription() helpers to consistently format component descriptions with title-cased names and Systematic branding.

- Agent descriptions: "{desc} ({Title-Name} - Systematic)"
- Command prefix: "(Systematic)" instead of "(systematic)"
- Skill prefix: "(Systematic - Skill)" instead of "(systematic - Skill)"