### PR TITLE
ci: configure Copilot coding agent

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,7 +19,7 @@ Run these before marking work complete:
 bun run build        # Build to dist/
 bun run typecheck    # TypeScript strict mode
 bun run lint         # Biome linter
-bun test tests/unit  # Unit tests
+bun test             # Unit and integration tests
 ```
 
 All four must pass. Do not skip any.

--- a/.github/workflows/copilot-setup-steps.yaml
+++ b/.github/workflows/copilot-setup-steps.yaml
@@ -14,7 +14,6 @@ permissions:
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Summary

Configures the GitHub Copilot coding agent for this repository with project-specific conventions and environment setup.

### New files

**`.github/copilot-instructions.md`** — Global instructions that steer Copilot toward this project's conventions:
- References `AGENTS.md` as the canonical source (avoids duplication)
- Explicit stack declaration (Bun, not Node; Biome, not ESLint; `bun:test`, not Jest)
- Concrete do/don't examples with code for the AI failure modes that matter most:
  - `node:` protocol for builtins, `.js` extensions on relative imports
  - `unknown` + type guards (never `any`, `@ts-ignore`, or `!`)
  - Functions only (zero classes convention)
  - `import type` for type-only imports
- Verification commands (`build`, `typecheck`, `lint`, `test`)
- Plugin architecture risk callout (3 hooks in `src/index.ts`)

**`.github/workflows/copilot-setup-steps.yaml`** — Environment preparation before the coding agent starts:
- Mirrors the main CI pattern: checkout → setup Bun → `bun install --frozen-lockfile` → `bun run build`
- Build step ensures `dist/` artifacts are current so Copilot PRs stay in sync with CI
- SHA-pinned actions matching existing workflow conventions

### What's NOT included (and why)

| Item | Reason |
|------|--------|
| Custom agents (`.github/agents/`) | No recurring specialist task patterns yet — add when needed |
| Hooks (`.github/hooks/`) | No security gates needed beyond what CI already enforces |
| Path-scoped instructions | Single-domain repo — global instructions are sufficient |
| MCP configuration | Configured via repo Settings UI, not committed to repo |

### Verification

- YAML syntax validated
- `bun run typecheck` passes
- `bun run lint` passes (2 pre-existing complexity warnings, unrelated)