### PR TITLE
fix(ci): fix Playwright install in docs deployment workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -40,7 +40,8 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install Playwright Chromium
-        run: bun --cwd docs x playwright install --with-deps chromium
+        run: bun playwright install --with-deps chromium
+        working-directory: docs
 
       - name: Generate reference content
         run: bun run docs:generate


### PR DESCRIPTION
## Summary

The docs deployment workflow (`docs.yaml`) uses `bun --cwd docs x playwright install` which fails because `bun x` is not a valid subcommand — bun interprets `x` as a script name and errors with `Script not found "x"`.

Aligns the Playwright install command with the already-correct version in `main.yaml`: `bun playwright install --with-deps chromium` with `working-directory: docs`.

After merge, re-run the Docs workflow via `workflow_dispatch` to deploy the v2.5.2 docs that failed.