### PR TITLE
chore: housekeeping — close Fro Bot review issues #304 and #305

### DIFF
--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -289,14 +289,26 @@ describe('TOOL_NAME_MAP / bootstrap template consistency', () => {
    * The bootstrap prose and the converter map only partially overlap by design —
    * the bootstrap is instructional text, not a serialised TOOL_NAME_MAP.
    */
+  // Section heading used to locate the tool-mapping block in the bootstrap
+  // template. Must match the literal heading in src/lib/bootstrap.ts's
+  // getToolMappingTemplate(). If that heading changes, this must be updated.
+  const TOOL_MAPPING_HEADING = '**Tool Mapping for OpenCode:**'
+
+  // Matches the start of the NEXT bold markdown heading after the tool-mapping
+  // section. The negative lookahead (?!Tool Mapping) prevents matching the
+  // section's own heading if it appears in a self-referential context.
+  // A new bold heading starting with "Tool" (but not "Tool Mapping") will
+  // correctly terminate the section — the lookahead only exempts the exact
+  // phrase "Tool Mapping".
+  const NEXT_BOLD_HEADING_RE = /\n\*\*(?!Tool Mapping)/
+
   function extractCCToolNames(template: string): string[] {
-    // Isolate the "Tool Mapping for OpenCode:" section to avoid false-positive
-    // matches on unrelated `→` arrows elsewhere in the bootstrap content.
-    const sectionStart = template.indexOf('**Tool Mapping for OpenCode:**')
+    // Isolate the tool-mapping section to avoid false-positive matches on
+    // unrelated `→` arrows elsewhere in the bootstrap content.
+    const sectionStart = template.indexOf(TOOL_MAPPING_HEADING)
     if (sectionStart === -1) return []
     const rest = template.slice(sectionStart)
-    // Section ends at the next bold heading that is NOT "Tool Mapping"
-    const nextHeading = rest.search(/\n\*\*(?!Tool Mapping)/)
+    const nextHeading = rest.search(NEXT_BOLD_HEADING_RE)
     const section = nextHeading >= 0 ? rest.slice(0, nextHeading) : rest
 
     // For each bullet line, extract backtick-quoted tokens from the LHS of `→`.

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -181,6 +181,21 @@ describe('normalizePermission', () => {
     expect(normalizePermission({ task: {} })).toBeUndefined()
   })
 
+  test('returns undefined when a field is explicitly set to undefined', () => {
+    // FRAGILITY: `{ edit: undefined }` has 'edit' in the object (the `in`
+    // operator returns true), so extractSimplePermission does NOT take the
+    // "key absent" path. Instead it evaluates `isPermissionSetting(undefined)`
+    // → false → returns null → normalizePermission returns undefined for the
+    // entire config. An explicitly-undefined field poisons the whole config
+    // rather than being ignored. Same silent-undefined chain as the tests
+    // above. Changing this (e.g., treating explicit undefined as "absent")
+    // must update this test intentionally.
+    expect(normalizePermission({ edit: undefined })).toBeUndefined()
+    expect(
+      normalizePermission({ edit: 'ask', webfetch: undefined }),
+    ).toBeUndefined()
+  })
+
   test('mixes simple fields and bash map in one config', () => {
     expect(
       normalizePermission({


### PR DESCRIPTION
## Summary

- **#305**: Add test for `normalizePermission({ edit: undefined })` — documents that an explicitly-undefined field poisons the entire config via the `extractSimplePermission` → `isPermissionSetting` → `null` chain (same FRAGILITY pattern as existing malformed-value tests).
- **#304**: Extract `TOOL_MAPPING_HEADING` and `NEXT_BOLD_HEADING_RE` from inline literals to named constants with explanatory JSDoc documenting the coupling to `bootstrap.ts` and the negative-lookahead boundary behavior.
- **#227, #231, #239**: GitHub API rate-limited — will be closed separately with reference to PR #290.

## Testing

| Check | Result |
|-------|--------|
| Build | ✅ 18.25KB + 46.74KB + 4.96KB |
| Typecheck | ✅ |
| Lint | ✅ |
| Unit tests | ✅ 374/374 (was 373 — +1 new validation test) |
| Node.js ESM smoke | ✅ |

No source code changes — test files only.