### PR TITLE
fix: preserve colon-prefixed skill names without systematic: prefix

### DIFF
--- a/src/lib/skill-loader.ts
+++ b/src/lib/skill-loader.ts
@@ -22,7 +22,7 @@ export interface LoadedSkill {
 }
 
 export function formatSkillCommandName(name: string): string {
-  if (name.startsWith(SKILL_PREFIX)) {
+  if (name.includes(':')) {
     return name
   }
   return `${SKILL_PREFIX}${name}`

--- a/src/lib/skill-tool.ts
+++ b/src/lib/skill-tool.ts
@@ -5,6 +5,7 @@ import type { ToolDefinition } from '@opencode-ai/plugin'
 import { tool } from '@opencode-ai/plugin/tool'
 import {
   extractSkillBody,
+  formatSkillCommandName,
   type LoadedSkill,
   loadSkill,
 } from './skill-loader.js'
@@ -26,7 +27,7 @@ export function formatSkillsXml(skills: SkillInfo[]): string {
   // Uses space-delimited join with indented XML structure
   const skillLines = skills.flatMap((skill) => [
     '  <skill>',
-    `    <name>systematic:${skill.name}</name>`,
+    `    <name>${formatSkillCommandName(skill.name)}</name>`,
     `    <description>${skill.description}</description>`,
     `    <location>${pathToFileURL(skill.path).href}</location>`,
     '  </skill>',
@@ -134,7 +135,7 @@ export function createSkillTool(options: SkillToolOptions): ToolDefinition {
     const skills = getDiscoverableSkills()
     const examples = skills
       .slice(0, 3)
-      .map((s) => `'systematic:${s.name}'`)
+      .map((s) => `'${s.prefixedName}'`)
       .join(', ')
     const hint = examples.length > 0 ? ` (e.g., ${examples}, ...)` : ''
     return `The name of the skill from available_skills${hint}`

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -230,6 +230,37 @@ Command template for ${name}.`,
       )
     })
 
+    test('registers colon-prefixed skills without systematic: prefix', async () => {
+      const skillDir = path.join(bundledDir, 'skills', 'ce-plan')
+      fs.mkdirSync(skillDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(skillDir, 'SKILL.md'),
+        `---
+name: ce:plan
+description: Plan workflow skill
+---
+# CE Plan
+
+Skill content for ce:plan.`,
+      )
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.command?.['ce:plan']).toBeDefined()
+      expect(config.command?.['systematic:ce:plan']).toBeUndefined()
+      expect(config.command?.['ce:plan']?.description).toBe(
+        '(Systematic - Skill) Plan workflow skill',
+      )
+    })
+
     test('preserves existing config entries', async () => {
       createAgent(
         path.join(bundledDir, 'agents'),

--- a/tests/unit/skill-loader.test.ts
+++ b/tests/unit/skill-loader.test.ts
@@ -25,6 +25,11 @@ describe('skill-loader', () => {
       )
     })
 
+    test('preserves names with a non-systematic colon prefix', () => {
+      expect(formatSkillCommandName('ce:plan')).toBe('ce:plan')
+      expect(formatSkillCommandName('ce:brainstorm')).toBe('ce:brainstorm')
+    })
+
     test('handles empty string', () => {
       expect(formatSkillCommandName('')).toBe('systematic:')
     })

--- a/tests/unit/skill-tool.test.ts
+++ b/tests/unit/skill-tool.test.ts
@@ -88,6 +88,20 @@ describe('skill-tool', () => {
       expect(result).toContain('skill-one')
       expect(result).toContain('skill-two')
     })
+
+    test('preserves names that already include a colon prefix', () => {
+      const result = formatSkillsXml([
+        {
+          path: '/test/path',
+          skillFile: '/test/path/SKILL.md',
+          name: 'ce:plan',
+          description: 'Plan workflow skill',
+        },
+      ])
+
+      expect(result).toContain('<name>ce:plan</name>')
+      expect(result).not.toContain('<name>systematic:ce:plan</name>')
+    })
   })
 
   describe('createSkillTool', () => {
@@ -232,6 +246,30 @@ description: Test
 
       expect(result).toContain('systematic:no-prefix')
       expect(result).toContain('# No Prefix Content')
+    })
+
+    test('loads skill that uses a non-systematic colon prefix', async () => {
+      const skillDir = path.join(testDir, 'ce-plan')
+      fs.mkdirSync(skillDir)
+      fs.writeFileSync(
+        path.join(skillDir, 'SKILL.md'),
+        `---
+name: ce:plan
+description: Test CE skill
+---
+# CE Plan Content`,
+      )
+
+      const tool = createSkillTool({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      const result = await tool.execute({ name: 'ce:plan' }, mockContext)
+
+      expect(result).toContain('ce:plan')
+      expect(result).toContain('# CE Plan Content')
+      expect(result).not.toContain('systematic:ce:plan')
     })
 
     test('throws error when skill not found', async () => {


### PR DESCRIPTION
## Summary

- Skills with an existing namespace prefix (e.g., `ce:plan`, `ce:brainstorm`) were incorrectly getting `systematic:` prepended, producing slash commands like `/systematic:ce:plan` instead of `/ce:plan`
- Root cause: `formatSkillCommandName` only checked `startsWith('systematic:')` instead of checking for any existing colon prefix
- Aligned with `collectCommands` in `config-handler.ts` which already handled this correctly via `includes(':')`

## Changes

| File | Change |
|------|--------|
| `src/lib/skill-loader.ts` | `formatSkillCommandName`: `startsWith(SKILL_PREFIX)` → `includes(':')` |
| `src/lib/skill-tool.ts` | XML listing and parameter hints use shared formatting logic instead of hardcoded `systematic:` |
| `tests/unit/skill-loader.test.ts` | Formatter test for non-systematic colon prefixes |
| `tests/unit/skill-tool.test.ts` | XML output and execute path tests for colon-prefixed skills |
| `tests/unit/config-handler.test.ts` | Registration path test: `ce:plan` skill → `config.command['ce:plan']` key |

## Behavior

| Input | Before | After |
|-------|--------|-------|
| `brainstorming` | `systematic:brainstorming` | `systematic:brainstorming` (unchanged) |
| `systematic:brainstorming` | `systematic:brainstorming` | `systematic:brainstorming` (unchanged) |
| `ce:plan` | `systematic:ce:plan` ❌ | `ce:plan` ✅ |
| `ce:brainstorm` | `systematic:ce:brainstorm` ❌ | `ce:brainstorm` ✅ |

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun test` — 359 pass, 0 fail