### PR TITLE
ci: wire content-integrity gate into build pipeline

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,6 +59,9 @@ jobs:
             console.log('Plugin loaded: ' + agents + ' agents, ' + commands + ' commands, tool: ' + (typeof plugin.tool.systematic_skill.execute));
           "
 
+      - name: Content integrity gate
+        run: bun scripts/content-integrity.ts
+
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds the content-integrity gate (`scripts/content-integrity.ts`) as a CI step in the build job. The gate enforces two invariants on every push and PR:

1. **Reference integrity** — every `systematic:<category>:<name>` dispatch directive in bundled skills and agents resolves to an actual file under `agents/`.
2. **Banned-pattern scan** — CC/CEP strings (branding, tool names, paths, env vars) only appear inside documented allowlist entries.

Failures block the release pipeline. The gate scans `skills/**/*.md`, `agents/**/*.md`, and `src/**/*.ts` — exemptions are maintained in `scripts/.drift-allowlist.json`.

The script has existed since v2.5.0 (PR #301) and runs clean locally — this PR wires it into CI so violations are caught automatically.

## What this would have caught

- The zsh word-split bug (v2.4.0) that shipped ~200 unconverted CC/CEP refs across 41 files
- The phantom `systematic:research:slack-researcher` dispatch refs in `ce-brainstorm`, `ce-ideate`, `ce-plan`