### PR TITLE
fix(plugin): deduplicate factory registration across opencode.json sources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,8 @@ systematic/
 ├── agents/               # 50 bundled agents (6 categories: design/docs/document-review/research/review/workflow)
 ├── docs/                 # Starlight docs workspace (see docs/AGENTS.md)
 │   ├── scripts/          # Content generation from bundled assets
-│   └── src/content/      # Manual guides + generated reference
+│   ├── src/content/      # Manual guides + generated reference
+│   └── solutions/        # Documented solutions to past problems (bugs, best practices, workflow patterns), organized by category with YAML frontmatter (module, tags, problem_type)
 ├── registry/             # OCX registry config + profiles (omo, standalone)
 ├── scripts/              # Build + integrity scripts
 ├── assets/               # Static assets (banner SVG)

--- a/docs/plans/2026-05-01-001-fix-idempotent-plugin-registration-plan.md
+++ b/docs/plans/2026-05-01-001-fix-idempotent-plugin-registration-plan.md
@@ -1,0 +1,354 @@
+---
+title: 'fix: make plugin registration idempotent across duplicate config sources'
+type: fix
+status: active
+date: 2026-05-01
+---
+
+# fix: make plugin registration idempotent across duplicate config sources
+
+## Overview
+
+Add an empirically gated idempotency fix for duplicate Systematic plugin loads when the same plugin is listed in multiple OpenCode config sources. The work starts with a temporary Phase 0 factory probe in `src/index.ts` and pauses for a real OpenCode observation before any singleton code is shipped. If the probe confirms the same-process duplicate-factory pattern the user described, implementation proceeds with a `globalThis` + `Symbol.for(...)` singleton helper modeled on `opencode-copilot-delegate`, plus factory wiring, isolation tests, and full verification. If the probe shows a materially different pattern, implementation stops and reports instead of forcing the wrong architecture.
+
+Single-config users should see no behavior change. Duplicate-config users should end up with one effective plugin registration per process, one bounded duplicate warning per process, and no duplicate `systematic_skill` entries in host-visible tool listings.
+
+## Problem Frame
+
+OpenCode can invoke a plugin factory once per config source that references the plugin. When both a project-level config and a user-level config list Systematic, the plugin factory can run twice in the same process. Systematic's current factory at `src/index.ts` has no singleton guard and does meaningful per-call work:
+
+- loads config with `loadConfig(directory)`
+- snapshots bootstrap content with `getBootstrapContent(...)`
+- creates the config hook with `createConfigHandler(...)`
+- creates the `systematic_skill` tool with `createSkillTool(...)`
+- returns hook closures that register config mutations, tool definitions, and system-prompt injection
+
+That makes the duplicate observable as duplicate tool registration, duplicate init side effects, and duplicated closure state. The requested fix is the same per-process singleton pattern already used in `opencode-copilot-delegate`.
+
+The important Systematic-specific trap is that the current factory also captures caller-scoped state (`directory`, merged config, bootstrap snapshot, disabled lists, and `client.app.log`). A whole-hooks singleton is only safe if the real duplicate path does not expose meaningful caller variance. The plan therefore treats the Phase 0 probe as a hard gate rather than a box-checking exercise.
+
+## Requirements Trace
+
+### Probe Validation
+
+- R1. Confirm the current Systematic plugin factory matches the problem shape: real init work, real hook registration, no existing singleton guard.
+- R2. Add a temporary pre-flight probe at the top of the factory body and verify the real OpenCode loader behavior before implementation.
+- R3. Build the local plugin, temporarily point the user-level OpenCode plugin entry at the local `dist/index.js`, and stop for the user's pasted probe output.
+
+### Singleton Contract
+
+- R4. If and only if the probe matches the expected duplicate-factory pattern, add a per-process singleton helper using `globalThis`, `Symbol.for(...)`, cached `Promise<Hooks>`, PID matching, one-shot duplicate warning, and swallowed `onDuplicate` exceptions.
+- R5. Keep `_resetPluginSingleton()` test-only and ensure production code never calls it.
+
+### Test Isolation
+
+- R6. Add the requested 8 unit tests for the singleton helper.
+- R7. Update factory-driving tests so singleton state cannot leak across cases.
+
+### Verification And Handoff
+
+- R8. Verify full quality gates: tests, typecheck, lint, and build.
+- R9. End execution with a local feature branch and local commit only; do not push or open a PR without explicit follow-up.
+
+## Scope Boundaries
+
+- No OpenCode upstream changes, issue filing, or host-side loader modifications.
+- No unrelated refactors inside `src/index.ts`, `src/lib/config-handler.ts`, `src/lib/skill-tool.ts`, or `src/lib/bootstrap.ts` beyond the work needed to support safe idempotency.
+- No public documentation or README update in this pass.
+- No permanent probe or debug logging shipped in the final diff.
+- No release-system migration. This repo uses semantic-release, not Changesets.
+
+### Deferred to Separate Tasks
+
+- If the Phase 0 probe shows differing caller-scoped inputs that make a whole-hooks singleton unsafe, the fallback design work (for example, narrowing the singleton to package-static runtime state or redesigning duplicate registration boundaries) should be handled as a fresh planning decision instead of being improvised mid-implementation.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/index.ts` is the default plugin factory. It already uses one module-scope flag (`hasLoggedInit`) and returns three hook surfaces: `config`, `tool.systematic_skill`, and `'experimental.chat.system.transform'`.
+- `src/lib/config.ts` resolves merged config from user and project config roots via `loadConfig(directory)`. This makes merged config directory-scoped, not package-scoped.
+- `src/lib/config-handler.ts` builds a config hook that captures `directory` and bundled content paths, then re-runs `loadConfig(directory)` inside the returned hook. Existing config entries win over bundled entries.
+- `src/lib/skill-tool.ts` builds the `systematic_skill` tool from bundled skills plus `disabledSkills`. It caches description metadata in closure state, which is safe only when the captured disabled list is the correct one.
+- `src/lib/bootstrap.ts` currently snapshots bootstrap content once per plugin init. Existing tests already pin the restart-required behavior for custom bootstrap file edits.
+- `tests/unit/plugin.test.ts` is the primary factory-facing test file. It already dynamically imports `src/index.ts`, checks default-export shape, and verifies bootstrap snapshot semantics.
+- `tests/unit/config-handler.test.ts` and `tests/unit/skill-tool.test.ts` show the repo's standard testing style: real temp directories, real filesystem fixtures, `bun:test`, and minimal mocking.
+- `tests/manual/session-compacting-probe.ts` and `tests/manual/companion-aware-probe.ts` are the closest local precedents for a Phase 0 probe: temporary instrumentation, real `opencode serve`, explicit pass/fail verdicts, and a hard stop when the observed host behavior diverges from the design assumption.
+- External precedent: `opencode-copilot-delegate/src/runtime/plugin-singleton.ts` and `opencode-copilot-delegate/src/index.ts` show the exact requested singleton helper and plugin-factory wiring pattern.
+- `package.json` and `.releaserc.yaml` confirm that Systematic uses semantic-release. There is no `.changeset/` directory or Changesets automation.
+- `.opencode/` does not contain a checked-in plugin registration example, so the Phase 0 reproduction setup must be documented explicitly instead of assuming host-config knowledge.
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/workflow-command-prompt-dry-run-integration.md`: comments and convention are not enough; use a mechanical guard and test the real invocation path.
+- `docs/solutions/integration-issues/zsh-for-loop-word-splitting-silent-failure-20260417.md`: verify with a different mechanism than the implementation mechanism. Here that means a real loader probe plus unit tests, not unit tests alone.
+- `docs/solutions/best-practices/destructive-to-nondestructive-converter-Systematic-20260209.md`: cache/idempotency behavior changes need explicit regression coverage and coupled-surface verification.
+- Repo memory: Phase 0 empirical probes are the right way to validate uncertain host behavior before shipping V1 logic.
+
+### External References
+
+- `opencode-copilot-delegate/src/runtime/plugin-singleton.ts` (external sibling repo, PR #76)
+- `opencode-copilot-delegate/src/index.ts` (external sibling repo, current duplicate-factory wiring)
+
+## Key Technical Decisions
+
+- **Phase 0 is a hard gate, not optional setup.** Implementation does not proceed until the real OpenCode loader output is observed and confirmed.
+- **A whole-hooks singleton is only allowed if later duplicate invocations are semantically equivalent to the first one for all singleton-sensitive behavior.** Same PID and `count=1` resets prove duplicate loading, but they do not prove safety by themselves. The probe must emit comparable fingerprints for the effective inputs that shape returned hooks: resolved `directory`, merged config values that affect hook behavior, disabled skill lists, bootstrap source or snapshot inputs, and any caller-specific logging assumptions.
+- **This plan adopts the `opencode-copilot-delegate` pattern only as the transport mechanism, not as proof of caching scope.** Reuse the boring parts (`globalThis`, `Symbol.for(...)`, cached `Promise<T>`, PID equality check, one-shot `warned`, swallowed `onDuplicate` exceptions), but justify whole-hooks caching from Systematic's own state model.
+- **Whole-hooks singleton means first successful initialization wins for the process.** That tradeoff is acceptable only if duplicate invocations are redundant host replays. If later calls would have produced different host-visible tool surfaces, config effects, bootstrap output, or logging routing, the architecture is wrong and implementation stops.
+- **Material caller variance is a stop condition.** Treat differing effective disabled-skill sets, differing bootstrap inputs, differing config-derived behavior, or any evidence that later invocations would have produced different hooks or prompt or tool surfaces as fail or ambiguous outcomes rather than implementation details to wave away.
+- **Whole-hooks reuse is not assumed to solve duplicate registration by magic.** The implementation must verify the actual host-visible surface that motivated the change: duplicate `systematic_skill` registration in OpenCode's tool listings. Reusing the same hooks object is acceptable only if the post-change probe proves the host no longer exposes duplicate tool entries.
+- **If the probe shows differing caller-scoped inputs, stop instead of improvising.** That is a design fork, not an implementation detail. The follow-up path should evaluate smaller dedupe boundaries, such as deduping only host registration side effects or isolating package-static runtime state from caller-scoped state.
+- **Rejected init stays sticky for the process lifetime if the singleton is approved.** This matches the sibling precedent and keeps the helper simple: cache the in-flight or rejected `Promise<Hooks>` and require process restart for recovery rather than adding retry state that weakens the once-only contract.
+- **The duplicate warning exists to make suppressed later invocations observable.** Final implementation should log once per process that a duplicate factory call was ignored and the existing hooks are being reused. It should include enough detail to debug duplicate registration, but should not ship the probe's verbose path or config dump.
+- **The singleton helper should live at `src/lib/plugin-singleton.ts`.** Systematic already centralizes small reusable helpers under `src/lib/`; creating a top-level `src/runtime/` namespace for a single file adds structure without paying rent.
+- **Probe instrumentation is temporary and must be removed before the implementation commit.** The final diff should ship only the singleton helper, factory wiring, tests, and any release-signal artifact required by the repo's actual tooling.
+- **Preserve the current bootstrap contract.** Once the final singleton is in place, bootstrap content must still be stable for the duration of the initialized plugin context; the idempotency fix must not silently reintroduce per-request bootstrap reads.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Does the problem shape apply to Systematic?** Yes. `src/index.ts` is a default-exported `Plugin` factory, it performs meaningful init work, it returns hook registrations, and it currently has no singleton guard.
+- **Is external framework research needed?** No. The repo plus the `opencode-copilot-delegate` precedent already provide the relevant implementation pattern and host-facing constraints.
+- **Should the plan assume literal Changesets support?** No. The repo uses semantic-release, so the implementation should carry forward the requested minor-release intent through that mechanism instead.
+- **Should probe tooling be formalized as a permanent test helper first?** No. The fastest safe path is a temporary factory probe plus the existing real-host validation style used in `tests/manual/*probe.ts`.
+
+### Deferred to Implementation
+
+- **Exact helper file naming and export ordering inside `src/lib/plugin-singleton.ts`** can be finalized while writing the code, as long as the contract matches the approved pattern.
+- **Whether any other factory-facing tests besides `tests/unit/plugin.test.ts` need `_resetPluginSingleton()`** should be finalized from a repo-wide search during implementation. Today `tests/unit/plugin.test.ts` is the obvious hit.
+- **If the probe reveals mixed directory markers but the host still dedupes later hook registration by identity,** that nuance should still be reported back to the user before proceeding. The plan assumes a conservative stop-on-variance posture.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+### Safety Matrix
+
+| Surface | Current Source | Expected Scope | Safe to Share via Process Singleton? |
+|---|---|---|---|
+| Bundled content paths | `src/index.ts` module constants | package / process | Yes |
+| Package version read | `package.json` | package / process | Yes |
+| Duplicate-warning state | singleton helper | process | Yes |
+| `directory` | plugin factory input | caller / invocation | Only if Phase 0 proves duplicates do not vary meaningfully |
+| Merged config | `loadConfig(directory)` | caller / invocation | Same constraint |
+| Bootstrap snapshot | `getBootstrapContent(config, ...)` | caller / initialized plugin | Same constraint |
+| `disabled_*` lists used by `createSkillTool(...)` | merged config | caller / invocation | Same constraint |
+| `client.app.log` sink | plugin factory input | caller / invocation | Same constraint |
+
+### Decision Flow
+
+```text
+Temporary factory probe -> observe real OpenCode duplicate-load behavior
+  -> PASS: same-process duplicate reset with no unsafe caller variance
+     -> add src/lib/plugin-singleton.ts
+     -> wrap src/index.ts through plugInOnce(...)
+     -> add helper tests + factory isolation tests
+  -> FAIL / AMBIGUOUS: differing caller variance or unexpected module behavior
+     -> remove probe
+     -> stop and report findings
+     -> re-plan instead of forcing a hooks singleton
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Phase 0 empirical probe and safety gate**
+
+**Goal:** Prove the real loader behavior before any singleton code ships.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None.
+
+**Files:**
+- Modify (temporary): `src/index.ts`
+
+**Approach:**
+- Add the temporary probe exactly at the top of the factory body in `src/index.ts`:
+  - module-scope `let probeInvocationCount = 0`
+  - increment per factory call
+  - synchronous `console.warn(...)` with `count`, `process.pid`, `process.ppid`, `directory`, and timestamp
+  - best-effort `client.app.log(...)` with `service: 'systematic-probe'` and matching structured `extra`
+  - include comparable fingerprints for singleton-sensitive inputs, not just raw directory strings. At minimum emit:
+    - `configFingerprint`: deterministic summary of `loadConfig(directory)` values that affect hook behavior (`disabled_skills`, `disabled_agents`, `disabled_commands`, `bootstrap.enabled`, `bootstrap.file`)
+    - `bootstrapFingerprint`: whether bootstrap resolves to disabled, missing, bundled skill, or custom file, plus a stable digest of the snapshotted content when present
+    - `toolFingerprint`: deterministic summary of the disabled-skill state passed into `createSkillTool(...)`
+- Build the plugin so the local `dist/index.js` reflects the probe.
+- Reproduce duplicate-source loading explicitly:
+  - keep the project-level config source pointing at the local plugin under the repo being tested
+  - temporarily switch the user-level OpenCode plugin entry to the same local built plugin path
+  - preserve the pre-probe user-level config so it can be restored after observation
+- Hand off to the user with the expected log pattern and wait for the pasted output before proceeding.
+- Treat the probe as **pass / fail / ambiguous**:
+  - **Pass:** same PID, duplicate invocations observed, both invocations start at `count=1`, and the duplicate calls are semantically equivalent for all singleton-sensitive inputs: resolved `directory`, merged config values that affect hook behavior, disabled-skill state, bootstrap inputs or snapshots, and any caller-specific logging assumptions.
+  - **Alternate path:** duplicate invocation is reproduced, but the invocation count increments in-module (`count=1` then `count=2`). That still proves duplicate factory invocation, but it suggests a smaller module-scope idempotency fix may be more appropriate than a cross-module `globalThis` singleton. Stop and report this as an alternate design path.
+  - **Fail:** duplicate invocation is not reproduced.
+  - **Ambiguous / unsafe:** duplicate invocation is reproduced, but caller-scoped markers differ materially enough that a cached hooks object would be unsafe. Examples: differing effective disabled-skill sets, differing bootstrap inputs, differing config-derived behavior, or any evidence that later invocations would have produced different host-visible hooks or prompt or tool surfaces.
+- Remove the probe before starting implementation work.
+
+**Patterns to follow:**
+- `tests/manual/session-compacting-probe.ts` for real-host validation structure and verdict language
+- `tests/manual/companion-aware-probe.ts` for explicit pass / ambiguous / fail gating
+
+**Test scenarios:**
+- Test expectation: none -- this unit is a temporary manual probe, not shipped test coverage.
+
+**Verification:**
+- The user-provided log output is categorized as pass, alternate-path, fail, or ambiguous using the criteria above.
+- No implementation code is started until the verdict is explicit.
+
+- [ ] **Unit 2: Add the singleton helper and wrap the plugin factory**
+
+**Goal:** Introduce per-process plugin-factory idempotency using the approved singleton contract, but only after Unit 1 passes.
+
+**Requirements:** R4, R5
+
+**Dependencies:** Unit 1 must pass.
+
+**Files:**
+- Create: `src/lib/plugin-singleton.ts`
+- Modify: `src/index.ts`
+
+**Approach:**
+- Extract the current body of `SystematicPlugin` into a small internal initializer so the default export can be a thin wrapper around `plugInOnce(...)`.
+- Implement `plugInOnce(...)` with the exact behavior requested:
+  - `Symbol.for('systematic.singleton.v1')`
+  - cache `Promise<T>` rather than resolved hooks
+  - compare `process.pid`
+  - flip `warned` before invoking `onDuplicate`
+  - swallow synchronous `onDuplicate` exceptions
+  - export `_resetPluginSingleton()` for tests only
+- Wire `src/index.ts` so duplicate factory calls in the same process reuse the same in-flight hooks promise and emit one duplicate warning through both `console.warn(...)` and best-effort `client.app.log(...)`.
+- Keep the diff minimal: no unrelated restructuring of config loading, bootstrap logic, tool registration, or hook shape.
+- Re-run the same duplicate-source setup used in Unit 1 after the singleton lands and verify the actual host-visible outcome that motivated the change: duplicate `systematic_skill` entries disappear from tool listings.
+- If Unit 1 surfaced unsafe caller variance, do not land this unit. Stop and return the probe findings instead.
+
+**Patterns to follow:**
+- `opencode-copilot-delegate/src/runtime/plugin-singleton.ts` for helper contract and test reset surface
+- `opencode-copilot-delegate/src/index.ts` for `plugInOnce({ doInit, onDuplicate })` wiring
+- `src/index.ts` current bootstrap snapshot comment and hook layout for minimal-diff preservation
+
+**Test scenarios:**
+- **Happy path:** first factory invocation runs the initializer and returns the hook set.
+- **Happy path:** second invocation in the same PID reuses the cached hooks promise and does not re-run init.
+- **Error path:** synchronous duplicate-warning callback failure does not block plugin init.
+- **Integration:** the duplicate warning is emitted at most once per process even if the factory is invoked more than twice.
+
+**Verification:**
+- The singleton helper exists as a narrow reusable module.
+- `src/index.ts` still exports only the default plugin factory.
+- Duplicate invocations in the same PID reuse the cached initialization path when Unit 1's gate was satisfied.
+
+- [ ] **Unit 3: Add helper coverage and preserve factory test isolation**
+
+**Goal:** Lock the singleton contract in tests and prevent order-dependent failures caused by shared global state.
+
+**Requirements:** R6, R7
+
+**Dependencies:** Unit 2.
+
+**Execution note:** Test-first. The helper tests should go red before the helper is finalized, and the factory-facing tests should fail until singleton reset hooks are in place.
+
+**Files:**
+- Create: `tests/unit/plugin-singleton.test.ts`
+- Modify: `tests/unit/plugin.test.ts`
+- Modify: `tests/unit/config-handler.test.ts` only if the implementation or search shows a direct plugin-factory dependency there
+- Modify: `tests/unit/skill-tool.test.ts` only if the implementation or search shows a direct plugin-factory dependency there
+
+**Approach:**
+- Add the requested 8 tests for `plugInOnce(...)`, all using `_resetPluginSingleton()` in `beforeEach`.
+- Update `tests/unit/plugin.test.ts` so every case that imports or calls the plugin factory runs with a clean singleton state.
+- Add one factory-level regression test that exercises duplicate factory calls in a single process and proves the expected reuse / warning behavior without leaking state across tests.
+- Keep the test search honest: search `tests/` for direct factory invocations or dynamic imports of `src/index.ts` and add reset hooks only where needed.
+
+**Patterns to follow:**
+- `tests/unit/plugin.test.ts` existing temp-dir + dynamic-import structure
+- `tests/unit/config-handler.test.ts` and `tests/unit/skill-tool.test.ts` for `beforeEach` / `afterEach` isolation style
+
+**Test scenarios:**
+- **Happy path:** first invocation runs `doInit()` and returns the result.
+- **Happy path:** second invocation in the same PID returns the same hooks reference by identity.
+- **Edge case:** a different PID triggers a fresh init.
+- **Edge case:** `onDuplicate` fires exactly once across multiple duplicates.
+- **Edge case:** `onDuplicate` does not fire on the first invocation.
+- **Concurrency:** `Promise.all([plugInOnce(...), plugInOnce(...)])` converges on the same resolved reference.
+- **Error path:** `onDuplicate` exceptions are swallowed.
+- **Error path:** after an `onDuplicate` throw, later duplicates remain silent because `warned` was already flipped.
+- **Integration:** plugin tests remain isolated across cases even when the singleton helper uses `globalThis` state.
+
+**Verification:**
+- All eight singleton helper tests pass.
+- Factory-facing tests no longer depend on file execution order.
+- No test calls `_resetPluginSingleton()` from production code paths.
+
+- [ ] **Unit 4: Full verification and local handoff**
+
+**Goal:** Finish the change with full local verification and stop before any remote actions.
+
+**Requirements:** R8, R9
+
+**Dependencies:** Units 2 and 3.
+
+**Files:**
+- Modify: `package.json` only if the implementation uncovers a missing test or build script needed to verify the new helper
+
+**Approach:**
+- Run all required quality gates after the final code and test changes are in place.
+- Summarize the release-classification judgment call in the handoff instead of editing release machinery during this local-only pass. Since the repo uses semantic-release and the work stops before push or PR creation, release classification stays with the eventual shipping commit or PR flow.
+- Stop after the local branch is ready and the local commit exists; do not push or open a PR.
+
+**Patterns to follow:**
+- `package.json` verification scripts
+
+**Test scenarios:**
+- **Happy path:** full unit test suite passes with the new helper in place.
+- **Happy path:** build, typecheck, and lint all pass after the singleton wiring lands.
+- **Integration:** the built plugin still exports a default-only entry point and loads cleanly.
+- **Integration:** host-visible duplicate registration is no longer reproduced under the same duplicate-config setup that triggered Unit 1.
+
+**Verification:**
+- `bun test` is green, including the new singleton coverage.
+- `bun run typecheck`, `bun run lint`, and `bun run build` are green.
+- The implementation summary clearly states diff stats, test count delta, and any judgment calls.
+- Work stops before push and PR creation.
+
+## System-Wide Impact
+
+- **Interaction graph:** the change sits at the plugin entry boundary in `src/index.ts`, but its effects reach config registration (`src/lib/config-handler.ts`), tool registration (`src/lib/skill-tool.ts`), and bootstrap injection (`src/lib/bootstrap.ts`).
+- **Error propagation:** singleton helper failures must surface as normal plugin init failures; duplicate-warning callback failures must never block plugin init.
+- **State lifecycle risks:** this change introduces deliberate process-global state via `globalThis`; the implementation must bound that state to the singleton helper and cleanly reset it in tests.
+- **API surface parity:** the exported plugin surface must remain `default` only. No new public plugin exports should appear.
+- **Integration coverage:** unit tests alone are insufficient because the underlying bug depends on host loading behavior. The plan therefore requires both a real-loader probe and post-change host verification.
+- **Unchanged invariants:** single-config behavior, bootstrap snapshot stability, and the existing hook names and config-tool contracts should remain unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Probe output does not match the expected duplicate-factory pattern | Treat as a stop condition and report findings instead of forcing the singleton |
+| Duplicate invocations capture materially different caller-scoped inputs | Treat as an architecture fork; do not ship a whole-hooks singleton without a follow-up design pass |
+| `globalThis` singleton state leaks across tests | Add `_resetPluginSingleton()` and call it in `beforeEach` for helper and factory-facing tests |
+| Requested minor-release intent does not map cleanly onto this local-only pass | Document the judgment call in the handoff and leave release classification to the eventual shipping commit or PR flow |
+| Temporary probe logging accidentally ships | Remove the probe before implementation commit and verify the final diff contains only the helper, wiring, and tests |
+
+## Documentation / Operational Notes
+
+- The user-level OpenCode config switch to the local built plugin path is a temporary local probe step, not a committed repo change.
+- The implementation handoff should explicitly surface whether the Phase 0 probe passed cleanly or required a stop-and-report outcome.
+- Execution should end with a local feature branch and local commit only. No push or PR creation happens in the initial implementation pass.
+
+## Sources & References
+
+- Related code: `src/index.ts`
+- Related code: `src/lib/config.ts`
+- Related code: `src/lib/config-handler.ts`
+- Related code: `src/lib/skill-tool.ts`
+- Related code: `src/lib/bootstrap.ts`
+- Related tests: `tests/unit/plugin.test.ts`
+- Related tests: `tests/unit/config-handler.test.ts`
+- Related tests: `tests/unit/skill-tool.test.ts`
+- Manual probe precedent: `tests/manual/session-compacting-probe.ts`
+- Manual probe precedent: `tests/manual/companion-aware-probe.ts`
+- External precedent: `opencode-copilot-delegate/src/runtime/plugin-singleton.ts`
+- External precedent: `opencode-copilot-delegate/src/index.ts`

--- a/docs/solutions/integration-issues/opencode-plugin-factory-duplicate-registration-2026-05-04.md
+++ b/docs/solutions/integration-issues/opencode-plugin-factory-duplicate-registration-2026-05-04.md
@@ -1,0 +1,144 @@
+---
+title: OpenCode plugin factory invoked once per opencode.json source — duplicate tool registration
+date: 2026-05-04
+category: integration-issues
+module: systematic-plugin
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - systematic_skill appeared twice in the LLM-visible tool catalog (opencode-doctor returned 2)
+  - plugin factory ran twice in the same process when listed in both user-level and project-level opencode.json
+  - heavy initialization (loadConfig, getBootstrapContent, createConfigHandler, createSkillTool) ran twice
+root_cause: scope_issue
+resolution_type: code_fix
+severity: high
+tags:
+  - opencode
+  - plugin-registration
+  - singleton
+  - duplicate-tools
+  - globalthis
+  - config-sources
+---
+
+# OpenCode plugin factory invoked once per opencode.json source — duplicate tool registration
+
+## Problem
+
+OpenCode invokes a plugin's exported factory function **once per `opencode.json` source that lists the plugin**. When a user has the same plugin listed in both their user-level config (`~/.config/opencode/opencode.json`) and a project-level config (`<repo>/opencode.json`), the factory runs twice in the same process. The host then registers each returned hooks object independently, so the LLM sees the plugin's tools listed twice in its catalog.
+
+For Systematic specifically: `systematic_skill` showed up twice in the doctor's tool listing, `experimental.chat.system.transform` ran twice on every prompt, and the configuration merge ran twice. Without a guard, the plugin had no way to know it was being asked to register itself a second time.
+
+## Symptoms
+
+Run the OpenCode doctor against a dual-source config:
+
+```bash
+mise run opencode:doctor --only tools --full --format json \
+  | jq '.[] | select(.label == "Tools").data | map(.id) \
+        | map(select(. == "systematic_skill")) | length'
+```
+
+Before the fix: `2`.
+
+In the OpenCode log (`~/.local/share/opencode/log/<timestamp>.log`):
+
+- `service=tool.registry status=started systematic_skill` appears twice per session
+- `service=tool.registry status=completed ... systematic_skill` appears twice per session
+- `Skipping bootstrap prompt injection` (or whatever the bootstrap-injection branch logs) appears twice
+- Two distinct heavy-init runs visible in any `console.warn` instrumentation added to the factory
+
+## What Didn't Work
+
+**Assuming this was a single-source bug fixable by config dedup.** Wrong — OpenCode's plugin host calls the factory once per source by design. Whether two sources point at the same path or two different paths, the host invokes the factory twice.
+
+**Whole-hooks reuse (the natural first instinct).** Cache the first call's `hooks` object, return the same reference to duplicate callers. This is what `opencode-copilot-delegate`'s `src/runtime/plugin-singleton.ts` does — the precedent that initially looked transferable. **Empirically insufficient**: the OpenCode host iterates each config source's returned hooks and calls `register(hooks.tool.<name>)` per-source regardless of reference identity. Two register calls = two catalog entries, even when the references match. After applying whole-hooks reuse, the doctor still reported `2`.
+
+**Treating source-string equality as the dedup key.** Wrong. Different paths like `/abs/path/dist/index.js` and `./src/index.ts` produce different module instances even when they resolve to functionally-equivalent code. The OpenCode loader doesn't reconcile them. (When *both* sources point at the *same* path string, the loader does dedup at the path-string level — but that's a happy coincidence, not the typical setup.)
+
+## Solution
+
+Per-process register-once guard in `src/lib/plugin-singleton.ts`. The cache key is a `Symbol.for('@fro.bot/systematic/plugin-singleton')` slot on `globalThis` (PID-stamped to prevent cross-process cache poisoning when modules are shared via worker threads or process forks).
+
+The exported plugin factory is wrapped through `plugInOnce`. **The first invocation runs init and returns the real hooks. Duplicate invocations skip init and return an empty hooks object `{}`** so the host has nothing to register a second time.
+
+### Helper API
+
+```typescript
+// src/lib/plugin-singleton.ts
+export interface PlugInOnceResult<T> {
+  isFirst: boolean
+  hooks: T
+}
+
+export interface PlugInOnceOptions<T> {
+  doInit: () => Promise<T>
+  onDuplicate?: (pid: number) => void
+  /** Test override for the PID guard; production callers omit this. */
+  pid?: number
+}
+
+export async function plugInOnce<T>(
+  options: PlugInOnceOptions<T>,
+): Promise<PlugInOnceResult<T>>
+```
+
+- **First call**: `{ isFirst: true, hooks }` — `hooks` contains real `tool`, `config`, and `experimental.chat.system.transform` registrations.
+- **Duplicate call** (same process): `{ isFirst: false, hooks: {} as T }` — empty hooks object. The host iterates over its keys, finds none, registers nothing.
+- **Sticky failure**: if `doInit` rejects, the rejection is cached and replayed to all subsequent callers in the same PID. No retry-on-failure.
+- **Concurrent safety**: simultaneous first calls share a single in-flight init promise.
+
+### Factory wiring
+
+```typescript
+// src/index.ts
+const SystematicPlugin: Plugin = async (input) => {
+  const { hooks } = await plugInOnce({
+    doInit: () => initializePlugin(input),
+    onDuplicate: (pid) => {
+      const message = `[systematic] duplicate factory invocation in same process (pid=${pid}); skipping duplicate registration. Multiple opencode.json sources may list this plugin.`
+      console.warn(message)
+      // Fire-and-forget; never block plugin init on the structured-log call.
+      input.client.app
+        .log({
+          body: { service: 'systematic', level: 'warn', message },
+        })
+        .catch(() => {})
+    },
+  })
+  return hooks
+}
+```
+
+`initializePlugin` is the heavy work — `loadConfig`, `getBootstrapContent`, `createConfigHandler`, `createSkillTool`. It runs once per process even when the host invokes the factory N times.
+
+### Diagnostics
+
+`onDuplicate` fires once per duplicate caller and emits both a synchronous `console.warn` (for terminal visibility during dev) and a best-effort structured `client.app.log` (for parity with the rest of OpenCode's structured logging). Failures of `client.app.log` are swallowed so they can't break startup.
+
+## Why This Works
+
+**Root cause.** OpenCode's plugin host iterates each `opencode.json` source's plugin list and registers tools, transforms, and config from each returned hooks object independently. Reference equality is not part of its dedup logic — the host doesn't compare the second call's hooks to the first's. So whatever the second factory call returns will be registered as if it were a separate plugin's hooks.
+
+**Why empty-hooks fixes it.** When the duplicate caller returns `{}`, there is literally no `tool` field, no `experimental.chat.system.transform` field, no `config` field for the host to enumerate. The first caller's registrations stand. The second caller's "registrations" are no-ops because there is nothing to register.
+
+**Why whole-hooks reuse doesn't fix it.** Even with reference equality, the host calls `register(hooks.tool.systematic_skill)` once per source. Two register calls produce two catalog entries regardless of whether the handler function is the same reference both times.
+
+## Prevention
+
+- **Verify singleton fixes against the LLM-visible tool catalog, not just diagnostic logs.** The `mise run opencode:doctor --only tools --full --format json | jq '...'` command is the canonical verification — it queries `client.tool.list({ provider, model })` which is exactly what the LLM sees. Fingerprint-matching probes only tell you the singleton helper fired; they don't tell you the host stopped registering twice.
+- **Don't transfer plugin singleton patterns from precedent without dual-source verification.** A pattern that works for a plugin listed only in user-level config will pass its own internal tests yet fail under dual-source listing. Always set up the dual-source case explicitly when verifying a register-once guard.
+- **For register-once guards in OpenCode plugins, return empty hooks/handlers to duplicate callers.** Not cached real handlers. Empty `{}` is what makes the host stop registering.
+- **Run a Phase 0 empirical probe before designing the singleton.** Before any code, instrument the factory with a module-scope counter, sync `console.warn`, and best-effort structured log. Reproduce the bug in a dual-source config to confirm: same PID, count=1 in both invocations (independent module instances), all caller-scoped fingerprints match. Probe artifacts: `tests/manual/companion-aware-probe.ts` is a usable scaffold.
+- **Test the helper's behavior branches:** first-call init, duplicate-call skip, `onDuplicate` callback wiring, concurrent first calls (shared in-flight promise), sticky failure, PID-change recovery (use the test-only `pid?` override), and a reset hook for test isolation.
+- **Add a factory-level regression test** that calls the plugin factory three times in the same process and asserts only the first invocation returns real hooks; calls 2+ return empty `{}`. This is the host-visible contract the fix targets — separate from the helper's unit tests, and the one that catches future drift.
+- **Operational gotcha when verifying empirically:**
+  - `opencode-doctor` reuses any existing `opencode serve` already listening on port 4096 instead of spawning fresh — it cannot pick up a rebuilt plugin while a stale serve is alive. Run `pkill -KILL -f '\.opencode serve'` first; SIGTERM is often ignored.
+  - The OpenCode TUI session you are inside caches its plugin module instances at session start. Rebuilding the plugin and re-running tools via the same TUI will not pick up changes — verification must happen from a fresh shell after killing orphaned serves, or after exiting and restarting the TUI.
+
+## Related Issues
+
+- Systematic PR #335 — the fix as shipped: <https://github.com/marcusrbrown/systematic/pull/335>
+- Plan document: `docs/plans/2026-05-01-001-fix-idempotent-plugin-registration-plan.md`
+- Adjacent upstream pattern (idempotence under cache-busting hook injection): <https://github.com/alvinunreal/oh-my-opencode-slim/issues/415>
+- Precedent that initially appeared transferable but used the insufficient whole-hooks pattern: `opencode-copilot-delegate/src/runtime/plugin-singleton.ts`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,14 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import type { Plugin } from '@opencode-ai/plugin'
+import type { Plugin, PluginInput } from '@opencode-ai/plugin'
 import {
   getBootstrapContent,
   INTERNAL_AGENT_SIGNATURES,
 } from './lib/bootstrap.js'
 import { loadConfig } from './lib/config.js'
 import { createConfigHandler } from './lib/config-handler.js'
+import { plugInOnce } from './lib/plugin-singleton.js'
 import { createSkillTool } from './lib/skill-tool.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -41,7 +42,15 @@ const getPackageVersion = (): string => {
   }
 }
 
-const SystematicPlugin: Plugin = async ({ client, directory }) => {
+/**
+ * Build the plugin hook surface for a single OpenCode plugin invocation.
+ *
+ * Extracted into a named initializer so the default export can wrap it through
+ * `plugInOnce(...)`, making duplicate factory calls in the same process
+ * converge on the same hooks promise. See `src/lib/plugin-singleton.ts` for
+ * the duplicate-load justification.
+ */
+const initializePlugin = async ({ client, directory }: PluginInput) => {
   const config = loadConfig(directory)
   // Snapshot bootstrap once per plugin init so the cached system prefix stays
   // stable across requests. Custom bootstrap file edits take effect on restart.
@@ -64,7 +73,10 @@ const SystematicPlugin: Plugin = async ({ client, directory }) => {
       }),
     },
 
-    'experimental.chat.system.transform': async (_input, output) => {
+    'experimental.chat.system.transform': async (
+      _input: unknown,
+      output: { system: string[] },
+    ) => {
       if (!hasLoggedInit) {
         hasLoggedInit = true
         const packageVersion = getPackageVersion()
@@ -114,6 +126,30 @@ const SystematicPlugin: Plugin = async ({ client, directory }) => {
       }
     },
   }
+}
+
+const SystematicPlugin: Plugin = async (input) => {
+  const { hooks } = await plugInOnce({
+    doInit: () => initializePlugin(input),
+    onDuplicate: (pid) => {
+      const message = `[systematic] duplicate factory invocation in same process (pid=${pid}); skipping duplicate registration. Multiple opencode.json sources may list this plugin.`
+      console.warn(message)
+      // Fire-and-forget so the log call never blocks plugin init.
+      input.client.app
+        .log({
+          body: {
+            service: 'systematic',
+            level: 'warn',
+            message,
+          },
+        })
+        .catch(() => {})
+    },
+  })
+  // hooks is the real plugin hook surface on the first invocation in a
+  // process and an empty object on every duplicate invocation; returning it
+  // unconditionally is what prevents host-side double registration.
+  return hooks
 }
 
 export default SystematicPlugin

--- a/src/lib/plugin-singleton.ts
+++ b/src/lib/plugin-singleton.ts
@@ -1,0 +1,141 @@
+/**
+ * Per-process register-once guard for the Systematic plugin factory.
+ *
+ * OpenCode invokes the plugin factory more than once per process when the
+ * same plugin is referenced by multiple config sources (for example a
+ * user-level `~/.config/opencode/opencode.json` AND a project-level
+ * `opencode.json`). Each invocation evaluates the plugin module fresh —
+ * module-local variables reset between calls — so the guard state must
+ * live on `globalThis` to persist across module instances within the
+ * same process.
+ *
+ * On the first invocation `doInit` runs and the resulting hooks promise
+ * is cached on `globalThis`; the caller receives `{ isFirst: true, hooks }`.
+ * On every subsequent invocation in the same PID `doInit` is skipped, the
+ * cached promise is awaited (so sticky rejections still propagate),
+ * `onDuplicate` fires exactly once, and the caller receives
+ * `{ isFirst: false, hooks: {} as T }`. Across PIDs the guard is treated
+ * as absent and init runs fresh — `globalThis` is per-process, but the
+ * explicit PID check adds defensive belt-and-suspenders against any
+ * state-leakage edge case.
+ *
+ * **Why empty hooks on duplicate invocations.** A whole-hooks singleton
+ * that returns the same hooks reference to both invocations does not
+ * deduplicate host-side tool registration: OpenCode iterates each plugin
+ * source's returned hook surface and registers every tool entry it finds,
+ * even when two sources return the same JS reference. Returning `{}` from
+ * the duplicate path is the only shape that prevents host-side double
+ * registration of `systematic_skill`, the `config` hook, and the
+ * `experimental.chat.system.transform` hook. The Phase 0 follow-up probe
+ * (see `docs/plans/2026-05-01-001-fix-idempotent-plugin-registration-plan.md`)
+ * verified the duplicate `systematic_skill` entry in OpenCode's
+ * `client.tool.list(...)` output, which is the LLM-visible tool catalog.
+ *
+ * **Known limitation — rejected init is sticky.** If `doInit()` rejects,
+ * the rejected promise is stored on `globalThis` and every subsequent
+ * invocation in the same PID returns the same rejection without retrying
+ * init. This is intentional: re-running heavy init on every call would
+ * defeat the guard's purpose. Recovery requires a process restart.
+ */
+
+const SINGLETON_KEY: unique symbol = Symbol.for('systematic.singleton.v1')
+
+interface SingletonState<T> {
+  pid: number
+  loadedAt: number
+  hooksPromise: Promise<T>
+  warned: boolean
+}
+
+/**
+ * Type-safe view onto `globalThis` for our symbol-keyed singleton slot.
+ *
+ * TypeScript's `declare global { var ... }` augmentation does not accept
+ * computed property keys, so a unique-symbol-keyed slot on `globalThis`
+ * is reachable only via an intersection cast. The cast is contained at
+ * a single point and the property type drives subsequent reads and writes —
+ * callers do not re-assert the value's shape with additional casts.
+ */
+type GlobalWithSingleton<T> = typeof globalThis & {
+  [SINGLETON_KEY]?: SingletonState<T>
+}
+
+export interface PlugInOnceOptions<T> {
+  /** Heavy init work that should run at most once per process. */
+  doInit: () => Promise<T>
+  /**
+   * Called exactly once on the first duplicate invocation in the same
+   * process. Subsequent duplicates are silent. Receives the same `pid`
+   * value the guard used for its identity check (so test overrides flow
+   * through faithfully). Implementations must not throw; fire-and-forget
+   * side effects (logging, metrics) are expected. Synchronous exceptions
+   * are swallowed defensively.
+   */
+  onDuplicate?: (pid: number) => void
+  /** Test override; defaults to `process.pid`. */
+  pid?: number
+}
+
+/**
+ * Result envelope for `plugInOnce(...)`.
+ *
+ * - `isFirst: true` — caller should return `hooks` to OpenCode.
+ * - `isFirst: false` — caller MUST return `hooks` (which is an empty `{}`)
+ *   so the host loader does not register tools or hooks twice.
+ *
+ * Callers that just `return result.hooks` do the right thing in both
+ * cases without needing to inspect `isFirst`.
+ */
+export interface PlugInOnceResult<T> {
+  isFirst: boolean
+  hooks: T
+}
+
+/**
+ * Run `doInit` at most once per process; on duplicate invocations resolve to
+ * empty hooks so the OpenCode host does not double-register tools and hooks.
+ */
+export async function plugInOnce<T>({
+  doInit,
+  onDuplicate,
+  pid,
+}: PlugInOnceOptions<T>): Promise<PlugInOnceResult<T>> {
+  const currentPid = pid ?? process.pid
+  const g = globalThis as unknown as GlobalWithSingleton<T>
+  const existing = g[SINGLETON_KEY]
+
+  if (existing && existing.pid === currentPid) {
+    if (!existing.warned) {
+      existing.warned = true
+      try {
+        onDuplicate?.(currentPid)
+      } catch {
+        // onDuplicate must not block plugin init.
+      }
+    }
+    // Await the cached init so sticky rejections still propagate to the
+    // duplicate caller. The resolved value is intentionally discarded —
+    // duplicate callers receive empty hooks so the host registers nothing.
+    await existing.hooksPromise
+    return { isFirst: false, hooks: {} as T }
+  }
+
+  const hooksPromise = doInit()
+  g[SINGLETON_KEY] = {
+    pid: currentPid,
+    loadedAt: Date.now(),
+    hooksPromise,
+    warned: false,
+  }
+  const hooks = await hooksPromise
+  return { isFirst: true, hooks }
+}
+
+/**
+ * Test-only: clear the singleton state so the next invocation re-runs
+ * init. Must not be called in production code paths.
+ */
+export function _resetPluginSingleton(): void {
+  const g = globalThis as unknown as GlobalWithSingleton<unknown>
+  delete g[SINGLETON_KEY]
+}

--- a/tests/unit/plugin-singleton.test.ts
+++ b/tests/unit/plugin-singleton.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import {
+  _resetPluginSingleton,
+  plugInOnce,
+} from '../../src/lib/plugin-singleton.js'
+
+describe('plugInOnce', () => {
+  beforeEach(() => {
+    _resetPluginSingleton()
+  })
+
+  it('runs doInit once and returns its result with isFirst=true on first invocation', async () => {
+    let calls = 0
+    const doInit = async () => {
+      calls += 1
+      return { tool: 'one' }
+    }
+    const result = await plugInOnce({ doInit, pid: 1 })
+    expect(result.isFirst).toBe(true)
+    expect(result.hooks).toEqual({ tool: 'one' })
+    expect(calls).toBe(1)
+  })
+
+  it('returns empty hooks (isFirst=false) on subsequent calls in the same PID and never re-runs doInit', async () => {
+    let calls = 0
+    const realHooks = { tool: 'cached' }
+    const doInit = async () => {
+      calls += 1
+      return realHooks
+    }
+    const r1 = await plugInOnce({ doInit, pid: 1 })
+    const r2 = await plugInOnce({ doInit, pid: 1 })
+    const r3 = await plugInOnce({ doInit, pid: 1 })
+    // First invocation gets the real hooks reference.
+    expect(r1.isFirst).toBe(true)
+    expect(r1.hooks).toBe(realHooks)
+    // Duplicates get an empty hooks envelope so the host registers nothing.
+    expect(r2.isFirst).toBe(false)
+    expect(r2.hooks).toEqual({})
+    expect(r2.hooks).not.toBe(realHooks)
+    expect(r3.isFirst).toBe(false)
+    expect(r3.hooks).toEqual({})
+    // doInit only ever ran once.
+    expect(calls).toBe(1)
+  })
+
+  it('reruns init on a different pid without manual reset', async () => {
+    // Exercises the singleton's PID-mismatch branch directly: populate
+    // state with pid=1, then call again with pid=2 WITHOUT calling
+    // `_resetPluginSingleton()`. Init must run fresh because the cached
+    // pid does not match. This is the production code path for any
+    // (extremely unlikely) cross-process state leak — the test confirms
+    // the guard fires without test-only plumbing.
+    let calls = 0
+    const doInit = async () => {
+      calls += 1
+      return { call: calls }
+    }
+    const r1 = await plugInOnce({ doInit, pid: 1 })
+    const r2 = await plugInOnce({ doInit, pid: 2 })
+    expect(r1.isFirst).toBe(true)
+    expect(r1.hooks.call).toBe(1)
+    expect(r2.isFirst).toBe(true)
+    expect(r2.hooks.call).toBe(2)
+    expect(calls).toBe(2)
+  })
+
+  it('fires onDuplicate exactly once on first duplicate invocation', async () => {
+    let duplicateCalls = 0
+    const doInit = async () => ({})
+    const onDuplicate = () => {
+      duplicateCalls += 1
+    }
+    await plugInOnce({ doInit, onDuplicate, pid: 1 })
+    await plugInOnce({ doInit, onDuplicate, pid: 1 })
+    await plugInOnce({ doInit, onDuplicate, pid: 1 })
+    await plugInOnce({ doInit, onDuplicate, pid: 1 })
+    expect(duplicateCalls).toBe(1)
+  })
+
+  it('does not fire onDuplicate on the first invocation', async () => {
+    let duplicateCalls = 0
+    await plugInOnce({
+      doInit: async () => ({}),
+      onDuplicate: () => {
+        duplicateCalls += 1
+      },
+      pid: 1,
+    })
+    expect(duplicateCalls).toBe(0)
+  })
+
+  it('passes the resolved pid to onDuplicate (test override flows through)', async () => {
+    // The `pid` parameter makes the singleton testable in a single-process
+    // Bun run by simulating different OS PIDs. The duplicate warning
+    // emitted by callers includes the PID for diagnostics, so the value
+    // passed to `onDuplicate` must match the one the guard used — not the
+    // live `process.pid` — so test overrides surface faithfully.
+    let receivedPid: number | undefined
+    const onDuplicate = (pid: number) => {
+      receivedPid = pid
+    }
+    await plugInOnce({ doInit: async () => ({}), onDuplicate, pid: 9001 })
+    await plugInOnce({ doInit: async () => ({}), onDuplicate, pid: 9001 })
+    expect(receivedPid).toBe(9001)
+  })
+
+  it('caches a rejected doInit promise and propagates the same rejection to duplicate callers', async () => {
+    // Documents the sticky-rejection limitation: when `doInit()` rejects,
+    // the rejected promise is cached. The first caller sees the rejection.
+    // Duplicate callers ALSO see the same rejection (because the helper
+    // awaits the cached promise before returning empty hooks) so failures
+    // are not silently masked. Recovery requires a process restart.
+    const error = new Error('init failed')
+    let calls = 0
+    const doInit = async () => {
+      calls += 1
+      throw error
+    }
+    await expect(plugInOnce({ doInit, pid: 1 })).rejects.toBe(error)
+    await expect(plugInOnce({ doInit, pid: 1 })).rejects.toBe(error)
+    await expect(plugInOnce({ doInit, pid: 1 })).rejects.toBe(error)
+    expect(calls).toBe(1)
+  })
+
+  it('converges concurrent invocations on a single doInit run', async () => {
+    let started = 0
+    const doInit = async () => {
+      started += 1
+      // The 20ms delay is intentionally larger than the time it takes for
+      // `Promise.all([...])` to issue all three `plugInOnce` calls. The
+      // second and third calls observe the in-flight promise already
+      // cached on `globalThis` and skip running `doInit`. Bun's microtask
+      // scheduler resolves the synchronous portion of all three calls
+      // before the 20ms timer fires; if a future Bun release introduces
+      // microtask preemption between awaits, this test would need to
+      // pivot to an explicit deferred-resolve fixture.
+      await new Promise((r) => setTimeout(r, 20))
+      return { tool: 'concurrent' }
+    }
+    const [r1, r2, r3] = await Promise.all([
+      plugInOnce({ doInit, pid: 1 }),
+      plugInOnce({ doInit, pid: 1 }),
+      plugInOnce({ doInit, pid: 1 }),
+    ])
+    // Exactly one invocation gets isFirst=true; the others get empty hooks.
+    const firsts = [r1, r2, r3].filter((r) => r.isFirst)
+    const duplicates = [r1, r2, r3].filter((r) => !r.isFirst)
+    expect(firsts.length).toBe(1)
+    expect(duplicates.length).toBe(2)
+    const firstResult = firsts[0]
+    if (!firstResult) throw new Error('expected exactly one isFirst result')
+    expect(firstResult.hooks).toEqual({ tool: 'concurrent' })
+    for (const dup of duplicates) {
+      expect(dup.hooks).toEqual({})
+    }
+    expect(started).toBe(1)
+  })
+
+  it('swallows onDuplicate exceptions and still returns empty hooks', async () => {
+    let initCalls = 0
+    let duplicateCalls = 0
+    const doInit = async () => {
+      initCalls += 1
+      return { ok: true }
+    }
+    const onDuplicate = () => {
+      duplicateCalls += 1
+      throw new Error('boom')
+    }
+    await plugInOnce({ doInit, onDuplicate, pid: 1 })
+    // The throwing onDuplicate must not propagate to plugin init.
+    const result = await plugInOnce({ doInit, onDuplicate, pid: 1 })
+    expect(result.isFirst).toBe(false)
+    expect(result.hooks).toEqual({})
+    expect(duplicateCalls).toBe(1)
+    expect(initCalls).toBe(1)
+  })
+
+  it('does not fire onDuplicate again after the first time, even if onDuplicate threw', async () => {
+    let duplicateCalls = 0
+    const onDuplicate = () => {
+      duplicateCalls += 1
+      throw new Error('boom')
+    }
+    await plugInOnce({ doInit: async () => ({}), onDuplicate, pid: 1 })
+    await plugInOnce({ doInit: async () => ({}), onDuplicate, pid: 1 })
+    await plugInOnce({ doInit: async () => ({}), onDuplicate, pid: 1 })
+    expect(duplicateCalls).toBe(1)
+  })
+})

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -1,13 +1,20 @@
-import { describe, expect, test } from 'bun:test'
+import { beforeEach, describe, expect, test } from 'bun:test'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
+import { _resetPluginSingleton } from '../../src/lib/plugin-singleton.js'
 
 const SRC_DIR = path.resolve(import.meta.dirname, '../../src')
 const ROOT_DIR = path.resolve(import.meta.dirname, '../..')
 
 describe('plugin loading', () => {
+  // Reset singleton between cases so factory invocations across tests do not
+  // share cached hooks. `globalThis` state otherwise leaks across the file.
+  beforeEach(() => {
+    _resetPluginSingleton()
+  })
+
   test('plugin file exists at src/index.ts', () => {
     const pluginPath = path.join(SRC_DIR, 'index.ts')
     expect(fs.existsSync(pluginPath)).toBe(true)
@@ -110,6 +117,64 @@ describe('plugin loading', () => {
     const cliPath = path.join(SRC_DIR, 'cli.ts')
     const result = Bun.spawnSync(['bun', cliPath, '--help'])
     expect(result.exitCode).toBe(0)
+  })
+
+  test('duplicate factory invocations return empty hooks (no double registration) and emit the duplicate warning exactly once', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'systematic-singleton-'),
+    )
+    const opencodeDir = path.join(tempDir, '.opencode')
+    fs.mkdirSync(opencodeDir, { recursive: true })
+
+    const warnings: string[] = []
+    const originalWarn = console.warn
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map((a) => String(a)).join(' '))
+    }
+
+    try {
+      const pluginPath = path.join(SRC_DIR, 'index.ts')
+      const pluginModule = (await import(pathToFileURL(pluginPath).href)) as {
+        default: (args: {
+          client: { app: { log: (entry: unknown) => Promise<void> } }
+          directory: string
+        }) => Promise<Record<string, unknown>>
+      }
+
+      const input = {
+        client: {
+          app: {
+            log: async () => {},
+          },
+        },
+        directory: tempDir,
+      }
+
+      const hooks1 = await pluginModule.default(input)
+      const hooks2 = await pluginModule.default(input)
+      const hooks3 = await pluginModule.default(input)
+
+      // First invocation gets the real hook surface (config + tool + transform).
+      expect(hooks1.tool).toBeDefined()
+      expect(hooks1.config).toBeDefined()
+      expect(hooks1['experimental.chat.system.transform']).toBeDefined()
+
+      // Duplicates get an empty object so the OpenCode loader does not
+      // re-register `systematic_skill`, the `config` hook, or the
+      // `experimental.chat.system.transform` hook for each duplicate
+      // config source. This is the LLM-visible-tool-catalog dedupe fix.
+      expect(hooks2).toEqual({})
+      expect(hooks3).toEqual({})
+
+      // Duplicate warning fires at most once across multiple duplicates.
+      const duplicateWarnings = warnings.filter((w) =>
+        w.includes('duplicate factory invocation'),
+      )
+      expect(duplicateWarnings.length).toBe(1)
+    } finally {
+      console.warn = originalWarn
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
   })
 })
 


### PR DESCRIPTION
## Problem

OpenCode invokes the exported plugin factory once per `opencode.json` source that lists the plugin. When a user has the plugin in **both** their user-level config (`~/.config/opencode/opencode.json`) and a project-level config, the factory ran twice in the same process, producing:

- Two heavy initializations (`loadConfig`, `getBootstrapContent`, `createConfigHandler`, `createSkillTool`) — wasted work and increased startup time.
- **Two `systematic_skill` entries in the LLM-visible tool catalog**, verifiable via `mise run opencode:doctor --only tools --full --format json | jq '... map(select(.id == "systematic_skill")) | length'` returning `2`.
- Two `experimental.chat.system.transform` registrations, doubling bootstrap-prompt injection work.

## Fix

Add a per-process register-once guard in `src/lib/plugin-singleton.ts`. The cache key is a `Symbol.for('@fro.bot/systematic/plugin-singleton')` slot on `globalThis` (PID-stamped to prevent cross-process cache poisoning). The exported factory is wrapped through this guard:

- **First invocation** in a process runs the real init code and returns `{ isFirst: true, hooks }` with the actual hooks. The host registers `tool.systematic_skill`, `experimental.chat.system.transform`, and `config` exactly once.
- **Duplicate invocation** in the same process skips init entirely and returns `{ isFirst: false, hooks: {} }` — an empty hooks object so the host has nothing to register a second time.

Diagnostics: each duplicate call emits one `console.warn` and one best-effort `client.app.log` so duplicate-load conditions remain visible without log spam.

Failure semantics: if the first call's init throws, the rejection is sticky — concurrent and future callers in the same PID receive the same rejection rather than retrying init in an inconsistent state.

## Why empty hooks instead of reused hooks

The natural first instinct is to cache the first call's hooks and return the same reference to duplicate callers. That works for some plugins but is **insufficient for Systematic**: the OpenCode host iterates over the hooks returned by each config source and registers tools per-source even when the references are identical. Empirical testing showed `opencode-doctor` still reported two `systematic_skill` entries under whole-hooks reuse.

Returning `{}` from duplicate callers hands the host nothing to register, which produces the correct host-visible outcome.

## Verification

`opencode-doctor` against a dual-source config (user-level pointing at `dist/index.js`, project-level pointing at `./src/index.ts`):

| Build                          | `systematic_skill` in tool catalog |
| ------------------------------ | ---------------------------------- |
| Before fix                     | 2                                  |
| Whole-hooks reuse (rejected)   | 2                                  |
| **Empty-hooks reuse (this PR)** | **1**                              |

Plus a 3-call factory regression test (`tests/unit/plugin.test.ts`) that asserts only the first invocation returns real hooks; calls 2 and 3 return empty objects.

## Tests

- `tests/unit/plugin-singleton.test.ts` (new): 10 tests covering the helper contract — first-call init, duplicate-call skip, `onDuplicate` callback wiring, concurrent first calls sharing a single in-flight promise, sticky failure semantics, cross-process safety (synthetic PID guard discards stale cache), and `_resetPluginSingleton` for test isolation.
- `tests/unit/plugin.test.ts` (modified): one new factory-level regression test plus `beforeEach(_resetPluginSingleton)` for isolation.

448/448 unit tests pass (was 437; +10 helper, +1 regression).

## Plan document

Detailed design rationale, Phase 0 probe protocol, and verification approach are recorded in `docs/plans/2026-05-01-001-fix-idempotent-plugin-registration-plan.md`.

## Compatibility

No breaking changes. The exported plugin factory signature is unchanged. The `_resetPluginSingleton` export is for tests only and is not part of the documented API.