### PR TITLE
fix: address Fro Bot review non-blocking items (#302, #303)

### DIFF
--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -318,9 +318,9 @@ function buildAllowlistWarnings(
 function isBroadPathGlob(pathGlob: string): boolean {
   if (!pathGlob.endsWith('/**')) return false
   const prefix = pathGlob.slice(0, -3)
-  // A prefix is "specific" when it has at least one non-empty path segment
-  // (e.g., `skills/foo` is specific; `skills` alone is too broad because it
-  // exempts every skill).
+  // A prefix needs ≥ 2 non-empty path segments to be "specific".
+  // `skills/foo/**` (2 segments) is specific; `skills/**` (1 segment) is broad
+  // because it exempts every skill with a single entry.
   return prefix.split('/').filter((s) => s.length > 0).length < 2
 }
 

--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -1,4 +1,11 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from 'bun:test'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -260,6 +267,13 @@ describe('INTERNAL_AGENT_SIGNATURES skip heuristic', () => {
 // ---------------------------------------------------------------------------
 
 describe('TOOL_NAME_MAP / bootstrap template consistency', () => {
+  // Track temp dirs created by createTempBundledSkillsDir for cleanup.
+  const tempDirs: string[] = []
+  afterAll(() => {
+    for (const dir of tempDirs) {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
   /**
    * Extract all CC tool names from the left side of `→` arrows in the
    * "Tool Mapping for OpenCode" section of the bootstrap template.
@@ -345,6 +359,7 @@ describe('TOOL_NAME_MAP / bootstrap template consistency', () => {
     const dir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'systematic-bootstrap-consistency-'),
     )
+    tempDirs.push(dir)
     fs.mkdirSync(path.join(dir, 'skills', 'using-systematic'), {
       recursive: true,
     })

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -370,6 +370,37 @@ describe('loadAllowlist', () => {
       fs.rmSync(root, { recursive: true, force: true })
     }
   })
+
+  test('isBroadPathGlob: agents/** (1 segment) is broad; agents/research/** (2 segments) is not', () => {
+    // Pins the ≥2-segment threshold so a comment/code mismatch is caught immediately.
+    const root = makeFixtureRepo()
+    try {
+      writeAllowlist(root, [
+        {
+          pathGlob: 'agents/**',
+          patterns: ['Claude Code'],
+          reason:
+            'Broad glob covering all agents, intentionally broad for test.',
+        },
+        {
+          pathGlob: 'agents/research/**',
+          patterns: ['Claude Code'],
+          reason: 'Narrow glob covering only research agents for this test.',
+        },
+      ])
+      const scanned = ['agents/research/real-agent.md']
+      const { warnings } = loadAllowlist(root, scanned)
+      const broadWarnings = warnings.filter((w) => w.kind === 'broad-pathglob')
+      // agents/** → 1 segment → broad
+      expect(broadWarnings.some((w) => w.pathGlob === 'agents/**')).toBe(true)
+      // agents/research/** → 2 segments → specific
+      expect(
+        broadWarnings.some((w) => w.pathGlob === 'agents/research/**'),
+      ).toBe(false)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('checkReferenceIntegrity', () => {


### PR DESCRIPTION
Closes #302, closes #303.

## What changed

**`scripts/content-integrity.ts`**
- Corrected `isBroadPathGlob` JSDoc comment: the threshold is ≥ 2 non-empty path segments (not ≥ 1). Comment now matches the implementation: `skills/foo/**` (2 segments) is specific; `skills/**` (1 segment) is broad.

**`tests/unit/content-integrity.test.ts`**
- Added `isBroadPathGlob` segment-count threshold test: `agents/**` (1 segment) triggers `broad-pathglob` warning; `agents/research/**` (2 segments) does not. Pins the threshold so a future comment/code drift is caught immediately.

**`tests/unit/bootstrap.test.ts`**
- Added `const tempDirs: string[]` + `afterAll` cleanup to the `TOOL_NAME_MAP / bootstrap template consistency` describe block.
- Wired `tempDirs.push(dir)` inside `createTempBundledSkillsDir` so dirs created by both tests are actually removed after the suite.
- Added `afterAll` import from `bun:test`.