### PR TITLE
fix: restore single-export plugin entry point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,18 +2,13 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { Plugin } from '@opencode-ai/plugin'
-import { getBootstrapContent } from './lib/bootstrap.js'
+import {
+  getBootstrapContent,
+  INTERNAL_AGENT_SIGNATURES,
+} from './lib/bootstrap.js'
 import { loadConfig } from './lib/config.js'
 import { createConfigHandler } from './lib/config-handler.js'
 import { createSkillTool } from './lib/skill-tool.js'
-
-// Exported so tests can reconstruct the skip predicate without duplicating
-// the signatures. Consumers outside tests should not depend on this.
-export const INTERNAL_AGENT_SIGNATURES = [
-  'You are a title generator',
-  'You are a helpful AI assistant tasked with summarizing conversations',
-  'Summarize what was done in this conversation',
-]
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -4,6 +4,17 @@ import path from 'node:path'
 import type { SystematicConfig } from './config.js'
 import { parseFrontmatter } from './frontmatter.js'
 
+// Signatures used to identify OpenCode internal agents (title generator,
+// summarizer, etc.) so bootstrap injection can be skipped. Exported for
+// test access — must NOT be re-exported from the plugin entry point
+// (src/index.ts) because OpenCode's plugin loader expects a single function
+// export; additional named exports break loading.
+export const INTERNAL_AGENT_SIGNATURES = [
+  'You are a title generator',
+  'You are a helpful AI assistant tasked with summarizing conversations',
+  'Summarize what was done in this conversation',
+]
+
 export interface BootstrapDeps {
   bundledSkillsDir: string
 }

--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -9,8 +9,10 @@ import {
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { INTERNAL_AGENT_SIGNATURES } from '../../src/index.ts'
-import { getBootstrapContent } from '../../src/lib/bootstrap.ts'
+import {
+  getBootstrapContent,
+  INTERNAL_AGENT_SIGNATURES,
+} from '../../src/lib/bootstrap.ts'
 import { TOOL_NAME_MAP } from '../../src/lib/converter.ts'
 
 /**


### PR DESCRIPTION
## Summary

Plugin fails to load in OpenCode with `Plugin export is not a function` since v2.5.0. Downgrading to v2.4.1 works.

## Root cause

OpenCode's plugin loader expects the entry point (`dist/index.js`) to export only a single function — the plugin factory. The `INTERNAL_AGENT_SIGNATURES` named export added in v2.5.0 introduced an additional export that broke loading:

```js
// v2.4.1 (works)
export { src_default as default, SystematicPlugin }

// v2.5.0+ (breaks)
export { src_default as default, SystematicPlugin, INTERNAL_AGENT_SIGNATURES }
```

## Fix

Move `INTERNAL_AGENT_SIGNATURES` from `src/index.ts` to `src/lib/bootstrap.ts` — where the skip-heuristic logic lives semantically. `src/index.ts` imports the constant without re-exporting it. Tests import directly from the lib file.

After fix, `dist/index.js` exports match v2.4.1:
```js
export { src_default as default, SystematicPlugin }
```

## Verification

- Build ✅ — `dist/index.js` 18.25KB, only `['SystematicPlugin', 'default']` exported
- Node.js ESM smoke test ✅ — `typeof m.default === 'function'`
- Typecheck ✅
- Lint ✅
- 373 unit + 14 integration tests pass ✅