### PR TITLE
docs: update AGENTS.md hierarchy with current counts and code map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md - Coding Agent Guidelines for Systematic
 
-**Generated:** 2026-03-22 | **Commit:** 500b805 | **Branch:** main
+**Generated:** 2026-04-25 | **Commit:** 7a64113 | **Branch:** main
 
 ## Overview
 
@@ -17,7 +17,7 @@ bun install              # Install deps
 bun run build            # Build to dist/
 bun run typecheck        # Type check (strict)
 bun run lint             # Biome linter
-bun test tests/unit      # Unit tests (11 files)
+bun test tests/unit      # Unit tests (14 files)
 bun test tests/integration  # Integration tests (2 files)
 bun test                 # All tests
 bun test --filter "pattern"  # Filter tests
@@ -31,7 +31,7 @@ bun run registry:validate  # Validate registry without building
 ## Stack
 
 - **Runtime:** Bun (Node.js API compatible)
-- **Language:** TypeScript 5.7+ strict mode
+- **Language:** TypeScript 6.x strict mode
 - **Modules:** ESM (`"type": "module"`)
 - **Linter:** Biome (not ESLint/Prettier)
 - **Tests:** `bun:test`
@@ -53,10 +53,10 @@ systematic/
 │   ├── scripts/          # Content generation from bundled assets
 │   └── src/content/      # Manual guides + generated reference
 ├── registry/             # OCX registry config + profiles (omo, standalone)
-├── scripts/              # Build scripts (build-registry.ts)
+├── scripts/              # Build + integrity scripts
 ├── assets/               # Static assets (banner SVG)
 ├── tests/
-│   ├── unit/             # 11 test files
+│   ├── unit/             # 14 test files
 │   └── integration/      # 2 test files
 ├── .opencode/            # Project-specific OC config + commands
 │   └── commands/         # Project-only commands (generate-readme)
@@ -82,6 +82,7 @@ systematic/
 | Add new skill | `skills/<name>/SKILL.md` |
 | Add new agent | `agents/<category>/<name>.md` |
 | OCX registry building | `scripts/build-registry.ts` |
+| Content integrity gate | `scripts/content-integrity.ts` |
 | Docs content generation | `docs/scripts/transform-content.ts` |
 | Docs site config | `docs/astro.config.mjs` |
 
@@ -89,12 +90,14 @@ systematic/
 
 | Symbol | Type | Location | Refs | Role |
 |--------|------|----------|------|------|
-| `SystematicPlugin` | export | src/index.ts:47 | 2 | Main plugin factory |
-| `createConfigHandler` | fn | src/lib/config-handler.ts:215 | 3 | Config hook — merges bundled assets |
-| `createSkillTool` | fn | src/lib/skill-tool.ts:87 | 3 | systematic_skill tool factory |
-| `getBootstrapContent` | fn | src/lib/bootstrap.ts:32 | 3 | System prompt injection |
-| `convertContent` | fn | src/lib/converter.ts:371 | 4 | CC→OpenCode body conversion |
-| `convertFileWithCache` | fn | src/lib/converter.ts:411 | 6 | Cached file conversion (mtime invalidation) |
+| `SystematicPlugin` | export | src/index.ts:44 | 2 | Main plugin factory |
+| `createConfigHandler` | fn | src/lib/config-handler.ts:221 | 3 | Config hook — merges bundled assets |
+| `createSkillTool` | fn | src/lib/skill-tool.ts:88 | 3 | systematic_skill tool factory |
+| `getBootstrapContent` | fn | src/lib/bootstrap.ts:43 | 3 | System prompt injection |
+| `INTERNAL_AGENT_SIGNATURES` | const | src/lib/bootstrap.ts:12 | 2 | Skip heuristic for internal agents |
+| `convertContent` | fn | src/lib/converter.ts:373 | 4 | CC→OpenCode body conversion |
+| `convertFileWithCache` | fn | src/lib/converter.ts:413 | 6 | Cached file conversion (mtime invalidation) |
+| `TOOL_NAME_MAP` | const | src/lib/converter.ts:85 | 2 | CC→OC tool name lookup |
 | `findSkillsInDir` | fn | src/lib/skills.ts:90 | 6 | Skill discovery (highest centrality) |
 | `findAgentsInDir` | fn | src/lib/agents.ts:49 | 4 | Agent discovery (category from subdir) |
 | `findCommandsInDir` | fn | src/lib/commands.ts:27 | 4 | Command discovery |
