### PR TITLE
feat(gate): content-integrity gate + close validation/bootstrap test coverage gaps

### DIFF
--- a/docs/plans/2026-04-18-001-feat-content-integrity-gate-plan.md
+++ b/docs/plans/2026-04-18-001-feat-content-integrity-gate-plan.md
@@ -1,0 +1,398 @@
+---
+title: Content-integrity gate and validation/bootstrap test coverage
+type: feat
+status: active
+date: 2026-04-18
+origin: docs/brainstorms/2026-04-18-infra-improvements-requirements.md
+---
+
+# Content-integrity gate and validation/bootstrap test coverage
+
+## Overview
+
+Add a content-integrity gate that runs as a unit test in the existing CI Test job. The gate enforces two content invariants across shipped `skills/`, `agents/`, and `src/*.ts` files: (1) every `systematic:<category>:<name>` reference resolves to an existing agent file, (2) a fixed list of CC/CEP banned patterns appears only in documented allowlist entries. Alongside the gate, close two longstanding unit-test gaps by adding `tests/unit/validation.test.ts` and `tests/unit/bootstrap.test.ts`, both including regression tests for known-fragile behavior with explicit CORRECTNESS/FRAGILITY tags so future refactors are intentional rather than silent.
+
+Ships as **2.5.0 minor** (single PR). No breaking API, no runtime behavior changes — all three units are pure additions (new script, new allowlist config, three new test files). The gate is already green on v2.4.1 main with the proposed allowlist, so no transition grace period is needed.
+
+## Problem Frame
+
+v2.4.0 shipped two classes of silent content drift past local verification: a zsh `for` loop that iterated once on its multi-line input (41 unconverted files), and a reconciliation-sync policy that imported skill updates without validating that the newly-referenced agents existed (phantom dispatch directives for `slack-researcher` and `session-historian`). Both bugs originated in sync infrastructure that is now deleted (no recurrence via the same mechanism). The risk this initiative addresses is forward-looking: manual edits, sub-agent bulk changes, and ad-hoc CLI conversions can still introduce the same classes of content errors, and markdown content has no compile-time, typecheck-time, lint-time, or test-time signal by default.
+
+In parallel, `src/lib/validation.ts` (168 lines) and `src/lib/bootstrap.ts` (69 lines) + the `INTERNAL_AGENT_SIGNATURES` skip heuristic in `src/index.ts` have no direct unit-test coverage. `loadAgentAsConfig` silently swallows validator errors returning `null`; the skip heuristic uses substring matching on the joined system prompt. Both are currently working, but neither has a signal when someone refactors them into broken.
+
+(see origin: `docs/brainstorms/2026-04-18-infra-improvements-requirements.md`)
+
+## Requirements Trace
+
+**Content-integrity gate (I3.a):**
+
+- R1. Add `scripts/content-integrity.ts` with `checkContentIntegrity(rootDir)` function covering phantom-ref + banned-pattern checks. (Unit 1)
+- R2. Ship a fixed banned-pattern list as a typed constant: `Claude Code`, `TaskCreate`, `AskUserQuestion`, `compound-engineering:`, `CLAUDE.md`, `${CLAUDE_PLUGIN_ROOT}`, `.claude/`, `.context/compound-engineering/`. (Unit 1)
+- R3. Add `tests/unit/content-integrity.test.ts` that invokes the gate and hard-fails on any violation; error output names file, line, and pattern/reference. (Unit 1)
+- R4. Add `scripts/.drift-allowlist.json` with structured per-file-per-pattern exemptions covering `claude-permissions-optimizer`, `orchestrating-swarms`, and `converter.ts`. (Unit 1)
+- R5. Typed schema validation of the allowlist, with warnings (non-fatal) for broad `**` pathGlobs and zero-match pathGlobs. A missing `.drift-allowlist.json` file is treated as an empty allowlist (gate still runs; no exemptions apply). (Unit 1)
+- R6. Gate is scoped to `skills/**/*.md`, `agents/**/*.md`, and `src/**/*.ts` — excludes `docs/`, `.opencode/`, `.github/`, `dist/`, `node_modules/`, `registry/`, and `src/**/*.md`. Reference-integrity check runs on `*.md` only; banned-pattern check runs on both `*.md` and `*.ts`. (Unit 1)
+
+**Validation module coverage (I3.b):**
+
+- R7. Add `tests/unit/validation.test.ts` covering every exported function in `src/lib/validation.ts`: `isRecord`, `isPermissionSetting`, `isToolsMap`, `isAgentMode`, `normalizePermission`, `extractString`, `extractNonEmptyString`, `extractNumber`, `extractBoolean` (all 9 exports as of v2.4.1). (Unit 2)
+- R8. At least one regression test in `validation.test.ts` tagged CORRECTNESS or FRAGILITY covering the silent-null-on-malformed-frontmatter chain — `loadAgentAsConfig` returns `null` when a validator returns `undefined` on malformed input. (Unit 2)
+
+**Bootstrap module coverage (I3.c):**
+
+- R9. Add `tests/unit/bootstrap.test.ts` covering `getBootstrapContent` + the `INTERNAL_AGENT_SIGNATURES` skip heuristic from `src/index.ts`. (Unit 3)
+- R10. At least one regression test in `bootstrap.test.ts` tagged CORRECTNESS or FRAGILITY covering the substring-match skip behavior. (Unit 3)
+- R11. Add a consistency assertion between the CC-tool-name mapping surfaces: every backticked tool name appearing in `getToolMappingTemplate`'s prose template in `src/lib/bootstrap.ts` must have a corresponding entry in `TOOL_NAME_MAP` in `src/lib/converter.ts`. Catches accidental drift between the two mappings, per the documented coupling in `docs/solutions/best-practices/destructive-to-nondestructive-converter-Systematic-20260209.md`. (Unit 3)
+
+## Scope Boundaries
+
+- **Not in scope — OCX registry auto-generation (I3.d).** Hand-maintained registry remains. Separate cycle.
+- **Not in scope — Bundled asset error surfacing (I3.e).** `loadAgentAsConfig` / `loadCommandAsConfig` continue to return `null` on failure. Separate cycle.
+- **Not in scope — Legacy `commands/` code path cleanup (I3.f).** `src/lib/commands.ts`, `tests/unit/commands.test.ts`, `collectCommands`/`loadCommandAsConfig` in `config-handler.ts` remain as dead code. Separate cycle.
+- **Not in scope — Refactoring the skip heuristic.** Tests document current behavior; a proper frontmatter-based opt-out is a separate design decision.
+- **Not in scope — Count drift, frontmatter schema, markdown link integrity.** Adjacent drift-prevention ideas rolled into OCX auto-gen territory.
+- **Not in scope — Regex anchoring check.** CodeQL handles this server-side already.
+- **Not in scope — CI comment bot / dedicated workflow file.** The gate runs inside the existing Test job.
+- **Not in scope — New OpenCode hook adoption.** `experimental.session.compacting` strategic-moat work is its own brainstorm.
+- **Not in scope — Initiative #2 work.** `orchestrating-swarms` rewrite-or-delete, `ce-work-beta`, `lfg`/`slfg` merge, todo trio consolidation — deferred to 3.0.0.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/build-registry.ts` — script-file conventions: `#!/usr/bin/env bun` shebang, `node:` protocol imports, manual argv loop, `main()` at bottom, `console.error + process.exit(1)` for fatal errors. Model for `scripts/content-integrity.ts`.
+- `src/lib/walk-dir.ts:17-51` — `walkDir(root, { maxDepth, filter })` returns `WalkEntry[]` with `path`, `name`, `isDirectory`, `depth`, `category`. Foundation for file discovery in the gate.
+- `src/lib/frontmatter.ts:19` — `parseFrontmatter` used by ~16 call sites; not needed by the gate directly but helpful reference for markdown scanning style.
+- `tests/unit/build-registry.test.ts` — pattern for testing a script via `Bun.spawnSync` (CLI-style). Relevant if we test the CLI entry point separately; the gate's pure `checkContentIntegrity` will be tested via direct import.
+- `tests/unit/skills.test.ts:13-18`, `tests/unit/config.test.ts:30-36` — temp-dir fixture pattern: `fs.mkdtempSync(path.join(os.tmpdir(), 'systematic-test-'))` in `beforeEach`, `fs.rmSync(testDir, { recursive: true, force: true })` in `afterEach`. Gate test needs fixtures for positive cases (phantom injected, banned pattern injected).
+- `tests/unit/plugin.test.ts` (137 lines) — only tests plugin-loading and bundled-content existence; does NOT currently test the transform hook. bootstrap.test.ts fills that gap.
+- `src/index.ts:10-14` — `INTERNAL_AGENT_SIGNATURES` array (3 signatures): "You are a title generator", "You are a helpful AI assistant tasked with summarizing conversations", "Summarize what was done in this conversation". Private const (not exported); Unit 3 makes it `export const` so bootstrap.test.ts can reconstruct the skip predicate without duplicating data.
+- `src/index.ts:91-113` — the skip predicate: `const existingSystem = output.system.join('\n').toLowerCase()` followed by `INTERNAL_AGENT_SIGNATURES.some((sig) => existingSystem.includes(sig.toLowerCase()))`. Inline inside the `experimental.chat.system.transform` hook. When true, the hook `return`s early, skipping bootstrap injection.
+- `src/lib/validation.ts` — 9 exports: `isRecord` (line 19), `isPermissionSetting` (23), `isToolsMap` (29), `isAgentMode` (34), `normalizePermission` (84), `extractString` (129, has `fallback = ''` default parameter), `extractNonEmptyString` (138), `extractNumber` (148), `extractBoolean` (156, **no fallback parameter**, returns `boolean | undefined`, coerces strings `'true'`/`'false'` case-insensitively). All need happy-path + malformed-shape coverage.
+- `src/lib/bootstrap.ts:32-69` — `getBootstrapContent(config, deps)` pure function; returns `string | null`. Five config branches to cover (enabled default, enabled custom-file-exists, enabled custom-file-missing, disabled, missing using-systematic skill).
+- `src/lib/bootstrap.ts:11-30` — `getToolMappingTemplate` returns a markdown template string containing CC tool names in prose (e.g., `` `TodoWrite` → `todowrite` ``). Unit 3's consistency test (R11) extracts tool names from this template via regex and cross-references against `TOOL_NAME_MAP`.
+- `src/lib/converter.ts:83-96` — `TOOL_NAME_MAP` is a private `const Record<string, string>` mapping CC tool names to their OpenCode equivalents. Must stay synchronized with `TOOL_MAPPINGS` (line 40) per the inline comment at lines 81-82. Unit 3 makes `TOOL_NAME_MAP` `export const` so the consistency test can import it.
+- `biome.json` — formatter/linter applies to new `.ts` files. `.drift-allowlist.json` is not linted.
+
+### Institutional Learnings
+
+- `docs/solutions/workflow-issues/reconciliation-sync-reference-integrity-20260417.md` — defines the phantom-ref grep pattern (lines 77-93) and the two-assertion CI gate spec (lines 97-101) this plan implements. **Direct foundation** for Unit 1's phantom-ref check.
+- `docs/solutions/integration-issues/zsh-for-loop-word-splitting-silent-failure-20260417.md` — same CI gate spec from the banned-pattern angle. Verification-iteration independence recommendation (lines 117-122): the gate must not use the same iteration pattern as any batch conversion script that might introduce drift. `find | while read` or `find -exec` is the canonical correct pattern, which we follow by using `walkDir` + array iteration instead of shell loops.
+- `docs/solutions/integration-issues/converter-code-block-tool-name-capitalization-20260210.md` — the converter's code-block-skipping is intentional for prose conversion; the gate must scan **inside** code blocks because CC tool names in code examples are exactly the drift we want to catch. (This differs from the converter's semantics by design.)
+- `docs/solutions/best-practices/destructive-to-nondestructive-converter-Systematic-20260209.md` — notes the `TOOL_NAME_MAP` (`converter.ts`) ↔ `TOOL_MAPPINGS` (`bootstrap.ts` template) coupling. Unit 3 includes a consistency check between these two mappings as a small bonus test.
+- `docs/solutions/workflow-patterns/truth-reset-scope-split-20260417.md` — context for why Initiative #3 is narrow: convergent document-review findings on the original bundled plan led to the three-initiative split. Not actionable for implementation; noted for posterity.
+
+### External References
+
+None. This is internal infrastructure; no external docs/APIs/libraries beyond the existing Bun + TypeScript stack.
+
+## Key Technical Decisions
+
+- **Hand-rolled glob matching, no new dependency.** Proposed pathGlobs in R4 are all prefix-match with `/**` suffix or exact path. Matching rule: `glob.endsWith('/**')` → `filePath.startsWith(glob.slice(0, -3))`; else exact match. Zero added runtime dep, trivial code, trivial test. Reconsider when patterns get more complex.
+- **Export `INTERNAL_AGENT_SIGNATURES` from `src/index.ts` and `TOOL_NAME_MAP` from `src/lib/converter.ts`.** Two one-line changes — `const` → `export const` — make both constants reachable from bootstrap.test.ts without duplicating data. Neither change has runtime behavior impact (both constants were previously private). The skip predicate itself stays inline in the transform hook (no behavior refactor); Unit 3's test reconstructs it locally using the exported data.
+- **Pure function + direct import for primary tests; `Bun.spawnSync` for CLI smoke only.** `checkContentIntegrity(rootDir)` is a pure function exported from `scripts/content-integrity.ts`; most tests import it and call it directly (faster, simpler, easier to assert on structured return values). One smoke test uses `Bun.spawnSync` (matching `build-registry.test.ts`) to verify the script's CLI entry point exits 0 on a clean repo. The script's `main()` wraps `checkContentIntegrity` and exits 0/1 based on the result.
+- **Runtime category discovery.** The gate reads `agents/` subdirectories at runtime (`fs.readdirSync('agents/')` filtered to `isDirectory()`) rather than hardcoding a regex alternation. Adding a new category auto-extends coverage.
+- **Reference-integrity check scans `*.md` only; banned-pattern check scans `*.md` + `*.ts`.** Reference resolution is a markdown-content concern (skills/agents reference each other in prose). Banned patterns can appear in code constants too (e.g., `converter.ts` holds them as documented rules — allowlisted). This asymmetric scope is cheaper than unifying behavior and matches the semantic difference.
+- **Missing `.drift-allowlist.json` file is treated as an empty allowlist.** The gate still runs against an empty-exemption set. This makes the gate work in fresh clones before anyone has added exemptions and keeps the "gate must not silently degrade" contract: an absent file doesn't mean "skip the gate," it means "no exemptions apply." Malformed JSON or unknown banned patterns still throw per R5.
+- **CORRECTNESS / FRAGILITY tags on regression tests.** Every regression test in R8 and R10 carries an inline comment declaring whether it documents intended behavior (CORRECTNESS) or known-suboptimal behavior (FRAGILITY with link to memory/doc). Makes future refactors explicit rather than inheriting ambiguity from the current author.
+- **Coverage reported in PR description, not CI-gated.** `bun test --coverage` output for `src/lib/validation.ts` and `src/lib/bootstrap.ts` is included in the PR body as an informational signal. No hard-fail on percentage. The regression tests are the real contract.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q: Glob library or hand-roll?** Hand-roll. Patterns are simple; new deps need justification.
+- **Q: How to test the inline skip heuristic?** Export `INTERNAL_AGENT_SIGNATURES` from `src/index.ts` (one-line change), reconstruct the predicate in the test using the exported data. No behavior refactor.
+- **Q: CLI entry point or library-only?** Both. Script exports `checkContentIntegrity` (library) AND has a `main()` wrapper invokable via `bun scripts/content-integrity.ts` (CLI). Matches `build-registry.ts` pattern.
+- **Q: How to assert the TOOL_NAME_MAP ↔ TOOL_MAPPINGS consistency given neither is currently exported?** Export `TOOL_NAME_MAP` from `converter.ts` (one-line change). `TOOL_MAPPINGS` is context-dependent regex and cannot be simply exported as structured data (per the comment at `converter.ts:81-82`); instead, the test extracts CC tool names from `getToolMappingTemplate`'s template string via regex (matching markdown list items like `` `TodoWrite` → `todowrite` ``) and asserts each extracted name is a key in the exported `TOOL_NAME_MAP`. The assertion is ~10 lines.
+- **Q: Missing `.drift-allowlist.json` file behavior?** Treated as an empty allowlist. The gate still runs; no exemptions apply. Malformed JSON or schema-invalid entries still throw per R5.
+
+### Deferred to Implementation
+
+- **Exact structure of `CheckResult`.** The requirements doc sketches `{ phantomRefs, bannedPatterns, exemptHits }`; implementation may refine (e.g., separate `errors` / `warnings` arrays for R5's typed-schema failures vs pathGlob warnings). Decided when writing the code.
+- **Exact error message format when the gate fails in the test.** Must include file, line, and pattern/reference per R3; exact string format is an implementation detail.
+- **Where to surface the two warnings (stale pathGlob, broad `**` pathGlob).** Options: stdout as part of the gate's normal output, or dedicated `console.warn` with a tag. Chosen during implementation after seeing how `bun test` displays warnings.
+
+## High-Level Technical Design
+
+> *This illustrates the intended module layout and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+scripts/
+├── content-integrity.ts              # NEW — checkContentIntegrity + CLI main()
+└── .drift-allowlist.json             # NEW — 3 allowlist entries per R4
+
+tests/unit/
+├── content-integrity.test.ts         # NEW — gate tests + fixtures (R3)
+├── validation.test.ts                # NEW — validation.ts coverage (R7, R8)
+└── bootstrap.test.ts                 # NEW — bootstrap.ts + skip heuristic (R9, R10)
+
+src/index.ts                          # MODIFY — one-line change: export INTERNAL_AGENT_SIGNATURES
+```
+
+**Module boundaries** for `scripts/content-integrity.ts`:
+
+```
+checkContentIntegrity(rootDir: string): CheckResult
+    ├── loadAllowlist(rootDir)      // parse + validate .drift-allowlist.json, emit warnings
+    ├── discoverCategories(rootDir) // read agents/ subdirs at runtime
+    ├── collectScanFiles(rootDir)   // walkDir for *.md under skills/, agents/; *.ts under src/
+    ├── checkReferenceIntegrity(files, categories)  // *.md only
+    └── checkBannedPatterns(files, bannedPatterns, allowlist)  // *.md + *.ts
+```
+
+**Dependency graph** for implementation units:
+
+```
+Unit 1 (content-integrity gate) ─── Independent, can land first
+Unit 2 (validation.test.ts)     ─── Independent, can land any time
+Unit 3 (bootstrap.test.ts)      ─── Independent, can land any time (requires 1-line edit to src/index.ts)
+```
+
+All three units commute — any order. Recommended order in one PR: 1 → 2 → 3 for reviewer narrative flow, but no technical dependency.
+
+## Implementation Units
+
+- [ ] **Unit 1: Content-integrity gate (script + allowlist + test)**
+
+**Goal:** Ship the content-integrity check as a pure exported function with a CLI wrapper, the allowlist config, and its unit test. After this unit, `bun test tests/unit` hard-fails on any phantom `systematic:*` reference or banned CC/CEP pattern appearing outside the documented allowlist.
+
+**Requirements:** R1, R2, R3, R4, R5, R6
+
+**Dependencies:** None
+
+**Files:**
+- Create: `scripts/content-integrity.ts`
+- Create: `scripts/.drift-allowlist.json`
+- Create: `tests/unit/content-integrity.test.ts`
+
+**Approach:**
+- Model script structure on `scripts/build-registry.ts`: shebang, `node:` imports, pure functions, `main()` at bottom.
+- Use `src/lib/walk-dir.ts`'s `walkDir` as the file-discovery foundation. Call it twice: once for `*.md` files under `skills/` + `agents/`, once for `*.ts` files under `src/`.
+- `discoverCategories(rootDir)` reads `agents/` subdirectories at runtime. Any subdirectory whose name is not `.DS_Store`-ish counts.
+- `loadAllowlist(rootDir)` parses `scripts/.drift-allowlist.json`. Schema validation: for each entry, `pathGlob` non-empty string, `patterns` non-empty array whose entries all appear in the hardcoded `BANNED_PATTERNS` constant, `reason` length ≥ 20 chars. Malformed entries → throw with the invalid entry named. Unknown pathGlob extensions (e.g., `?` or `[abc]` glob chars) are rejected — we only support prefix-`/**` or exact match.
+- Two warnings (non-fatal): (a) pathGlob matches zero files in the scan set, (b) pathGlob contains `**` without a specific subdirectory prefix (regex check: `/\*\*/` with no non-`**` path segment before it). Warnings print to stderr with a clear prefix like `drift-allowlist warning:` so the test can assert on them.
+- `checkReferenceIntegrity(files, categories)` iterates scanned markdown files, extracts all `systematic:<category>:<name>` via a regex where `<category>` is built from the `categories` array at runtime, checks each against `agents/<category>/<name>.md` existence.
+- `checkBannedPatterns(files, bannedPatterns, allowlist)` iterates scanned files, for each line checks every banned-pattern substring. Non-allowlisted hits go to `bannedPatterns[]`; allowlisted hits go to `exemptHits[]` (so tests can verify allowlist coverage).
+- `main()` runs `checkContentIntegrity` against `process.cwd()`, prints human-readable output, exits 0 on clean / 1 on failure.
+- Test uses temp-dir fixture pattern (`fs.mkdtempSync(...)`). Test fixtures include: (a) a clean repo snapshot that should produce zero violations, (b) a phantom-ref fixture that adds `systematic:research:ghost-agent` to a skill and verifies the check reports it with file+line, (c) a banned-pattern fixture that adds `TaskCreate` to a skill outside allowlist and verifies the check reports it, (d) a malformed allowlist fixture to verify schema validation errors, (e) a broad-pathGlob fixture (`skills/**`) to verify the warning, (f) a zero-match pathGlob fixture (`skills/nonexistent/**`) to verify the warning.
+- Run the gate against the real repo root as one of the test cases (integration smoke): assert zero phantom refs, zero non-exempt banned patterns. This is the "catches both v2.4.0 bugs if reintroduced" contract.
+
+**Patterns to follow:**
+- `scripts/build-registry.ts` — script conventions
+- `src/lib/walk-dir.ts:17-51` — `walkDir` API
+- `tests/unit/skills.test.ts:13-18` — temp-dir fixture
+- `tests/unit/build-registry.test.ts` — script-invoked-from-test pattern (used here for the CLI `main()` smoke test)
+
+**Test scenarios:**
+- Happy path: `checkContentIntegrity(repoRoot)` on v2.4.1 main returns `{ phantomRefs: [], bannedPatterns: [], exemptHits: [<~39 hits across allowlisted files>] }`.
+- Happy path (CLI): `bun scripts/content-integrity.ts` on v2.4.1 main exits 0.
+- Happy path: valid allowlist entry with patterns matching R2's banned-pattern list validates successfully.
+- Happy path: reference `systematic:research:learnings-researcher` in any scanned file resolves to `agents/research/learnings-researcher.md` and does not appear in `phantomRefs`.
+- Edge case: skill file with zero `systematic:*` references contributes nothing to any output array.
+- Edge case: a new category (e.g., creating `agents/new-category/foo.md` in a fixture) is auto-discovered and `systematic:new-category:foo` resolves.
+- Error path: phantom reference `systematic:research:nonexistent-agent` in a fixture skill is reported with `{ file, line, reference }`.
+- Error path: banned pattern `TaskCreate` in a fixture skill (outside allowlist) is reported with `{ file, line, pattern }`.
+- Error path: malformed `.drift-allowlist.json` (not valid JSON) throws with clear error.
+- Error path: allowlist entry with empty `pathGlob` throws.
+- Error path: allowlist entry with `patterns: ["Unknown Pattern"]` (not in R2 list) throws.
+- Error path: allowlist entry with `reason` length < 20 chars throws.
+- Error path: allowlist entry with unsupported glob chars (e.g., `skills/[abc]/**`) throws.
+- Warning path: pathGlob `skills/nonexistent-dir/**` matches zero files and emits a warning on stderr.
+- Warning path: pathGlob `skills/**` (broad `**` without subdirectory prefix) emits a warning on stderr.
+- Integration: allowlisted banned pattern (`Claude Code` inside `skills/claude-permissions-optimizer/SKILL.md`) appears in `exemptHits` but not `bannedPatterns`.
+
+**Verification:**
+- `bun test tests/unit/content-integrity.test.ts` passes all scenarios.
+- Whole-repo assertion: `checkContentIntegrity(process.cwd())` returns zero `phantomRefs` and zero `bannedPatterns` on v2.4.1 main before any Unit 2 / 3 changes.
+- Introducing `systematic:research:test-phantom` anywhere in `skills/**/*.md` causes the test to fail with a clear error message.
+- Introducing `TaskCreate` in any non-allowlisted file causes the test to fail.
+- `bun run build && bun run typecheck && bun run lint` all pass for the new files.
+
+---
+
+- [ ] **Unit 2: validation.ts test coverage**
+
+**Goal:** Every exported function in `src/lib/validation.ts` has direct unit coverage, and at least one regression test documents the "silent null on malformed frontmatter" chain with an explicit CORRECTNESS or FRAGILITY tag.
+
+**Requirements:** R7, R8
+
+**Dependencies:** None (independent of Units 1 and 3)
+
+**Files:**
+- Create: `tests/unit/validation.test.ts`
+- Read-only reference: `src/lib/validation.ts` (the subject)
+
+**Approach:**
+- Follow the existing `tests/unit/*.test.ts` import convention: `import { afterEach, beforeEach, describe, expect, test } from 'bun:test'`.
+- Import every exported function from `../../src/lib/validation.ts` directly. No mocking.
+- One `describe` block per exported function. Each function's block contains happy-path assertions (every documented shape) and malformed-shape assertions (wrong types, nulls, unknown keys).
+- `isRecord`, `isPermissionSetting`, `isToolsMap`, `isAgentMode`: type-guard predicates — true for every valid form, false for representative invalid forms (null, undefined, number, string when object expected, array when object expected, malformed object).
+- `normalizePermission` needs the most cases: every `AgentMode` string literal, every `PermissionSetting` object shape, bash-map variants, array forms. Read `validation.ts` first to enumerate; don't invent contracts.
+- `extractString` accepts a `fallback = ''` default parameter — tests cover happy paths, null/undefined/wrong-type returning the supplied fallback, and default fallback when omitted.
+- `extractNonEmptyString`: returns the trimmed value for non-empty strings, `undefined` for empty/whitespace-only/non-string input.
+- `extractNumber`: returns the number value for numeric input, `undefined` for non-numeric input (may also coerce numeric strings — verify from source before asserting).
+- `extractBoolean` has **no fallback parameter** and returns `boolean | undefined`. Tests cover: `true`/`false` happy path, string coercion (`'true'` / `'false'` / `'TRUE'` / `'  true  '` return the coerced boolean), non-boolean non-string input returns `undefined`, missing key returns `undefined`.
+- Regression test for the "silent null on malformed frontmatter" chain: construct an agent config-like object that would reach `validation.ts` via `loadAgentAsConfig` (see `src/lib/agents.ts`) with an invalid `permissions` shape. Call the validator directly on the malformed object and assert the return value matches the **current** behavior (either `undefined` or a default). Add the inline comment:
+
+  ```ts
+  // FRAGILITY: validation.ts silently returns null/undefined on malformed input.
+  // loadAgentAsConfig then swallows the null at the caller. Broken bundled assets
+  // disappear with no CI signal. See docs/brainstorms/2026-04-18-infra-improvements-requirements.md
+  // (trade-off: "bundled asset error surfacing" is I3.e, deferred). If a future
+  // initiative adds build-time error surfacing, this test's assertion must change.
+  ```
+
+  The tag is `FRAGILITY` because the current behavior is documented as suboptimal in the requirements doc's trade-offs section.
+
+**Patterns to follow:**
+- `tests/unit/frontmatter.test.ts` — clean function-by-function coverage style
+- `tests/unit/config.test.ts:30-36` — temp-dir fixture (may not be needed here if all inputs are constructed in-memory)
+- `tests/unit/config-handler.test.ts` — integration-style coverage of a 648-line module (for structural inspiration)
+
+**Test scenarios:**
+
+*Type-guard predicates (R7):*
+- Happy path: `isRecord({})`, `isRecord({ a: 1 })` return `true`; `isRecord(null)`, `isRecord([])`, `isRecord('string')`, `isRecord(42)` all return `false`.
+- Happy path: `isPermissionSetting({ ask: 'allow', edit: 'ask' })` returns `true` for valid permission shape; verify exact required fields from source before asserting.
+- Error path: `isPermissionSetting({})`, `isPermissionSetting(null)`, `isPermissionSetting([])` return `false`.
+- Happy path: `isToolsMap({ bash: true, edit: false })` returns `true`; `isToolsMap({ bash: 'not-boolean' })` returns `false`.
+- Happy path: every `AgentMode` literal string value passes `isAgentMode` (read source for the full list).
+- Error path: `isAgentMode(null)`, `isAgentMode(undefined)`, `isAgentMode(123)`, `isAgentMode('not-a-mode')` all return `false`.
+
+*`normalizePermission` (R7):*
+- Happy path: `normalizePermission('ask')` returns the equivalent `PermissionSetting` object form (verify from source).
+- Happy path: `normalizePermission({ bash: { 'ls *': 'allow' } })` returns a well-formed structure.
+- Edge case: `normalizePermission(null)`, `normalizePermission(undefined)` return the current fallback (determine from source; likely `undefined`).
+- Edge case: `normalizePermission({ bash: 'not-a-map' })` returns the current fallback.
+- Edge case: `normalizePermission(['allow'])` — array form — returns whatever the current contract says.
+
+*`extractString` (R7, has `fallback = ''`):*
+- Happy path: `extractString({ foo: 'bar' }, 'foo', 'fallback')` returns `'bar'`.
+- Happy path: `extractString({ foo: 'bar' }, 'foo')` returns `'bar'` (default fallback not used).
+- Edge case: `extractString({}, 'missing', 'fb')` returns `'fb'`.
+- Edge case: `extractString({}, 'missing')` returns `''` (default fallback).
+- Edge case: `extractString({ foo: 42 }, 'foo', 'fb')` returns `'fb'` (wrong type).
+
+*`extractNonEmptyString` (R7):*
+- Happy path: `extractNonEmptyString({ foo: 'bar' }, 'foo')` returns `'bar'` (verify trimming behavior from source).
+- Edge case: `extractNonEmptyString({ foo: '' }, 'foo')` returns `undefined`.
+- Edge case: `extractNonEmptyString({ foo: '   ' }, 'foo')` returns `undefined` (whitespace-only).
+- Edge case: `extractNonEmptyString({ foo: 42 }, 'foo')` returns `undefined` (wrong type).
+- Edge case: `extractNonEmptyString({}, 'missing')` returns `undefined`.
+
+*`extractNumber` (R7):*
+- Happy path: `extractNumber({ n: 42 }, 'n')` returns `42`.
+- Happy path: `extractNumber({ n: 0 }, 'n')` returns `0`.
+- Edge case: `extractNumber({ n: 'not-a-number' }, 'n')` returns `undefined` (or coerced value — verify from source).
+- Edge case: `extractNumber({}, 'missing')` returns `undefined`.
+
+*`extractBoolean` (R7, no fallback, returns `boolean | undefined`):*
+- Happy path: `extractBoolean({ flag: true }, 'flag')` returns `true`.
+- Happy path: `extractBoolean({ flag: false }, 'flag')` returns `false`.
+- Happy path (string coercion): `extractBoolean({ flag: 'true' }, 'flag')` returns `true`.
+- Happy path (string coercion): `extractBoolean({ flag: 'false' }, 'flag')` returns `false`.
+- Happy path (case + whitespace): `extractBoolean({ flag: '  TRUE  ' }, 'flag')` returns `true`.
+- Edge case: `extractBoolean({ flag: 'yes' }, 'flag')` returns `undefined` (not a recognized string).
+- Edge case: `extractBoolean({ flag: 1 }, 'flag')` returns `undefined` (number not coerced).
+- Edge case: `extractBoolean({}, 'missing')` returns `undefined`.
+
+*Regression (R8):*
+- Regression: construct a malformed agent-config object that would reach `validation.ts` via the `loadAgentAsConfig` chain (e.g., `permissions: { bash: 'not-a-map' }` on a full agent config). Call the relevant validator directly and assert the return value matches the current contract. Include the inline `// FRAGILITY: ...` comment tying to the origin doc and noting that `loadAgentAsConfig` swallows the resulting fallback into a silent `null` return, which is I3.e scope to fix.
+
+**Verification:**
+- `bun test tests/unit/validation.test.ts` passes all scenarios.
+- `bun test --coverage` reports per-file coverage for `src/lib/validation.ts`; figure is recorded in the PR description. No hard threshold.
+- Regression test carries the `// FRAGILITY: ...` comment exactly as specified.
+- `bun run lint` clean on the new file.
+
+---
+
+- [ ] **Unit 3: bootstrap.ts test coverage (plus INTERNAL_AGENT_SIGNATURES export)**
+
+**Goal:** `getBootstrapContent` has coverage for all five config branches, the `INTERNAL_AGENT_SIGNATURES` skip heuristic is testable via a one-line export of the signatures array, at least one regression test documents the substring-match behavior with an explicit CORRECTNESS or FRAGILITY tag, and a small bonus test verifies the `TOOL_NAME_MAP` ↔ `TOOL_MAPPINGS` consistency.
+
+**Requirements:** R9, R10
+
+**Dependencies:** None (independent of Units 1 and 2); requires a one-line edit to `src/index.ts` captured in this unit's file list.
+
+**Files:**
+- Create: `tests/unit/bootstrap.test.ts`
+- Modify: `src/index.ts` (one line: `const INTERNAL_AGENT_SIGNATURES = [...]` → `export const INTERNAL_AGENT_SIGNATURES = [...]`)
+- Modify: `src/lib/converter.ts` (one line: `const TOOL_NAME_MAP: Record<string, string> = { ... }` → `export const TOOL_NAME_MAP: Record<string, string> = { ... }`)
+- Read-only reference: `src/lib/bootstrap.ts`
+
+**Approach:**
+- Export `INTERNAL_AGENT_SIGNATURES` from `src/index.ts` (one-line change) so bootstrap.test.ts can import the canonical signatures array and reconstruct the skip predicate locally without duplicating the data. Similarly export `TOOL_NAME_MAP` from `src/lib/converter.ts` (one-line change) for the consistency test in R11. Both are strictly additive — no runtime behavior change.
+- Import `getBootstrapContent` from `../../src/lib/bootstrap.ts`, `INTERNAL_AGENT_SIGNATURES` from `../../src/index.ts`, and `TOOL_NAME_MAP` from `../../src/lib/converter.ts`. Define a test-local `shouldSkipBootstrap(system: string[])` helper that mirrors the production predicate: `INTERNAL_AGENT_SIGNATURES.some(sig => system.join('\n').toLowerCase().includes(sig.toLowerCase()))`.
+- Use temp-dir fixtures to construct `bundledSkillsDir` for `getBootstrapContent` test cases. Seed the temp dir with a minimal `using-systematic/SKILL.md` for the happy path; omit it for the missing-skill path.
+- For the `config.bootstrap.file` custom-override path, create a temp file with known contents and assert `getBootstrapContent` returns it verbatim. For the custom-file-missing case, point at a nonexistent path and assert the fallback behavior (current contract: falls through to the bundled skill path per `bootstrap.ts:40-47`).
+- For the skip heuristic, construct representative `output.system` arrays (arrays of strings, joined with `\n` inside the predicate): one with content containing a signature substring, one with unrelated content. Assert the local `shouldSkipBootstrap` helper matches production behavior. Add a regression test for the substring-match edge case: a legitimate prompt about "title generation" that happens to contain a signature substring triggers the skip. Tag the comment as `FRAGILITY` because the substring match is explicitly documented as fragile in the origin doc's trade-offs.
+- R11 consistency test: extract CC tool names from `getToolMappingTemplate`'s template string using a regex that matches markdown-list backtick patterns like `` `ToolName` → ``. The template is a hardcoded string constant in `bootstrap.ts:11-30`; import the function and call it with a synthetic `bundledSkillsDir` to get the rendered template, then regex-extract. Assert every extracted CC tool name is a key (case-insensitive, as `TOOL_NAME_MAP` stores lowercase keys per `converter.ts:187`) in `TOOL_NAME_MAP`.
+
+**Patterns to follow:**
+- `tests/unit/plugin.test.ts` — plugin-loading test pattern (for reference; this new file tests bootstrap-specific behavior directly, not plugin loading)
+- `tests/unit/skills.test.ts:13-18` — temp-dir fixture
+- `tests/unit/config.test.ts:30-36` — config fixture pattern
+
+**Test scenarios:**
+- Happy path: `getBootstrapContent({ bootstrap: { enabled: true, file: null } }, { bundledSkillsDir })` with a seeded `using-systematic/SKILL.md` returns a string containing `<SYSTEMATIC_WORKFLOWS>` and the tool-mapping template.
+- Happy path: `getBootstrapContent({ bootstrap: { enabled: false, file: null } }, deps)` returns `null`.
+- Happy path: `getBootstrapContent({ bootstrap: { enabled: true, file: '/tmp/custom.md' } }, deps)` with a seeded custom file returns the custom file's contents verbatim.
+- Happy path: `getBootstrapContent({ bootstrap: { enabled: true, file: '~/custom.md' } }, deps)` expands `~/` to `os.homedir()`.
+- Edge case: custom `config.bootstrap.file` pointing to a nonexistent path falls back to the bundled skill (verify current contract from source).
+- Edge case: `using-systematic/SKILL.md` missing from `bundledSkillsDir` returns `null` (current contract).
+- Happy path (skip heuristic): `shouldSkipBootstrap(['You are a title generator ...'])` returns `true`.
+- Happy path (skip heuristic): `shouldSkipBootstrap(['You are a helpful AI assistant tasked with summarizing conversations ...'])` returns `true`.
+- Happy path (skip heuristic): `shouldSkipBootstrap(['Summarize what was done in this conversation ...'])` returns `true`.
+- Happy path (skip heuristic): `shouldSkipBootstrap(['You are helping the user build a feature.'])` returns `false` (no signature substring).
+- Regression (FRAGILITY-tagged): `shouldSkipBootstrap(['You are documenting the title generator agent for future work.'])` — legitimate prompt containing "title generator" as prose — returns `true`. Tag documents this as known-fragile; a frontmatter-based opt-out would fix it. Comment references `docs/brainstorms/2026-04-18-infra-improvements-requirements.md` trade-offs section.
+- Consistency check (R11): every CC tool name extracted from `getToolMappingTemplate` via regex is a case-insensitive key in `TOOL_NAME_MAP`. Construct the reverse assertion too: any key in `TOOL_NAME_MAP` that appears in the template prose must map consistently. Exact extraction regex and assertion resolved at implementation time.
+
+**Verification:**
+- `bun test tests/unit/bootstrap.test.ts` passes all scenarios.
+- `bun test --coverage` reports per-file coverage for `src/lib/bootstrap.ts`; figure recorded in PR description.
+- Regression test carries the `// FRAGILITY: ...` comment exactly as specified.
+- The one-line `export` change to `src/index.ts` does not break any existing plugin behavior: `bun test tests/unit/plugin.test.ts` still passes, Node.js smoke test (`node --input-type=module -e "import('./dist/index.js')"`) still exits 0.
+- `bun run build && bun run typecheck && bun run lint` all pass.
+
+## System-Wide Impact
+
+- **Interaction graph:** `scripts/content-integrity.ts` has no runtime consumers in the plugin itself; it runs only at test time and via CLI. The two one-line `export` additions (`INTERNAL_AGENT_SIGNATURES` in `src/index.ts` and `TOOL_NAME_MAP` in `src/lib/converter.ts`) have no caller impact — both constants were previously private, so adding export is strictly additive.
+- **Error propagation:** The gate's test file hard-fails on any phantom-ref or non-allowlisted banned-pattern hit. Schema-invalid allowlist entries throw with the invalid entry named. Warnings (stale pathGlob, broad `**`) surface in test stderr but do not fail.
+- **State lifecycle risks:** None. Gate is pure (reads files, computes result, returns). No state persistence, no cleanup concerns.
+- **API surface parity:** No public API changes. The two `export const` additions (`INTERNAL_AGENT_SIGNATURES`, `TOOL_NAME_MAP`) are reachable from `@fro.bot/systematic` but are not advertised or documented externally; no consumer should depend on them.
+- **Integration coverage:** Unit 1's test includes a real-repo integration smoke — `checkContentIntegrity(process.cwd())` against the actual working tree — so the gate's behavior on the shipped catalog is verified end-to-end, not just against synthetic fixtures.
+- **Unchanged invariants:** The three plugin hooks (`config`, `tool`, `system.transform`) retain identical signatures and behavior. The `SystematicPlugin` factory function's return shape is unchanged. `skills/`, `agents/`, and `.opencode/` directory layouts are unchanged. All existing tests continue to pass.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| Hand-rolled glob matching misses an edge case in allowlist pathGlobs | R5's allowlist schema validation rejects unsupported glob chars up front (`?`, `[`, `]`, non-`**` wildcards). Only `<path>/**` and exact match are accepted. Matching rule is ~5 lines, covered by explicit unit tests in Unit 1. |
+| Runtime category discovery breaks if someone flattens `agents/` or introduces a non-category subdirectory (e.g., `.tmp/`) | Category discovery filters to `isDirectory()` and skips names starting with `.`. Noted as an acknowledged trade-off in the origin document; regression test covers the happy path explicitly. |
+| Exporting `INTERNAL_AGENT_SIGNATURES` from `src/index.ts` and `TOOL_NAME_MAP` from `src/lib/converter.ts` alters the published plugin's shape | Both changes are strictly additive (previously private → now exported const). No external consumers; not part of the documented public API. Smoke test verifies plugin loads cleanly in Node.js. |
+| Regression tests lock in a bug instead of a feature | CORRECTNESS / FRAGILITY tags on each regression test make the contract explicit. Future refactors that improve FRAGILITY-tagged behavior must update the test intentionally. |
+| `bun test --coverage` output format is hard to parse into a PR description | Coverage is informational, not CI-gated. Copying the table from `bun test --coverage` output into the PR description is manual; tolerable for a single-maintainer repo. |
+| `TOOL_NAME_MAP` ↔ `TOOL_MAPPINGS` consistency test is brittle if either side is refactored | The consistency check uses a semantic assertion ("every name in one appears in the other"), not a hash match. If the refactor is intentional, the test needs updating — same contract as other regression tests. |
+| Allowlist entry for `orchestrating-swarms` persists after Initiative #2 rewrites/deletes the skill | R5's zero-match pathGlob warning surfaces a stale allowlist entry as soon as the pathGlob stops matching any files. Cleanup is one commit in Initiative #2. |
+
+## Documentation / Operational Notes
+
+- **README / AGENTS.md:** No changes required. The drift gate is internal infrastructure and does not affect user-visible behavior.
+- **CONTRIBUTING-style guidance:** After this PR lands, add a short note to the repo (either in the repo root `CONTRIBUTING.md` if one exists, or in `AGENTS.md`) explaining the `.drift-allowlist.json` process: when to add an entry, what `reason` content is expected (minimum 20 chars, ideally cite a memory or doc), and what the two warnings mean. This is not a blocker for the PR; a follow-up commit can add it.
+- **PR description:** Must include `bun test --coverage` output for `src/lib/validation.ts` and `src/lib/bootstrap.ts` per success criteria; no hard threshold.
+- **Release notes (2.5.0):** "Add content-integrity gate for reference-resolution and banned-pattern drift detection; close test-coverage gaps in `validation.ts` and `bootstrap.ts`." No user-facing impact, no migration needed.
+- **Monitoring:** No operational change. No new telemetry, no new runtime paths.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-18-infra-improvements-requirements.md](../brainstorms/2026-04-18-infra-improvements-requirements.md)
+- **Institutional learnings cited:**
+  - [docs/solutions/workflow-issues/reconciliation-sync-reference-integrity-20260417.md](../solutions/workflow-issues/reconciliation-sync-reference-integrity-20260417.md)
+  - [docs/solutions/integration-issues/zsh-for-loop-word-splitting-silent-failure-20260417.md](../solutions/integration-issues/zsh-for-loop-word-splitting-silent-failure-20260417.md)
+  - [docs/solutions/integration-issues/converter-code-block-tool-name-capitalization-20260210.md](../solutions/integration-issues/converter-code-block-tool-name-capitalization-20260210.md)
+  - [docs/solutions/best-practices/destructive-to-nondestructive-converter-Systematic-20260209.md](../solutions/best-practices/destructive-to-nondestructive-converter-Systematic-20260209.md)
+- **Prior initiative plan (context):** [docs/plans/2026-04-17-002-refactor-truth-reset-plan.md](./2026-04-17-002-refactor-truth-reset-plan.md) — completed as v2.4.0
+- **Related PRs:** #290 (v2.4.0 truth reset), #291 (plan completion metadata), #294 (Anthropic model alias fix, v2.4.1)
+- **External docs:** None

--- a/scripts/.drift-allowlist.json
+++ b/scripts/.drift-allowlist.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "./.drift-allowlist.schema.json",
+  "exemptions": [
+    {
+      "pathGlob": "skills/claude-permissions-optimizer/**",
+      "patterns": ["Claude Code", ".claude/", "CLAUDE.md"],
+      "reason": "Skill explicitly targets Claude Code's settings files and permission allowlist format. CC refs are intentional and documented in the skill's README."
+    },
+    {
+      "pathGlob": "skills/orchestrating-swarms/SKILL.md",
+      "patterns": [
+        "Claude Code",
+        "TaskCreate",
+        ".claude/",
+        "${CLAUDE_PLUGIN_ROOT}"
+      ],
+      "reason": "Pre-existing 114 CC-specific patterns in this skill. Rewrite-or-delete decision is Initiative #2 scope (breaking, 3.0.0); not in scope for Initiative #3 drift prevention. Disable-model-invocation in frontmatter mitigates runtime risk."
+    },
+    {
+      "pathGlob": "src/lib/converter.ts",
+      "patterns": [
+        "Claude Code",
+        "TaskCreate",
+        "AskUserQuestion",
+        "compound-engineering:",
+        "CLAUDE.md",
+        "${CLAUDE_PLUGIN_ROOT}",
+        ".claude/"
+      ],
+      "reason": "Holds the CEP->Systematic conversion rules as documented string constants (TOOL_MAPPINGS and PATH_REPLACEMENTS). These are the canonical source of truth for what the converter rewrites; they must match the banned pattern list verbatim."
+    },
+    {
+      "pathGlob": "src/lib/skills.ts",
+      "patterns": ["Claude Code"],
+      "reason": "Comments annotate converter-mapped YAML fields (disableModelInvocation, userInvocable, allowedTools, etc.) with their CC-format origin. Historical documentation, not accidental reintroduction. Same category as src/lib/converter.ts."
+    }
+  ]
+}

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -1,0 +1,659 @@
+#!/usr/bin/env bun
+/**
+ * Content-Integrity Gate
+ *
+ * Enforces two content invariants across Systematic's shipped assets:
+ *
+ * 1. **Reference integrity** — every `systematic:<category>:<name>` reference
+ *    in bundled skills and agents resolves to an actual `agents/<category>/<name>.md`
+ *    file. Catches phantom dispatch directives left over from sync operations or
+ *    sub-agent bulk edits.
+ *
+ * 2. **Banned-pattern scan** — a fixed list of CC/CEP strings (branding, tool
+ *    names, plugin prefix, paths, env vars) appears only inside documented
+ *    allowlist entries. Catches accidental reintroduction of Claude Code or
+ *    Compound Engineering refs after the v2.4.0 divorce.
+ *
+ * Scope is narrow by design: `skills/**\/*.md`, `agents/**\/*.md`, and
+ * `src/**\/*.ts`. The gate does not scan `docs/`, `.opencode/`, `.github/`,
+ * `dist/`, `node_modules/`, `registry/`, or markdown files under `src/` —
+ * those intentionally contain historical or documented CC/CEP references.
+ *
+ * Agent categories are discovered at runtime from `agents/` subdirectories so
+ * adding a new category auto-extends coverage without a regex update.
+ *
+ * Usage:
+ *   bun scripts/content-integrity.ts            # Run against the repo; exit 0/1
+ *   bun scripts/content-integrity.ts --verbose  # Also print exempt hits + scan stats
+ *
+ * See docs/plans/2026-04-18-001-feat-content-integrity-gate-plan.md for the
+ * design rationale; docs/brainstorms/2026-04-18-infra-improvements-requirements.md
+ * for the originating requirements.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { walkDir } from '../src/lib/walk-dir.js'
+
+// ---------------------------------------------------------------------------
+// Banned-pattern list (R2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fixed list of CC/CEP strings the gate scans for. Every entry is a literal
+ * substring match (case-sensitive). Edits to this list require a corresponding
+ * review of `scripts/.drift-allowlist.json` — adding a pattern will surface
+ * hits across the catalog; removing one silently widens the gate.
+ */
+// biome-ignore-start lint/suspicious/noTemplateCurlyInString: literal ${CLAUDE_PLUGIN_ROOT} string is what we scan for.
+export const BANNED_PATTERNS = [
+  'Claude Code',
+  'TaskCreate',
+  'AskUserQuestion',
+  'compound-engineering:',
+  'CLAUDE.md',
+  '${CLAUDE_PLUGIN_ROOT}',
+  '.claude/',
+  '.context/compound-engineering/',
+] as const
+// biome-ignore-end lint/suspicious/noTemplateCurlyInString: literal ${CLAUDE_PLUGIN_ROOT} string is what we scan for.
+
+export type BannedPattern = (typeof BANNED_PATTERNS)[number]
+
+function isBannedPattern(value: unknown): value is BannedPattern {
+  return (
+    typeof value === 'string' &&
+    (BANNED_PATTERNS as readonly string[]).includes(value)
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Allowlist types (R4, R5)
+// ---------------------------------------------------------------------------
+
+export interface AllowlistEntry {
+  pathGlob: string
+  patterns: BannedPattern[]
+  reason: string
+}
+
+export interface AllowlistFile {
+  exemptions: AllowlistEntry[]
+}
+
+export interface AllowlistWarning {
+  kind: 'zero-match' | 'broad-pathglob'
+  pathGlob: string
+  reason: string
+  message: string
+}
+
+// ---------------------------------------------------------------------------
+// Check result types
+// ---------------------------------------------------------------------------
+
+export interface PhantomRef {
+  file: string
+  line: number
+  reference: string
+  category: string
+  name: string
+}
+
+export interface BannedPatternHit {
+  file: string
+  line: number
+  pattern: BannedPattern
+  lineContent: string
+}
+
+export interface ExemptHit {
+  file: string
+  line: number
+  pattern: BannedPattern
+  reason: string
+}
+
+export interface CheckResult {
+  rootDir: string
+  categories: string[]
+  allowlistWarnings: AllowlistWarning[]
+  phantomRefs: PhantomRef[]
+  bannedPatterns: BannedPatternHit[]
+  exemptHits: ExemptHit[]
+  scanStats: {
+    markdownFiles: number
+    typescriptFiles: number
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Allowlist loader (R4, R5)
+// ---------------------------------------------------------------------------
+
+const ALLOWLIST_RELATIVE_PATH = 'scripts/.drift-allowlist.json'
+const MIN_REASON_LENGTH = 20
+
+/**
+ * Throw-on-invalid, warn-on-suspicious allowlist loader.
+ *
+ * - Missing file: treated as an empty allowlist (gate still runs, no exemptions apply).
+ * - Malformed JSON: throws with the parse error location.
+ * - Entry validation: pathGlob non-empty string; patterns non-empty array of
+ *   known banned patterns; reason length >= MIN_REASON_LENGTH; no unsupported
+ *   glob chars (only `<path>/**` or exact match).
+ * - Warnings (non-fatal, returned in the result): zero-match pathGlobs (likely
+ *   stale) and broad `**` pathGlobs without a specific subdirectory prefix.
+ */
+export function loadAllowlist(
+  rootDir: string,
+  scannedFiles: readonly string[] = [],
+): { allowlist: AllowlistFile; warnings: AllowlistWarning[] } {
+  const allowlistPath = path.join(rootDir, ALLOWLIST_RELATIVE_PATH)
+
+  if (!fs.existsSync(allowlistPath)) {
+    return { allowlist: { exemptions: [] }, warnings: [] }
+  }
+
+  const raw = readAllowlistFile(allowlistPath)
+  const parsed = parseAllowlistJson(raw)
+  const exemptions = parsed.exemptions.map((entry, i) =>
+    validateAllowlistEntry(entry, i),
+  )
+  const warnings = buildAllowlistWarnings(exemptions, scannedFiles)
+  return { allowlist: { exemptions }, warnings }
+}
+
+function readAllowlistFile(allowlistPath: string): string {
+  try {
+    return fs.readFileSync(allowlistPath, 'utf8')
+  } catch (err) {
+    throw new Error(
+      `Failed to read allowlist at ${ALLOWLIST_RELATIVE_PATH}: ${(err as Error).message}`,
+    )
+  }
+}
+
+function parseAllowlistJson(raw: string): { exemptions: unknown[] } {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    throw new Error(
+      `Invalid JSON in ${ALLOWLIST_RELATIVE_PATH}: ${(err as Error).message}`,
+    )
+  }
+
+  if (!isRecord(parsed) || !Array.isArray(parsed.exemptions)) {
+    throw new Error(
+      `${ALLOWLIST_RELATIVE_PATH}: expected { exemptions: [...] } at the top level`,
+    )
+  }
+  return { exemptions: parsed.exemptions }
+}
+
+function validateAllowlistEntry(entry: unknown, index: number): AllowlistEntry {
+  const where = `${ALLOWLIST_RELATIVE_PATH} exemptions[${index}]`
+
+  if (!isRecord(entry)) {
+    throw new Error(`${where}: expected an object, got ${typeof entry}`)
+  }
+
+  const { pathGlob, patterns, reason } = entry
+  assertValidPathGlob(pathGlob, where)
+  assertValidPatterns(patterns, where)
+  assertValidReason(reason, where)
+
+  return {
+    pathGlob: pathGlob as string,
+    patterns: patterns as BannedPattern[],
+    reason: reason as string,
+  }
+}
+
+function assertValidPathGlob(pathGlob: unknown, where: string): void {
+  if (typeof pathGlob !== 'string' || pathGlob.length === 0) {
+    throw new Error(`${where}: pathGlob must be a non-empty string`)
+  }
+  if (!isSupportedPathGlob(pathGlob)) {
+    throw new Error(
+      `${where}: pathGlob ${JSON.stringify(pathGlob)} uses unsupported glob syntax. ` +
+        `Only "<path>/**" prefix or exact match is supported.`,
+    )
+  }
+}
+
+function assertValidPatterns(patterns: unknown, where: string): void {
+  if (!Array.isArray(patterns) || patterns.length === 0) {
+    throw new Error(`${where}: patterns must be a non-empty array`)
+  }
+  for (const pat of patterns) {
+    if (!isBannedPattern(pat)) {
+      throw new Error(
+        `${where}: pattern ${JSON.stringify(pat)} is not a known banned pattern. ` +
+          `Known: ${BANNED_PATTERNS.join(', ')}`,
+      )
+    }
+  }
+}
+
+function assertValidReason(reason: unknown, where: string): void {
+  if (typeof reason !== 'string' || reason.trim().length < MIN_REASON_LENGTH) {
+    throw new Error(
+      `${where}: reason must be a string of at least ${MIN_REASON_LENGTH} characters`,
+    )
+  }
+}
+
+/**
+ * Allowlist pathGlob syntax: either `<path>/**` (prefix match) or an exact path.
+ * Reject anything containing other glob wildcards (`?`, `[...]`, bare `*`).
+ */
+function isSupportedPathGlob(pathGlob: string): boolean {
+  if (pathGlob.endsWith('/**')) {
+    const prefix = pathGlob.slice(0, -3)
+    return prefix.length > 0 && !containsUnsupportedGlobChars(prefix)
+  }
+  return !containsUnsupportedGlobChars(pathGlob)
+}
+
+function containsUnsupportedGlobChars(value: string): boolean {
+  return /[*?[\]]/.test(value)
+}
+
+/**
+ * True when `filePath` (repo-relative) matches `pathGlob`.
+ *
+ * - `<path>/**` matches any file under `<path>/`.
+ * - exact path matches byte-for-byte.
+ */
+export function matchesPathGlob(filePath: string, pathGlob: string): boolean {
+  if (pathGlob.endsWith('/**')) {
+    const prefix = pathGlob.slice(0, -3)
+    return filePath === prefix || filePath.startsWith(`${prefix}/`)
+  }
+  return filePath === pathGlob
+}
+
+function buildAllowlistWarnings(
+  exemptions: readonly AllowlistEntry[],
+  scannedFiles: readonly string[],
+): AllowlistWarning[] {
+  const warnings: AllowlistWarning[] = []
+
+  for (const entry of exemptions) {
+    if (isBroadPathGlob(entry.pathGlob)) {
+      warnings.push({
+        kind: 'broad-pathglob',
+        pathGlob: entry.pathGlob,
+        reason: entry.reason,
+        message:
+          `Broad pathGlob ${JSON.stringify(entry.pathGlob)} uses '**' without a ` +
+          `specific subdirectory prefix. This exempts a large swath of the catalog; ` +
+          `prefer narrower globs when possible.`,
+      })
+    }
+
+    if (scannedFiles.length > 0) {
+      const matched = scannedFiles.some((f) =>
+        matchesPathGlob(f, entry.pathGlob),
+      )
+      if (!matched) {
+        warnings.push({
+          kind: 'zero-match',
+          pathGlob: entry.pathGlob,
+          reason: entry.reason,
+          message:
+            `pathGlob ${JSON.stringify(entry.pathGlob)} matched zero scanned files. ` +
+            `The exemption is likely stale (file renamed or deleted) and can be removed.`,
+        })
+      }
+    }
+  }
+
+  return warnings
+}
+
+function isBroadPathGlob(pathGlob: string): boolean {
+  if (!pathGlob.endsWith('/**')) return false
+  const prefix = pathGlob.slice(0, -3)
+  // A prefix is "specific" when it has at least one non-empty path segment
+  // (e.g., `skills/foo` is specific; `skills` alone is too broad because it
+  // exempts every skill).
+  return prefix.split('/').filter((s) => s.length > 0).length < 2
+}
+
+// ---------------------------------------------------------------------------
+// Category discovery (R1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read `agents/` subdirectories at runtime. Any directory whose name does not
+ * start with `.` is treated as a valid category.
+ */
+export function discoverCategories(rootDir: string): string[] {
+  const agentsDir = path.join(rootDir, 'agents')
+  if (!fs.existsSync(agentsDir)) return []
+
+  const entries = fs.readdirSync(agentsDir, { withFileTypes: true })
+  return entries
+    .filter((e) => e.isDirectory() && !e.name.startsWith('.'))
+    .map((e) => e.name)
+    .sort()
+}
+
+// ---------------------------------------------------------------------------
+// Scan-target collection (R6)
+// ---------------------------------------------------------------------------
+
+export interface ScanTargets {
+  markdown: string[] // repo-relative paths under skills/ and agents/
+  typescript: string[] // repo-relative paths under src/ (excluding markdown)
+}
+
+/**
+ * Collect the files the gate scans. Paths are repo-relative for consistent
+ * allowlist matching.
+ */
+export function collectScanTargets(rootDir: string): ScanTargets {
+  const markdown: string[] = []
+  for (const area of ['skills', 'agents']) {
+    const areaDir = path.join(rootDir, area)
+    if (!fs.existsSync(areaDir)) continue
+
+    const entries = walkDir(areaDir, {
+      maxDepth: 10,
+      filter: (e) => !e.isDirectory && e.name.endsWith('.md'),
+    })
+    for (const e of entries) {
+      markdown.push(path.relative(rootDir, e.path))
+    }
+  }
+
+  const typescript: string[] = []
+  const srcDir = path.join(rootDir, 'src')
+  if (fs.existsSync(srcDir)) {
+    const entries = walkDir(srcDir, {
+      maxDepth: 10,
+      filter: (e) => !e.isDirectory && e.name.endsWith('.ts'),
+    })
+    for (const e of entries) {
+      typescript.push(path.relative(rootDir, e.path))
+    }
+  }
+
+  markdown.sort()
+  typescript.sort()
+  return { markdown, typescript }
+}
+
+// ---------------------------------------------------------------------------
+// Reference-integrity check (R1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Match `systematic:<category>:<name>` references. The category list is
+ * built at runtime from `discoverCategories`, so the final regex is assembled
+ * per-invocation rather than hardcoded.
+ */
+function buildReferenceRegex(categories: readonly string[]): RegExp | null {
+  if (categories.length === 0) return null
+  const escaped = categories.map(escapeRegex).join('|')
+  // Category + name both kebab-case-ish: [a-z0-9-]+
+  return new RegExp(`systematic:(${escaped}):([a-z0-9-]+)`, 'g')
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export function checkReferenceIntegrity(
+  rootDir: string,
+  markdownFiles: readonly string[],
+  categories: readonly string[],
+): PhantomRef[] {
+  const regex = buildReferenceRegex(categories)
+  if (!regex) return []
+
+  const phantoms: PhantomRef[] = []
+
+  for (const relPath of markdownFiles) {
+    const absPath = path.join(rootDir, relPath)
+    const content = readFileSafe(absPath)
+    if (content === null) continue
+
+    const lines = content.split('\n')
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i] ?? ''
+      for (const match of line.matchAll(regex)) {
+        const [ref, category, name] = match as unknown as [
+          string,
+          string,
+          string,
+        ]
+        const targetPath = path.join(rootDir, 'agents', category, `${name}.md`)
+        if (!fs.existsSync(targetPath)) {
+          phantoms.push({
+            file: relPath,
+            line: i + 1,
+            reference: ref,
+            category,
+            name,
+          })
+        }
+      }
+    }
+  }
+
+  return phantoms
+}
+
+// ---------------------------------------------------------------------------
+// Banned-pattern check (R2, R6)
+// ---------------------------------------------------------------------------
+
+export function checkBannedPatterns(
+  rootDir: string,
+  scanFiles: readonly string[],
+  allowlist: AllowlistFile,
+): { hits: BannedPatternHit[]; exempt: ExemptHit[] } {
+  const hits: BannedPatternHit[] = []
+  const exempt: ExemptHit[] = []
+
+  for (const relPath of scanFiles) {
+    const absPath = path.join(rootDir, relPath)
+    const content = readFileSafe(absPath)
+    if (content === null) continue
+    scanFileForBanned(relPath, content, allowlist, hits, exempt)
+  }
+
+  return { hits, exempt }
+}
+
+function scanFileForBanned(
+  relPath: string,
+  content: string,
+  allowlist: AllowlistFile,
+  hits: BannedPatternHit[],
+  exempt: ExemptHit[],
+): void {
+  const lines = content.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? ''
+    for (const pattern of BANNED_PATTERNS) {
+      if (!line.includes(pattern)) continue
+      const exemption = findExemption(relPath, pattern, allowlist)
+      if (exemption) {
+        exempt.push({
+          file: relPath,
+          line: i + 1,
+          pattern,
+          reason: exemption.reason,
+        })
+      } else {
+        hits.push({
+          file: relPath,
+          line: i + 1,
+          pattern,
+          lineContent: line.trim(),
+        })
+      }
+    }
+  }
+}
+
+function findExemption(
+  filePath: string,
+  pattern: BannedPattern,
+  allowlist: AllowlistFile,
+): AllowlistEntry | null {
+  for (const entry of allowlist.exemptions) {
+    if (!matchesPathGlob(filePath, entry.pathGlob)) continue
+    if (entry.patterns.includes(pattern)) return entry
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Top-level check
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the full content-integrity check against `rootDir`. Returns a structured
+ * result; does not throw on content violations (callers decide policy). Throws
+ * only on malformed allowlist / filesystem errors.
+ */
+export function checkContentIntegrity(rootDir: string): CheckResult {
+  const categories = discoverCategories(rootDir)
+  const targets = collectScanTargets(rootDir)
+  const allScannedFiles = [...targets.markdown, ...targets.typescript]
+
+  const { allowlist, warnings: allowlistWarnings } = loadAllowlist(
+    rootDir,
+    allScannedFiles,
+  )
+
+  const phantomRefs = checkReferenceIntegrity(
+    rootDir,
+    targets.markdown,
+    categories,
+  )
+  const { hits: bannedPatterns, exempt: exemptHits } = checkBannedPatterns(
+    rootDir,
+    allScannedFiles,
+    allowlist,
+  )
+
+  return {
+    rootDir,
+    categories,
+    allowlistWarnings,
+    phantomRefs,
+    bannedPatterns,
+    exemptHits,
+    scanStats: {
+      markdownFiles: targets.markdown.length,
+      typescriptFiles: targets.typescript.length,
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small utilities
+// ---------------------------------------------------------------------------
+
+function readFileSafe(absPath: string): string | null {
+  try {
+    return fs.readFileSync(absPath, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+// ---------------------------------------------------------------------------
+// CLI main()
+// ---------------------------------------------------------------------------
+
+function printResult(result: CheckResult, verbose: boolean): void {
+  // Warnings first (non-fatal, routed to stderr so CI can surface them)
+  for (const w of result.allowlistWarnings) {
+    process.stderr.write(`drift-allowlist warning: ${w.message}\n`)
+  }
+
+  if (result.phantomRefs.length > 0) {
+    process.stderr.write(
+      `\nPhantom references (${result.phantomRefs.length}):\n`,
+    )
+    for (const p of result.phantomRefs) {
+      process.stderr.write(
+        `  ${p.file}:${p.line}  ${p.reference}  (no such agent: agents/${p.category}/${p.name}.md)\n`,
+      )
+    }
+  }
+
+  if (result.bannedPatterns.length > 0) {
+    process.stderr.write(
+      `\nBanned patterns outside allowlist (${result.bannedPatterns.length}):\n`,
+    )
+    for (const h of result.bannedPatterns) {
+      process.stderr.write(
+        `  ${h.file}:${h.line}  ${JSON.stringify(h.pattern)}  ${h.lineContent}\n`,
+      )
+    }
+  }
+
+  if (result.phantomRefs.length === 0 && result.bannedPatterns.length === 0) {
+    process.stdout.write(
+      `content-integrity: clean (${result.scanStats.markdownFiles} md + ` +
+        `${result.scanStats.typescriptFiles} ts scanned, ` +
+        `${result.exemptHits.length} exempt hits, ` +
+        `${result.allowlistWarnings.length} warnings)\n`,
+    )
+  }
+
+  if (verbose) {
+    process.stdout.write(
+      `\ncategories: ${result.categories.join(', ')}\n` +
+        `scanStats: ${result.scanStats.markdownFiles} md + ${result.scanStats.typescriptFiles} ts\n` +
+        `exemptHits: ${result.exemptHits.length}\n`,
+    )
+  }
+}
+
+function main(): number {
+  const args = process.argv.slice(2)
+  const verbose = args.includes('--verbose') || args.includes('-v')
+  const rootArg = args.find((a) => !a.startsWith('-'))
+
+  const rootDir = rootArg ? path.resolve(rootArg) : resolveRepoRoot()
+
+  let result: CheckResult
+  try {
+    result = checkContentIntegrity(rootDir)
+  } catch (err) {
+    process.stderr.write(`content-integrity: ${(err as Error).message}\n`)
+    return 1
+  }
+
+  printResult(result, verbose)
+
+  const violationCount =
+    result.phantomRefs.length + result.bannedPatterns.length
+  return violationCount > 0 ? 1 : 0
+}
+
+function resolveRepoRoot(): string {
+  const __filename = fileURLToPath(import.meta.url)
+  const __dirname = path.dirname(__filename)
+  return path.resolve(__dirname, '..')
+}
+
+// Invoke when run directly (not when imported by tests)
+if (import.meta.main) {
+  process.exit(main())
+}

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -37,7 +37,7 @@ import { fileURLToPath } from 'node:url'
 import { walkDir } from '../src/lib/walk-dir.js'
 
 // ---------------------------------------------------------------------------
-// Banned-pattern list (R2)
+// Banned-pattern list
 // ---------------------------------------------------------------------------
 
 /**
@@ -69,7 +69,7 @@ function isBannedPattern(value: unknown): value is BannedPattern {
 }
 
 // ---------------------------------------------------------------------------
-// Allowlist types (R4, R5)
+// Allowlist types
 // ---------------------------------------------------------------------------
 
 export interface AllowlistEntry {
@@ -129,7 +129,7 @@ export interface CheckResult {
 }
 
 // ---------------------------------------------------------------------------
-// Allowlist loader (R4, R5)
+// Allowlist loader
 // ---------------------------------------------------------------------------
 
 const ALLOWLIST_RELATIVE_PATH = 'scripts/.drift-allowlist.json'
@@ -325,7 +325,7 @@ function isBroadPathGlob(pathGlob: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Category discovery (R1)
+// Category discovery
 // ---------------------------------------------------------------------------
 
 /**
@@ -344,7 +344,7 @@ export function discoverCategories(rootDir: string): string[] {
 }
 
 // ---------------------------------------------------------------------------
-// Scan-target collection (R6)
+// Scan-target collection
 // ---------------------------------------------------------------------------
 
 export interface ScanTargets {
@@ -389,7 +389,7 @@ export function collectScanTargets(rootDir: string): ScanTargets {
 }
 
 // ---------------------------------------------------------------------------
-// Reference-integrity check (R1)
+// Reference-integrity check
 // ---------------------------------------------------------------------------
 
 /**
@@ -450,7 +450,7 @@ export function checkReferenceIntegrity(
 }
 
 // ---------------------------------------------------------------------------
-// Banned-pattern check (R2, R6)
+// Banned-pattern check
 // ---------------------------------------------------------------------------
 
 export function checkBannedPatterns(

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -271,7 +271,7 @@ function containsUnsupportedGlobChars(value: string): boolean {
 export function matchesPathGlob(filePath: string, pathGlob: string): boolean {
   if (pathGlob.endsWith('/**')) {
     const prefix = pathGlob.slice(0, -3)
-    return filePath === prefix || filePath.startsWith(`${prefix}/`)
+    return filePath.startsWith(`${prefix}/`)
   }
   return filePath === pathGlob
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,9 @@ import { loadConfig } from './lib/config.js'
 import { createConfigHandler } from './lib/config-handler.js'
 import { createSkillTool } from './lib/skill-tool.js'
 
-const INTERNAL_AGENT_SIGNATURES = [
+// Exported so tests can reconstruct the skip predicate without duplicating
+// the signatures. Consumers outside tests should not depend on this.
+export const INTERNAL_AGENT_SIGNATURES = [
   'You are a title generator',
   'You are a helpful AI assistant tasked with summarizing conversations',
   'Summarize what was done in this conversation',

--- a/src/lib/converter.ts
+++ b/src/lib/converter.ts
@@ -80,7 +80,9 @@ const PATH_REPLACEMENTS: ReadonlyArray<readonly [RegExp, string]> = [
 // Maps CC tool names (lowercased) to OC tool IDs for frontmatter `tools` arrays.
 // Must stay in sync with TOOL_MAPPINGS above. Not derived programmatically because
 // TOOL_MAPPINGS uses context-dependent regex patterns that can't be reliably parsed.
-const TOOL_NAME_MAP: Record<string, string> = {
+// Exported so the bootstrap tool-mapping template (src/lib/bootstrap.ts) can be
+// cross-checked for consistency with the converter's canonical mapping.
+export const TOOL_NAME_MAP: Record<string, string> = {
   task: 'task',
   todowrite: 'todowrite',
   askuserquestion: 'question',

--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -1,0 +1,332 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { INTERNAL_AGENT_SIGNATURES } from '../../src/index.ts'
+import { getBootstrapContent } from '../../src/lib/bootstrap.ts'
+import { TOOL_NAME_MAP } from '../../src/lib/converter.ts'
+
+/**
+ * Reconstruct the production skip predicate from src/index.ts:91-97 using the
+ * exported INTERNAL_AGENT_SIGNATURES constant. This mirrors the inline check
+ * in the experimental.chat.system.transform hook without duplicating the data.
+ *
+ * If the production logic changes shape (e.g., joins with a different
+ * separator, or stops lowercasing), both the production code and this helper
+ * must be updated together.
+ */
+function shouldSkipBootstrap(system: readonly string[]): boolean {
+  const existingSystem = system.join('\n').toLowerCase()
+  return INTERNAL_AGENT_SIGNATURES.some((sig) =>
+    existingSystem.includes(sig.toLowerCase()),
+  )
+}
+
+// ---------------------------------------------------------------------------
+// getBootstrapContent
+// ---------------------------------------------------------------------------
+
+describe('getBootstrapContent', () => {
+  let testDir: string
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'systematic-bootstrap-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true })
+  })
+
+  function makeBundledSkillsDir(usingSystematicBody?: string): string {
+    const bundledSkillsDir = path.join(testDir, 'skills')
+    fs.mkdirSync(bundledSkillsDir, { recursive: true })
+    if (usingSystematicBody !== undefined) {
+      fs.mkdirSync(path.join(bundledSkillsDir, 'using-systematic'))
+      fs.writeFileSync(
+        path.join(bundledSkillsDir, 'using-systematic', 'SKILL.md'),
+        usingSystematicBody,
+      )
+    }
+    return bundledSkillsDir
+  }
+
+  test('default config returns content with SYSTEMATIC_WORKFLOWS wrapper', () => {
+    const bundledSkillsDir = makeBundledSkillsDir(
+      '---\nname: using-systematic\n---\nBootstrap body content here.',
+    )
+    const config = {
+      bootstrap: { enabled: true, file: undefined },
+      disabled_skills: [] as string[],
+      disabled_agents: [] as string[],
+      disabled_commands: [] as string[],
+    }
+
+    const content = getBootstrapContent(config, { bundledSkillsDir })
+
+    expect(content).not.toBeNull()
+    expect(content).toContain('<SYSTEMATIC_WORKFLOWS>')
+    expect(content).toContain('</SYSTEMATIC_WORKFLOWS>')
+    expect(content).toContain('Bootstrap body content here.')
+    expect(content).toContain('**Tool Mapping for OpenCode:**')
+  })
+
+  test('config.bootstrap.enabled = false returns null', () => {
+    const bundledSkillsDir = makeBundledSkillsDir('body')
+    const config = {
+      bootstrap: { enabled: false, file: undefined },
+      disabled_skills: [] as string[],
+      disabled_agents: [] as string[],
+      disabled_commands: [] as string[],
+    }
+    expect(getBootstrapContent(config, { bundledSkillsDir })).toBeNull()
+  })
+
+  test('custom config.bootstrap.file returns the file contents verbatim when it exists', () => {
+    const bundledSkillsDir = makeBundledSkillsDir('bundled body')
+    const customPath = path.join(testDir, 'custom-bootstrap.md')
+    fs.writeFileSync(customPath, 'CUSTOM bootstrap override content')
+
+    const config = {
+      bootstrap: { enabled: true, file: customPath },
+      disabled_skills: [] as string[],
+      disabled_agents: [] as string[],
+      disabled_commands: [] as string[],
+    }
+    const content = getBootstrapContent(config, { bundledSkillsDir })
+
+    expect(content).toBe('CUSTOM bootstrap override content')
+    // Must NOT be wrapped with <SYSTEMATIC_WORKFLOWS> when using a custom file.
+    expect(content).not.toContain('<SYSTEMATIC_WORKFLOWS>')
+  })
+
+  test('custom config.bootstrap.file with ~/ prefix expands to the home directory', () => {
+    const bundledSkillsDir = makeBundledSkillsDir('bundled body')
+    // Write a file in the real home dir (use a timestamped filename to avoid conflicts)
+    const homeFilename = `.systematic-test-bootstrap-${Date.now()}-${Math.random().toString(36).slice(2)}.md`
+    const realHomePath = path.join(os.homedir(), homeFilename)
+    fs.writeFileSync(realHomePath, 'HOME-DIR bootstrap')
+    try {
+      const config = {
+        bootstrap: { enabled: true, file: `~/${homeFilename}` },
+        disabled_skills: [] as string[],
+        disabled_agents: [] as string[],
+        disabled_commands: [] as string[],
+      }
+      expect(getBootstrapContent(config, { bundledSkillsDir })).toBe(
+        'HOME-DIR bootstrap',
+      )
+    } finally {
+      fs.unlinkSync(realHomePath)
+    }
+  })
+
+  test('custom config.bootstrap.file pointing to nonexistent path falls through to the bundled skill', () => {
+    // CORRECTNESS: bootstrap.ts:40-47 does not return early when the custom
+    // file is missing — it falls through to the bundled using-systematic path.
+    // This test locks in that intentional fallback. Change only with a
+    // behavior change (e.g., return null on missing custom file).
+    const bundledSkillsDir = makeBundledSkillsDir(
+      '---\nname: using-systematic\n---\nBundled body',
+    )
+    const config = {
+      bootstrap: {
+        enabled: true,
+        file: path.join(testDir, 'does-not-exist.md'),
+      },
+      disabled_skills: [] as string[],
+      disabled_agents: [] as string[],
+      disabled_commands: [] as string[],
+    }
+    const content = getBootstrapContent(config, { bundledSkillsDir })
+    expect(content).not.toBeNull()
+    expect(content).toContain('<SYSTEMATIC_WORKFLOWS>')
+    expect(content).toContain('Bundled body')
+  })
+
+  test('returns null when using-systematic/SKILL.md is missing from bundledSkillsDir', () => {
+    const bundledSkillsDir = makeBundledSkillsDir() // no SKILL.md
+    const config = {
+      bootstrap: { enabled: true, file: undefined },
+      disabled_skills: [] as string[],
+      disabled_agents: [] as string[],
+      disabled_commands: [] as string[],
+    }
+    expect(getBootstrapContent(config, { bundledSkillsDir })).toBeNull()
+  })
+
+  test('strips YAML frontmatter from the bundled skill content', () => {
+    const bundledSkillsDir = makeBundledSkillsDir(
+      '---\nname: using-systematic\ndescription: Test skill\n---\n\nActual body content.',
+    )
+    const config = {
+      bootstrap: { enabled: true, file: undefined },
+      disabled_skills: [] as string[],
+      disabled_agents: [] as string[],
+      disabled_commands: [] as string[],
+    }
+    const content = getBootstrapContent(config, { bundledSkillsDir })
+
+    expect(content).not.toBeNull()
+    expect(content).toContain('Actual body content.')
+    expect(content).not.toContain('---')
+    expect(content).not.toContain('description: Test skill')
+  })
+
+  test('embeds bundledSkillsDir absolute path in the tool-mapping template', () => {
+    const bundledSkillsDir = makeBundledSkillsDir(
+      '---\nname: using-systematic\n---\nbody',
+    )
+    const config = {
+      bootstrap: { enabled: true, file: undefined },
+      disabled_skills: [] as string[],
+      disabled_agents: [] as string[],
+      disabled_commands: [] as string[],
+    }
+    const content = getBootstrapContent(config, { bundledSkillsDir })
+
+    expect(content).not.toBeNull()
+    expect(content).toContain(bundledSkillsDir)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// INTERNAL_AGENT_SIGNATURES skip heuristic (src/index.ts:91-97)
+// ---------------------------------------------------------------------------
+
+describe('INTERNAL_AGENT_SIGNATURES skip heuristic', () => {
+  test('exports the 3 documented signatures', () => {
+    expect(INTERNAL_AGENT_SIGNATURES).toEqual([
+      'You are a title generator',
+      'You are a helpful AI assistant tasked with summarizing conversations',
+      'Summarize what was done in this conversation',
+    ])
+  })
+
+  test('skips when any signature appears in the joined system prompt', () => {
+    for (const sig of INTERNAL_AGENT_SIGNATURES) {
+      expect(shouldSkipBootstrap([`Context\n\n${sig}\n\nRules...`])).toBe(true)
+    }
+  })
+
+  test('is case-insensitive', () => {
+    expect(shouldSkipBootstrap(['YOU ARE A TITLE GENERATOR'])).toBe(true)
+    expect(shouldSkipBootstrap(['you are a title generator'])).toBe(true)
+    expect(shouldSkipBootstrap(['You Are A Title Generator'])).toBe(true)
+  })
+
+  test('joins the system array with newline before matching', () => {
+    // Signature split across array entries: if production joined with an empty
+    // string, the substring would still match; but newline is the documented
+    // separator, so this test pins the behavior.
+    const split = ['You are a', 'title generator']
+    const joined = split.join('\n').toLowerCase()
+    expect(joined.includes('you are a title generator')).toBe(false) // split by \n
+    expect(shouldSkipBootstrap(split)).toBe(false)
+  })
+
+  test('does not skip for unrelated prompts', () => {
+    expect(
+      shouldSkipBootstrap([
+        'You are a helpful assistant doing domain work.',
+        'Rules: follow the plan, write tests, stay scoped.',
+      ]),
+    ).toBe(false)
+    expect(shouldSkipBootstrap([])).toBe(false)
+    expect(shouldSkipBootstrap([''])).toBe(false)
+  })
+
+  test('FRAGILITY: a legitimate prompt containing a signature substring triggers skip', () => {
+    // FRAGILITY: the skip heuristic uses substring matching on the joined
+    // system prompt. A legitimate prompt that happens to contain a signature
+    // phrase ("You are a title generator") will incorrectly skip bootstrap
+    // injection. Documented as acceptable in docs/brainstorms/
+    // 2026-04-18-infra-improvements-requirements.md (trade-off: refactoring to
+    // a frontmatter-based opt-out is a separate design decision, deferred).
+    //
+    // If a future refactor moves to an explicit opt-out (e.g., frontmatter
+    // flag or first-line marker), this test must be updated intentionally:
+    // the legitimate prompt below should no longer trigger the skip.
+    const legitimate = [
+      'You are an agent building a UI for a CMS.',
+      'Users can configure pages. You are a title generator panel designer.',
+      'Generate layout recommendations.',
+    ]
+    expect(shouldSkipBootstrap(legitimate)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TOOL_NAME_MAP ↔ bootstrap template consistency
+// ---------------------------------------------------------------------------
+
+describe('TOOL_NAME_MAP / bootstrap template consistency', () => {
+  /**
+   * Render the tool-mapping template and extract every `` `X` → `y` ``
+   * markdown-list mapping. Returns the CC (left) and OC (right) tool names
+   * as they appear in the template.
+   */
+  function extractToolMappings(template: string): { cc: string; oc: string }[] {
+    const mappings: { cc: string; oc: string }[] = []
+    const lineRe = /^- `([^`]+)` → `([^`]+)`/gm
+    for (const match of template.matchAll(lineRe)) {
+      mappings.push({ cc: match[1] ?? '', oc: match[2] ?? '' })
+    }
+    return mappings
+  }
+
+  /**
+   * Names that appear on the left of `X → y` mappings but are intentionally
+   * Systematic-specific rather than imported from CC. These do not need to
+   * appear in TOOL_NAME_MAP (which is the CEP→Systematic converter's mapping,
+   * not a registry of every tool mentioned in prose).
+   */
+  const SYSTEMATIC_ONLY_TOOLS = new Set(['systematicskill'])
+
+  test('rendered template contains at least one mapping', () => {
+    const content = getBootstrapContent(
+      {
+        bootstrap: { enabled: true, file: undefined },
+        disabled_skills: [],
+        disabled_agents: [],
+        disabled_commands: [],
+      },
+      { bundledSkillsDir: createTempBundledSkillsDir() },
+    )
+    expect(content).not.toBeNull()
+    expect(extractToolMappings(content ?? '').length).toBeGreaterThan(0)
+  })
+
+  test('every CC tool name in the template is a key in TOOL_NAME_MAP', () => {
+    const content = getBootstrapContent(
+      {
+        bootstrap: { enabled: true, file: undefined },
+        disabled_skills: [],
+        disabled_agents: [],
+        disabled_commands: [],
+      },
+      { bundledSkillsDir: createTempBundledSkillsDir() },
+    )
+    const mappings = extractToolMappings(content ?? '')
+
+    for (const { cc, oc } of mappings) {
+      const ccLower = cc.toLowerCase()
+      if (SYSTEMATIC_ONLY_TOOLS.has(ccLower)) continue
+      expect(TOOL_NAME_MAP).toHaveProperty(ccLower)
+      expect(TOOL_NAME_MAP[ccLower]).toBe(oc)
+    }
+  })
+
+  function createTempBundledSkillsDir(): string {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'systematic-bootstrap-consistency-'),
+    )
+    fs.mkdirSync(path.join(dir, 'skills', 'using-systematic'), {
+      recursive: true,
+    })
+    fs.writeFileSync(
+      path.join(dir, 'skills', 'using-systematic', 'SKILL.md'),
+      '---\nname: using-systematic\n---\nbody',
+    )
+    return path.join(dir, 'skills')
+  }
+})

--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -261,28 +261,49 @@ describe('INTERNAL_AGENT_SIGNATURES skip heuristic', () => {
 
 describe('TOOL_NAME_MAP / bootstrap template consistency', () => {
   /**
-   * Render the tool-mapping template and extract every `` `X` → `y` ``
-   * markdown-list mapping. Returns the CC (left) and OC (right) tool names
-   * as they appear in the template.
+   * Extract all CC tool names from the left side of `→` arrows in the
+   * "Tool Mapping for OpenCode" section of the bootstrap template.
+   *
+   * Handles all three bullet forms found in the template:
+   *   - `X` → `y`              (simple 1:1, backtick-delimited OC name)
+   *   - `X` tool with … → prose  (prose RHS; extracts X only)
+   *   - `A`, `B`, `C` → prose  (multi-name LHS; extracts A, B, C)
+   *
+   * Note: this is an overlap-subset check, not a full-map consistency check.
+   * The bootstrap prose and the converter map only partially overlap by design —
+   * the bootstrap is instructional text, not a serialised TOOL_NAME_MAP.
    */
-  function extractToolMappings(template: string): { cc: string; oc: string }[] {
-    const mappings: { cc: string; oc: string }[] = []
-    const lineRe = /^- `([^`]+)` → `([^`]+)`/gm
-    for (const match of template.matchAll(lineRe)) {
-      mappings.push({ cc: match[1] ?? '', oc: match[2] ?? '' })
-    }
-    return mappings
+  function extractCCToolNames(template: string): string[] {
+    // Isolate the "Tool Mapping for OpenCode:" section to avoid false-positive
+    // matches on unrelated `→` arrows elsewhere in the bootstrap content.
+    const sectionStart = template.indexOf('**Tool Mapping for OpenCode:**')
+    if (sectionStart === -1) return []
+    const rest = template.slice(sectionStart)
+    // Section ends at the next bold heading that is NOT "Tool Mapping"
+    const nextHeading = rest.search(/\n\*\*(?!Tool Mapping)/)
+    const section = nextHeading >= 0 ? rest.slice(0, nextHeading) : rest
+
+    // For each bullet line, extract backtick-quoted tokens from the LHS of `→`.
+    // Uses flatMap to avoid nested loops that inflate cognitive complexity.
+    return section
+      .split('\n')
+      .filter((line) => line.startsWith('- '))
+      .flatMap((line) => {
+        const arrowIdx = line.indexOf(' → ')
+        const lhs = arrowIdx >= 0 ? line.slice(0, arrowIdx) : line
+        return [...lhs.matchAll(/`([^`]+)`/g)].map((m) => m[1] ?? '')
+      })
+      .filter(Boolean)
   }
 
   /**
-   * Names that appear on the left of `X → y` mappings but are intentionally
-   * Systematic-specific rather than imported from CC. These do not need to
-   * appear in TOOL_NAME_MAP (which is the CEP→Systematic converter's mapping,
-   * not a registry of every tool mentioned in prose).
+   * Names that appear in the template mapping section but are intentionally
+   * Systematic-specific rather than imported from CC. These do not need a
+   * TOOL_NAME_MAP entry (the map covers CC→Systematic converter renames only).
    */
   const SYSTEMATIC_ONLY_TOOLS = new Set(['systematicskill'])
 
-  test('rendered template contains at least one mapping', () => {
+  test('rendered template contains at least one CC tool reference', () => {
     const content = getBootstrapContent(
       {
         bootstrap: { enabled: true, file: undefined },
@@ -293,10 +314,10 @@ describe('TOOL_NAME_MAP / bootstrap template consistency', () => {
       { bundledSkillsDir: createTempBundledSkillsDir() },
     )
     expect(content).not.toBeNull()
-    expect(extractToolMappings(content ?? '').length).toBeGreaterThan(0)
+    expect(extractCCToolNames(content ?? '').length).toBeGreaterThan(0)
   })
 
-  test('every CC tool name in the template is a key in TOOL_NAME_MAP', () => {
+  test('every CC tool name in the template mapping section is a key in TOOL_NAME_MAP', () => {
     const content = getBootstrapContent(
       {
         bootstrap: { enabled: true, file: undefined },
@@ -306,13 +327,17 @@ describe('TOOL_NAME_MAP / bootstrap template consistency', () => {
       },
       { bundledSkillsDir: createTempBundledSkillsDir() },
     )
-    const mappings = extractToolMappings(content ?? '')
+    const ccNames = extractCCToolNames(content ?? '')
+    // Guard against section-parse regressions
+    expect(ccNames.length).toBeGreaterThan(0)
 
-    for (const { cc, oc } of mappings) {
-      const ccLower = cc.toLowerCase()
-      if (SYSTEMATIC_ONLY_TOOLS.has(ccLower)) continue
-      expect(TOOL_NAME_MAP).toHaveProperty(ccLower)
-      expect(TOOL_NAME_MAP[ccLower]).toBe(oc)
+    for (const cc of ccNames) {
+      const normalized = cc.toLowerCase()
+      if (SYSTEMATIC_ONLY_TOOLS.has(normalized)) continue
+      expect(
+        TOOL_NAME_MAP,
+        `Bootstrap template references "${cc}" but TOOL_NAME_MAP has no key "${normalized}"`,
+      ).toHaveProperty(normalized)
     }
   })
 

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -1,0 +1,717 @@
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  type AllowlistEntry,
+  BANNED_PATTERNS,
+  checkBannedPatterns,
+  checkContentIntegrity,
+  checkReferenceIntegrity,
+  collectScanTargets,
+  discoverCategories,
+  loadAllowlist,
+  matchesPathGlob,
+} from '../../scripts/content-integrity.ts'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const REPO_ROOT = path.resolve(__dirname, '../..')
+const SCRIPT_PATH = path.join(REPO_ROOT, 'scripts/content-integrity.ts')
+
+/**
+ * Build a minimal fixture repo with the scan-target directory shape the gate
+ * expects. Returns the temp root; tests create skills/agents/src files beneath.
+ */
+function makeFixtureRepo(): string {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'content-integrity-'))
+  fs.mkdirSync(path.join(tmp, 'skills'), { recursive: true })
+  fs.mkdirSync(path.join(tmp, 'agents'), { recursive: true })
+  fs.mkdirSync(path.join(tmp, 'src', 'lib'), { recursive: true })
+  fs.mkdirSync(path.join(tmp, 'scripts'), { recursive: true })
+  return tmp
+}
+
+function writeFile(root: string, relPath: string, content: string): void {
+  const full = path.join(root, relPath)
+  fs.mkdirSync(path.dirname(full), { recursive: true })
+  fs.writeFileSync(full, content)
+}
+
+function writeAllowlist(root: string, exemptions: AllowlistEntry[]): void {
+  writeFile(
+    root,
+    'scripts/.drift-allowlist.json',
+    JSON.stringify({ exemptions }, null, 2),
+  )
+}
+
+function writeAgent(root: string, category: string, name: string): void {
+  writeFile(
+    root,
+    `agents/${category}/${name}.md`,
+    `---\nname: ${name}\n---\nagent body`,
+  )
+}
+
+function writeSkill(root: string, name: string, body: string): void {
+  writeFile(root, `skills/${name}/SKILL.md`, body)
+}
+
+// ---------------------------------------------------------------------------
+
+describe('BANNED_PATTERNS', () => {
+  test('exposes the 8 patterns documented in the plan', () => {
+    expect(BANNED_PATTERNS).toEqual([
+      'Claude Code',
+      'TaskCreate',
+      'AskUserQuestion',
+      'compound-engineering:',
+      'CLAUDE.md',
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: literal string the gate scans for.
+      '${CLAUDE_PLUGIN_ROOT}',
+      '.claude/',
+      '.context/compound-engineering/',
+    ])
+  })
+})
+
+describe('matchesPathGlob', () => {
+  test('matches exact path', () => {
+    expect(
+      matchesPathGlob('src/lib/converter.ts', 'src/lib/converter.ts'),
+    ).toBe(true)
+    expect(matchesPathGlob('src/lib/other.ts', 'src/lib/converter.ts')).toBe(
+      false,
+    )
+  })
+
+  test('matches /** prefix including nested files', () => {
+    expect(matchesPathGlob('skills/foo/SKILL.md', 'skills/foo/**')).toBe(true)
+    expect(
+      matchesPathGlob('skills/foo/references/bar.md', 'skills/foo/**'),
+    ).toBe(true)
+  })
+
+  test('treats the exact prefix as inside its /** scope', () => {
+    expect(matchesPathGlob('skills/foo', 'skills/foo/**')).toBe(true)
+  })
+
+  test('does not match sibling directories with a similar prefix', () => {
+    expect(matchesPathGlob('skills/foobar/SKILL.md', 'skills/foo/**')).toBe(
+      false,
+    )
+  })
+})
+
+describe('discoverCategories', () => {
+  test('lists agents/ subdirectories at runtime', () => {
+    const root = makeFixtureRepo()
+    try {
+      fs.mkdirSync(path.join(root, 'agents', 'research'))
+      fs.mkdirSync(path.join(root, 'agents', 'review'))
+      fs.mkdirSync(path.join(root, 'agents', 'workflow'))
+
+      expect(discoverCategories(root)).toEqual([
+        'research',
+        'review',
+        'workflow',
+      ])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('skips hidden directories (names starting with .)', () => {
+    const root = makeFixtureRepo()
+    try {
+      fs.mkdirSync(path.join(root, 'agents', 'research'))
+      fs.mkdirSync(path.join(root, 'agents', '.tmp'))
+
+      expect(discoverCategories(root)).toEqual(['research'])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('returns empty array when agents/ does not exist', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'no-agents-'))
+    try {
+      expect(discoverCategories(tmp)).toEqual([])
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('collectScanTargets', () => {
+  test('collects markdown from skills/ and agents/, typescript from src/', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(root, 'skills/foo/SKILL.md', 'skill')
+      writeFile(root, 'skills/foo/references/ref.md', 'ref')
+      writeFile(root, 'agents/research/a.md', 'agent')
+      writeFile(root, 'src/lib/foo.ts', 'ts')
+      writeFile(root, 'docs/not-scanned.md', 'should be excluded')
+      writeFile(root, 'src/lib/AGENTS.md', 'docs markdown in src excluded')
+
+      const targets = collectScanTargets(root)
+
+      expect(targets.markdown).toEqual([
+        'agents/research/a.md',
+        'skills/foo/SKILL.md',
+        'skills/foo/references/ref.md',
+      ])
+      expect(targets.typescript).toEqual(['src/lib/foo.ts'])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('skips *.md files under src/ (developer-facing documentation)', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(root, 'src/lib/notes.md', 'docs — should be excluded from scan')
+      writeFile(root, 'src/lib/code.ts', 'code')
+
+      const targets = collectScanTargets(root)
+      expect(targets.markdown).not.toContain('src/lib/notes.md')
+      expect(targets.typescript).toContain('src/lib/code.ts')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('loadAllowlist', () => {
+  test('returns empty allowlist and no warnings when file is missing', () => {
+    const root = makeFixtureRepo()
+    try {
+      const { allowlist, warnings } = loadAllowlist(root)
+      expect(allowlist).toEqual({ exemptions: [] })
+      expect(warnings).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('loads a valid allowlist with structured entries', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAllowlist(root, [
+        {
+          pathGlob: 'skills/foo/**',
+          patterns: ['Claude Code'],
+          reason: 'Documents a CC-targeting skill explicitly by design.',
+        },
+      ])
+      const { allowlist } = loadAllowlist(root)
+      expect(allowlist.exemptions).toHaveLength(1)
+      expect(allowlist.exemptions[0]?.patterns).toEqual(['Claude Code'])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('throws on malformed JSON', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(root, 'scripts/.drift-allowlist.json', '{ not valid json')
+      expect(() => loadAllowlist(root)).toThrow(/Invalid JSON/)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('throws on missing exemptions array', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(root, 'scripts/.drift-allowlist.json', '{}')
+      expect(() => loadAllowlist(root)).toThrow(
+        /expected \{ exemptions: \[\.\.\.\] \}/,
+      )
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('throws on empty pathGlob', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAllowlist(root, [
+        {
+          pathGlob: '',
+          patterns: ['Claude Code'],
+          reason: 'Reason long enough to pass the minimum-length check.',
+        },
+      ])
+      expect(() => loadAllowlist(root)).toThrow(
+        /pathGlob must be a non-empty string/,
+      )
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('throws on unknown banned pattern', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAllowlist(root, [
+        {
+          pathGlob: 'skills/foo/**',
+          patterns: ['NotARealPattern' as never],
+          reason: 'Reason long enough to pass the minimum-length check.',
+        },
+      ])
+      expect(() => loadAllowlist(root)).toThrow(/not a known banned pattern/)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('throws on reason shorter than 20 chars', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAllowlist(root, [
+        {
+          pathGlob: 'skills/foo/**',
+          patterns: ['Claude Code'],
+          reason: 'too short',
+        },
+      ])
+      expect(() => loadAllowlist(root)).toThrow(/at least 20 characters/)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('throws on unsupported glob syntax (? or [abc])', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAllowlist(root, [
+        {
+          pathGlob: 'skills/[abc]/**',
+          patterns: ['Claude Code'],
+          reason: 'Reason long enough to pass the minimum-length check.',
+        },
+      ])
+      expect(() => loadAllowlist(root)).toThrow(/unsupported glob syntax/)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('emits zero-match warning for pathGlob that matches no scanned files', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAllowlist(root, [
+        {
+          pathGlob: 'skills/nonexistent/**',
+          patterns: ['Claude Code'],
+          reason: 'Reason long enough to pass the minimum-length check.',
+        },
+      ])
+      const scanned = ['skills/other/SKILL.md']
+      const { warnings } = loadAllowlist(root, scanned)
+      expect(warnings).toHaveLength(1)
+      expect(warnings[0]?.kind).toBe('zero-match')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('emits broad-pathglob warning for skills/** (no subdirectory prefix)', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAllowlist(root, [
+        {
+          pathGlob: 'skills/**',
+          patterns: ['Claude Code'],
+          reason: 'Reason long enough to pass the minimum-length check.',
+        },
+      ])
+      const scanned = ['skills/foo/SKILL.md']
+      const { warnings } = loadAllowlist(root, scanned)
+      const broad = warnings.find((w) => w.kind === 'broad-pathglob')
+      expect(broad).toBeDefined()
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('does not warn on specific prefixes like skills/foo/**', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAllowlist(root, [
+        {
+          pathGlob: 'skills/foo/**',
+          patterns: ['Claude Code'],
+          reason: 'Reason long enough to pass the minimum-length check.',
+        },
+      ])
+      const scanned = ['skills/foo/SKILL.md']
+      const { warnings } = loadAllowlist(root, scanned)
+      expect(warnings.filter((w) => w.kind === 'broad-pathglob')).toHaveLength(
+        0,
+      )
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('checkReferenceIntegrity', () => {
+  test('resolves references that exist and flags ones that do not', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAgent(root, 'research', 'real-agent')
+      writeSkill(
+        root,
+        'foo',
+        'See systematic:research:real-agent for details.\n' +
+          'Dispatch systematic:research:ghost-agent as needed.\n',
+      )
+
+      const targets = collectScanTargets(root)
+      const phantoms = checkReferenceIntegrity(root, targets.markdown, [
+        'research',
+      ])
+
+      expect(phantoms).toHaveLength(1)
+      expect(phantoms[0]).toMatchObject({
+        file: 'skills/foo/SKILL.md',
+        line: 2,
+        reference: 'systematic:research:ghost-agent',
+        category: 'research',
+        name: 'ghost-agent',
+      })
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('reports multiple phantoms on the same line', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'foo',
+        'See systematic:research:a and systematic:review:b on the same line.',
+      )
+      const targets = collectScanTargets(root)
+      const phantoms = checkReferenceIntegrity(root, targets.markdown, [
+        'research',
+        'review',
+      ])
+      expect(phantoms).toHaveLength(2)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('returns empty when categories list is empty', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(root, 'foo', 'systematic:research:anything')
+      const targets = collectScanTargets(root)
+      expect(checkReferenceIntegrity(root, targets.markdown, [])).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('auto-extends coverage when a new category is added at runtime', () => {
+    const root = makeFixtureRepo()
+    try {
+      // Category "new-category" doesn't match the legacy hardcoded regex, but
+      // the gate reads agents/ at runtime, so references resolve or fail correctly.
+      writeAgent(root, 'new-category', 'foo')
+      writeSkill(root, 'bar', 'Dispatch systematic:new-category:foo.\n')
+
+      const categories = discoverCategories(root)
+      expect(categories).toContain('new-category')
+
+      const targets = collectScanTargets(root)
+      const phantoms = checkReferenceIntegrity(
+        root,
+        targets.markdown,
+        categories,
+      )
+      expect(phantoms).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('checkBannedPatterns', () => {
+  test('flags banned patterns in markdown outside the allowlist', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(root, 'foo', 'Use TaskCreate here.\n')
+      const targets = collectScanTargets(root)
+      const { hits, exempt } = checkBannedPatterns(
+        root,
+        [...targets.markdown, ...targets.typescript],
+        { exemptions: [] },
+      )
+      expect(hits).toHaveLength(1)
+      expect(hits[0]).toMatchObject({
+        file: 'skills/foo/SKILL.md',
+        line: 1,
+        pattern: 'TaskCreate',
+      })
+      expect(exempt).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags banned patterns in typescript files too', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'src/lib/has-ban.ts',
+        "const msg = 'Claude Code is not this project'\n",
+      )
+      const targets = collectScanTargets(root)
+      const { hits } = checkBannedPatterns(
+        root,
+        [...targets.markdown, ...targets.typescript],
+        { exemptions: [] },
+      )
+      expect(hits).toHaveLength(1)
+      expect(hits[0]?.pattern).toBe('Claude Code')
+      expect(hits[0]?.file).toBe('src/lib/has-ban.ts')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('routes allowlisted files to exemptHits rather than hits', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'cc-skill',
+        'Use TaskCreate and `.claude/` paths here.\n',
+      )
+      const targets = collectScanTargets(root)
+      const { hits, exempt } = checkBannedPatterns(
+        root,
+        [...targets.markdown, ...targets.typescript],
+        {
+          exemptions: [
+            {
+              pathGlob: 'skills/cc-skill/**',
+              patterns: ['TaskCreate', '.claude/'],
+              reason: 'CC-targeting skill; both patterns are intentional.',
+            },
+          ],
+        },
+      )
+      expect(hits).toEqual([])
+      expect(exempt).toHaveLength(2)
+      expect(exempt[0]?.reason).toContain('CC-targeting')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('only exempts patterns listed in the matching allowlist entry', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'cc-skill',
+        'TaskCreate is exempt here.\nAskUserQuestion is not.\n',
+      )
+      const targets = collectScanTargets(root)
+      const { hits, exempt } = checkBannedPatterns(
+        root,
+        [...targets.markdown, ...targets.typescript],
+        {
+          exemptions: [
+            {
+              pathGlob: 'skills/cc-skill/**',
+              patterns: ['TaskCreate'],
+              reason: 'Only TaskCreate is intentional in this skill.',
+            },
+          ],
+        },
+      )
+      expect(exempt).toHaveLength(1)
+      expect(hits).toHaveLength(1)
+      expect(hits[0]?.pattern).toBe('AskUserQuestion')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('checkContentIntegrity (top-level)', () => {
+  test('clean repo with no violations returns empty arrays', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAgent(root, 'research', 'a')
+      writeSkill(root, 'foo', 'See systematic:research:a.\n')
+      writeFile(root, 'src/lib/foo.ts', '// clean\nexport const x = 1\n')
+
+      const result = checkContentIntegrity(root)
+      expect(result.phantomRefs).toEqual([])
+      expect(result.bannedPatterns).toEqual([])
+      expect(result.scanStats.markdownFiles).toBe(2) // SKILL.md + agent a.md
+      expect(result.scanStats.typescriptFiles).toBe(1)
+      expect(result.categories).toEqual(['research'])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('reports both phantom refs and banned patterns in one pass', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAgent(root, 'research', 'real')
+      writeSkill(
+        root,
+        'foo',
+        'systematic:research:real is fine.\n' +
+          'systematic:research:phantom is not.\n' +
+          'TaskCreate is also not.\n',
+      )
+
+      const result = checkContentIntegrity(root)
+      expect(result.phantomRefs).toHaveLength(1)
+      expect(result.phantomRefs[0]?.name).toBe('phantom')
+      expect(result.bannedPatterns).toHaveLength(1)
+      expect(result.bannedPatterns[0]?.pattern).toBe('TaskCreate')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('propagates allowlist warnings into the result', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(root, 'foo', 'Clean content only.\n')
+      writeAllowlist(root, [
+        {
+          pathGlob: 'skills/nonexistent-dir/**',
+          patterns: ['Claude Code'],
+          reason: 'Reason long enough to pass the minimum-length check.',
+        },
+      ])
+
+      const result = checkContentIntegrity(root)
+      expect(result.allowlistWarnings).toHaveLength(1)
+      expect(result.allowlistWarnings[0]?.kind).toBe('zero-match')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Integration smoke: run the gate against the real repo. This is the test
+// that catches both v2.4.0 cycle bugs if they reintroduce themselves, and the
+// one that actually fails CI when content drifts.
+// ---------------------------------------------------------------------------
+
+describe('integration: real repo', () => {
+  test('content-integrity gate passes against current HEAD', () => {
+    const result = checkContentIntegrity(REPO_ROOT)
+
+    // Zero phantoms, zero non-exempt banned patterns, zero warnings.
+    if (result.phantomRefs.length > 0) {
+      const details = result.phantomRefs
+        .map((p) => `${p.file}:${p.line}  ${p.reference}`)
+        .join('\n  ')
+      throw new Error(`Phantom references in repo:\n  ${details}`)
+    }
+
+    if (result.bannedPatterns.length > 0) {
+      const details = result.bannedPatterns
+        .map(
+          (h) =>
+            `${h.file}:${h.line}  ${JSON.stringify(h.pattern)}  ${h.lineContent}`,
+        )
+        .join('\n  ')
+      throw new Error(`Banned patterns outside allowlist:\n  ${details}`)
+    }
+
+    expect(result.phantomRefs).toEqual([])
+    expect(result.bannedPatterns).toEqual([])
+    expect(result.allowlistWarnings).toEqual([])
+    expect(result.scanStats.markdownFiles).toBeGreaterThan(0)
+    expect(result.scanStats.typescriptFiles).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CLI smoke: the script exits 0 on a clean repo.
+// ---------------------------------------------------------------------------
+
+describe('CLI', () => {
+  test('exits 0 against a clean fixture repo', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAgent(root, 'research', 'a')
+      writeSkill(root, 'foo', 'Clean skill. systematic:research:a\n')
+
+      const result = Bun.spawnSync(['bun', SCRIPT_PATH, root], {
+        cwd: REPO_ROOT,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout.toString()).toContain('content-integrity: clean')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('exits 1 when phantom references exist', () => {
+    const root = makeFixtureRepo()
+    try {
+      // At least one agents/ category must exist for the reference regex to build.
+      fs.mkdirSync(path.join(root, 'agents', 'research'), { recursive: true })
+      writeSkill(root, 'foo', 'systematic:research:ghost\n')
+
+      const result = Bun.spawnSync(['bun', SCRIPT_PATH, root], {
+        cwd: REPO_ROOT,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr.toString()).toContain('Phantom references')
+      expect(result.stderr.toString()).toContain('ghost')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('exits 1 when banned patterns are outside the allowlist', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(root, 'foo', 'Reintroduced TaskCreate accidentally.\n')
+
+      const result = Bun.spawnSync(['bun', SCRIPT_PATH, root], {
+        cwd: REPO_ROOT,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr.toString()).toContain(
+        'Banned patterns outside allowlist',
+      )
+      expect(result.stderr.toString()).toContain('TaskCreate')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -94,8 +94,19 @@ describe('matchesPathGlob', () => {
     ).toBe(true)
   })
 
-  test('treats the exact prefix as inside its /** scope', () => {
-    expect(matchesPathGlob('skills/foo', 'skills/foo/**')).toBe(true)
+  test('does not match the bare prefix itself (/** requires a child path)', () => {
+    // `skills/foo/**` means "any file under skills/foo/" — not the directory
+    // itself. The old behavior (true for the prefix) was semantically wrong
+    // and never occurs in practice (scanned files are always file paths).
+    expect(matchesPathGlob('skills/foo', 'skills/foo/**')).toBe(false)
+  })
+
+  test('bare segment glob (no /**) matches only exact paths', () => {
+    // A pathGlob without /** is an exact-path match; it does not act as
+    // a directory prefix.
+    expect(matchesPathGlob('src', 'src')).toBe(true)
+    expect(matchesPathGlob('src/lib/x.ts', 'src')).toBe(false)
+    expect(matchesPathGlob('src/lib/x.ts', 'src/lib/x.ts')).toBe(true)
   })
 
   test('does not match sibling directories with a similar prefix', () => {
@@ -520,6 +531,33 @@ describe('checkBannedPatterns', () => {
     }
   })
 
+  test('BLIND SPOT: banned pattern split across two lines is not detected (line-by-line scan)', () => {
+    // The gate scans each line independently. A banned pattern whose characters
+    // span a line break will NOT be detected. This is a known limitation — the
+    // patterns are short ASCII strings and in practice are never intentionally
+    // split across lines in skill/agent content.
+    //
+    // This test pins the current behavior. If the implementation moves to a
+    // whole-file scan (e.g., content.includes(pattern) before splitting into
+    // lines), this test must be updated intentionally.
+    const root = makeFixtureRepo()
+    try {
+      // "Claude Code" split across a line: "Claude\nCode" — neither line
+      // contains the full banned string, so the gate returns zero hits.
+      writeSkill(root, 'foo', 'Claude\nCode\n')
+      const targets = collectScanTargets(root)
+      const { hits } = checkBannedPatterns(
+        root,
+        [...targets.markdown, ...targets.typescript],
+        { exemptions: [] },
+      )
+      // KNOWN LIMITATION: split pattern is not detected.
+      expect(hits).toHaveLength(0)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   test('only exempts patterns listed in the matching allowlist entry', () => {
     const root = makeFixtureRepo()
     try {
@@ -710,6 +748,24 @@ describe('CLI', () => {
         'Banned patterns outside allowlist',
       )
       expect(result.stderr.toString()).toContain('TaskCreate')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('exits 1 when the allowlist file contains malformed JSON', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(root, 'scripts/.drift-allowlist.json', '{ invalid json }')
+
+      const result = Bun.spawnSync(['bun', SCRIPT_PATH, root], {
+        cwd: REPO_ROOT,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr.toString()).toContain('content-integrity:')
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  extractBoolean,
+  extractNonEmptyString,
+  extractNumber,
+  extractString,
+  isAgentMode,
+  isPermissionSetting,
+  isRecord,
+  isToolsMap,
+  normalizePermission,
+} from '../../src/lib/validation.ts'
+
+// ---------------------------------------------------------------------------
+// Type-guard predicates
+// ---------------------------------------------------------------------------
+
+describe('isRecord', () => {
+  test('true for plain objects', () => {
+    expect(isRecord({})).toBe(true)
+    expect(isRecord({ a: 1 })).toBe(true)
+    expect(isRecord({ nested: { b: 2 } })).toBe(true)
+  })
+
+  test('false for null, undefined, primitives, and arrays', () => {
+    expect(isRecord(null)).toBe(false)
+    expect(isRecord(undefined)).toBe(false)
+    expect(isRecord('string')).toBe(false)
+    expect(isRecord(42)).toBe(false)
+    expect(isRecord(true)).toBe(false)
+    expect(isRecord([])).toBe(false)
+    expect(isRecord([1, 2, 3])).toBe(false)
+  })
+})
+
+describe('isPermissionSetting', () => {
+  test('true for the three documented literals', () => {
+    expect(isPermissionSetting('ask')).toBe(true)
+    expect(isPermissionSetting('allow')).toBe(true)
+    expect(isPermissionSetting('deny')).toBe(true)
+  })
+
+  test('false for other strings, nullish, objects, arrays, and wrong-case variants', () => {
+    expect(isPermissionSetting('ALLOW')).toBe(false)
+    expect(isPermissionSetting('allowed')).toBe(false)
+    expect(isPermissionSetting('')).toBe(false)
+    expect(isPermissionSetting(null)).toBe(false)
+    expect(isPermissionSetting(undefined)).toBe(false)
+    expect(isPermissionSetting({})).toBe(false)
+    expect(isPermissionSetting([])).toBe(false)
+    expect(isPermissionSetting(1)).toBe(false)
+  })
+})
+
+describe('isToolsMap', () => {
+  test('true for records with only boolean values', () => {
+    expect(isToolsMap({})).toBe(true)
+    expect(isToolsMap({ bash: true })).toBe(true)
+    expect(isToolsMap({ bash: true, edit: false, read: true })).toBe(true)
+  })
+
+  test('false when any value is not a boolean', () => {
+    expect(isToolsMap({ bash: 'not-a-boolean' })).toBe(false)
+    expect(isToolsMap({ bash: true, edit: 'ask' })).toBe(false)
+    expect(isToolsMap({ bash: 1 })).toBe(false)
+    expect(isToolsMap({ bash: null })).toBe(false)
+    expect(isToolsMap({ bash: { nested: true } })).toBe(false)
+  })
+
+  test('false for non-records', () => {
+    expect(isToolsMap(null)).toBe(false)
+    expect(isToolsMap(undefined)).toBe(false)
+    expect(isToolsMap([])).toBe(false)
+    expect(isToolsMap('tools')).toBe(false)
+    expect(isToolsMap(42)).toBe(false)
+  })
+})
+
+describe('isAgentMode', () => {
+  test('true for the three AgentMode literals', () => {
+    expect(isAgentMode('subagent')).toBe(true)
+    expect(isAgentMode('primary')).toBe(true)
+    expect(isAgentMode('all')).toBe(true)
+  })
+
+  test('false for other strings and non-string values', () => {
+    expect(isAgentMode('SUBAGENT')).toBe(false)
+    expect(isAgentMode('other')).toBe(false)
+    expect(isAgentMode('')).toBe(false)
+    expect(isAgentMode(null)).toBe(false)
+    expect(isAgentMode(undefined)).toBe(false)
+    expect(isAgentMode(123)).toBe(false)
+    expect(isAgentMode({})).toBe(false)
+    expect(isAgentMode(['subagent'])).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// normalizePermission
+// ---------------------------------------------------------------------------
+
+describe('normalizePermission', () => {
+  test('returns undefined for non-records (null, undefined, primitives, arrays)', () => {
+    expect(normalizePermission(null)).toBeUndefined()
+    expect(normalizePermission(undefined)).toBeUndefined()
+    expect(normalizePermission('ask')).toBeUndefined()
+    expect(normalizePermission(42)).toBeUndefined()
+    expect(normalizePermission(['allow'])).toBeUndefined()
+  })
+
+  test('returns undefined for an empty object (no fields set)', () => {
+    expect(normalizePermission({})).toBeUndefined()
+  })
+
+  test('returns a permission config with a single simple field', () => {
+    expect(normalizePermission({ edit: 'ask' })).toEqual({ edit: 'ask' })
+    expect(normalizePermission({ webfetch: 'allow' })).toEqual({
+      webfetch: 'allow',
+    })
+  })
+
+  test('returns a permission config with every simple field set', () => {
+    expect(
+      normalizePermission({
+        edit: 'ask',
+        webfetch: 'allow',
+        doom_loop: 'deny',
+        external_directory: 'ask',
+        task: 'allow',
+        skill: 'allow',
+      }),
+    ).toEqual({
+      edit: 'ask',
+      webfetch: 'allow',
+      doom_loop: 'deny',
+      external_directory: 'ask',
+      task: 'allow',
+      skill: 'allow',
+    })
+  })
+
+  test('accepts bash as a single permission setting', () => {
+    expect(normalizePermission({ bash: 'allow' })).toEqual({ bash: 'allow' })
+    expect(normalizePermission({ bash: 'deny' })).toEqual({ bash: 'deny' })
+  })
+
+  test('accepts bash as a command map of permission settings', () => {
+    expect(
+      normalizePermission({
+        bash: { 'ls *': 'allow', 'rm -rf *': 'deny' },
+      }),
+    ).toEqual({
+      bash: { 'ls *': 'allow', 'rm -rf *': 'deny' },
+    })
+  })
+
+  test('returns undefined when bash is a record with non-PermissionSetting values', () => {
+    // FRAGILITY: validation.ts returns undefined on any malformed field rather than
+    // dropping just the bad field. Downstream loadAgentAsConfig then swallows the
+    // undefined into a silent `null`, so broken bundled assets disappear with no
+    // CI signal. Documented as I3.e scope (bundled asset error surfacing) in
+    // docs/brainstorms/2026-04-18-infra-improvements-requirements.md. Changing
+    // this behavior (e.g., dropping only the bad field or throwing) must update
+    // this test intentionally.
+    expect(
+      normalizePermission({ bash: { 'ls *': 'not-a-setting' } }),
+    ).toBeUndefined()
+  })
+
+  test('returns undefined when bash is a non-record non-PermissionSetting value', () => {
+    // FRAGILITY: same silent-undefined chain as the test above.
+    expect(normalizePermission({ bash: 42 })).toBeUndefined()
+    expect(normalizePermission({ bash: ['ls *'] })).toBeUndefined()
+    expect(normalizePermission({ bash: null })).toBeUndefined()
+  })
+
+  test('returns undefined when any simple field has a malformed value', () => {
+    // FRAGILITY: same silent-undefined chain as above.
+    expect(normalizePermission({ edit: 'not-a-setting' })).toBeUndefined()
+    expect(normalizePermission({ webfetch: 123 })).toBeUndefined()
+    expect(normalizePermission({ task: {} })).toBeUndefined()
+  })
+
+  test('mixes simple fields and bash map in one config', () => {
+    expect(
+      normalizePermission({
+        edit: 'ask',
+        bash: { 'git *': 'allow' },
+        webfetch: 'deny',
+      }),
+    ).toEqual({
+      edit: 'ask',
+      bash: { 'git *': 'allow' },
+      webfetch: 'deny',
+    })
+  })
+
+  test('ignores unknown keys (only documented fields appear in output)', () => {
+    expect(
+      normalizePermission({
+        edit: 'ask',
+        unknown_field: 'something',
+      }),
+    ).toEqual({ edit: 'ask' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractString
+// ---------------------------------------------------------------------------
+
+describe('extractString', () => {
+  test('returns the string value when present', () => {
+    expect(extractString({ name: 'hello' }, 'name')).toBe('hello')
+    expect(extractString({ name: '' }, 'name')).toBe('')
+  })
+
+  test('returns the default fallback ("") when key is missing', () => {
+    expect(extractString({}, 'missing')).toBe('')
+  })
+
+  test('returns the supplied fallback when key is missing', () => {
+    expect(extractString({}, 'missing', 'fb')).toBe('fb')
+  })
+
+  test('returns the fallback when value is the wrong type', () => {
+    expect(extractString({ name: 42 }, 'name', 'fb')).toBe('fb')
+    expect(extractString({ name: null }, 'name', 'fb')).toBe('fb')
+    expect(extractString({ name: true }, 'name', 'fb')).toBe('fb')
+    expect(extractString({ name: { nested: 'x' } }, 'name', 'fb')).toBe('fb')
+    expect(extractString({ name: ['arr'] }, 'name', 'fb')).toBe('fb')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractNonEmptyString
+// ---------------------------------------------------------------------------
+
+describe('extractNonEmptyString', () => {
+  test('returns the trimmed value for non-empty strings', () => {
+    expect(extractNonEmptyString({ name: 'hello' }, 'name')).toBe('hello')
+    expect(extractNonEmptyString({ name: '  hello  ' }, 'name')).toBe('hello')
+  })
+
+  test('returns undefined for empty or whitespace-only strings', () => {
+    expect(extractNonEmptyString({ name: '' }, 'name')).toBeUndefined()
+    expect(extractNonEmptyString({ name: '   ' }, 'name')).toBeUndefined()
+    expect(extractNonEmptyString({ name: '\t\n' }, 'name')).toBeUndefined()
+  })
+
+  test('returns undefined for non-string values', () => {
+    expect(extractNonEmptyString({ name: 42 }, 'name')).toBeUndefined()
+    expect(extractNonEmptyString({ name: null }, 'name')).toBeUndefined()
+    expect(extractNonEmptyString({ name: true }, 'name')).toBeUndefined()
+    expect(extractNonEmptyString({ name: {} }, 'name')).toBeUndefined()
+  })
+
+  test('returns undefined when key is missing', () => {
+    expect(extractNonEmptyString({}, 'missing')).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractNumber
+// ---------------------------------------------------------------------------
+
+describe('extractNumber', () => {
+  test('returns the numeric value when present', () => {
+    expect(extractNumber({ n: 42 }, 'n')).toBe(42)
+    expect(extractNumber({ n: 0 }, 'n')).toBe(0)
+    expect(extractNumber({ n: -3.14 }, 'n')).toBe(-3.14)
+  })
+
+  test('returns undefined for non-numeric values (no string coercion)', () => {
+    expect(extractNumber({ n: '42' }, 'n')).toBeUndefined()
+    expect(extractNumber({ n: 'forty-two' }, 'n')).toBeUndefined()
+    expect(extractNumber({ n: null }, 'n')).toBeUndefined()
+    expect(extractNumber({ n: true }, 'n')).toBeUndefined()
+    expect(extractNumber({ n: {} }, 'n')).toBeUndefined()
+  })
+
+  test('returns undefined when key is missing', () => {
+    expect(extractNumber({}, 'missing')).toBeUndefined()
+  })
+
+  test('preserves NaN as a number (typeof NaN === "number")', () => {
+    // CORRECTNESS: extractNumber uses typeof, which considers NaN a number.
+    // Callers must handle NaN themselves if they need finite-number semantics.
+    expect(extractNumber({ n: Number.NaN }, 'n')).toBeNaN()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractBoolean
+// ---------------------------------------------------------------------------
+
+describe('extractBoolean', () => {
+  test('returns the boolean value when present', () => {
+    expect(extractBoolean({ flag: true }, 'flag')).toBe(true)
+    expect(extractBoolean({ flag: false }, 'flag')).toBe(false)
+  })
+
+  test('coerces the strings "true" and "false" (case-insensitive, trimmed)', () => {
+    expect(extractBoolean({ flag: 'true' }, 'flag')).toBe(true)
+    expect(extractBoolean({ flag: 'false' }, 'flag')).toBe(false)
+    expect(extractBoolean({ flag: 'TRUE' }, 'flag')).toBe(true)
+    expect(extractBoolean({ flag: 'False' }, 'flag')).toBe(false)
+    expect(extractBoolean({ flag: '  true  ' }, 'flag')).toBe(true)
+    expect(extractBoolean({ flag: '\tFALSE\n' }, 'flag')).toBe(false)
+  })
+
+  test('returns undefined for strings that are not "true" or "false"', () => {
+    expect(extractBoolean({ flag: 'yes' }, 'flag')).toBeUndefined()
+    expect(extractBoolean({ flag: 'no' }, 'flag')).toBeUndefined()
+    expect(extractBoolean({ flag: '1' }, 'flag')).toBeUndefined()
+    expect(extractBoolean({ flag: '' }, 'flag')).toBeUndefined()
+  })
+
+  test('returns undefined for non-boolean non-string values (no coercion)', () => {
+    expect(extractBoolean({ flag: 1 }, 'flag')).toBeUndefined()
+    expect(extractBoolean({ flag: 0 }, 'flag')).toBeUndefined()
+    expect(extractBoolean({ flag: null }, 'flag')).toBeUndefined()
+    expect(extractBoolean({ flag: [] }, 'flag')).toBeUndefined()
+    expect(extractBoolean({ flag: {} }, 'flag')).toBeUndefined()
+  })
+
+  test('returns undefined when key is missing', () => {
+    expect(extractBoolean({}, 'missing')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes the two largest test coverage gaps in the plugin, adds a static drift gate that catches the category of regression that previously shipped unconverted or dangling references, and exposes two internal constants needed for direct testing.

No runtime behavior changes. CI-only gate + test additions + two one-line `const` → `export const` changes.

## What changed

### Content-integrity gate (`scripts/content-integrity.ts`)

Two invariants enforced against 147 markdown + 14 TypeScript source files:

1. **Reference integrity** — every `systematic:*` agent/skill reference in bundled assets resolves to a real file in `skills/` or `agents/`. Catches the class of drift that shipped dangling `systematic:research:slack-researcher` refs in v2.4.0 (the slack-researcher agent was added but the skills referencing it were updated without the dependency being verified).

2. **Banned patterns** — no unconverted CC/CEP strings (`Claude Code`, `compound-engineering:`, `.context/compound-engineering/`, `AskUserQuestion`, `CLAUDE.md`, `${CLAUDE_PLUGIN_ROOT}`) outside the documented allowlist. Catches the zsh word-split bug that silently shipped unconverted refs across 41 files in a prior batch conversion.

`scripts/.drift-allowlist.json` documents 4 intentional exemptions with rationale (claude-permissions-optimizer targets Claude Code intentionally; orchestrating-swarms is pending rewrite; converter.ts and skills.ts contain mapping tables for the conversion CLI).

Gate scans clean against the current repo (0 violations). **Not yet wired into CI** — that's a one-line follow-up (`bun scripts/content-integrity.ts` after tests in the build job).

### Test coverage

Fills coverage gaps on two previously untested modules:

| Module | Before | After |
|--------|--------|-------|
| `validation.ts` (9 exports) | 0 direct tests | 37 tests, 100% coverage |
| `bootstrap.ts` | 0 direct tests | 16 tests, 100% coverage |
| `content-integrity.ts` | new | 36 tests incl. real-repo smoke |
| **Total** | ~280 | **369 (+89)** |

`bootstrap.test.ts` covers injection behavior, the `INTERNAL_AGENT_SIGNATURES` skip heuristic (the fragile string-matching that suppresses system prompt injection for internal agents), and `TOOL_NAME_MAP` cross-consistency with the bootstrap template.

### Export changes

- `src/index.ts`: `INTERNAL_AGENT_SIGNATURES` promoted from `const` to `export const` (enables direct testing of the skip heuristic)
- `src/lib/converter.ts`: `TOOL_NAME_MAP` promoted from `const` to `export const` (enables cross-consistency test with bootstrap template)

Both are additive — no behavior change, no breaking API surface change.

## Files

| File | Change |
|------|--------|
| `scripts/content-integrity.ts` | New — drift gate |
| `scripts/.drift-allowlist.json` | New — exemption registry |
| `tests/unit/content-integrity.test.ts` | New — 36 gate tests |
| `tests/unit/validation.test.ts` | New — 37 validation tests |
| `tests/unit/bootstrap.test.ts` | New — 16 bootstrap tests |
| `src/index.ts` | `const` → `export const` for `INTERNAL_AGENT_SIGNATURES` |
| `src/lib/converter.ts` | `const` → `export const` for `TOOL_NAME_MAP` |
| `docs/plans/2026-04-18-001-feat-content-integrity-gate-plan.md` | Implementation plan (reference doc) |

---

> Built with [Systematic](https://github.com/marcusrbrown/systematic) · Target: v2.5.0