### PR TITLE
feat(skills): add Systematic skill authoring guardrails

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,7 +47,8 @@ jobs:
         run: |
           node --input-type=module -e "
             const m = await import('./dist/index.js');
-            const plugin = await m.SystematicPlugin({
+            const pluginFactory = m.default;
+            const plugin = await pluginFactory({
               client: { app: { log: async () => {} } },
               directory: process.cwd()
             });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ systematic/
 │   ├── index.ts          # Plugin entry (SystematicPlugin)
 │   ├── cli.ts            # CLI entry (list/convert/config commands)
 │   └── lib/              # 12 core modules (see src/lib/AGENTS.md)
-├── skills/               # 45 bundled skills (SKILL.md format)
+├── skills/               # 46 bundled skills (SKILL.md format)
 ├── agents/               # 50 bundled agents (6 categories: design/docs/document-review/research/review/workflow)
 ├── commands/             # Empty (.gitkeep) — commands converted to skills; dir kept for backward compat
 ├── docs/                 # Starlight docs workspace (see docs/AGENTS.md)
@@ -164,4 +164,3 @@ The `commands/` directory contains only `.gitkeep` (all commands converted to sk
 - `commands/` dir retained (with `.gitkeep`) for backward compatibility — code paths still support commands
 - `registry/` provides OCX component-level installation with omo and standalone profiles
 - `.opencode/commands/` has project-only commands: `generate-readme` (README generation)
-

--- a/agents/review/api-contract-reviewer.md
+++ b/agents/review/api-contract-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: api-contract-reviewer
 description: Conditional code-review persona, selected when the diff touches API routes, request/response types, serialization, versioning, or exported type signatures. Reviews code for breaking contract changes.
+model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent
@@ -46,4 +47,3 @@ Return your findings as JSON matching the findings schema. No prose outside the 
   "testing_gaps": []
 }
 ```
-

--- a/agents/review/correctness-reviewer.md
+++ b/agents/review/correctness-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: correctness-reviewer
 description: Always-on code-review persona. Reviews code for logic errors, edge cases, state management bugs, error propagation failures, and intent-vs-implementation mismatches.
+model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent
@@ -46,4 +47,3 @@ Return your findings as JSON matching the findings schema. No prose outside the 
   "testing_gaps": []
 }
 ```
-

--- a/agents/review/data-migrations-reviewer.md
+++ b/agents/review/data-migrations-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: data-migrations-reviewer
 description: Conditional code-review persona, selected when the diff touches migration files, schema changes, data transformations, or backfill scripts. Reviews code for data integrity and migration safety.
+model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent
@@ -50,4 +51,3 @@ Return your findings as JSON matching the findings schema. No prose outside the 
   "testing_gaps": []
 }
 ```
-

--- a/agents/review/dhh-rails-reviewer.md
+++ b/agents/review/dhh-rails-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: dhh-rails-reviewer
 description: Conditional code-review persona, selected when Rails diffs introduce architectural choices, abstractions, or frontend patterns that may fight the framework. Reviews code from an opinionated DHH perspective.
+model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent
@@ -44,4 +45,3 @@ Return your findings as JSON matching the findings schema. No prose outside the 
   "testing_gaps": []
 }
 ```
-

--- a/agents/review/julik-frontend-races-reviewer.md
+++ b/agents/review/julik-frontend-races-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: julik-frontend-races-reviewer
 description: Conditional code-review persona, selected when the diff touches async UI code, Stimulus/Turbo lifecycles, or DOM-timing-sensitive frontend behavior. Reviews code for race conditions and janky UI failure modes.
+model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent
@@ -47,4 +48,3 @@ Return your findings as JSON matching the findings schema. No prose outside the 
 ```
 
 Discourage the user from pulling in too many dependencies, explaining that the job is to first understand the race conditions, and then pick a tool for removing them. That tool is usually just a dozen lines, if not less - no need to pull in half of NPM for that.
-

--- a/agents/review/kieran-python-reviewer.md
+++ b/agents/review/kieran-python-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: kieran-python-reviewer
 description: Conditional code-review persona, selected when the diff touches Python code. Reviews changes with Kieran's strict bar for Pythonic clarity, type hints, and maintainability.
+model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent
@@ -45,4 +46,3 @@ Return your findings as JSON matching the findings schema. No prose outside the 
   "testing_gaps": []
 }
 ```
-

--- a/agents/review/kieran-rails-reviewer.md
+++ b/agents/review/kieran-rails-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: kieran-rails-reviewer
 description: Conditional code-review persona, selected when the diff touches Rails application code. Reviews Rails changes with Kieran's strict bar for clarity, conventions, and maintainability.
+model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent
@@ -45,4 +46,3 @@ Return your findings as JSON matching the findings schema. No prose outside the 
   "testing_gaps": []
 }
 ```
-

--- a/agents/review/kieran-typescript-reviewer.md
+++ b/agents/review/kieran-typescript-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: kieran-typescript-reviewer
 description: Conditional code-review persona, selected when the diff touches TypeScript code. Reviews changes with Kieran's strict bar for type safety, clarity, and maintainability.
+model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent
@@ -45,4 +46,3 @@ Return your findings as JSON matching the findings schema. No prose outside the 
   "testing_gaps": []
 }
 ```
-

--- a/agents/review/maintainability-reviewer.md
+++ b/agents/review/maintainability-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: maintainability-reviewer
 description: Always-on code-review persona. Reviews code for premature abstraction, unnecessary indirection, dead code, coupling between unrelated modules, and naming that obscures intent.
+model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent
@@ -46,4 +47,3 @@ Return your findings as JSON matching the findings schema. No prose outside the 
   "testing_gaps": []
 }
 ```
-

--- a/agents/review/performance-reviewer.md
+++ b/agents/review/performance-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: performance-reviewer
 description: Conditional code-review persona, selected when the diff touches database queries, loop-heavy data transforms, caching layers, or I/O-intensive paths. Reviews code for runtime performance and scalability issues.
+model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent
@@ -48,4 +49,3 @@ Return your findings as JSON matching the findings schema. No prose outside the 
   "testing_gaps": []
 }
 ```
-

--- a/agents/review/reliability-reviewer.md
+++ b/agents/review/reliability-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: reliability-reviewer
 description: Conditional code-review persona, selected when the diff touches error handling, retries, circuit breakers, timeouts, health checks, background jobs, or async handlers. Reviews code for production reliability and failure modes.
+model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent
@@ -46,4 +47,3 @@ Return your findings as JSON matching the findings schema. No prose outside the 
   "testing_gaps": []
 }
 ```
-

--- a/agents/review/security-reviewer.md
+++ b/agents/review/security-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: security-reviewer
 description: Conditional code-review persona, selected when the diff touches auth middleware, public endpoints, user input handling, or permission checks. Reviews code for exploitable vulnerabilities.
+model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent
@@ -48,4 +49,3 @@ Return your findings as JSON matching the findings schema. No prose outside the 
   "testing_gaps": []
 }
 ```
-

--- a/agents/workflow/bug-reproduction-validator.md
+++ b/agents/workflow/bug-reproduction-validator.md
@@ -1,6 +1,7 @@
 ---
 name: bug-reproduction-validator
 description: Systematically reproduces and validates bug reports to confirm whether reported behavior is an actual bug. Use when you receive a bug report or issue that needs verification.
+model: inherit
 mode: subagent
 temperature: 0.1
 ---
@@ -81,4 +82,3 @@ Key Principles:
 - If you cannot reproduce after reasonable attempts, clearly state what you tried
 
 When you cannot access certain resources or need additional information, explicitly state what would help validate the bug further. Your goal is to provide definitive validation of whether the reported issue is a genuine bug requiring a fix.
-

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -33,7 +33,7 @@ docs/
 │       ├── getting-started/  # 2 manual pages (installation, configuration)
 │       ├── guides/           # 7 manual pages (philosophy, main-loop, agent-install, architecture, conversion-guide, ocx-registry, exemplary-checklist)
 │       └── reference/        # Generated — DO NOT EDIT
