### PR TITLE
fix(ci): add Node.js 22 setup to docs workflow for Astro 5 compat

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,6 +28,11 @@ jobs:
         with:
           fetch-tags: true
 
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 


### PR DESCRIPTION
## Summary

- Add `actions/setup-node@v4.4.0` with `node-version: 22` to the docs workflow

## Root Cause

Astro 5 requires Node.js ≥ 22.12.0. The docs workflow had no `setup-node` step, falling back to the `ubuntu-latest` runner default (Node.js 20.20.1), causing `astro build` to fail:

```
Node.js v20.20.1 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```

## Fix

Add `setup-node` before `setup-bun` to ensure Node.js 22 is available when Astro runs via `bun run --cwd docs build`.

Fixes workflow failure: https://github.com/marcusrbrown/systematic/actions/runs/23424630121/job/68136731092