### PR TITLE
fix: copy dotfiles (.nojekyll) in docs deployment

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -72,9 +72,9 @@ jobs:
           # Create or switch to gh-pages branch
           git checkout gh-pages 2>/dev/null || git checkout --orphan gh-pages
 
-          # Clean and copy new docs (preserve .git directory)
+          # Clean and copy new docs (preserve .git directory, include dotfiles)
           find . -mindepth 1 -not -path './.git' -not -path './.git/*' -delete
-          cp -r ../docs/dist/* .
+          cp -r ../docs/dist/. .
 
           # Commit and push if there are changes
           git add -A


### PR DESCRIPTION
## Problem
The workflow was using `cp -r dist/*` which doesn't copy dotfiles, causing `.nojekyll` to be missing from the gh-pages branch.

## Fix
Changed to `cp -r dist/. .` to include all files including dotfiles.

## Evidence
Before:
```bash
$ gh api 'repos/fro-bot/systematic/contents/.nojekyll?ref=gh-pages'
404 Not Found
```

After this fix, .nojekyll will be present and the site will work correctly.