-│           ├── skills/       # 45 pages + index.mdx (generated from skills/)
+│           ├── skills/       # 46 pages + index.mdx (generated from skills/)
 │           └── agents/       # 50 pages + index.mdx (generated from agents/)
 └── package.json
 ```

--- a/docs/plans/2026-04-30-001-feat-writing-systematic-skills-plan.md
+++ b/docs/plans/2026-04-30-001-feat-writing-systematic-skills-plan.md
@@ -1,0 +1,519 @@
+---
+title: 'feat: Add writing-systematic-skills authoring spec + foundation validators'
+type: feat
+status: completed
+date: 2026-04-30
+origin: docs/brainstorms/2026-04-28-writing-systematic-skills-requirements.md
+---
+
+# feat: Add writing-systematic-skills authoring spec + foundation validators
+
+## Overview
+
+Ship V1 of the Systematic authoring conventions spec as a bundled skill (`systematic:writing-systematic-skills`) layered on top of the user-installed `writing-skills` foundation, plus two new content-integrity validators that enforce the foundation rules in CI. The validator's allowed-fields set is descriptive of the runtime loader's actual contract (`src/lib/skills.ts:71–84`); only `preconditions` is banned (the one field with no runtime consumer). The validator runs in dry-run mode against the live catalog FIRST as the empirical audit, then cleanup is regenerated from that output, then the validator flips to enforcing. Audit-driven cleanup means the gate runs zero violations on `main` from day one.
+
+This is a single-PR shipment targeting v2.7.0 minor.
+
+## Problem Frame
+
+Systematic ships 45 skills and 50 agents with no written authoring spec. Every new skill makes one-off frontmatter and file-layout decisions, and drift compounds. One skill carries an idiosyncratic frontmatter field with no runtime consumer (`compound-docs` uses `preconditions`); 13 of 50 bundled agents lack the `model: inherit` declaration the other 37 carry. (`claude-permissions-optimizer` carries `context: fork` + `subtask: true`, which the runtime loader actively reads at `src/lib/skills.ts:79` to drive forked-subtask dispatch — NOT idiosyncratic; preserved as-is.) The recent infra investments (content-integrity gate from PR #301, sub-file integrity from PR #319, registry generator from PR #315) make this the right moment to consolidate validators.
+
+A spec without validators is documentation-only; validators without a spec are opaque. The V1 thesis is that the combination compounds: the skill is the source of truth authors read; the gate is the enforcement that catches drift before merge. (See origin: docs/brainstorms/2026-04-28-writing-systematic-skills-requirements.md.)
+
+## Requirements Trace
+
+- R1–R7. Foundation skill content (frontmatter rules, file layout, identity defaults). Mapped to Units 3 + 4. R7's `ai:systematic` sub-rule is reframed: it is the machine-id / API-attribution string (per `skills/proof/SKILL.md:22`), not a skill cross-reference convention.
+- R12. `checkFrontmatter` validator extension. Mapped to Unit 1.
+- R13. `checkAgentModel` validator extension. Mapped to Unit 1.
+- R14. Pre-V1 audit. **Empirical, not conceptual**: Unit 1 lands the validators in dry-run mode and runs them against the live catalog; output is the audit. Unit 2 cleanup uses that empirical output. Unit 5 flips the validator to enforcing mode.
+- R15. Cleanup of every frontmatter violation surfaced by the empirical audit. Mapped to Unit 2.
+- R16. Cleanup of every agent-model violation surfaced by the empirical audit. Mapped to Unit 2.
+- R17. Remove `workflows` from `SUBFILE_DIRECTORY_NAMES` constant. Mapped to Unit 1.
+
+## Scope Boundaries
+
+- `ce:*` workflow conventions (phase numbering, document-review interleave, output filename patterns) — deferred to V2 per origin doc; empirical phase-catalog disproof during brainstorm.
+- Composition + robustness conventions — deferred to V2.
+- Tone/voice rules beyond writing-skills — not codified.
+- Full agent authoring spec beyond `model: inherit` — not in V1.
+- Generator/templating tooling (`scaffold-skill`) — deferred to V2.
+- Bulk normalization beyond audit findings — V1 cleanup matches audit scope exactly; broader normalization is organic via future PRs.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/content-integrity.ts` (800 lines) — already exposes `checkReferenceIntegrity`, `checkSubfileReferences`, `checkBannedPatterns`. The new `checkFrontmatter` and `checkAgentModel` follow the exact same shape: pure functions returning typed violation arrays, called from `checkContentIntegrity()`, printed by per-check `printX` helpers. **Critical detail**: `main()` at lines 784–787 currently computes its exit code via an INLINE SUM, NOT via `totalViolations()`. Unit 1 must update both `totalViolations()` (line 759) AND replace the inline sum in `main()` with a `totalViolations(result)` call so future checks only require one update.
+- `src/lib/skills.ts:71–84` — `extractFrontmatter` is the runtime loader's source of truth for what frontmatter fields a skill may carry. Reads: `name`, `description`, `license`, `compatibility`, `metadata`, `disable-model-invocation`, `user-invocable`, `context` (derives `subtask: true` when value is `'fork'`), `agent`, `model`, `argument-hint`, `allowed-tools`. The validator's allowed-fields set must match this enumeration.
+- `src/lib/frontmatter.ts:19` — `parseFrontmatter` returns `{ data, body, hadFrontmatter, parseError }`. On `parseError: true`, `data` is `{}`; the validator emits ONE `malformed-frontmatter` violation and short-circuits remaining field checks for that file.
+- `tests/unit/content-integrity.test.ts` (1034 lines) — `bun:test` + real temp dirs via `os.mkdtempSync`; no mocking libraries. New validator tests follow the same fixture pattern (`makeFixtureRepo`, `writeSkill`, `writeAgent`, `writeAllowlist`).
+- `skills/ce-brainstorm/SKILL.md` (198 lines) — body length target reference (target ≤ 350 lines for the new skill). `skills/ce-plan/SKILL.md` is 737 lines; the spec target is intentionally tighter than ce:plan, treating ce:plan as a skill where content density warranted depth, not a structural guideline.
+- `skills/document-review/SKILL.md` — example of a skill with rich frontmatter (`argument-hint`, `disable-model-invocation: true`) following current conventions.
+- `agents/review/testing-reviewer.md` — canonical placement reference for `model: inherit` in agents that also carry `mode: subagent` and `temperature: 0.1` (matches the 12 review agents in Unit 2 cleanup; closer pattern than `agents/research/best-practices-researcher.md` which lacks those siblings fields).
+
+### Pre-Plan Audit — Conceptual
+
+A conceptual audit during planning (grep-based) confirmed the following at the time the plan was written:
+
+| Audit dimension                | Conceptual result                                                                       |
+| ------------------------------ | --------------------------------------------------------------------------------------- |
+| Banned-field hits (`preconditions`) | 1 (compound-docs)                                                                         |
+| Runtime-recognized field usage | `context: fork` + `subtask: true` on claude-permissions-optimizer (both ALLOWED, not banned) |
+| Missing `model:` in agents       | 13 (12 in `agents/review/`, 1 in `agents/workflow/bug-reproduction-validator.md`)         |
+| Non-`inherit` model values       | Zero                                                                                    |
+| `workflows/` sub-dirs in skills  | Zero                                                                                    |
+| Optional standardized usage    | `argument-hint` 21 / `disable-model-invocation` 15 / `allowed-tools` 4 — all valid        |
+
+**The empirical audit is Unit 1's dry-run pass against the live catalog.** The conceptual numbers above are the expected baseline; Unit 2 cleanup is regenerated from Unit 1's output, not from this table. Edge cases the conceptual audit may not catch include malformed YAML, whitespace-only field values, files where the regex in `parseFrontmatter` doesn't match (e.g., trailing whitespace before closing fence), and `name: null` parsing under JSON_SCHEMA. Unit 1's dry-run pass is the source of truth.
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/zsh-for-loop-word-splitting-silent-failure-2026-04-17.md` — for any batch file iteration in this PR, use `find ... | while IFS= read -r f` or `find ... -exec sed`. Verification grep must use a different iteration pattern than the conversion.
+- Plan-taxonomy leak rule (memory + WORKFLOW_RULES): `R1`/`Unit 1`/`(v1)` patterns must NOT appear in shipped source files. Spec text describes conventions directly. Pre-PR grep gate: `grep -rn -E "\bR[0-9]+|Unit [0-9]+|\(v[0-9]+\)" <source files>` returns zero.
+
+### External References
+
+- None used. Codebase has all needed patterns. (writing-skills upstream is at `~/.agents/skills/writing-skills/SKILL.md`; the new skill cites it but does not duplicate its content.)
+
+## Key Technical Decisions
+
+- **Validator allow-list is descriptive of runtime loader.** The R5 allowed-fields set enumerates every field `extractFrontmatter` in `src/lib/skills.ts:71–84` recognizes: `name`, `description`, `argument-hint`, `disable-model-invocation`, `allowed-tools`, `license`, `compatibility`, `metadata`, `user-invocable`, `agent`, `model`, `context`, `subtask`. Banned set is a literal denylist of just `preconditions` (the one field with no runtime consumer; compound-docs is the only current user). This eliminates semantic drift between loader and validator and preserves runtime contract for `claude-permissions-optimizer`'s forked-subtask dispatch.
+- **Reuse `parseFrontmatter` from `src/lib/frontmatter.ts`** for both new validators. Single source of truth for YAML parsing.
+- **`argument-hint` format = accept any non-empty string in V1.** All 21 current uses are free-text bracketed; slot-typing deferred to V2.
+- **No `--dry-run` flag in shipped CLI.** The validator runs in dry-run mode internally during Unit 1 (via a private function flag, not a CLI surface) to capture the audit output. After Unit 5 flips to enforcing mode, no permanent CLI flag remains. Per scope-guardian S2: a permanent flag adds CLI surface without a documented current consumer; deferred to V2 if a real iteration pain emerges.
+- **All foundation violations exit non-zero.** No advisory tier.
+- **Validator surface = extend `scripts/content-integrity.ts`, not a new script.** One CI step, one report. The file is currently 800 lines; adding two checks brings it to ~950. If V2 adds a third check pattern that pushes the file past ~1000 lines or 5 distinct check types, split into `scripts/content-integrity/{checks,reports,main}.ts`. V1 stays in-place.
+- **No frontmatter-on-sub-file rules in V1.** Existing sub-file integrity check (PR #319) verifies path resolution; per-type rules would be premature.
+- **`workflows` removal from `SUBFILE_DIRECTORY_NAMES` ships with the validator code (Unit 1)**, including doc-comment updates at `scripts/content-integrity.ts:12–13` and `:486–487` (which currently example `workflows/foo.yml` and would otherwise lie).
+- **Skill body lives in `skills/writing-systematic-skills/SKILL.md`; depth content lives in a SINGLE `references/foundation-conventions.md`** with H2 sections matching the SKILL.md body. Target ≤ 350 lines for SKILL.md; reference file unbounded. Per scope-guardian S1: the 3-file split mirrors R5/R6/R7 taxonomy without a navigation-driven justification. Implementer may split if a section grows past ~250 lines, but the default is one file.
+- **`name: systematic:writing-systematic-skills` for the new skill.** No existing Systematic skill uses the `systematic:` prefix in its `name:` field (8 use `ce:` prefix; 37 are bare). The new skill is the first. Per origin R1; namespace migration for existing 37 bare-name skills is deferred to V2 with a migration plan. V1 documents the convention; the validator does not enforce `name:` value patterns.
+- **`ai:systematic` is reframed as agent-identity attribution**, NOT a skill cross-reference convention. Per `skills/proof/SKILL.md:22`: 'Machine ID (`by` on every op, `X-Agent-Id` header): `ai:systematic`'. R7's third sub-bullet documents this accurately. V1 does not validate it (documentation-only).
+
+## Open Questions
+
+### Resolved During Planning
+
+- **`parseFrontmatter` reuse vs inline YAML**: Reuse. Single source of truth.
+- **`argument-hint` shape enforcement**: Accept any non-empty string in V1. Stricter shape is a V2 question.
+- **Audit mode**: Empirical — Unit 1's dry-run pass against the live catalog. No permanent CLI `--dry-run` flag.
+- **Cleanup scope**: Determined empirically by Unit 1's output. Conceptual baseline is 1 banned-field skill (compound-docs/preconditions) + 13 agents missing `model: inherit`; final scope flexes to whatever Unit 1 surfaces.
+- **Sub-file frontmatter rules in V1**: None. Path-resolution check (PR #319) is sufficient.
+- **`ai:systematic` framing**: Agent-identity attribution (machine ID), not skill cross-reference. Documented in spec body; not validated in V1.
+- **Validator allow-list scope**: Match the runtime loader's full set (`src/lib/skills.ts:71–84`). Single banned field: `preconditions`.
+- **Forked-subtask dispatch (`context: fork` / `subtask: true`)**: Preserved. Both fields are runtime-recognized and on the allow-list.
+- **References/ split**: Single `references/foundation-conventions.md` by default. Implementer may split if a section grows past ~250 lines.
+- **PR shipping**: Single PR, but re-sequenced — validators land FIRST in dry-run, cleanup follows, validator flips to enforcing mode last.
+- **Parse-error short-circuit**: When `parseFrontmatter` returns `parseError: true`, emit one `malformed-frontmatter` violation per file and skip remaining field-level checks.
+- **`name: null` ambiguity**: A `name:` field that parses to `null` (e.g., bare `name:` or `name: ~`) is treated as `missing-required-field`, NOT `empty-required-field`. Empty-required-field applies only to literal empty strings (`name: ""`). Documented in Unit 1 type definitions.
+- **Registry script path**: Use `scripts/build-registry.ts` (the canonical npm-script-exposed entrypoint per `package.json: registry:build`). `scripts/generate-registry.ts` exists but is not the documented public path.
+
+### Deferred to Implementation
+
+- **Skill body section ordering**: writing-skills uses a particular section order; the new skill should follow it but minor adjustments are likely once content is being written.
+- **Reference file split timing**: Whether `foundation-conventions.md` ever exceeds the ~250-line threshold and needs splitting. Decide at write time.
+- **Exact remediation message phrasing**: Each validator emits a one-line remediation pointing to the spec; specific wording is implementation-time polish.
+- **`--validate-only` vs `--check` flag for build-registry.ts**: Confirm exact CLI flag during Unit 6's registry regeneration step (the `package.json` script uses `--validate-only`).
+
+## Output Structure
+
+```text
+skills/writing-systematic-skills/
+├── SKILL.md                                 # Bedrock spec (≤350 lines)
+└── references/
+    └── foundation-conventions.md            # H2: Frontmatter / File Layout / Identity Defaults
+```
+
+The implementer may split `foundation-conventions.md` if a section grows past ~250 lines, but the V1 default is one file.
+
+## Implementation Units
+
+The ordering below is the empirical audit pattern: validators land FIRST in dry-run mode, their output drives cleanup scope, and the validator flips to enforcing mode last. This avoids the failure mode where Unit 4 surfaces a violation Unit 1 missed in a single-PR shipment.
+
+- [ ] **Unit 1: Validator implementation (dry-run by default, no CLI flag)**
+
+  **Goal:** Add `checkFrontmatter` and `checkAgentModel` to the content-integrity gate. Wire them into the result type. Have them run automatically as part of `checkContentIntegrity()`. **Do not yet flip the gate's exit code to count their violations.** This unit ships a validator that prints violations to stderr but exits 0; Unit 5 flips it to enforcing mode.
+
+  **Requirements:** R12, R13, R17
+
+  **Dependencies:** None.
+
+  **Execution note:** Test-first. Add failing tests for the new violation types; implement until green; repeat per rule. Mirrors PR #301's TDD pattern for `checkSubfileReferences`.
+
+  **Files:**
+  - Modify: `scripts/content-integrity.ts`
+    - Add `FrontmatterViolation` and `AgentModelViolation` types
+    - Add `checkFrontmatter` and `checkAgentModel` functions
+    - Extend `CheckResult` with `frontmatterViolations` and `agentModelViolations` arrays
+    - Update `totalViolations()` to sum both new arrays
+    - Replace the inline sum in `main()` (lines 784–787) with a `totalViolations(result)` call so future checks only require one update
+    - Add `printFrontmatterViolations()` and `printAgentModelViolations()` helpers per the existing `printX` pattern
+    - **Crucially**: have `main()` exit 0 even when the new violations are non-empty. The check still runs and prints; only the exit code is held back. Implement via a feature flag constant `ENFORCE_FRONTMATTER_RULES = false` at module scope, gating only the exit-code calculation. Unit 5 flips this to `true`.
+    - Remove `workflows` from `SUBFILE_DIRECTORY_NAMES` (line 480 area)
+    - Update doc comments at lines 12–13 (header block) and lines 486–487 (regex example) to drop `workflows/foo.yml` from the example list
+  - Test: `tests/unit/content-integrity.test.ts` (extends existing 1034-line file; adds new `describe` blocks per check)
+
+  **Approach:**
+  - **Type definitions:**
+
+    ```typescript
+    export interface FrontmatterViolation {
+      file: string
+      rule:
+        | 'banned-field' // currently only `preconditions`
+        | 'unknown-field' // not in allowed-fields list
+        | 'missing-required-field' // name or description absent (or parses to null)
+        | 'empty-required-field' // name or description is literal empty string
+        | 'malformed-frontmatter' // parseFrontmatter returned parseError: true
+        | 'missing-frontmatter' // no --- markers at all
+      message: string
+      remediation: string
+    }
+    export interface AgentModelViolation {
+      file: string
+      message: string
+    }
+    ```
+
+    *(Directional sketch; final shape may evolve at write time.)*
+
+  - **Allowed-fields constant** (matches `extractFrontmatter` in `src/lib/skills.ts:71–84`):
+
+    ```typescript
+    const ALLOWED_SKILL_FRONTMATTER_FIELDS = new Set([
+      'name',
+      'description',
+      'argument-hint',
+      'disable-model-invocation',
+      'allowed-tools',
+      'license',
+      'compatibility',
+      'metadata',
+      'user-invocable',
+      'agent',
+      'model',
+      'context',
+      'subtask',
+    ])
+    const BANNED_SKILL_FRONTMATTER_FIELDS = new Set(['preconditions'])
+    ```
+
+  - **`checkFrontmatter(rootDir, skillFiles)`**: filters to `skills/*/SKILL.md`; calls `parseFrontmatter`. **Short-circuit on parseError**: emit one `malformed-frontmatter` violation and skip remaining checks for that file. Otherwise: emit `missing-frontmatter` if `hadFrontmatter === false`; emit `missing-required-field` if `name` is absent or null; emit `empty-required-field` if `name === ''`; same for `description`; emit `banned-field` (with specific message) for any field in `BANNED_SKILL_FRONTMATTER_FIELDS`; emit `unknown-field` for any field not in `ALLOWED_SKILL_FRONTMATTER_FIELDS ∪ BANNED_SKILL_FRONTMATTER_FIELDS`.
+
+  - **`checkAgentModel(rootDir, agentFiles)`**: walks every agent `.md` file; calls `parseFrontmatter`; flags missing `model:` field OR non-`inherit` value (including null and empty-string). Emits one violation per file.
+
+  - **`CheckResult` extension**: add `frontmatterViolations: FrontmatterViolation[]` and `agentModelViolations: AgentModelViolation[]`.
+
+  - **`totalViolations()` update**: include both new arrays. Then replace `main()`'s inline sum with `totalViolations(result)`.
+
+  - **`ENFORCE_FRONTMATTER_RULES = false` gate**: in `main()`, compute the violation count as: `phantomRefs + brokenSubfileRefs + bannedPatterns + (ENFORCE_FRONTMATTER_RULES ? frontmatterViolations + agentModelViolations : 0)`. Helpers print regardless. Unit 5 sets the constant to `true`.
+
+  - **`workflows` removal**: one-line edit to `SUBFILE_DIRECTORY_NAMES`. Regex at line 499 auto-updates. Update the doc comments in the header (lines 12–13) and the SUBFILE_PATH_REGEX comment (lines 486–487).
+
+  **Patterns to follow:**
+  - `checkSubfileReferences` (lines 513–565) for per-check function signature and scan loop.
+  - `printPhantomRefs` / `printBrokenSubfileRefs` (lines 727–745) for output format (`process.stderr.write` with `file:line message`).
+
+  **Test scenarios:**
+  - **Happy path — `checkFrontmatter`:**
+    - Skill with `{name, description}` only → zero violations.
+    - Skill with all 13 allowed fields populated → zero violations.
+  - **Banned-field (only `preconditions`):**
+    - Skill with `preconditions: foo` → 1 violation, rule=`banned-field`, message names `preconditions`, remediation references `systematic:writing-systematic-skills`.
+    - Skill with `subtask: true` → zero violations (allowed; runtime-recognized).
+    - Skill with `context: fork` → zero violations.
+  - **Unknown-field violations:**
+    - Skill with `experimental: true` → 1 violation, rule=`unknown-field`.
+    - Skill with multiple unknown fields → multiple violations, one per field.
+  - **Missing/empty/null required fields:**
+    - Skill with frontmatter but no `name:` → 1 violation, rule=`missing-required-field`, message names `name`.
+    - Skill with `name:` (bare, parses to null) → 1 violation, rule=`missing-required-field`.
+    - Skill with `name: ~` (parses to null) → 1 violation, rule=`missing-required-field`.
+    - Skill with `name: ""` → 1 violation, rule=`empty-required-field`.
+    - Skill with no `description:` → 1 violation, rule=`missing-required-field`, message names `description`.
+  - **Frontmatter parsing edge cases (parse-error short-circuit):**
+    - Skill with no `---` markers → 1 violation, rule=`missing-frontmatter`. No additional field-level violations.
+    - Skill with malformed YAML inside fences → 1 violation, rule=`malformed-frontmatter`. **Asserts: exactly 1 violation, not 3** (no cascading missing-name/missing-description noise).
+  - **Happy path — `checkAgentModel`:**
+    - Agent with `model: inherit` → zero violations.
+  - **`checkAgentModel` violations:**
+    - Agent with no `model:` field → 1 violation.
+    - Agent with `model: anthropic/claude-haiku-4-5` → 1 violation.
+    - Agent with `model: ""` (empty) → 1 violation.
+    - Agent with `model: ~` (null) → 1 violation.
+  - **Edge case — scope:**
+    - `checkFrontmatter` ignores `agents/**/*.md`.
+    - `checkAgentModel` ignores `skills/**/*.md`.
+    - Reference sub-files (e.g., `skills/foo/references/bar.md`) are not scanned by either validator.
+  - **Integration scenario — dry-run gate:**
+    - Fixture with 1 banned-field skill + 1 missing-model agent → violations printed; `main()` returns 0 (because `ENFORCE_FRONTMATTER_RULES = false`).
+  - **Integration scenario — `checkSubfileReferences` after `workflows` removal:**
+    - Skill SKILL.md citing `workflows/foo.yml` no longer triggers a sub-file integrity check (the path is no longer recognized as a skill sub-directory).
+
+  **Verification:**
+  - All new tests pass; existing 418 tests still pass.
+  - `bun scripts/content-integrity.ts` exits 0 on the live catalog (validators run, print violations, but flag is off).
+  - `bun scripts/content-integrity.ts --verbose` includes counts of `frontmatterViolations` and `agentModelViolations` in its summary.
+  - `SUBFILE_DIRECTORY_NAMES` no longer contains `workflows`; doc comments updated.
+
+- [ ] **Unit 2: Cleanup of empirically-surfaced violations**
+
+  **Goal:** Drive the catalog to zero foundation-rule violations using Unit 1's empirical output as the source of truth.
+
+  **Requirements:** R15, R16
+
+  **Dependencies:** Unit 1 (validator must exist and have produced the audit output).
+
+  **Approach:**
+  - Run `bun scripts/content-integrity.ts --verbose` against the live catalog. Capture the listed `frontmatterViolations` and `agentModelViolations`.
+  - The expected baseline (per the conceptual audit during planning):
+    - `frontmatterViolations`: compound-docs has `preconditions` (1 violation, rule=banned-field).
+    - `agentModelViolations`: 13 agents missing `model: inherit`.
+  - **Files actually modified depend on Unit 1's output.** If the empirical audit surfaces violations the conceptual audit missed (e.g., a malformed-frontmatter file, an unknown field on a skill not previously inspected, an agent with `model:` set to something unexpected), this unit's file list expands to cover them. The unit is complete when re-running the validator produces zero violations of either new type.
+  - **Expected file list (will be confirmed against Unit 1 output before commit):**
+    - Modify: `skills/compound-docs/SKILL.md` (remove `preconditions:` field; move semantics to body as a "Prerequisites" section if present)
+    - Modify: `agents/review/api-contract-reviewer.md` (add `model: inherit`)
+    - Modify: `agents/review/correctness-reviewer.md`
+    - Modify: `agents/review/data-migrations-reviewer.md`
+    - Modify: `agents/review/dhh-rails-reviewer.md`
+    - Modify: `agents/review/julik-frontend-races-reviewer.md`
+    - Modify: `agents/review/kieran-python-reviewer.md`
+    - Modify: `agents/review/kieran-rails-reviewer.md`
+    - Modify: `agents/review/kieran-typescript-reviewer.md`
+    - Modify: `agents/review/maintainability-reviewer.md`
+    - Modify: `agents/review/performance-reviewer.md`
+    - Modify: `agents/review/reliability-reviewer.md`
+    - Modify: `agents/review/security-reviewer.md`
+    - Modify: `agents/workflow/bug-reproduction-validator.md`
+  - For agent edits: add `model: inherit` line in frontmatter, matching the placement convention in `agents/review/testing-reviewer.md` (a sibling agent already carrying `model: inherit` along with `mode: subagent` and `temperature: 0.1` — closer pattern than research-category agents which lack `mode`/`temperature` fields).
+  - For `compound-docs/SKILL.md`: drop `preconditions:`. Move equivalent prose into body as "Prerequisites" section if not already present.
+  - **`claude-permissions-optimizer/SKILL.md` is NOT modified.** Its `context: fork` and `subtask: true` are runtime-recognized and on the allow-list; the conceptual audit's earlier framing (banned-field violation) was wrong and is corrected in this plan.
+  - Run `bun scripts/content-integrity.ts --verbose` after each batch to confirm violations decrease toward zero.
+
+  **Patterns to follow:**
+  - `agents/review/testing-reviewer.md` for canonical `model: inherit` placement in agents that also carry `mode: subagent` / `temperature: 0.1`.
+  - Existing skills with no banned fields (`ce:brainstorm`, `ce:plan`, `document-review`) for compliant frontmatter shape.
+
+  **Test scenarios:**
+  - Test expectation: none — pure content cleanup. Coverage comes from Unit 1's validator tests; Unit 6's catalog-wide assertion confirms zero violations.
+
+  **Verification:**
+  - All listed agent files contain `model: inherit` in frontmatter.
+  - `compound-docs/SKILL.md` frontmatter has no `preconditions` key.
+  - `claude-permissions-optimizer/SKILL.md` frontmatter is unchanged (still has `context: fork` and `subtask: true`).
+  - `bun scripts/content-integrity.ts` reports zero `frontmatterViolations` and zero `agentModelViolations` (still exits 0 because flag is off; Unit 5 flips it).
+  - `bun test tests/unit` still passing.
+
+- [ ] **Unit 3: Author skills/writing-systematic-skills/SKILL.md (bedrock spec)**
+
+  **Goal:** Ship the foundation-spec skill body — concise, scannable, layered on writing-skills.
+
+  **Requirements:** R1, R2, R3, R4, R5, R6, R7 (skill-scoped sub-rules surfaced in body)
+
+  **Dependencies:** Unit 2 (so the spec describes a clean baseline).
+
+  **Files:**
+  - Create: `skills/writing-systematic-skills/SKILL.md`
+
+  **Approach:**
+  - Frontmatter: `name: systematic:writing-systematic-skills`; `description` is third-person "Use when…" pattern (per writing-skills); under 1024 chars total.
+  - Body sections (working order, adjust at write-time):
+    1. **When to use** — one-paragraph trigger conditions: authoring a new Systematic skill, auditing an existing one, fixing a CI gate violation.
+    2. **Foundation: invoke writing-skills first** — explicit pointer to `~/.agents/skills/writing-skills/SKILL.md`; this skill carries only the Systematic delta (R3).
+    3. **Frontmatter rules** — required (`name`, `description`); optional standardized fields enumerated with one-line purpose for each (`argument-hint`, `disable-model-invocation`, `allowed-tools`, `license`, `compatibility`, `metadata`, `user-invocable`, `agent`, `model`, `context`, `subtask`); single banned field (`preconditions`). Direct prose, no R-IDs. Point to `references/foundation-conventions.md` for worked examples.
+    4. **File layout** — `skills/<name>/SKILL.md` plus optional `references/`, `scripts/`, `assets/`, `templates/`. Direct prose. Point to `references/foundation-conventions.md` for examples.
+    5. **Identity defaults** — agent `model: inherit`; skill `description` third-person "Use when…"; `ai:systematic` is the machine-id / API-attribution string used by `skills/proof/SKILL.md` (per `:22` verbatim) and `ce:*` handoff docs — NOT a skill cross-reference convention. Point to `references/foundation-conventions.md`.
+    6. **Validator** — `bun scripts/content-integrity.ts` enforces these rules in CI; one paragraph naming the gate and the kinds of violations it catches.
+  - Body length target: ≤ 350 lines. Mirror `ce:brainstorm` (198 lines) for tone/density. (Note: `ce:plan` at 737 lines is denser and is treated as a counter-example, not a structural exemplar.)
+  - Self-referential test: the skill's own SKILL.md must pass every rule it codifies (R4). Verified by Unit 6's catalog-wide assertion.
+
+  **Patterns to follow:**
+  - `skills/ce-brainstorm/SKILL.md` for body structure tone (concise, action-oriented, references for depth).
+  - `skills/document-review/SKILL.md` for skill-with-rich-frontmatter shape.
+  - `~/.agents/skills/writing-skills/SKILL.md` for the user-foundational skill being layered on.
+
+  **Test scenarios:**
+  - Test expectation: none for SKILL.md content directly. Validator tests in Unit 1 prove the file passes every rule. Unit 6's catalog-wide assertion confirms compliance.
+
+  **Verification:**
+  - `bun scripts/content-integrity.ts` passes with the new SKILL.md present (no new violations).
+  - File length under 350 lines.
+  - Frontmatter contains only `name` and `description` (the new spec skill does not need any optional standardized fields, though R5 permits them).
+  - Manual readthrough confirms the skill does not duplicate writing-skills content.
+
+- [ ] **Unit 4: Author references/foundation-conventions.md**
+
+  **Goal:** Ship judgment-call guidance and worked examples in a single reference file.
+
+  **Requirements:** R2 (depth lives in references/)
+
+  **Dependencies:** Unit 3 (SKILL.md establishes section names that references mirror).
+
+  **Files:**
+  - Create: `skills/writing-systematic-skills/references/foundation-conventions.md`
+
+  **Approach:**
+  - Single file with H2 sections matching the SKILL.md body sections:
+    - `## Frontmatter` — detailed table of every allowed field with one-line purpose, when to use, and example. Includes a "common mistakes" section (e.g., `preconditions:` is banned because it has no runtime consumer; `subtask: true` and `context: fork` are equivalent for the runtime loader and either is acceptable).
+    - `## File Layout` — directory tree examples; when to add `scripts/` (executable helpers) vs `templates/` (stubs an agent fills in) vs `assets/` (static content not modified at runtime). Reference to PR #319 sub-file integrity rule.
+    - `## Identity Defaults` — why `model: inherit` is mandatory for bundled agents (provider portability — hardcoded `anthropic/*` IDs break non-Anthropic users); `ai:systematic` as machine-id / API-attribution string (with the `skills/proof/SKILL.md:22` example); third-person "Use when…" pattern.
+  - File starts with a single `# Foundation Conventions` H1 heading. No YAML frontmatter (matches existing pattern in `skills/ce-brainstorm/references/handoff.md`).
+  - Implementer may split if a section grows past ~250 lines; otherwise keep one file.
+
+  **Patterns to follow:**
+  - `skills/ce-brainstorm/references/handoff.md`, `skills/ce-brainstorm/references/requirements-capture.md` (PR #319 imports) for reference-file tone, density, and lack of YAML frontmatter.
+  - `skills/ce-plan/references/visual-communication.md` for reference-as-decision-tree structure.
+
+  **Test scenarios:**
+  - Test expectation: none — plain markdown content. Sub-file path resolution is verified by Unit 1's `checkSubfileReferences` (the SKILL.md citing this reference must resolve).
+
+  **Verification:**
+  - The reference path cited in `skills/writing-systematic-skills/SKILL.md` resolves on disk.
+  - `bun scripts/content-integrity.ts` passes with the reference file present.
+  - Total reference content roughly ≤ 600 lines (informational target; not a hard rule).
+
+- [ ] **Unit 5: Flip the validator to enforcing mode**
+
+  **Goal:** Activate the foundation-rule violations as gate-blocking errors. After this unit, any future PR introducing a banned field, missing required field, or missing `model: inherit` will fail CI.
+
+  **Requirements:** R12, R13 (enforcement)
+
+  **Dependencies:** Unit 2 (catalog must be clean), Unit 3 (new skill is itself compliant), Unit 4 (reference file resolves).
+
+  **Files:**
+  - Modify: `scripts/content-integrity.ts` — set `ENFORCE_FRONTMATTER_RULES = true` (one-line edit). Optionally remove the constant and inline the sum if the gate flag is no longer useful.
+
+  **Approach:**
+  - Run `bun scripts/content-integrity.ts` — must exit 0 against the live catalog (Unit 2 cleanup + Unit 3/4 new skill must already produce zero violations).
+  - Add a regression test asserting that introducing a synthetic banned-field violation in the test fixture causes `main()` to return 1.
+
+  **Patterns to follow:**
+  - PR #301 / #319 / #313 — same flip-to-enforcing pattern.
+
+  **Test scenarios:**
+  - **Integration scenario — enforcing-mode gate:**
+    - Fixture with 1 banned-field skill + 1 missing-model agent → `main()` returns 1.
+  - **Real-repo integration smoke:**
+    - `checkContentIntegrity(REPO_ROOT)` returns `frontmatterViolations: []` and `agentModelViolations: []` on the post-Unit-2 repo; `main()` returns 0.
+
+  **Verification:**
+  - All tests pass.
+  - `bun scripts/content-integrity.ts` exits 0 on the live catalog.
+  - Local test: introduce a synthetic violation (e.g., add `preconditions:` to a test fixture skill), run the gate, assert exit 1, revert.
+
+- [ ] **Unit 6: Register the new skill in registry + update AGENTS.md**
+
+  **Goal:** Ship the skill in the OCX registry so it's installable and update the documented skill count.
+
+  **Requirements:** None directly — operational completeness.
+
+  **Dependencies:** Units 3 + 4 (skill files exist on disk).
+
+  **Files:**
+  - Modify: `registry/registry.jsonc` (auto-regenerated)
+  - Modify: `dist/registry/` (auto-regenerated; committed as required by registry drift check)
+  - Modify: `AGENTS.md` (root) — update skill count from 45 to 46
+  - Modify: `docs/AGENTS.md` — update skill count from 45 to 46
+
+  **Approach:**
+  - Run `bun run registry:build` (which calls `scripts/build-registry.ts` per `package.json`). The generator auto-discovers the new skill, sanitizes the name (`writing-systematic-skills` is already kebab-case-clean), and adds it to the registry. The single reference sub-file becomes a file entry automatically.
+  - Update both `AGENTS.md` files for the skill count (45 → 46).
+  - Verify `bun run registry:validate` (which calls `scripts/build-registry.ts --validate-only`) exits 0 (no drift) before commit.
+
+  **Patterns to follow:**
+  - Registry regeneration pattern from PR #315 / #319.
+  - `AGENTS.md` count updates from PR #314.
+
+  **Test scenarios:**
+  - Test expectation: none — generated artifact + doc updates. Coverage comes from CI's existing registry drift check.
+
+  **Verification:**
+  - `bun run registry:validate` exits 0.
+  - `dist/registry/` reflects the new skill component.
+  - `bun test` still passing.
+  - Both AGENTS.md files show skill count 46.
+
+- [ ] **Unit 7: Final quality gate + plan-taxonomy verification**
+
+  **Goal:** Confirm the PR is ready for review. Catalog-wide compliance, all gates green, no plan-taxonomy leakage.
+
+  **Requirements:** verifies AE5 (catalog-wide cleanliness) — no new R-IDs.
+
+  **Dependencies:** Units 1–6.
+
+  **Files:** None (verification only).
+
+  **Approach:**
+  - Run full quality gate locally:
+    - `bun run build`
+    - `bun run typecheck`
+    - `bun run lint`
+    - `bun test` (all unit + integration)
+    - `bun scripts/content-integrity.ts` (must exit 0)
+    - `bun run registry:validate` (must exit 0)
+    - `node --input-type=module -e "import('./dist/index.js')"` (Node ESM smoke)
+  - Run plan-taxonomy grep against changed source/spec files:
+    `grep -rn -E "\bR[0-9]+|Unit [0-9]+|\(v[0-9]+\)" skills/writing-systematic-skills/ scripts/content-integrity.ts tests/unit/content-integrity.test.ts`
+    Must return zero in shipped source. (Plan doc may keep taxonomy; shipped source must not.)
+  - Verify `checkFrontmatter` returns `[]` against the new skill's own SKILL.md (R4 self-referential test).
+  - Verify catalog-wide assertion: `checkContentIntegrity(REPO_ROOT)` returns zero violations across all 46 skills + 50 agents.
+
+  **Test scenarios:**
+  - Test expectation: none — verification step.
+
+  **Verification:**
+  - All quality gates exit 0.
+  - Plan-taxonomy grep returns zero matches in shipped source.
+  - Catalog-wide content integrity is clean.
+
+## System-Wide Impact
+
+- **Interaction graph:** Skill loader (`src/lib/skill-loader.ts`) discovers the new skill automatically via `findSkillsInDir`. Registry generator (`scripts/build-registry.ts`) auto-includes it. Content-integrity gate (`scripts/content-integrity.ts`) gains two new checks; existing checks unchanged.
+- **Error propagation:** New validators emit violations through the existing `CheckResult` pipeline. Exit code aggregation runs through `totalViolations()` after Unit 1's refactor (the inline sum at `scripts/content-integrity.ts:784–787` is replaced). CI build job already runs the gate.
+- **State lifecycle risks:** None. Validators are pure functions over filesystem; cleanup is idempotent.
+- **API surface parity:** Two new exported types (`FrontmatterViolation`, `AgentModelViolation`) and two new exported functions (`checkFrontmatter`, `checkAgentModel`). Existing exports unchanged. No breaking changes to plugin entry point.
+- **Integration coverage:** Real-repo smoke test in `tests/unit/content-integrity.test.ts` (mirroring existing pattern at lines 980+) asserts `frontmatterViolations: []` and `agentModelViolations: []` against actual `main` post-Unit-2.
+- **Unchanged invariants:**
+  - `dist/index.js` still exports only the plugin factory function. No new named exports leak to entry point (per OpenCode plugin loader constraint).
+  - Runtime loader contract is preserved — `claude-permissions-optimizer`'s forked-subtask dispatch (`context: fork` / `subtask: true`) is not modified.
+  - Existing `BANNED_PATTERNS` and allowlist behavior are preserved.
+  - `parseFrontmatter` API unchanged.
+  - Skill loader behavior unchanged.
+
+## Risks & Dependencies
+
+| Risk                                                                                                                  | Mitigation                                                                                                                                                                                                                                                                                                                            |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Empirical audit (Unit 1 dry-run pass) surfaces violations the conceptual audit missed                                | Expected and accommodated: Unit 2's file list flexes to whatever Unit 1 surfaces. The Unit 2 description explicitly reads the empirical output before committing the cleanup. If a malformed-frontmatter or unknown-field hit appears on a previously-uninspected file, decide between fix-in-place vs. allowlist-with-reason inline. |
+| Mid-PR scope expansion if Unit 1 surfaces violations needing per-case decisions                                        | The single-PR re-sequencing means Unit 5 (validator enforcement) is the LAST commit. If Unit 2 cleanup needs to expand or split, Unit 5 simply waits. Decision tree: (a) for runtime-recognized fields, allowlist; (b) for new unknown fields, add to Unit 2 cleanup; (c) for malformed YAML, fix in place.                            |
+| Spec body grows past 350-line target                                                                                  | 350-line target is informational; if content warrants depth, push it into `references/foundation-conventions.md` rather than letting SKILL.md grow. Single threshold (350); no second 400-line threshold.                                                                                                                             |
+| `ENFORCE_FRONTMATTER_RULES` flag remains `false` after merge by oversight                                              | Unit 5's verification includes a synthetic-violation-then-revert local test that proves the flag is `true` and the gate exits 1 on violations. CI on the post-merge `main` will also fail if the flag is left off and any violation slips in.                                                                                          |
+| `name:` namespace migration creates inconsistency — 1 skill with `systematic:` prefix, 37 with bare names               | Acknowledged. V2 migration plan handles this. V1 documents the convention without enforcing it. The new skill is the first instance and sets precedent.                                                                                                                                                                               |
+| New validator semantics differ subtly from runtime skill-loader's frontmatter expectations                              | Both use `parseFrontmatter` from `src/lib/frontmatter.ts`. The validator's allow-list constant explicitly mirrors the runtime loader's enumerated set. Single source of truth prevents drift.                                                                                                                                          |
+| Plan-taxonomy leak from this plan into shipped source                                                                 | Unit 7 runs the documented grep gate. The reference file `foundation-conventions.md` will contain prose that may incidentally use the words "unit" or "requirement" in non-taxonomy senses; the grep is `\bR[0-9]+|Unit [0-9]+|\(v[0-9]+\)` so plain English is safe.                                                                  |
+| Self-referential test reveals the new skill itself violates a rule                                                    | Catalog-wide assertion in Unit 7 catches this. If it fails, fix in place before merge.                                                                                                                                                                                                                                                |
+| Author behavior change (skill being invoked before authoring) is unenforced                                            | Acknowledged limitation. The validator's remediation messages reference `systematic:writing-systematic-skills` so authors hit the spec via gate failure rather than relying on voluntary invocation. Authoring-time enforcement (pre-commit hook, scaffold tool) is deferred to V2. Same class as recently invalidated probes; documented but not solved by V1. |
+
+## Documentation / Operational Notes
+
+- **CHANGELOG**: v2.7.0 minor entry covering: new bundled skill `systematic:writing-systematic-skills`, `checkFrontmatter` + `checkAgentModel` validators, `workflows` removal from `SUBFILE_DIRECTORY_NAMES`, audit-driven cleanup of 13 agents + 1 skill (compound-docs).
+- **PR description**: should describe what authors gain (a written spec, gate enforcement, clean baseline) without referencing internal session details (no R-IDs, no Unit numbers).
+- **No rollout concerns**: validators are CI-time only; no runtime impact on plugin consumers. Cleanup is content-only with no behavioral consequences. `claude-permissions-optimizer` is unchanged — its forked-subtask dispatch is preserved.
+- **Post-merge**: V2 brainstorm candidates: (1) `ce:*` workflow conventions (phase numbering, document-review interleave); (2) `name:` namespace migration plan (37 bare-name skills → `systematic:` prefix); (3) authoring-time enforcement (scaffold tool, pre-commit); (4) `argument-hint` slot-typing.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-28-writing-systematic-skills-requirements.md](../brainstorms/2026-04-28-writing-systematic-skills-requirements.md)
+- **Related code:**
+  - `scripts/content-integrity.ts` — gate runtime; new checks slot into existing pattern
+  - `src/lib/skills.ts:71–84` — `extractFrontmatter` is the runtime loader's allowed-fields source of truth
+  - `src/lib/frontmatter.ts:19` — `parseFrontmatter` reused by both new validators
+  - `tests/unit/content-integrity.test.ts:980+` — real-repo smoke test pattern to mirror
+  - `skills/ce-brainstorm/SKILL.md` — body length / density reference (198 lines)
+  - `skills/proof/SKILL.md:22` — `ai:systematic` machine-id usage example
+  - `agents/review/testing-reviewer.md` — canonical `model: inherit` placement for review agents with `mode: subagent`
+  - `package.json` (`registry:build`, `registry:validate`) — canonical registry script entrypoints
+- **Related PRs:**
+  - PR #301 — content-integrity gate base (TDD pattern, fixture helpers)
+  - PR #315 — registry generator
+  - PR #319 — sub-file integrity check
+- **External docs:** None used. writing-skills is a user-installed skill; the new skill cites it but does not duplicate.

