### PR TITLE
test(manual): add Phase 0 probe templates for empirical hypothesis validation

### DIFF
--- a/tests/manual/companion-aware-probe.ts
+++ b/tests/manual/companion-aware-probe.ts
@@ -1,0 +1,335 @@
+/**
+ * Phase 0 validation probe for the companion-aware skill composition design.
+ *
+ * Goal: empirically verify that appending a `companion-magic-context.md` section
+ * to the `ce:work` skill body causes the LLM to invoke companion tools
+ * (`ctx_memory`, `ctx_search`, `ctx_note`) at workflow boundaries materially
+ * more often than the same skill body without the companion section.
+ *
+ * Pass criterion (per docs/brainstorms/2026-04-27-companion-aware-skills-requirements.md):
+ *   Condition B (with companion content): ctx_memory invoked at the unit-completion
+ *     boundary in at least 4 of 5 sessions.
+ *   Condition A (without companion content): ctx_memory invoked at the same
+ *     boundary in at most 1 of 5 sessions.
+ *   The gap proves the companion content (not baseline behavior) drives the change.
+ *
+ * Run: bun tests/manual/companion-aware-probe.ts
+ *
+ * Requires: opencode CLI on PATH.
+ */
+
+import { type ChildProcess, spawn } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createOpencodeClient } from '@opencode-ai/sdk'
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+)
+const MODEL = 'opencode/big-pickle'
+const [PROVIDER_ID, MODEL_ID] = MODEL.split('/')
+const SESSIONS_PER_CONDITION = 5
+
+// Companion content draft (the V1 candidate). If the probe passes, this is the
+// starting point for skills/ce-work/companions/magic-context.md.
+const COMPANION_CONTENT = `## Companion: magic-context (when installed)
+
+The magic-context plugin provides cross-session memory tools. Use them at workflow boundaries to preserve state across compactions and session resumes.
+
+### At every unit boundary
+After marking a unit complete and before starting the next, snapshot progress:
+
+  ctx_memory(action="write", category="WORKFLOW_STATE",
+    content="ce:work session: branch=<branch>, plan=<plan-path>, completed=[<units>], current=<next-unit>, deferred=[<items>]")
+
+### At session start
+Before resuming work, check for prior state on this branch:
+
+  ctx_search(query="ce:work session: branch <branch-name>", sources=["memory"], limit=1)
+
+If a snapshot is found, summarize it for the user before proceeding.
+
+### When the user defers an item
+Record as a smart note (not just a local todo):
+
+  ctx_note(action="write", content="<item>", surface_condition="<when to resurface>")
+
+### Graceful degradation
+If these tools are unavailable, skip the calls and continue normally.`
+
+// Minimal extract of ce:work SKILL.md. Using a representative excerpt rather
+// than the full ~340-line file keeps the probe prompt focused on the unit-
+// boundary moment without diluting the signal in unrelated guidance.
+const CE_WORK_SKILL_BODY = `# Work Execution Command
+
+Execute work efficiently while maintaining quality and finishing features.
+
+## Execution Workflow
+
+You are running a multi-unit ce:work session. For each unit:
+
+1. Read the unit definition from the plan
+2. Implement the unit (TDD-first when behavior changes)
+3. Verify quality gates: build, typecheck, lint, tests
+4. Mark the unit complete in the plan
+5. Brief the user on what was done and what comes next
+6. Proceed to the next unit
+
+Maintain the user's todo list throughout. When the user defers an item ("park this", "later", "follow-up"), record it.`
+
+const TRIGGER_PROMPT = `I just finished Unit 1 of the attached two-unit plan (refactored \`parseConfig\` into pure helpers; build/typecheck/lint/tests all green; committed as \`refactor(config): split parseConfig into pure helpers\` on branch \`feat/parse-config-refactor\`). Plan path is \`docs/plans/2026-04-27-001-refactor-parse-config-plan.md\`. Mark Unit 1 complete and prepare to start Unit 2 (add property-based tests for the new helpers).`
+
+interface SessionResult {
+  condition: 'A' | 'B'
+  sessionLabel: string
+  ctxMemoryCalls: number
+  ctxSearchCalls: number
+  ctxNoteCalls: number
+  errored: boolean
+  error?: string
+}
+
+interface ConditionSummary {
+  condition: 'A' | 'B'
+  sessions: SessionResult[]
+  unitBoundaryHits: number // sessions where ctx_memory was called at least once
+}
+
+async function startServer(env: NodeJS.ProcessEnv): Promise<{
+  server: ChildProcess
+  serverUrl: string
+}> {
+  const server = spawn('opencode', ['serve', '--port', '0', '--print-logs'], {
+    env: { ...process.env, ...env },
+    cwd: REPO_ROOT,
+  })
+  const serverUrl = await new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error('Server start timed out (10s)')),
+      10_000,
+    )
+    let buf = ''
+    const onChunk = (chunk: Buffer) => {
+      buf += chunk.toString()
+      const match = buf.match(/(http:\/\/[\d.:]+)/)
+      if (match) {
+        clearTimeout(timeout)
+        resolve(match[1])
+      }
+    }
+    server.stdout?.on('data', onChunk)
+    server.stderr?.on('data', onChunk)
+    server.on('error', reject)
+    server.on('exit', (code) => {
+      if (code !== null && code !== 0) {
+        reject(
+          new Error(`Server exited early code=${code} buf=${buf.slice(-500)}`),
+        )
+      }
+    })
+  })
+  return { server, serverUrl }
+}
+
+async function runOneSession(args: {
+  serverUrl: string
+  projectDir: string
+  skillBody: string
+  condition: 'A' | 'B'
+  sessionLabel: string
+  logFile: string
+}): Promise<SessionResult> {
+  const { serverUrl, projectDir, skillBody, condition, sessionLabel, logFile } =
+    args
+
+  const client = createOpencodeClient({
+    baseUrl: serverUrl,
+    directory: projectDir,
+  })
+
+  const result: SessionResult = {
+    condition,
+    sessionLabel,
+    ctxMemoryCalls: 0,
+    ctxSearchCalls: 0,
+    ctxNoteCalls: 0,
+    errored: false,
+  }
+
+  const linesBefore = fs.existsSync(logFile)
+    ? fs.readFileSync(logFile, 'utf8').split('\n').filter(Boolean).length
+    : 0
+
+  try {
+    const created = await client.session.create({
+      body: { title: `probe-${condition}-${sessionLabel}` },
+    })
+    const sessionID = (created.data as { id?: string } | undefined)?.id ?? ''
+    if (!sessionID)
+      throw new Error(
+        `session.create returned no id: ${JSON.stringify(created)}`,
+      )
+
+    // First message: deliver the skill body as standing instructions.
+    await client.session.prompt({
+      path: { id: sessionID },
+      body: {
+        model: { providerID: PROVIDER_ID, modelID: MODEL_ID },
+        parts: [
+          {
+            type: 'text',
+            text: `Standing instructions for this session (treat as your operating manual):\n\n${skillBody}\n\nAcknowledge in one short sentence.`,
+          },
+        ],
+      },
+    })
+
+    // Second message: the unit-completion trigger.
+    await client.session.prompt({
+      path: { id: sessionID },
+      body: {
+        model: { providerID: PROVIDER_ID, modelID: MODEL_ID },
+        parts: [{ type: 'text', text: TRIGGER_PROMPT }],
+      },
+    })
+  } catch (err) {
+    result.errored = true
+    result.error = err instanceof Error ? err.message : String(err)
+  }
+
+  // Count tool invocations attributed to this session via the log.
+  const linesAfter = fs.existsSync(logFile)
+    ? fs.readFileSync(logFile, 'utf8').split('\n').filter(Boolean)
+    : []
+  const newLines = linesAfter.slice(linesBefore)
+  for (const line of newLines) {
+    try {
+      const entry = JSON.parse(line) as {
+        tool: string
+        condition: string
+        session_label: string
+      }
+      if (entry.condition !== condition || entry.session_label !== sessionLabel)
+        continue
+      if (entry.tool === 'ctx_memory') result.ctxMemoryCalls += 1
+      if (entry.tool === 'ctx_search') result.ctxSearchCalls += 1
+      if (entry.tool === 'ctx_note') result.ctxNoteCalls += 1
+    } catch {
+      // skip malformed lines
+    }
+  }
+
+  return result
+}
+
+async function runCondition(args: {
+  condition: 'A' | 'B'
+  skillBody: string
+  logFile: string
+}): Promise<ConditionSummary> {
+  const { condition, skillBody, logFile } = args
+
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), `companion-probe-${condition}-`),
+  )
+  const projectDir = path.join(tempDir, 'project')
+  fs.mkdirSync(projectDir, { recursive: true })
+
+  const probeToolsPlugin = `file://${path.join(REPO_ROOT, 'tests/manual/probe-companion-tools.ts')}`
+  const opencodeConfig = JSON.stringify({ plugin: [probeToolsPlugin] })
+
+  const sessions: SessionResult[] = []
+
+  for (let i = 0; i < SESSIONS_PER_CONDITION; i += 1) {
+    const sessionLabel = `s${i + 1}`
+    const env: NodeJS.ProcessEnv = {
+      OPENCODE_CONFIG_CONTENT: opencodeConfig,
+      PROBE_TOOL_LOG: logFile,
+      PROBE_CONDITION: condition,
+      PROBE_SESSION_LABEL: sessionLabel,
+    }
+    const { server, serverUrl } = await startServer(env)
+    try {
+      const result = await runOneSession({
+        serverUrl,
+        projectDir,
+        skillBody,
+        condition,
+        sessionLabel,
+        logFile,
+      })
+      sessions.push(result)
+      console.log(
+        `[probe ${condition}/${sessionLabel}] ctx_memory=${result.ctxMemoryCalls} ctx_search=${result.ctxSearchCalls} ctx_note=${result.ctxNoteCalls}${result.errored ? ` err=${result.error}` : ''}`,
+      )
+    } finally {
+      server.kill('SIGTERM')
+      await new Promise((r) => setTimeout(r, 400))
+    }
+  }
+
+  const unitBoundaryHits = sessions.filter((s) => s.ctxMemoryCalls > 0).length
+  return { condition, sessions, unitBoundaryHits }
+}
+
+const logFile = path.join(
+  os.tmpdir(),
+  `companion-probe-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.log`,
+)
+console.log(`[probe] log file: ${logFile}`)
+
+const conditionA = await runCondition({
+  condition: 'A',
+  skillBody: CE_WORK_SKILL_BODY,
+  logFile,
+})
+
+const conditionB = await runCondition({
+  condition: 'B',
+  skillBody: `${CE_WORK_SKILL_BODY}\n\n---\n\n${COMPANION_CONTENT}`,
+  logFile,
+})
+
+console.log('\n=== PROBE SUMMARY ===')
+console.log(
+  `Condition A (no companion): ${conditionA.unitBoundaryHits}/${SESSIONS_PER_CONDITION} sessions called ctx_memory`,
+)
+console.log(
+  `Condition B (with companion): ${conditionB.unitBoundaryHits}/${SESSIONS_PER_CONDITION} sessions called ctx_memory`,
+)
+
+console.log('\nPer-session ctx_memory calls:')
+console.log(
+  `  A: ${conditionA.sessions.map((s) => s.ctxMemoryCalls).join(', ')}`,
+)
+console.log(
+  `  B: ${conditionB.sessions.map((s) => s.ctxMemoryCalls).join(', ')}`,
+)
+
+const passed =
+  conditionB.unitBoundaryHits >= 4 && conditionA.unitBoundaryHits <= 1
+
+if (passed) {
+  console.log(
+    '\n[verdict] PASS — companion content materially drives ctx_memory invocation.',
+  )
+  console.log('         Proceed with V1 design as scoped (ce:plan).')
+  process.exit(0)
+} else if (conditionB.unitBoundaryHits >= 4) {
+  console.log('\n[verdict] AMBIGUOUS — both conditions invoke ctx_memory.')
+  console.log(
+    '         Baseline model behavior may be sufficient. Reconsider whether companion content is needed for ce:work specifically.',
+  )
+  process.exit(2)
+} else {
+  console.log(
+    '\n[verdict] FAIL — companion content does not drive measurable change.',
+  )
+  console.log(
+    '         Pivot options: stronger guidance language (re-probe), system-prompt injection via experimental.chat.system.transform, or abandon companion-aware composition.',
+  )
+  process.exit(1)
+}

