### PR TITLE
chore: rename write-readme command, fix typo, and update asset counts

### DIFF
--- a/.opencode/commands/generate-readme.md
+++ b/.opencode/commands/generate-readme.md
@@ -1,5 +1,5 @@
 ---
-name: write-readme
+name: generate-readme
 description: Create or update README.md with accurate project documentation
 argument-hint: "[full|section-name]"
 ---

--- a/.opencode/skills/convert-cc-defs/SKILL.md
+++ b/.opencode/skills/convert-cc-defs/SKILL.md
@@ -18,7 +18,7 @@ Import and convert agent, skill, and command definitions written in Claude Code 
 
 ## When NOT to Use
 
-- Writing new Systematic-native skills/agents/commands (use `creating-agent-skills` skill instead)
+- Writing new Systematic-native skills/agents/commands (use `create-agent-skills` skill instead)
 - Editing existing bundled content that has no upstream source
 - Converting definitions for a different project (use the CLI: `systematic convert`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,8 @@ systematic/
 │   ├── index.ts          # Plugin entry (SystematicPlugin)
 │   ├── cli.ts            # CLI entry (list/convert/config commands)
 │   └── lib/              # 13 core modules (see src/lib/AGENTS.md)
-├── skills/               # 8 bundled skills (SKILL.md format)
-├── agents/               # 11 bundled agents (4 categories: design/research/review/workflow)
+├── skills/               # 11 bundled skills (SKILL.md format)
+├── agents/               # 24 bundled agents (4 categories: design/research/review/workflow)
 ├── commands/             # 9 bundled commands (5 workflow + 4 utility)
 │   └── workflows/        # brainstorm, compound, plan, review, work
 ├── docs/                 # Starlight docs workspace (see docs/AGENTS.md)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Most AI coding assistants respond to requests without structure or methodology. 
 - **Specialized Agents** — Purpose-built subagents for architecture, security, and performance
 - **Zero Configuration** — Works immediately after installation via config hooks
 - **Extensible** — Add project-specific skills and commands alongside bundled ones
-- **Batteries Included** — 8 skills, 24 agents, and 9 commands ship with the npm package
+- **Batteries Included** — 11 skills, 24 agents, and 9 commands ship with the npm package
 - **CLI Tooling** — Inspect, list, and convert assets from the command line
 
 ## Quick Start
@@ -88,9 +88,12 @@ Skills are structured workflows that guide the AI through systematic engineering
 | `agent-browser` | Browser automation using Vercel's agent-browser CLI |
 | `agent-native-architecture` | Design systems where AI agents are first-class citizens |
 | `compound-docs` | Capture solved problems as categorized documentation |
-| `creating-agent-skills` | Expert guidance for writing and refining skills |
+| `create-agent-skills` | Expert guidance for writing and refining skills |
+| `document-review` | Refine brainstorm or plan documents before proceeding to the next workflow step |
 | `file-todos` | File-based todo tracking with status and dependency management |
+| `frontend-design` | Create distinctive, production-grade frontend interfaces with high design quality |
 | `git-worktree` | Manage git worktrees for isolated parallel development |
+| `orchestrating-swarms` | Coordinate multi-agent swarms, parallel reviews, and pipeline workflows |
 
 ### How Skills Work
 
@@ -369,7 +372,7 @@ systematic/
 │       ├── manifest.ts       # Upstream sync manifest tracking
 │       ├── validation.ts     # Agent config validation + type guards
 │       └── walk-dir.ts       # Recursive directory walker
-├── skills/                   # 8 bundled skills (SKILL.md files)
+├── skills/                   # 11 bundled skills (SKILL.md files)
 ├── agents/                   # 24 bundled agents (4 categories)
 ├── commands/                 # 9 bundled commands (with workflows/ subdir)
 ├── docs/                     # Starlight documentation site


### PR DESCRIPTION
- Rename write-readme command to generate-readme for action-oriented naming
- Fix skill name typo: creating-agent-skills → create-agent-skills
- Update stale counts in AGENTS.md and README.md (8 skills → 11, 11 agents → 24)
- Add 3 missing skills to README.md table (document-review, frontend-design, orchestrating-swarms)