@@ -151,6 +154,7 @@ The `commands/` directory contains only `.gitkeep` (all commands converted to sk
 
 ## Notes
 
+- Content-integrity gate runs in CI (build job) — catches phantom `systematic:*` refs and banned CC/CEP patterns
 - Bootstrap injection is opt-out via `bootstrap.enabled: false`
 - Converter caches results using file mtime
 - CLI commands: `list` (skills/agents/commands), `convert` (file conversion), `config show/path`

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -33,8 +33,8 @@ docs/
 │       ├── getting-started/  # 2 manual pages (installation, configuration)
 │       ├── guides/           # 7 manual pages (philosophy, main-loop, agent-install, architecture, conversion-guide, ocx-registry, exemplary-checklist)
 │       └── reference/        # Generated — DO NOT EDIT
-│           ├── skills/       # 48 pages + index.mdx (generated from skills/)
-│           └── agents/       # 29 pages + index.mdx (generated from agents/)
+│           ├── skills/       # 45 pages + index.mdx (generated from skills/)
+│           └── agents/       # 50 pages + index.mdx (generated from agents/)
 └── package.json
 ```
 
@@ -49,9 +49,9 @@ docs/
 
 Pipeline: `read file → parseFrontmatter → transformFrontmatter (name→title, agent category→badge) → generatePage → write`
 
-Each run cleans output dirs before regenerating. Index pages (`index.mdx`) are dynamically generated from the same enumerated entries using Starlight `CardGrid`/`LinkCard` components. Agents are grouped by category (design/docs/research/review/workflow). Slug collisions abort with error.
+Each run cleans output dirs before regenerating. Index pages (`index.mdx`) are dynamically generated from the same enumerated entries using Starlight `CardGrid`/`LinkCard` components. Agents are grouped by category (design/docs/document-review/research/review/workflow). Slug collisions abort with error.
 
-NOTE: `commands/` is empty (all commands converted to skills in upstream CEP sync). The generation script may still have command handling code but produces no command pages from current source.
+NOTE: `commands/` is empty (all commands converted to skills). The generation script may still have command handling code but produces no command pages from current source.
 
 ## Where to Look
 

--- a/src/lib/AGENTS.md
+++ b/src/lib/AGENTS.md
@@ -33,7 +33,7 @@ All discovery follows same pattern: `dir → walkDir() → find files → parseF
 
 | Module | Key Exports | Role |
 |--------|-------------|------|
-| `converter.ts` | `convertContent`, `convertFileWithCache`, `clearConverterCache` | CEP→OpenCode transforms (tool names, models, body refs) |
+| `converter.ts` | `convertContent`, `convertFileWithCache`, `clearConverterCache`, `TOOL_NAME_MAP` | CEP→OpenCode transforms (tool names, models, body refs) |
 | `skill-loader.ts` | `loadSkill`, `LoadedSkill`, `SKILL_PREFIX` | Loads + wraps skill content in XML template |
 | `validation.ts` | `isAgentMode`, `isPermissionSetting`, `normalizePermission`, `extractString`, `extractBoolean` | Agent config extraction + type guards + safe value extraction |
 
@@ -44,7 +44,7 @@ All discovery follows same pattern: `dir → walkDir() → find files → parseF
 | `config.ts` | `loadConfig`, `getConfigPaths`, `SystematicConfig`, `DEFAULT_CONFIG` | JSONC config loading + merging |
 | `config-handler.ts` | `createConfigHandler`, `ConfigHandlerDeps`, `formatAgentDescription`, `toTitleCase` | OpenCode config hook (collects + converts all assets) |
 | `skill-tool.ts` | `createSkillTool`, `SkillToolOptions` | `systematic_skill` tool (XML description, skill execution) |
-| `bootstrap.ts` | `getBootstrapContent`, `BootstrapDeps` | System prompt injection (using-systematic skill) |
+| `bootstrap.ts` | `getBootstrapContent`, `INTERNAL_AGENT_SIGNATURES`, `BootstrapDeps` | System prompt injection (using-systematic skill) |
 
 ## Key Types
 


### PR DESCRIPTION
## Summary

Updates all three AGENTS.md files in the project hierarchy to reflect current state after v2.5.x changes.

### Root AGENTS.md
- Test file count: 11 → 14 (added validation, bootstrap, content-integrity tests)
- TypeScript version: 5.7+ → 6.x
- Code map: line numbers updated from LSP, added `INTERNAL_AGENT_SIGNATURES` and `TOOL_NAME_MAP` entries
- Where to Look: added content-integrity gate (`scripts/content-integrity.ts`)
- Notes: added CI enforcement note for content-integrity gate
- Scripts description: "Build scripts" → "Build + integrity scripts"
- Generated timestamp and commit hash updated

### docs/AGENTS.md
- Skills reference pages: 48 → 45
- Agents reference pages: 29 → 50
- Agent category list: added missing `document-review`
- Removed stale CEP sync reference

### src/lib/AGENTS.md
- `converter.ts` exports: added `TOOL_NAME_MAP`
- `bootstrap.ts` exports: added `INTERNAL_AGENT_SIGNATURES`