### PR TITLE
fix: deploy docs after releases

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,7 +7,7 @@ on:
     inputs:
       version:
         description: Release version (optional, semver or v-prefixed)
-        required: true
+        required: false
         type: string
 
 concurrency:
@@ -21,6 +21,7 @@ jobs:
   build-and-deploy:
     name: Build and Deploy Docs
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'release' || !github.event.release.prerelease }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- Trigger docs deployment on published releases and manual dispatch
- Resolve registry version from release tag or dispatch input
- Require version input for manual runs to avoid 0.0.0-dev

## Why
Docs deploy was running before semantic-release created tags, so the registry index published 0.0.0-dev. This ties docs deploy to release timing to ensure correct version injection.

## Details
- Switched workflow trigger to `release.published` + `workflow_dispatch`
- Added a step to resolve the registry version from `release.tag_name` or manual input
- Updated build step to pass `--version` when resolved
- Made manual version input required