--- a/docs/scripts/transform-content.ts
+++ b/docs/scripts/transform-content.ts
@@ -170,6 +170,7 @@ const AGENT_CATEGORY_ORDER = [
   'Review',
   'Research',
   'Design',
+  'Document-review',
   'Docs',
   'Workflow',
 ] as const

--- a/docs/scripts/transform-content.ts
+++ b/docs/scripts/transform-content.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import yaml from 'js-yaml'
+import { parseFrontmatter } from '../../src/lib/frontmatter.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -22,25 +23,6 @@ interface DefinitionEntry {
   description: string
   slug: string
   category?: string
-}
-
-function parseFrontmatter(
-  content: string,
-  sourcePath: string,
-): {
-  data: Frontmatter
-  body: string
-} {
-  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n?---\r?\n([\s\S]*)$/)
-  if (!match) return { data: {}, body: content }
-
-  try {
-    const parsed = yaml.load(match[1], { schema: yaml.JSON_SCHEMA })
-    return { data: (parsed ?? {}) as Frontmatter, body: match[2] }
-  } catch (error) {
-    console.warn(`⚠️  Failed to parse frontmatter in: ${sourcePath}`, error)
-    return { data: {}, body: match[2] }
-  }
 }
 
 const ACRONYMS = new Set([
@@ -295,7 +277,11 @@ function processDirectory(
   for (const file of files) {
     try {
       const content = fs.readFileSync(file, 'utf8')
-      const { data, body } = parseFrontmatter(content, file)
+      const parsed = parseFrontmatter<Frontmatter>(content)
+      if (parsed.parseError) {
+        console.warn(`⚠️  Failed to parse frontmatter in: ${file}`)
+      }
+      const { data, body } = parsed
 
       const name = deriveName(data, file, definitionType)
       const category = deriveCategory(file, definitionType)

--- a/registry/registry.jsonc
+++ b/registry/registry.jsonc
@@ -727,6 +727,15 @@
       "files": ["skills/using-systematic/SKILL.md"]
     },
     {
+      "name": "writing-systematic-skills",
+      "type": "skill",
+      "description": "Use when creating, editing, auditing, or fixing bundled Systematic skills, especially when authoring SKILL.md files, adding skill reference files, resolving content-integrity frontmatter failures, or deciding which Systematic conventions apply beyond the general writing-skills guidance.",
+      "files": [
+        "skills/writing-systematic-skills/SKILL.md",
+        "skills/writing-systematic-skills/references/foundation-conventions.md"
+      ]
+    },
+    {
       "name": "skills",
       "type": "bundle",
       "description": "All Systematic skills",
@@ -775,7 +784,8 @@
         "todo-create",
         "todo-resolve",
         "todo-triage",
-        "using-systematic"
+        "using-systematic",
+        "writing-systematic-skills"
       ],
       "files": []
     },

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -709,7 +709,8 @@ export function checkAgentModel(
     const content = readFileSafe(path.join(rootDir, relPath))
     if (content === null) continue
     const parsed = parseFrontmatter(content)
-    if (parsed.data.model !== 'inherit') {
+    const model = isRecord(parsed.data) ? parsed.data.model : undefined
+    if (model !== 'inherit') {
       violations.push({
         file: relPath,
         message: 'Bundled agents must declare model: inherit.',

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -2,7 +2,7 @@
 /**
  * Content-Integrity Gate
  *
- * Enforces three content invariants across Systematic's shipped assets:
+ * Enforces five content invariants across Systematic's shipped assets:
  *
  * 1. **Cross-skill reference integrity** — every `systematic:<category>:<name>`
  *    reference in bundled skills and agents resolves to an actual
@@ -10,7 +10,7 @@
  *    over from sync operations or sub-agent bulk edits.
  *
  * 2. **Sub-file reference integrity** — every `references/foo.md`, `scripts/foo.sh`,
- *    `templates/foo.md`, `assets/foo.md`, or `workflows/foo.yml` mentioned in a
+ *    `templates/foo.md`, or `assets/foo.md` mentioned in a
  *    `skills/<name>/SKILL.md` resolves to a real file in that skill's directory.
  *    Catches drift from CEP syncs that imported the SKILL.md but missed the
  *    referenced sub-files (the failure mode that motivated this PR).
@@ -19,6 +19,12 @@
  *    names, plugin prefix, paths, env vars) appears only inside documented
  *    allowlist entries. Catches accidental reintroduction of Claude Code or
  *    Compound Engineering refs after the v2.4.0 divorce.
+ *
+ * 4. **Skill frontmatter integrity** — bundled skills declare required fields
+ *    and use only frontmatter keys recognized by the runtime loader.
+ *
+ * 5. **Agent model portability** — bundled agents inherit the user's configured
+ *    model instead of hardcoding provider-specific model IDs.
  *
  * Scope is narrow by design: `skills/**\/*.md`, `agents/**\/*.md`, and
  * `src/**\/*.ts`. The gate does not scan `docs/`, `.opencode/`, `.github/`,
@@ -40,6 +46,8 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { parseFrontmatter } from '../src/lib/frontmatter.js'
+import { SKILL_FRONTMATTER_FIELDS } from '../src/lib/skills.js'
 import { walkDir } from '../src/lib/walk-dir.js'
 
 // ---------------------------------------------------------------------------
@@ -128,6 +136,25 @@ export interface ExemptHit {
   reason: string
 }
 
+export interface FrontmatterViolation {
+  file: string
+  rule:
+    | 'banned-field'
+    | 'unknown-field'
+    | 'missing-required-field'
+    | 'empty-required-field'
+    | 'malformed-frontmatter'
+    | 'missing-frontmatter'
+  field?: string
+  message: string
+  remediation: string
+}
+
+export interface AgentModelViolation {
+  file: string
+  message: string
+}
+
 export interface CheckResult {
   rootDir: string
   categories: string[]
@@ -135,12 +162,22 @@ export interface CheckResult {
   phantomRefs: PhantomRef[]
   brokenSubfileRefs: BrokenSubfileRef[]
   bannedPatterns: BannedPatternHit[]
+  frontmatterViolations: FrontmatterViolation[]
+  agentModelViolations: AgentModelViolation[]
   exemptHits: ExemptHit[]
   scanStats: {
     markdownFiles: number
     typescriptFiles: number
   }
 }
+
+const ALLOWED_SKILL_FRONTMATTER_FIELDS: ReadonlySet<string> = new Set(
+  SKILL_FRONTMATTER_FIELDS,
+)
+
+const BANNED_SKILL_FRONTMATTER_FIELDS = new Set(['preconditions'])
+const FRONTMATTER_REMEDIATION =
+  'Update frontmatter to match systematic:writing-systematic-skills.'
 
 // ---------------------------------------------------------------------------
 // Allowlist loader
@@ -477,14 +514,13 @@ export const SUBFILE_DIRECTORY_NAMES = [
   'scripts',
   'templates',
   'assets',
-  'workflows',
 ] as const
 
 /**
  * Match relative paths under a skill's sub-directory:
  *
  *   `references/foo.md`, `scripts/foo.sh`, `templates/foo.md`,
- *   `assets/foo.md`, `workflows/foo.yml`, `./references/foo.md`, etc.
+ *   `assets/foo.md`, `./references/foo.md`, etc.
  *
  * The match boundary on the left side requires start-of-line, whitespace,
  * an opening parenthesis, or a backtick. This avoids false positives like
@@ -551,6 +587,147 @@ function scanSkillForBrokenSubfiles(
       })
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter checks
+// ---------------------------------------------------------------------------
+
+export function checkFrontmatter(
+  rootDir: string,
+  markdownFiles: readonly string[],
+): FrontmatterViolation[] {
+  const violations: FrontmatterViolation[] = []
+
+  for (const relPath of markdownFiles) {
+    if (!isSkillEntryFile(relPath)) continue
+    const content = readFileSafe(path.join(rootDir, relPath))
+    if (content === null) continue
+    scanSkillFrontmatter(relPath, content, violations)
+  }
+
+  return violations
+}
+
+function scanSkillFrontmatter(
+  relPath: string,
+  content: string,
+  violations: FrontmatterViolation[],
+): void {
+  const parsed = parseFrontmatter(content)
+
+  if (parsed.parseError) {
+    violations.push({
+      file: relPath,
+      rule: 'malformed-frontmatter',
+      message: 'Skill frontmatter is malformed YAML.',
+      remediation: FRONTMATTER_REMEDIATION,
+    })
+    return
+  }
+
+  if (!parsed.hadFrontmatter) {
+    violations.push({
+      file: relPath,
+      rule: 'missing-frontmatter',
+      message: 'Skill is missing YAML frontmatter.',
+      remediation: FRONTMATTER_REMEDIATION,
+    })
+    return
+  }
+
+  checkRequiredSkillField(relPath, parsed.data, 'name', violations)
+  checkRequiredSkillField(relPath, parsed.data, 'description', violations)
+  checkSkillFrontmatterFields(relPath, parsed.data, violations)
+}
+
+function checkRequiredSkillField(
+  relPath: string,
+  data: Record<string, unknown>,
+  field: 'name' | 'description',
+  violations: FrontmatterViolation[],
+): void {
+  if (!Object.hasOwn(data, field) || data[field] === null) {
+    violations.push({
+      file: relPath,
+      rule: 'missing-required-field',
+      field,
+      message: `Skill frontmatter is missing required ${field} field.`,
+      remediation: FRONTMATTER_REMEDIATION,
+    })
+    return
+  }
+
+  if (typeof data[field] === 'string' && data[field].trim() === '') {
+    violations.push({
+      file: relPath,
+      rule: 'empty-required-field',
+      field,
+      message: `Skill frontmatter ${field} field must not be empty.`,
+      remediation: FRONTMATTER_REMEDIATION,
+    })
+  }
+}
+
+function checkSkillFrontmatterFields(
+  relPath: string,
+  data: Record<string, unknown>,
+  violations: FrontmatterViolation[],
+): void {
+  for (const field of Object.keys(data)) {
+    if (BANNED_SKILL_FRONTMATTER_FIELDS.has(field)) {
+      violations.push({
+        file: relPath,
+        rule: 'banned-field',
+        field,
+        message: `Skill frontmatter field ${field} is banned.`,
+        remediation: FRONTMATTER_REMEDIATION,
+      })
+      continue
+    }
+
+    if (!ALLOWED_SKILL_FRONTMATTER_FIELDS.has(field)) {
+      violations.push({
+        file: relPath,
+        rule: 'unknown-field',
+        field,
+        message: `Skill frontmatter field ${field} is not recognized by the runtime loader.`,
+        remediation: FRONTMATTER_REMEDIATION,
+      })
+    }
+  }
+}
+
+export function checkAgentModel(
+  rootDir: string,
+  markdownFiles: readonly string[],
+): AgentModelViolation[] {
+  const violations: AgentModelViolation[] = []
+
+  for (const relPath of markdownFiles) {
+    if (!isAgentFile(relPath)) continue
+    const content = readFileSafe(path.join(rootDir, relPath))
+    if (content === null) continue
+    const parsed = parseFrontmatter(content)
+    if (parsed.data.model !== 'inherit') {
+      violations.push({
+        file: relPath,
+        message: 'Bundled agents must declare model: inherit.',
+      })
+    }
+  }
+
+  return violations
+}
+
+function isAgentFile(relPath: string): boolean {
+  const parts = relPath.split('/')
+  return (
+    parts.length === 3 &&
+    parts[0] === 'agents' &&
+    parts[2]?.endsWith('.md') === true &&
+    (parts[1]?.length ?? 0) > 0
+  )
 }
 
 function isSkillEntryFile(relPath: string): boolean {
@@ -655,6 +832,8 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     categories,
   )
   const brokenSubfileRefs = checkSubfileReferences(rootDir, targets.markdown)
+  const frontmatterViolations = checkFrontmatter(rootDir, targets.markdown)
+  const agentModelViolations = checkAgentModel(rootDir, targets.markdown)
   const { hits: bannedPatterns, exempt: exemptHits } = checkBannedPatterns(
     rootDir,
     allScannedFiles,
@@ -668,6 +847,8 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     phantomRefs,
     brokenSubfileRefs,
     bannedPatterns,
+    frontmatterViolations,
+    agentModelViolations,
     exemptHits,
     scanStats: {
       markdownFiles: targets.markdown.length,
@@ -705,6 +886,8 @@ function printResult(result: CheckResult, verbose: boolean): void {
   printPhantomRefs(result.phantomRefs)
   printBrokenSubfileRefs(result.brokenSubfileRefs)
   printBannedPatterns(result.bannedPatterns)
+  printFrontmatterViolations(result.frontmatterViolations)
+  printAgentModelViolations(result.agentModelViolations)
 
   if (totalViolations(result) === 0) {
     process.stdout.write(
@@ -719,6 +902,8 @@ function printResult(result: CheckResult, verbose: boolean): void {
     process.stdout.write(
       `\ncategories: ${result.categories.join(', ')}\n` +
         `scanStats: ${result.scanStats.markdownFiles} md + ${result.scanStats.typescriptFiles} ts\n` +
+        `frontmatterViolations: ${result.frontmatterViolations.length}\n` +
+        `agentModelViolations: ${result.agentModelViolations.length}\n` +
         `exemptHits: ${result.exemptHits.length}\n`,
     )
   }
@@ -756,11 +941,35 @@ function printBannedPatterns(hits: readonly BannedPatternHit[]): void {
   }
 }
 
+function printFrontmatterViolations(
+  violations: readonly FrontmatterViolation[],
+): void {
+  if (violations.length === 0) return
+  process.stderr.write(`\nFrontmatter violations (${violations.length}):\n`)
+  for (const v of violations) {
+    const field = v.field ? ` (${v.field})` : ''
+    process.stderr.write(`  ${v.file}  ${v.rule}${field}: ${v.message}\n`)
+    process.stderr.write(`    fix: ${v.remediation}\n`)
+  }
+}
+
+function printAgentModelViolations(
+  violations: readonly AgentModelViolation[],
+): void {
+  if (violations.length === 0) return
+  process.stderr.write(`\nAgent model violations (${violations.length}):\n`)
+  for (const v of violations) {
+    process.stderr.write(`  ${v.file}  ${v.message}\n`)
+  }
+}
+
 function totalViolations(result: CheckResult): number {
   return (
     result.phantomRefs.length +
     result.brokenSubfileRefs.length +
-    result.bannedPatterns.length
+    result.bannedPatterns.length +
+    result.frontmatterViolations.length +
+    result.agentModelViolations.length
   )
 }
 
@@ -781,10 +990,7 @@ function main(): number {
 
   printResult(result, verbose)
 
-  const violationCount =
-    result.phantomRefs.length +
-    result.brokenSubfileRefs.length +
-    result.bannedPatterns.length
+  const violationCount = totalViolations(result)
   return violationCount > 0 ? 1 : 0
 }
 

--- a/skills/compound-docs/SKILL.md
+++ b/skills/compound-docs/SKILL.md
@@ -7,9 +7,6 @@ allowed-tools:
   - Write
   - Bash
   - Grep
-preconditions:
-  - Problem has been solved (not in-progress)
-  - Solution has been verified working
 ---
 
 # compound-docs Skill
@@ -21,6 +18,8 @@ preconditions:
 This skill captures problem solutions immediately after confirmation, creating structured documentation that serves as a searchable knowledge base for future sessions.
 
 **Organization:** Single-file architecture - each problem documented as one markdown file in its symptom category directory (e.g., `docs/solutions/performance-issues/n-plus-one-briefs.md`). Files use YAML frontmatter for metadata and searchability.
+
+**Prerequisites:** The problem has been solved and the solution has been verified working. Do not document in-progress investigations as finalized solutions.
 
 ---
 

--- a/skills/writing-systematic-skills/SKILL.md
+++ b/skills/writing-systematic-skills/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: writing-systematic-skills
+description: Use when creating, editing, auditing, or fixing bundled Systematic skills, especially when authoring SKILL.md files, adding skill reference files, resolving content-integrity frontmatter failures, or deciding which Systematic conventions apply beyond the general writing-skills guidance.
+---
+
+# Writing Systematic Skills
+
+Systematic skills are OpenCode-native workflow assets. Use this skill after loading the general `writing-skills` foundation; this file only covers the Systematic-specific delta.
+
+## When To Use
+
+Use this skill when you are:
+
+- Creating a new bundled skill under `skills/`
+- Editing an existing bundled skill's frontmatter or file layout
+- Fixing content-integrity frontmatter or sub-file failures
+- Deciding whether a skill needs references, scripts, assets, or templates
+- Auditing bundled skills for provider-portable defaults
+
+Do not use this as a replacement for `~/.agents/skills/writing-skills/SKILL.md`. Load that foundation first when authoring or substantially editing skill content.
+
+## Foundation
+
+`writing-skills` supplies the authoring discipline: pressure scenarios, clear trigger-oriented descriptions, concise bodies, and reference files only when depth earns its keep.
+
+Systematic adds repository-specific constraints:
+
+- Runtime-recognized frontmatter fields are fixed by the skill loader.
+- Skill sub-files live in a small set of conventional directories.
+- Bundled agents must use provider-portable model defaults.
+- Content-integrity enforces the mechanical parts in CI.
+
+For worked examples and judgment calls, read `references/foundation-conventions.md`.
+
+## Frontmatter Rules
+
+Every bundled skill must have YAML frontmatter with:
+
+- `name` - unprefixed skill identifier. The loader adds the `systematic:` command prefix automatically unless the skill intentionally belongs to another namespace such as `ce:`.
+- `description` - third-person trigger conditions. Prefer `Use when...`; describe when to load the skill, not its internal workflow.
+
+Optional fields are allowed only when the runtime loader recognizes them:
+
+| Field | Use |
+|---|---|
+| `argument-hint` | Shows expected invocation arguments. |
+| `disable-model-invocation` | Prevents direct model invocation for dispatcher-style skills. |
+| `allowed-tools` | Declares tool constraints for skill execution. |
+| `license` | Carries skill licensing metadata. |
+| `compatibility` | Notes platform or version compatibility. |
+| `metadata` | String-only metadata map. |
+| `user-invocable` | Marks whether users should invoke the skill directly. |
+| `agent` | Selects a companion agent when the loader supports it. |
+| `model` | Selects a model for skill execution when justified. |
+| `context` | Use `fork` when the skill should run in forked subtask context. |
+| `subtask` | Explicit forked-subtask marker recognized by the runtime. |
+
+`preconditions` is banned. It has no runtime consumer. Put prerequisite guidance in the skill body instead.
+
+## File Layout
+
+The required entry point is:
+
+```text
+skills/<skill-name>/SKILL.md
+```
+
+Optional sub-files must live under one of these directories:
+
+- `references/` - deeper guidance, decision tables, long examples, or API notes
+- `scripts/` - executable helpers an agent can run
+- `assets/` - static files used by the skill
+- `templates/` - reusable stubs or document templates
+
+Keep the main `SKILL.md` small enough to decide whether and how to proceed. Move heavy detail to `references/`, and cite it with a repo-local path such as `references/foundation-conventions.md` so the sub-file integrity gate can verify it exists.
+
+## Identity Defaults
+
+Bundled agents must declare:
+
+```yaml
+model: inherit
+```
+
+Hardcoded provider model IDs break users who do not use that provider. Use `model: inherit` unless a future design explicitly proves a provider-specific dependency and documents the tradeoff.
+
+For agent or API attribution, `ai:systematic` is the machine ID used by Systematic-owned operations, such as Proof's `by` field and `X-Agent-Id` header. It is not a skill cross-reference convention.
+
+## Validator
+
+Run the content-integrity gate before shipping skill changes:
+
+```bash
+bun 'scripts/content-integrity.ts'
+```
+
+The gate checks:
+
+- Skill frontmatter is present and uses only runtime-recognized fields.
+- Required `name` and `description` fields are non-empty.
+- Banned frontmatter such as `preconditions` is absent.
+- Bundled agents use `model: inherit`.
+- Skill references to `references/`, `scripts/`, `assets/`, and `templates/` resolve on disk.
+
+If the gate fails, fix the content rather than broadening the validator unless the runtime loader contract has actually changed.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Adding a new frontmatter field because it reads well | Add body prose instead, unless the runtime loader consumes the field. |
+| Summarizing the whole workflow in `description` | Describe trigger conditions only. |
+| Adding provider-specific agent models | Use `model: inherit`. |
+| Linking to a non-existent reference file | Create the file or remove the link. |
+| Duplicating the general writing-skills guidance | Link to the foundation and document only the Systematic delta. |

--- a/skills/writing-systematic-skills/references/foundation-conventions.md
+++ b/skills/writing-systematic-skills/references/foundation-conventions.md
@@ -1,0 +1,143 @@
+# Foundation Conventions
+
+This reference expands the Systematic-specific rules from `SKILL.md`. The mechanical rules are enforced by `bun scripts/content-integrity.ts`; this file explains the judgment calls behind them.
+
+## Frontmatter
+
+Systematic skill frontmatter mirrors what the runtime loader actually reads. Do not invent fields for documentation structure. If the loader does not consume the field, put the information in the body.
+
+| Field | Required | When To Use | Example |
+|---|---:|---|---|
+| `name` | Yes | Every skill. Use the unprefixed skill identifier unless another namespace is intentional. | `name: writing-systematic-skills` |
+| `description` | Yes | Trigger-oriented discovery text. Third person. Prefer `Use when...`. | `description: Use when fixing bundled skill frontmatter failures...` |
+| `argument-hint` | No | The skill accepts meaningful invocation arguments. | `argument-hint: "[path/to/document.md]"` |
+| `disable-model-invocation` | No | Dispatcher or routing skills that should not be directly model-invoked. | `disable-model-invocation: true` |
+| `allowed-tools` | No | The skill needs an explicit tool allowlist. | `allowed-tools: Bash, Read` |
+| `license` | No | Licensing metadata matters for distribution. | `license: MIT` |
+| `compatibility` | No | A platform or version caveat is real and useful. | `compatibility: OpenCode` |
+| `metadata` | No | String-only metadata map. Keep it boring. | `metadata: { owner: systematic }` |
+| `user-invocable` | No | Direct user invocation should be explicitly advertised or suppressed. | `user-invocable: false` |
+| `agent` | No | A loader-supported companion agent is required. | `agent: general` |
+| `model` | No | A skill-level model choice is justified. Prefer inheritance elsewhere. | `model: inherit` |
+| `context` | No | Forked execution is required. `fork` derives subtask behavior at runtime. | `context: fork` |
+| `subtask` | No | Explicit forked-subtask dispatch marker. | `subtask: true` |
+
+### Required Fields
+
+`name` and `description` must be present. Empty strings are not valid values. Bare YAML keys such as `name:` parse as null and count as missing.
+
+### Banned Field
+
+`preconditions` is banned because it has no runtime consumer. Use a body section instead:
+
+```markdown
+## Prerequisites
+
+Only run this skill after the bug is reproduced and the fix has been verified.
+```
+
+### Runtime-Recognized Forking Fields
+
+`context: fork` and `subtask: true` are allowed. They are runtime-recognized and must not be treated as idiosyncratic frontmatter.
+
+Use them only when the skill genuinely needs forked subtask behavior. Do not cargo-cult them onto normal skills.
+
+### Description Style
+
+Good descriptions answer: should the agent load this skill now?
+
+Good:
+
+```yaml
+description: Use when creating, editing, auditing, or fixing bundled Systematic skills, especially when authoring SKILL.md files or resolving content-integrity frontmatter failures.
+```
+
+Bad:
+
+```yaml
+description: This skill explains frontmatter, file layout, validation, and identity defaults for Systematic skills.
+```
+
+The bad version describes content. The good version describes trigger conditions.
+
+## File Layout
+
+Every skill has exactly one entry point:
+
+```text
+skills/<skill-name>/SKILL.md
+```
+
+Use sub-files only when the content is too bulky or operationally distinct for the main skill.
+
+```text
+skills/<skill-name>/
+├── SKILL.md
+├── references/
+│   └── detailed-guidance.md
+├── scripts/
+│   └── helper.mjs
+├── assets/
+│   └── diagram.svg
+└── templates/
+    └── output-template.md
+```
+
+### Directory Choices
+
+| Directory | Use For | Do Not Use For |
+|---|---|---|
+| `references/` | Long explanations, decision tables, extended examples | Required setup that must be read before deciding to use the skill |
+| `scripts/` | Executable helpers the agent can run | Pseudocode or prose examples |
+| `assets/` | Static images, fixtures, or other bundled files | Markdown guidance that belongs in `references/` |
+| `templates/` | Fillable documents, prompts, or output stubs | Examples that should not be copied verbatim |
+
+### Sub-File Links
+
+When `SKILL.md` mentions a sub-file path, the content-integrity gate verifies it exists. Prefer direct repo-local paths:
+
+```markdown
+Read `references/foundation-conventions.md` for examples.
+```
+
+Avoid ambiguous references such as "the conventions doc". They are harder for agents to follow and impossible for the gate to verify.
+
+## Identity Defaults
+
+### Bundled Agent Model
+
+Bundled agents must use:
+
+```yaml
+model: inherit
+```
+
+This keeps Systematic provider-portable. Hardcoded provider IDs make an agent unusable for users on other providers and are almost never worth the lock-in.
+
+If a future agent truly depends on a specific provider, document the constraint in the plan and get explicit review before adding the hardcoded model.
+
+### Machine ID
+
+`ai:systematic` is a machine identity string for Systematic-owned operations. Proof uses it as the `by` field on operations and the `X-Agent-Id` header. Keep it lowercase and stable.
+
+Do not use `ai:systematic` as a skill-reference pattern. Skill and agent references use their own namespaces, such as `systematic:writing-systematic-skills` or `systematic:research:best-practices-researcher`.
+
+### Public-Facing Voice
+
+Skill text should be reusable guidance, not a session transcript. Avoid first-person process narration, internal note IDs, and references to how a particular implementation session unfolded.
+
+## Validator Workflow
+
+Run:
+
+```bash
+bun scripts/content-integrity.ts --verbose
+```
+
+Use the output as the source of truth for cleanup. If a violation surprises you, check the runtime loader before changing the validator:
+
+- Skill frontmatter rules mirror `src/lib/skills.ts`.
+- YAML parsing behavior comes from `src/lib/frontmatter.ts`.
+- Sub-file directories come from `SUBFILE_DIRECTORY_NAMES` in `scripts/content-integrity.ts`.
+
+When the runtime contract changes, update the loader and validator together. A validator allow-list that drifts from the loader creates false failures or misses real runtime-invisible fields.

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ const getPackageVersion = (): string => {
   }
 }
 
-export const SystematicPlugin: Plugin = async ({ client, directory }) => {
+const SystematicPlugin: Plugin = async ({ client, directory }) => {
   const config = loadConfig(directory)
 
   const configHandler = createConfigHandler({

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -19,7 +19,7 @@ export interface SkillFrontmatter {
   // Claude Code converted fields
   disableModelInvocation?: boolean // from YAML key: disable-model-invocation
   userInvocable?: boolean // from YAML key: user-invocable
-  subtask?: boolean // derived from context: "fork"
+  subtask?: boolean // from YAML key: subtask, or derived from context: "fork"
   agent?: string // from YAML key: agent
   model?: string // from YAML key: model
   argumentHint?: string // from YAML key: argument-hint
@@ -44,6 +44,22 @@ export interface SkillInfo {
   argumentHint?: string
   allowedTools?: string
 }
+
+export const SKILL_FRONTMATTER_FIELDS = [
+  'name',
+  'description',
+  'argument-hint',
+  'disable-model-invocation',
+  'allowed-tools',
+  'license',
+  'compatibility',
+  'metadata',
+  'user-invocable',
+  'agent',
+  'model',
+  'context',
+  'subtask',
+] as const
 
 export function extractFrontmatter(filePath: string): SkillFrontmatter {
   try {
@@ -76,7 +92,10 @@ export function extractFrontmatter(filePath: string): SkillFrontmatter {
       metadata,
       disableModelInvocation: extractBoolean(data, 'disable-model-invocation'),
       userInvocable: extractBoolean(data, 'user-invocable'),
-      subtask: data.context === 'fork' ? true : undefined,
+      subtask:
+        data.context === 'fork'
+          ? true
+          : (extractBoolean(data, 'subtask') ?? undefined),
       agent: extractNonEmptyString(data, 'agent'),
       model: extractNonEmptyString(data, 'model'),
       argumentHint: argumentHint !== '' ? argumentHint : undefined,

--- a/tests/integration/opencode.test.ts
+++ b/tests/integration/opencode.test.ts
@@ -115,10 +115,10 @@ describe.skipIf(!OPENCODE_AVAILABLE)('opencode integration', () => {
   })
 
   test(
-    'systematic_skill tool loads systematic:brainstorming skill',
+    'systematic_skill tool loads systematic skill with prefix',
     async () => {
       const result = await runOpencode(
-        'Use the systematic_skill tool to load systematic:brainstorming',
+        'Use the systematic_skill tool to load systematic:setup',
         {
           cwd: testEnv.projectDir,
           configContent: buildOpencodeConfig(),
@@ -126,24 +126,26 @@ describe.skipIf(!OPENCODE_AVAILABLE)('opencode integration', () => {
       )
 
       expect(result.stdout).toMatch(
-        /<skill-instruction>|brainstorm|systematic|skill loaded|loaded/i,
+        /Review agent configuration is no longer needed/i,
       )
     },
     TIMEOUT_MS * MAX_RETRIES,
   )
 
   test(
-    'systematic_skill tool lists systematic skills in description',
+    'systematic_skill tool loads systematic skill without prefix',
     async () => {
       const result = await runOpencode(
-        'What skills are available? List the systematic skills you can load.',
+        'Use the systematic_skill tool to load setup',
         {
           cwd: testEnv.projectDir,
           configContent: buildOpencodeConfig(),
         },
       )
 
-      expect(result.stdout).toMatch(/brainstorming|systematic.*skills/i)
+      expect(result.stdout).toMatch(
+        /Review agent configuration is no longer needed/i,
+      )
     },
     TIMEOUT_MS * MAX_RETRIES,
   )

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -6,8 +6,10 @@ import { fileURLToPath } from 'node:url'
 import {
   type AllowlistEntry,
   BANNED_PATTERNS,
+  checkAgentModel,
   checkBannedPatterns,
   checkContentIntegrity,
+  checkFrontmatter,
   checkReferenceIntegrity,
   checkSubfileReferences,
   collectScanTargets,
@@ -53,12 +55,20 @@ function writeAgent(root: string, category: string, name: string): void {
   writeFile(
     root,
     `agents/${category}/${name}.md`,
-    `---\nname: ${name}\n---\nagent body`,
+    `---\nname: ${name}\nmodel: inherit\n---\nagent body`,
   )
 }
 
 function writeSkill(root: string, name: string, body: string): void {
   writeFile(root, `skills/${name}/SKILL.md`, body)
+}
+
+function writeCompliantSkill(root: string, name: string, body: string): void {
+  writeSkill(
+    root,
+    name,
+    `---\nname: ${name}\ndescription: Test skill\n---\n${body}`,
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -622,17 +632,295 @@ describe('checkBannedPatterns', () => {
   })
 })
 
+describe('checkFrontmatter', () => {
+  test('allows minimal skill frontmatter with name and description', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeCompliantSkill(root, 'foo', 'body')
+      const targets = collectScanTargets(root)
+      expect(checkFrontmatter(root, targets.markdown)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('allows every runtime-recognized skill frontmatter field', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'foo',
+        [
+          '---',
+          'name: foo',
+          'description: Test skill',
+          'argument-hint: "[topic]"',
+          'disable-model-invocation: true',
+          'allowed-tools: read, grep',
+          'license: MIT',
+          'compatibility: opencode',
+          'metadata:',
+          '  owner: systematic',
+          'user-invocable: true',
+          'agent: general',
+          'model: inherit',
+          'context: fork',
+          'subtask: true',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const targets = collectScanTargets(root)
+      expect(checkFrontmatter(root, targets.markdown)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags banned preconditions field but allows context and subtask', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'foo',
+        [
+          '---',
+          'name: foo',
+          'description: Test skill',
+          'preconditions: must run first',
+          'context: fork',
+          'subtask: true',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkFrontmatter(root, targets.markdown)
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({
+        file: 'skills/foo/SKILL.md',
+        rule: 'banned-field',
+        field: 'preconditions',
+      })
+      expect(violations[0]?.message).toContain('preconditions')
+      expect(violations[0]?.remediation).toContain(
+        'systematic:writing-systematic-skills',
+      )
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags unknown fields one violation per field', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'foo',
+        [
+          '---',
+          'name: foo',
+          'description: Test skill',
+          'experimental: true',
+          'owner: platform',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkFrontmatter(root, targets.markdown)
+      expect(violations.map((v) => v.field).sort()).toEqual([
+        'experimental',
+        'owner',
+      ])
+      expect(violations.every((v) => v.rule === 'unknown-field')).toBe(true)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags missing, null, and empty required fields distinctly', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'missing-name',
+        '---\ndescription: Test skill\n---\nbody',
+      )
+      writeSkill(
+        root,
+        'bare-name',
+        '---\nname:\ndescription: Test skill\n---\nbody',
+      )
+      writeSkill(
+        root,
+        'null-name',
+        '---\nname: ~\ndescription: Test skill\n---\nbody',
+      )
+      writeSkill(
+        root,
+        'empty-name',
+        '---\nname: ""\ndescription: Test skill\n---\nbody',
+      )
+      writeSkill(
+        root,
+        'blank-name',
+        '---\nname: "   "\ndescription: Test skill\n---\nbody',
+      )
+      writeSkill(
+        root,
+        'blank-description',
+        '---\nname: blank-description\ndescription: "   "\n---\nbody',
+      )
+      writeSkill(
+        root,
+        'missing-description',
+        '---\nname: missing-description\n---\nbody',
+      )
+
+      const targets = collectScanTargets(root)
+      const violations = checkFrontmatter(root, targets.markdown)
+      expect(
+        violations.map((v) => `${v.file}:${v.field}:${v.rule}`).sort(),
+      ).toEqual([
+        'skills/bare-name/SKILL.md:name:missing-required-field',
+        'skills/blank-description/SKILL.md:description:empty-required-field',
+        'skills/blank-name/SKILL.md:name:empty-required-field',
+        'skills/empty-name/SKILL.md:name:empty-required-field',
+        'skills/missing-description/SKILL.md:description:missing-required-field',
+        'skills/missing-name/SKILL.md:name:missing-required-field',
+        'skills/null-name/SKILL.md:name:missing-required-field',
+      ])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('short-circuits parse edge cases without cascading field violations', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(root, 'missing-frontmatter', '# no frontmatter\n')
+      writeSkill(
+        root,
+        'malformed-frontmatter',
+        '---\nname: [unterminated\ndescription: Test skill\n---\nbody',
+      )
+
+      const targets = collectScanTargets(root)
+      const violations = checkFrontmatter(root, targets.markdown)
+      expect(violations).toHaveLength(2)
+      expect(
+        violations.map((v) => `${v.file}:${v.rule}:${v.field ?? ''}`).sort(),
+      ).toEqual([
+        'skills/malformed-frontmatter/SKILL.md:malformed-frontmatter:',
+        'skills/missing-frontmatter/SKILL.md:missing-frontmatter:',
+      ])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('scans only skill entry files', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/a.md',
+        '---\nname: a\nexperimental: true\n---\nagent',
+      )
+      writeFile(
+        root,
+        'skills/foo/references/ref.md',
+        '---\nexperimental: true\n---\nreference',
+      )
+      writeCompliantSkill(root, 'foo', 'body')
+      const targets = collectScanTargets(root)
+      expect(checkFrontmatter(root, targets.markdown)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('checkAgentModel', () => {
+  test('allows agents with model inherit', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAgent(root, 'research', 'a')
+      const targets = collectScanTargets(root)
+      expect(checkAgentModel(root, targets.markdown)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags missing, non-inherit, empty, and null model values', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/missing.md',
+        '---\nname: missing\n---\nbody',
+      )
+      writeFile(
+        root,
+        'agents/research/hardcoded.md',
+        '---\nname: hardcoded\nmodel: anthropic/claude-haiku-4-5\n---\nbody',
+      )
+      writeFile(
+        root,
+        'agents/research/empty.md',
+        '---\nname: empty\nmodel: ""\n---\nbody',
+      )
+      writeFile(
+        root,
+        'agents/research/null.md',
+        '---\nname: null\nmodel: ~\n---\nbody',
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkAgentModel(root, targets.markdown)
+      expect(violations.map((v) => v.file).sort()).toEqual([
+        'agents/research/empty.md',
+        'agents/research/hardcoded.md',
+        'agents/research/missing.md',
+        'agents/research/null.md',
+      ])
+      expect(
+        violations.every((v) => v.message.includes('model: inherit')),
+      ).toBe(true)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('scans only agent markdown files', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeCompliantSkill(root, 'foo', 'model: anthropic/claude-haiku-4-5\n')
+      writeFile(root, 'skills/foo/references/ref.md', 'model: anthropic/x\n')
+      writeAgent(root, 'research', 'a')
+      const targets = collectScanTargets(root)
+      expect(checkAgentModel(root, targets.markdown)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
 describe('checkContentIntegrity (top-level)', () => {
   test('clean repo with no violations returns empty arrays', () => {
     const root = makeFixtureRepo()
     try {
       writeAgent(root, 'research', 'a')
-      writeSkill(root, 'foo', 'See systematic:research:a.\n')
+      writeCompliantSkill(root, 'foo', 'See systematic:research:a.\n')
       writeFile(root, 'src/lib/foo.ts', '// clean\nexport const x = 1\n')
 
       const result = checkContentIntegrity(root)
       expect(result.phantomRefs).toEqual([])
+      expect(result.brokenSubfileRefs).toEqual([])
       expect(result.bannedPatterns).toEqual([])
+      expect(result.frontmatterViolations).toEqual([])
+      expect(result.agentModelViolations).toEqual([])
       expect(result.scanStats.markdownFiles).toBe(2) // SKILL.md + agent a.md
       expect(result.scanStats.typescriptFiles).toBe(1)
       expect(result.categories).toEqual(['research'])
@@ -682,6 +970,26 @@ describe('checkContentIntegrity (top-level)', () => {
       fs.rmSync(root, { recursive: true, force: true })
     }
   })
+
+  test('exposes frontmatter and agent-model violations in one pass', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'foo',
+        '---\nname: foo\ndescription: Test skill\npreconditions: before use\n---\nbody',
+      )
+      writeFile(root, 'agents/research/a.md', '---\nname: a\n---\nagent')
+
+      const result = checkContentIntegrity(root)
+      expect(result.frontmatterViolations).toHaveLength(1)
+      expect(result.frontmatterViolations[0]?.rule).toBe('banned-field')
+      expect(result.agentModelViolations).toHaveLength(1)
+      expect(result.agentModelViolations[0]?.file).toBe('agents/research/a.md')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -691,13 +999,12 @@ describe('checkContentIntegrity (top-level)', () => {
 // ---------------------------------------------------------------------------
 
 describe('SUBFILE_DIRECTORY_NAMES', () => {
-  test('covers the five conventional skill sub-directories', () => {
+  test('covers the four conventional skill sub-directories', () => {
     expect(SUBFILE_DIRECTORY_NAMES).toEqual([
       'references',
       'scripts',
       'templates',
       'assets',
-      'workflows',
     ])
   })
 })
@@ -835,7 +1142,7 @@ describe('checkSubfileReferences', () => {
     }
   })
 
-  test('handles all five conventional sub-directories', () => {
+  test('handles all four conventional sub-directories', () => {
     const root = makeFixtureRepo()
     try {
       writeSkill(
@@ -848,7 +1155,6 @@ describe('checkSubfileReferences', () => {
           'Run `scripts/missing.sh`.',
           'Use `templates/missing.md`.',
           'Reference `assets/missing.md`.',
-          'Workflow at `workflows/missing.yml`.',
         ].join('\n'),
       )
       const targets = collectScanTargets(root)
@@ -859,8 +1165,18 @@ describe('checkSubfileReferences', () => {
         'references/missing.md',
         'scripts/missing.sh',
         'templates/missing.md',
-        'workflows/missing.yml',
       ])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('does not flag workflows paths after removing workflows as a skill sub-directory', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(root, 'foo', '# foo\n\nWorkflow at `workflows/missing.yml`.\n')
+      const targets = collectScanTargets(root)
+      expect(checkSubfileReferences(root, targets.markdown)).toEqual([])
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }
@@ -939,9 +1255,25 @@ describe('integration: real repo', () => {
       throw new Error(`Broken sub-file references in repo:\n  ${details}`)
     }
 
+    if (result.frontmatterViolations.length > 0) {
+      const details = result.frontmatterViolations
+        .map((v) => `${v.file}  ${v.rule}  ${v.field ?? ''}`)
+        .join('\n  ')
+      throw new Error(`Frontmatter violations in repo:\n  ${details}`)
+    }
+
+    if (result.agentModelViolations.length > 0) {
+      const details = result.agentModelViolations
+        .map((v) => `${v.file}  ${v.message}`)
+        .join('\n  ')
+      throw new Error(`Agent model violations in repo:\n  ${details}`)
+    }
+
     expect(result.phantomRefs).toEqual([])
     expect(result.brokenSubfileRefs).toEqual([])
     expect(result.bannedPatterns).toEqual([])
+    expect(result.frontmatterViolations).toEqual([])
+    expect(result.agentModelViolations).toEqual([])
     expect(result.allowlistWarnings).toEqual([])
     expect(result.scanStats.markdownFiles).toBeGreaterThan(0)
     expect(result.scanStats.typescriptFiles).toBeGreaterThan(0)
@@ -957,7 +1289,7 @@ describe('CLI', () => {
     const root = makeFixtureRepo()
     try {
       writeAgent(root, 'research', 'a')
-      writeSkill(root, 'foo', 'Clean skill. systematic:research:a\n')
+      writeCompliantSkill(root, 'foo', 'Clean skill. systematic:research:a\n')
 
       const result = Bun.spawnSync(['bun', SCRIPT_PATH, root], {
         cwd: REPO_ROOT,
@@ -977,7 +1309,7 @@ describe('CLI', () => {
     try {
       // At least one agents/ category must exist for the reference regex to build.
       fs.mkdirSync(path.join(root, 'agents', 'research'), { recursive: true })
-      writeSkill(root, 'foo', 'systematic:research:ghost\n')
+      writeCompliantSkill(root, 'foo', 'systematic:research:ghost\n')
 
       const result = Bun.spawnSync(['bun', SCRIPT_PATH, root], {
         cwd: REPO_ROOT,
@@ -996,7 +1328,11 @@ describe('CLI', () => {
   test('exits 1 when banned patterns are outside the allowlist', () => {
     const root = makeFixtureRepo()
     try {
-      writeSkill(root, 'foo', 'Reintroduced TaskCreate accidentally.\n')
+      writeCompliantSkill(
+        root,
+        'foo',
+        'Reintroduced TaskCreate accidentally.\n',
+      )
 
       const result = Bun.spawnSync(['bun', SCRIPT_PATH, root], {
         cwd: REPO_ROOT,
@@ -1027,6 +1363,36 @@ describe('CLI', () => {
 
       expect(result.exitCode).toBe(1)
       expect(result.stderr.toString()).toContain('content-integrity:')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('exits 1 when enforced frontmatter and agent-model violations exist', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'foo',
+        '---\nname: foo\ndescription: Test skill\npreconditions: before use\n---\nbody',
+      )
+      writeFile(root, 'agents/research/a.md', '---\nname: a\n---\nagent')
+
+      const result = Bun.spawnSync(['bun', SCRIPT_PATH, root], {
+        cwd: REPO_ROOT,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+
+      expect(result.exitCode).toBe(1)
+      const stderr = result.stderr.toString()
+      expect(stderr).toContain('Frontmatter violations (1)')
+      expect(stderr).toContain('Agent model violations (1)')
+      expect(stderr).toContain('preconditions')
+      expect(stderr).toContain(
+        'fix: Update frontmatter to match systematic:writing-systematic-skills.',
+      )
+      expect(stderr).toContain('agents/research/a.md')
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -893,6 +893,27 @@ describe('checkAgentModel', () => {
     }
   })
 
+  test('flags non-object frontmatter as a missing model', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/list.md',
+        '---\n- model: inherit\n---\nbody',
+      )
+
+      const targets = collectScanTargets(root)
+      expect(checkAgentModel(root, targets.markdown)).toEqual([
+        {
+          file: 'agents/research/list.md',
+          message: 'Bundled agents must declare model: inherit.',
+        },
+      ])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   test('scans only agent markdown files', () => {
     const root = makeFixtureRepo()
     try {

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -24,6 +24,15 @@ describe('plugin loading', () => {
     expect(pluginModule.SystematicPlugin).toBeUndefined()
   })
 
+  test('CI smoke test loads the default plugin export', () => {
+    const workflowPath = path.join(ROOT_DIR, '.github/workflows/main.yaml')
+    const workflow = fs.readFileSync(workflowPath, 'utf8')
+
+    expect(workflow).toContain('const pluginFactory = m.default;')
+    expect(workflow).toContain('await pluginFactory({')
+    expect(workflow).not.toContain('m.SystematicPlugin')
+  })
+
   test('cli runs under Bun', async () => {
     const cliPath = path.join(SRC_DIR, 'cli.ts')
     const result = Bun.spawnSync(['bun', cliPath, '--help'])

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -20,7 +20,8 @@ describe('plugin loading', () => {
   test('plugin module loads', async () => {
     const pluginPath = path.join(SRC_DIR, 'index.ts')
     const pluginModule = await import(pathToFileURL(pluginPath).href)
-    expect(pluginModule.SystematicPlugin).toBeDefined()
+    expect(pluginModule.default).toBeDefined()
+    expect(pluginModule.SystematicPlugin).toBeUndefined()
   })
 
   test('cli runs under Bun', async () => {

--- a/tests/unit/skills.test.ts
+++ b/tests/unit/skills.test.ts
@@ -132,6 +132,36 @@ context: fork
       expect(result.subtask).toBe(true)
     })
 
+    test('extracts explicit subtask boolean', () => {
+      const filePath = path.join(testDir, 'test.md')
+      fs.writeFileSync(
+        filePath,
+        `---
+name: test-skill
+description: A test skill
+subtask: true
+---
+# Skill Content`,
+      )
+      const result = skills.extractFrontmatter(filePath)
+      expect(result.subtask).toBe(true)
+    })
+
+    test('preserves explicit subtask false when context is not fork', () => {
+      const filePath = path.join(testDir, 'test.md')
+      fs.writeFileSync(
+        filePath,
+        `---
+name: test-skill
+description: A test skill
+subtask: false
+---
+# Skill Content`,
+      )
+      const result = skills.extractFrontmatter(filePath)
+      expect(result.subtask).toBe(false)
+    })
+
     test('subtask is undefined when context is not fork', () => {
       const filePath = path.join(testDir, 'test.md')
       fs.writeFileSync(


### PR DESCRIPTION
## Summary
- Add the `writing-systematic-skills` bundled skill and foundation reference for Systematic-specific authoring conventions.
- Extend content-integrity with enforced skill frontmatter and bundled-agent `model: inherit` checks.
- Normalize existing catalog drift surfaced by the new checks and keep registry/docs counts aligned.

## Validation
- `bun run build`
- `bun run typecheck`
- `bun test`
- `bun scripts/content-integrity.ts`
- `bun run registry:build`
- `bun run registry:validate`
- `bun run docs:build`
- `node --input-type=module -e "const m = await import('./dist/index.js'); if (typeof m.default !== 'function') throw new Error('default export is not function'); const keys = Object.keys(m); if (keys.length !== 1 || keys[0] !== 'default') throw new Error('unexpected exports: ' + keys.join(','));"`
- `grep -rn -E "\\bR[0-9]+|Unit [0-9]+|\\(v[0-9]+\\)" "skills/writing-systematic-skills/" "scripts/content-integrity.ts" "tests/unit/content-integrity.test.ts"`

## Notes
- `bun run lint` still reports pre-existing unrelated Biome warnings in `skills/claude-permissions-optimizer/scripts`, `skills/onboarding/scripts`, and manual probe files; touched files pass `biome check`.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This changes bundled content, validation scripts, tests, and generated registry metadata only; there is no long-running service path to monitor.