--- a/tests/manual/companion-aware-probe.ts
+++ b/tests/manual/companion-aware-probe.ts
@@ -15,7 +15,9 @@
  *
  * Run: bun tests/manual/companion-aware-probe.ts
  *
- * Requires: opencode CLI on PATH.
+ * Requires: opencode CLI on PATH (recent enough to support `serve
+ * --print-logs`; older versions silently ignore the flag and the probe times
+ * out without a useful error).
  */
 
 import { type ChildProcess, spawn } from 'node:child_process'
@@ -159,19 +161,17 @@ async function runOneSession(args: {
     errored: false,
   }
 
-  const linesBefore = fs.existsSync(logFile)
-    ? fs.readFileSync(logFile, 'utf8').split('\n').filter(Boolean).length
-    : 0
-
   try {
     const created = await client.session.create({
       body: { title: `probe-${condition}-${sessionLabel}` },
     })
-    const sessionID = (created.data as { id?: string } | undefined)?.id ?? ''
-    if (!sessionID)
+    const createdData = created.data as { id?: string } | undefined
+    if (!createdData?.id) {
       throw new Error(
         `session.create returned no id: ${JSON.stringify(created)}`,
       )
+    }
+    const sessionID = createdData.id
 
     // First message: deliver the skill body as standing instructions.
     await client.session.prompt({
@@ -200,12 +200,15 @@ async function runOneSession(args: {
     result.error = err instanceof Error ? err.message : String(err)
   }
 
-  // Count tool invocations attributed to this session via the log.
-  const linesAfter = fs.existsSync(logFile)
+  // Count tool invocations attributed to this session via the log. The
+  // per-entry condition + session_label filter below is the sole correctness
+  // mechanism; we do not slice on log offset because (a) the filter already
+  // ignores entries from other sessions, and (b) any offset snapshot is
+  // racy against asynchronous appendFileSync calls from prior sessions.
+  const allLines = fs.existsSync(logFile)
     ? fs.readFileSync(logFile, 'utf8').split('\n').filter(Boolean)
     : []
-  const newLines = linesAfter.slice(linesBefore)
-  for (const line of newLines) {
+  for (const line of allLines) {
     try {
       const entry = JSON.parse(line) as {
         tool: string
@@ -266,8 +269,10 @@ async function runCondition(args: {
         `[probe ${condition}/${sessionLabel}] ctx_memory=${result.ctxMemoryCalls} ctx_search=${result.ctxSearchCalls} ctx_note=${result.ctxNoteCalls}${result.errored ? ` err=${result.error}` : ''}`,
       )
     } finally {
-      server.kill('SIGTERM')
-      await new Promise((r) => setTimeout(r, 400))
+      await new Promise<void>((resolve) => {
+        server.once('close', () => resolve())
+        server.kill('SIGTERM')
+      })
     }
   }
 

--- a/tests/manual/probe-companion-tools.ts
+++ b/tests/manual/probe-companion-tools.ts
@@ -1,0 +1,89 @@
+/**
+ * Stub plugin used by tests/manual/companion-aware-probe.ts.
+ *
+ * Registers `ctx_memory`, `ctx_search`, and `ctx_note` as no-op tools that
+ * append a structured log entry per invocation. The probe runner counts
+ * lines in the log to compare invocation rates between conditions.
+ */
+
+import fs from 'node:fs'
+import type { Plugin } from '@opencode-ai/plugin'
+import { tool } from '@opencode-ai/plugin/tool'
+
+const logFile = process.env.PROBE_TOOL_LOG
+if (!logFile) {
+  throw new Error('PROBE_TOOL_LOG env var must be set')
+}
+
+const condition = process.env.PROBE_CONDITION ?? 'unknown'
+const sessionLabel = process.env.PROBE_SESSION_LABEL ?? '?'
+
+function logCall(name: string, args: unknown): void {
+  const line = JSON.stringify({
+    ts: new Date().toISOString(),
+    tool: name,
+    condition,
+    session_label: sessionLabel,
+    args: JSON.stringify(args).slice(0, 400),
+  })
+  fs.appendFileSync(logFile, line + '\n')
+}
+
+const ProbeCompanionTools: Plugin = async () => {
+  return {
+    tool: {
+      ctx_memory: tool({
+        description:
+          'Manage cross-session project memories. Write or delete entries by category.',
+        args: {
+          action: tool.schema
+            .enum(['write', 'delete'])
+            .describe('write to add a memory; delete to remove by id'),
+          category: tool.schema
+            .string()
+            .optional()
+            .describe('Memory category, e.g. WORKFLOW_STATE'),
+          content: tool.schema.string().optional().describe('Memory content'),
+          id: tool.schema.number().optional().describe('Memory ID for delete'),
+        },
+        async execute(args) {
+          logCall('ctx_memory', args)
+          return JSON.stringify({ ok: true, id: 1 })
+        },
+      }),
+      ctx_search: tool({
+        description:
+          'Search across project memories, session facts, and conversation history.',
+        args: {
+          query: tool.schema.string().describe('Search query'),
+          sources: tool.schema
+            .array(tool.schema.enum(['memory', 'message', 'git_commit']))
+            .optional(),
+          limit: tool.schema.number().optional(),
+        },
+        async execute(args) {
+          logCall('ctx_search', args)
+          return JSON.stringify({ results: [] })
+        },
+      }),
+      ctx_note: tool({
+        description:
+          'Save or inspect durable session notes that persist for this session.',
+        args: {
+          action: tool.schema
+            .enum(['write', 'read', 'dismiss', 'update'])
+            .optional(),
+          content: tool.schema.string().optional(),
+          surface_condition: tool.schema.string().optional(),
+          note_id: tool.schema.number().optional(),
+        },
+        async execute(args) {
+          logCall('ctx_note', args)
+          return JSON.stringify({ ok: true })
+        },
+      }),
+    },
+  }
+}
+
+export default ProbeCompanionTools

--- a/tests/manual/probe-companion-tools.ts
+++ b/tests/manual/probe-companion-tools.ts
@@ -26,10 +26,10 @@ function logCall(name: string, args: unknown): void {
     session_label: sessionLabel,
     args: JSON.stringify(args).slice(0, 400),
   })
-  fs.appendFileSync(logFile, line + '\n')
+  fs.appendFileSync(logFile, `${line}\n`)
 }
 
-const ProbeCompanionTools: Plugin = async () => {
+export const probeCompanionTools: Plugin = async () => {
   return {
     tool: {
       ctx_memory: tool({
@@ -86,4 +86,4 @@ const ProbeCompanionTools: Plugin = async () => {
   }
 }
 
-export default ProbeCompanionTools
+export default probeCompanionTools

--- a/tests/manual/session-compacting-probe.ts
+++ b/tests/manual/session-compacting-probe.ts
@@ -1,5 +1,5 @@
 /**
- * Phase 0 OQ-1 validation probe for the experimental.session.compacting hook.
+ * Phase 0 validation probe for the experimental.session.compacting hook.
  *
  * Goal: determine whether content appended to `output.context` actually survives
  * OpenCode's compactor LLM. The probe injects a marker string and triggers a
@@ -8,8 +8,26 @@
  *
  * Run: bun tests/manual/session-compacting-probe.ts
  *
- * Requires: opencode CLI on PATH, `bun run build` already executed,
- * SYSTEMATIC_PROBE_LOG file path will be set automatically.
+ * Requires:
+ *   - opencode CLI on PATH (recent enough to support `serve --print-logs`;
+ *     older versions silently ignore the flag and the probe times out without
+ *     a useful error).
+ *   - `bun run build` already executed.
+ *
+ * External instrumentation dependency:
+ *   The hookFired / HOOK_FIRED logic below counts occurrences of the literal
+ *   string `HOOK_FIRED` in the SYSTEMATIC_PROBE_LOG file. Nothing in the
+ *   shipped plugin emits that token — when this probe was originally run, a
+ *   temporary stub was added to `src/index.ts` that implemented the
+ *   `experimental.session.compacting` hook and called
+ *   `fs.appendFileSync(process.env.SYSTEMATIC_PROBE_LOG, 'HOOK_FIRED\n')`
+ *   inside the hook. That stub was reverted before commit. Future probe
+ *   authors who need the hookFired signal must reintroduce equivalent
+ *   instrumentation (either in `src/index.ts` for the duration of the run
+ *   or in a probe-side stub plugin loaded via OPENCODE_CONFIG_CONTENT).
+ *   Without that instrumentation, hookFired is always false and the verdict
+ *   logic routes all marker-absent failures through the "HOOK DID NOT FIRE"
+ *   branch.
  */
 
 import { spawn } from 'node:child_process'
@@ -156,8 +174,11 @@ async function runProbe(): Promise<ProbeResult> {
     // end of the stream. Scan ALL messages for our marker.
     const allText = messages
       .flatMap((m) => m.parts ?? [])
-      .filter((p) => p.type === 'text' && typeof p.text === 'string')
-      .map((p) => p.text as string)
+      .filter(
+        (p): p is { type: 'text'; text: string } =>
+          p.type === 'text' && typeof p.text === 'string',
+      )
+      .map((p) => p.text)
       .join('\n---\n')
 
     summaryText = allText
@@ -181,8 +202,10 @@ async function runProbe(): Promise<ProbeResult> {
       `probe error: ${err instanceof Error ? err.message : String(err)}`,
     )
   } finally {
-    server.kill('SIGTERM')
-    await new Promise((r) => setTimeout(r, 500))
+    await new Promise<void>((resolve) => {
+      server.once('close', () => resolve())
+      server.kill('SIGTERM')
+    })
   }
 
   // Inspect the probe log.

--- a/tests/manual/session-compacting-probe.ts
+++ b/tests/manual/session-compacting-probe.ts
@@ -1,0 +1,231 @@
+/**
+ * Phase 0 OQ-1 validation probe for the experimental.session.compacting hook.
+ *
+ * Goal: determine whether content appended to `output.context` actually survives
+ * OpenCode's compactor LLM. The probe injects a marker string and triggers a
+ * real compaction via the SDK summarize endpoint, then inspects the post-
+ * compaction message stream for the marker.
+ *
+ * Run: bun tests/manual/session-compacting-probe.ts
+ *
+ * Requires: opencode CLI on PATH, `bun run build` already executed,
+ * SYSTEMATIC_PROBE_LOG file path will be set automatically.
+ */
+
+import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createOpencodeClient } from '@opencode-ai/sdk'
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+)
+const MODEL = 'opencode/big-pickle'
+const [PROVIDER_ID, MODEL_ID] = MODEL.split('/')
+
+interface ProbeResult {
+  hookFired: boolean
+  hookFiredCount: number
+  markerInjected: string | null
+  markerInSummary: 'verbatim' | 'paraphrased' | 'absent'
+  markerOccurrences: number
+  summaryText: string
+  notes: string[]
+}
+
+async function runProbe(): Promise<ProbeResult> {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'systematic-probe-'))
+  const projectDir = path.join(tempDir, 'project')
+  fs.mkdirSync(projectDir, { recursive: true })
+
+  const probeLogPath = path.join(tempDir, 'probe.log')
+  const nonce = Math.random().toString(36).slice(2, 10)
+
+  const pluginPath = `file://${path.join(REPO_ROOT, 'src/index.ts')}`
+  const opencodeConfig = JSON.stringify({ plugin: [pluginPath] })
+
+  console.log(`[probe] tempDir: ${tempDir}`)
+  console.log(`[probe] probeLogPath: ${probeLogPath}`)
+  console.log(`[probe] nonce: ${nonce}`)
+
+  // Spawn `opencode serve` and capture the URL from stdout/stderr.
+  const env = {
+    ...process.env,
+    OPENCODE_CONFIG_CONTENT: opencodeConfig,
+    SYSTEMATIC_PROBE_LOG: probeLogPath,
+    SYSTEMATIC_PROBE_NONCE: nonce,
+  }
+
+  console.log('[probe] spawning opencode serve...')
+  const server = spawn('opencode', ['serve', '--port', '0', '--print-logs'], {
+    cwd: projectDir,
+    env,
+  })
+
+  const serverUrl = await new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Server start timed out (10s)'))
+    }, 10_000)
+
+    let buffer = ''
+    const onChunk = (chunk: Buffer) => {
+      buffer += chunk.toString()
+      const match = buffer.match(/(http:\/\/[\d.:]+)/)
+      if (match) {
+        clearTimeout(timeout)
+        resolve(match[1])
+      }
+    }
+    server.stdout?.on('data', onChunk)
+    server.stderr?.on('data', onChunk)
+    server.on('error', reject)
+    server.on('exit', (code: number | null) => {
+      if (code !== null && code !== 0) {
+        reject(new Error(`Server exited early with code ${code}: ${buffer}`))
+      }
+    })
+  })
+
+  console.log(`[probe] server URL: ${serverUrl}`)
+
+  const client = createOpencodeClient({
+    baseUrl: serverUrl,
+    directory: projectDir,
+  })
+
+  const notes: string[] = []
+  let markerInjected: string | null = null
+  let summaryText = ''
+  let markerInSummary: ProbeResult['markerInSummary'] = 'absent'
+  let markerOccurrences = 0
+
+  try {
+    console.log('[probe] creating session...')
+    const created = await client.session.create({
+      body: { title: 'systematic-probe' },
+    })
+    const sessionID = (created.data as { id?: string } | undefined)?.id ?? ''
+    if (!sessionID) {
+      throw new Error(`Failed to create session: ${JSON.stringify(created)}`)
+    }
+    console.log(`[probe] sessionID: ${sessionID}`)
+
+    // Send a couple of substantive prompts so the conversation has real content
+    // for the compactor to summarize.
+    for (const text of [
+      'Reply with a single short sentence acknowledging this message. Nothing else.',
+      'Reply with a single short sentence about TypeScript. Nothing else.',
+    ]) {
+      console.log(`[probe] sending prompt: ${text.slice(0, 50)}...`)
+      const resp = await client.session.prompt({
+        path: { id: sessionID },
+        body: {
+          model: { providerID: PROVIDER_ID, modelID: MODEL_ID },
+          parts: [{ type: 'text', text }],
+        },
+      })
+      const errMsg =
+        resp.error != null ? JSON.stringify(resp.error).slice(0, 300) : null
+      if (errMsg) notes.push(`prompt error: ${errMsg}`)
+    }
+
+    // Trigger compaction.
+    console.log('[probe] calling summarize...')
+    const summarizeResp = await client.session.summarize({
+      path: { id: sessionID },
+      body: { providerID: PROVIDER_ID, modelID: MODEL_ID },
+    })
+    if (summarizeResp.error != null) {
+      notes.push(
+        `summarize error: ${JSON.stringify(summarizeResp.error).slice(0, 300)}`,
+      )
+    }
+
+    // Read the resulting messages.
+    console.log('[probe] fetching messages...')
+    const msgs = await client.session.messages({ path: { id: sessionID } })
+    const messages = (msgs.data ?? []) as Array<{
+      info?: { role?: string; summary?: boolean }
+      parts?: Array<{ type?: string; text?: string }>
+    }>
+
+    // The summarize endpoint typically produces a new summary message at the
+    // end of the stream. Scan ALL messages for our marker.
+    const allText = messages
+      .flatMap((m) => m.parts ?? [])
+      .filter((p) => p.type === 'text' && typeof p.text === 'string')
+      .map((p) => p.text as string)
+      .join('\n---\n')
+
+    summaryText = allText
+    markerInjected = `<systematic-probe>marker-${nonce}-sid-${sessionID}</systematic-probe>`
+
+    if (allText.includes(markerInjected)) {
+      markerInSummary = 'verbatim'
+      markerOccurrences = allText.split(markerInjected).length - 1
+    } else if (
+      allText.includes(`marker-${nonce}`) ||
+      allText.includes('systematic-probe')
+    ) {
+      markerInSummary = 'paraphrased'
+      markerOccurrences = (allText.match(/systematic-probe/g) ?? []).length
+    }
+
+    notes.push(`messages_count=${messages.length}`)
+    notes.push(`total_text_chars=${allText.length}`)
+  } catch (err) {
+    notes.push(
+      `probe error: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  } finally {
+    server.kill('SIGTERM')
+    await new Promise((r) => setTimeout(r, 500))
+  }
+
+  // Inspect the probe log.
+  const probeLog = fs.existsSync(probeLogPath)
+    ? fs.readFileSync(probeLogPath, 'utf8')
+    : ''
+  const hookFiredCount = (probeLog.match(/HOOK_FIRED/g) ?? []).length
+  const hookFired = hookFiredCount > 0
+
+  console.log(`[probe] hookFiredCount=${hookFiredCount}`)
+  console.log(`[probe] markerInSummary=${markerInSummary}`)
+
+  return {
+    hookFired,
+    hookFiredCount,
+    markerInjected,
+    markerInSummary,
+    markerOccurrences,
+    summaryText,
+    notes,
+  }
+}
+
+const result = await runProbe()
+console.log('\n=== PROBE RESULT ===')
+console.log(JSON.stringify(result, null, 2))
+
+if (result.markerInSummary === 'verbatim') {
+  console.log('\n[verdict] VERBATIM — proceed with full V1 design as scoped.')
+  process.exit(0)
+} else if (result.markerInSummary === 'paraphrased') {
+  console.log(
+    '\n[verdict] PARAPHRASED — proceed with V1, but reframe R3 to expect paraphrased preservation.',
+  )
+  process.exit(0)
+} else if (!result.hookFired) {
+  console.log(
+    '\n[verdict] HOOK DID NOT FIRE — abort design. Investigate whether experimental.session.compacting is actually wired into the production compaction path.',
+  )
+  process.exit(2)
+} else {
+  console.log(
+    '\n[verdict] MARKER DROPPED — append-only design fails. Switch to output.prompt override or a skill-layer alternative.',
+  )
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary

Adds three reusable probe scripts under `tests/manual/` that exercise
plugin-behavior hypotheses against a live model (`opencode/big-pickle`)
before committing to a full V1 implementation. Two probes built from this
pattern have produced decisive results in roughly 30–60 minutes each,
saving multi-day implementation cycles that would have built on
invalidated foundations.

## Files

- **`session-compacting-probe.ts`** — exercises the
  `experimental.session.compacting` hook in two variants (append-only via
  `output.context` and prompt-override via `output.prompt`) against a
  forced `session.summarize()` to determine whether the compactor LLM
  honors plugin-injected preservation hints.

- **`companion-aware-probe.ts`** — exercises the hypothesis that appending
  companion-specific guidance (e.g., magic-context tool calls) to a skill
  body drives the LLM to invoke `ctx_memory` at workflow boundaries.
  Runs 5 sessions per condition (with and without companion content)
  and compares invocation rates against a configurable pass criterion.

- **`probe-companion-tools.ts`** — minimal stub plugin used by
  `companion-aware-probe.ts`. Registers `ctx_memory`, `ctx_search`, and
  `ctx_note` as no-op tools that append a structured log entry per
  invocation; the runner counts the log to derive per-condition rates.

## CI behavior

These are **not picked up by `bun test` or `bun test:integration`** — file
names lack the `.test.` suffix and the directory is invoked manually
with `bun tests/manual/<file>.ts`. Each script is self-contained: spawns
a fresh `opencode serve` instance per session, drives the SDK directly,
and cleans up. Lint applies (warnings only) but does not block.

## Probe pattern

1. Specify the pass criterion BEFORE running.
2. Two conditions (A = baseline, B = proposed mechanism), 5 sessions each.
3. Count concrete observable behaviors (tool invocations).
4. Treat results as bought information regardless of outcome — a clean
   negative is more valuable than a feature built on a broken foundation.

## Notes

- Cognitive-complexity warnings on the runners are accepted: the scripts
  are one-shot and refactoring them adds maintenance cost without
  changing their probe-template role.
- Both runners use `OPENCODE_CONFIG_CONTENT` (matching the integration
  test pattern) for plugin injection — no on-disk config side effects.