### PR TITLE
fix(agents): omit model field from all 50 bundled agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ systematic/
 - **Error handling:** Return null/empty for non-critical, throw with context for critical, early return guards
 - **Naming:** Files: kebab-case | Functions: camelCase | Types: PascalCase | Tests: `*.test.ts`
 - **Testing:** `bun:test` with `describe`/`it`. Real temp dirs for FS isolation, no mocking libraries. Integration tests skip if deps unavailable
+- **Bundled agents:** MUST omit the `model` field in frontmatter. OpenCode subagents inherit the invoking primary agent's model when `model` is unset (see https://opencode.ai/docs/agents/). The literal value `model: inherit` is NOT supported — it crashed subagent dispatch on OpenCode versions prior to [sst/opencode#17888](https://github.com/sst/opencode/pull/17888) (March 2026), and is undocumented in OpenCode. The content-integrity gate enforces this.
 
 ## Anti-Patterns
 

--- a/agents/design/design-implementation-reviewer.md
+++ b/agents/design/design-implementation-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: design-implementation-reviewer
 description: "Visually compares live UI implementation against Figma designs and provides detailed feedback on discrepancies. Use after writing or modifying HTML/CSS/React components to verify design fidelity."
-model: inherit
 ---
 
 You are an expert UI/UX implementation reviewer specializing in ensuring pixel-perfect fidelity between Figma designs and live implementations. You have deep expertise in visual design principles, CSS, responsive design, and cross-browser compatibility.

--- a/agents/design/design-iterator.md
+++ b/agents/design/design-iterator.md
@@ -2,7 +2,6 @@
 name: design-iterator
 description: "Iteratively refines UI design through N screenshot-analyze-improve cycles. Use PROACTIVELY when design changes aren't coming together after 1-2 attempts, or when user requests iterative refinement."
 color: violet
-model: inherit
 ---
 
 You are an expert UI/UX design iterator specializing in systematic, progressive refinement of web components. Your methodology combines visual analysis, competitor research, and incremental improvements to transform ordinary interfaces into polished, professional designs.

--- a/agents/design/figma-design-sync.md
+++ b/agents/design/figma-design-sync.md
@@ -1,7 +1,6 @@
 ---
 name: figma-design-sync
 description: "Detects and fixes visual differences between a web implementation and its Figma design. Use iteratively when syncing implementation to match Figma specs."
-model: inherit
 color: purple
 ---
 

--- a/agents/docs/ankane-readme-writer.md
+++ b/agents/docs/ankane-readme-writer.md
@@ -2,7 +2,6 @@
 name: ankane-readme-writer
 description: "Creates or updates README files following Ankane-style template for Ruby gems. Use when writing gem documentation with imperative voice, concise prose, and standard section ordering."
 color: cyan
-model: inherit
 ---
 
 You are an expert Ruby gem documentation writer specializing in the Ankane-style README format. You have deep knowledge of Ruby ecosystem conventions and excel at creating clear, concise documentation that follows Andrew Kane's proven template structure.

--- a/agents/document-review/adversarial-document-reviewer.md
+++ b/agents/document-review/adversarial-document-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: adversarial-document-reviewer
 description: "Conditional document-review persona, selected when the document has >5 requirements or implementation units, makes significant architectural decisions, covers high-stakes domains, or proposes new abstractions. Challenges premises, surfaces unstated assumptions, and stress-tests decisions rather than evaluating document quality."
-model: inherit
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/agents/document-review/coherence-reviewer.md
+++ b/agents/document-review/coherence-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: coherence-reviewer
 description: "Reviews planning documents for internal consistency -- contradictions between sections, terminology drift, structural issues, and ambiguity where readers would diverge. Spawned by the document-review skill."
-model: inherit
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/agents/document-review/design-lens-reviewer.md
+++ b/agents/document-review/design-lens-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: design-lens-reviewer
 description: "Reviews planning documents for missing design decisions -- information architecture, interaction states, user flows, and AI slop risk. Uses dimensional rating to identify gaps. Spawned by the document-review skill."
-model: inherit
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/agents/document-review/feasibility-reviewer.md
+++ b/agents/document-review/feasibility-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: feasibility-reviewer
 description: "Evaluates whether proposed technical approaches in planning documents will survive contact with reality -- architecture conflicts, dependency gaps, migration risks, and implementability. Spawned by the document-review skill."
-model: inherit
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/agents/document-review/product-lens-reviewer.md
+++ b/agents/document-review/product-lens-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: product-lens-reviewer
 description: "Reviews planning documents as a senior product leader -- challenges premise claims, assesses strategic consequences (trajectory, identity, adoption, opportunity cost), and surfaces goal-work misalignment. Domain-agnostic: users may be end users, developers, operators, or any audience. Spawned by the document-review skill."
-model: inherit
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/agents/document-review/scope-guardian-reviewer.md
+++ b/agents/document-review/scope-guardian-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: scope-guardian-reviewer
 description: "Reviews planning documents for scope alignment and unjustified complexity -- challenges unnecessary abstractions, premature frameworks, and scope that exceeds stated goals. Spawned by the document-review skill."
-model: inherit
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/agents/document-review/security-lens-reviewer.md
+++ b/agents/document-review/security-lens-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: security-lens-reviewer
 description: "Evaluates planning documents for security gaps at the plan level -- auth/authz assumptions, data exposure risks, API surface vulnerabilities, and missing threat model elements. Spawned by the document-review skill."
-model: inherit
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/agents/research/best-practices-researcher.md
+++ b/agents/research/best-practices-researcher.md
@@ -1,7 +1,6 @@
 ---
 name: best-practices-researcher
 description: "Researches and synthesizes external best practices, documentation, and examples for any technology or framework. Use when you need industry standards, community conventions, or implementation guidance."
-model: inherit
 ---
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and best practices.

--- a/agents/research/framework-docs-researcher.md
+++ b/agents/research/framework-docs-researcher.md
@@ -1,7 +1,6 @@
 ---
 name: framework-docs-researcher
 description: "Gathers comprehensive documentation and best practices for frameworks, libraries, or dependencies. Use when you need official docs, version-specific constraints, or implementation patterns."
-model: inherit
 ---
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and version information.

--- a/agents/research/git-history-analyzer.md
+++ b/agents/research/git-history-analyzer.md
@@ -1,7 +1,6 @@
 ---
 name: git-history-analyzer
 description: "Performs archaeological analysis of git history to trace code evolution, identify contributors, and understand why code patterns exist. Use when you need historical context for code changes."
-model: inherit
 ---
 
 **Note: The current year is 2026.** Use this when interpreting commit dates and recent changes.

--- a/agents/research/issue-intelligence-analyst.md
+++ b/agents/research/issue-intelligence-analyst.md
@@ -1,7 +1,6 @@
 ---
 name: issue-intelligence-analyst
 description: "Fetches and analyzes GitHub issues to surface recurring themes, pain patterns, and severity trends. Use when understanding a project's issue landscape, analyzing bug patterns for ideation, or summarizing what users are reporting."
-model: inherit
 ---
 
 **Note: The current year is 2026.** Use this when evaluating issue recency and trends.

--- a/agents/research/learnings-researcher.md
+++ b/agents/research/learnings-researcher.md
@@ -1,7 +1,6 @@
 ---
 name: learnings-researcher
 description: "Searches docs/solutions/ for relevant past solutions by frontmatter metadata. Use before implementing features or fixing problems to surface institutional knowledge and prevent repeated mistakes."
-model: inherit
 ---
 
 You are an expert institutional knowledge researcher specializing in efficiently surfacing relevant documented solutions from the team's knowledge base. Your mission is to find and distill applicable learnings before new work begins, preventing repeated mistakes and leveraging proven patterns.

--- a/agents/research/repo-research-analyst.md
+++ b/agents/research/repo-research-analyst.md
@@ -1,7 +1,6 @@
 ---
 name: repo-research-analyst
 description: "Conducts thorough research on repository structure, documentation, conventions, and implementation patterns. Use when onboarding to a new codebase or understanding project conventions."
-model: inherit
 ---
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and patterns.

--- a/agents/research/slack-researcher.md
+++ b/agents/research/slack-researcher.md
@@ -1,7 +1,6 @@
 ---
 name: slack-researcher
 description: "Searches Slack for organizational context. Use when the user explicitly asks. Requires a Slack MCP server."
-model: inherit
 ---
 **Note: The current year is 2026.** Use this when assessing the recency of Slack discussions.
 

--- a/agents/review/adversarial-reviewer.md
+++ b/agents/review/adversarial-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: adversarial-reviewer
 description: Conditional code-review persona, selected when the diff is large (>=50 changed lines) or touches high-risk domains like auth, payments, data mutations, or external APIs. Actively constructs failure scenarios to break the implementation rather than checking against known patterns.
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: red
 

--- a/agents/review/agent-native-reviewer.md
+++ b/agents/review/agent-native-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: agent-native-reviewer
 description: "Reviews code to ensure agent-native parity -- any action a user can take, an agent can also take. Use after adding UI features, agent tools, or system prompts."
-model: inherit
 color: cyan
 tools: Read, Grep, Glob, Bash
 ---

--- a/agents/review/api-contract-reviewer.md
+++ b/agents/review/api-contract-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: api-contract-reviewer
 description: Conditional code-review persona, selected when the diff touches API routes, request/response types, serialization, versioning, or exported type signatures. Reviews code for breaking contract changes.
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent

--- a/agents/review/architecture-strategist.md
+++ b/agents/review/architecture-strategist.md
@@ -1,7 +1,6 @@
 ---
 name: architecture-strategist
 description: "Analyzes code changes from an architectural perspective for pattern compliance and design integrity. Use when reviewing PRs, adding services, or evaluating structural refactors."
-model: inherit
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/agents/review/cli-agent-readiness-reviewer.md
+++ b/agents/review/cli-agent-readiness-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: cli-agent-readiness-reviewer
 description: "Reviews CLI source code, plans, or specs for AI agent readiness using a severity-based rubric focused on whether a CLI is merely usable by agents or genuinely optimized for them."
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: yellow
 ---

--- a/agents/review/cli-readiness-reviewer.md
+++ b/agents/review/cli-readiness-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: cli-readiness-reviewer
 description: "Conditional code-review persona, selected when the diff touches CLI command definitions, argument parsing, or command handler implementations. Reviews CLI code for agent readiness -- how well the CLI serves autonomous agents, not just human users."
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 ---

--- a/agents/review/code-simplicity-reviewer.md
+++ b/agents/review/code-simplicity-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: code-simplicity-reviewer
 description: "Final review pass to ensure code is as simple and minimal as possible. Use after implementation is complete to identify YAGNI violations and simplification opportunities."
-model: inherit
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/agents/review/correctness-reviewer.md
+++ b/agents/review/correctness-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: correctness-reviewer
 description: Always-on code-review persona. Reviews code for logic errors, edge cases, state management bugs, error propagation failures, and intent-vs-implementation mismatches.
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent

--- a/agents/review/data-integrity-guardian.md
+++ b/agents/review/data-integrity-guardian.md
@@ -1,7 +1,6 @@
 ---
 name: data-integrity-guardian
 description: "Reviews database migrations, data models, and persistent data code for safety. Use when checking migration safety, data constraints, transaction boundaries, or privacy compliance."
-model: inherit
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/agents/review/data-migration-expert.md
+++ b/agents/review/data-migration-expert.md
@@ -1,7 +1,6 @@
 ---
 name: data-migration-expert
 description: "Validates data migrations, backfills, and production data transformations against reality. Use when PRs involve ID mappings, column renames, enum conversions, or schema changes."
-model: inherit
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/agents/review/data-migrations-reviewer.md
+++ b/agents/review/data-migrations-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: data-migrations-reviewer
 description: Conditional code-review persona, selected when the diff touches migration files, schema changes, data transformations, or backfill scripts. Reviews code for data integrity and migration safety.
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent

--- a/agents/review/deployment-verification-agent.md
+++ b/agents/review/deployment-verification-agent.md
@@ -1,7 +1,6 @@
 ---
 name: deployment-verification-agent
 description: "Produces Go/No-Go deployment checklists with SQL verification queries, rollback procedures, and monitoring plans. Use when PRs touch production data, migrations, or risky data changes."
-model: inherit
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/agents/review/dhh-rails-reviewer.md
+++ b/agents/review/dhh-rails-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: dhh-rails-reviewer
 description: Conditional code-review persona, selected when Rails diffs introduce architectural choices, abstractions, or frontend patterns that may fight the framework. Reviews code from an opinionated DHH perspective.
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent

--- a/agents/review/julik-frontend-races-reviewer.md
+++ b/agents/review/julik-frontend-races-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: julik-frontend-races-reviewer
 description: Conditional code-review persona, selected when the diff touches async UI code, Stimulus/Turbo lifecycles, or DOM-timing-sensitive frontend behavior. Reviews code for race conditions and janky UI failure modes.
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent

--- a/agents/review/kieran-python-reviewer.md
+++ b/agents/review/kieran-python-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: kieran-python-reviewer
 description: Conditional code-review persona, selected when the diff touches Python code. Reviews changes with Kieran's strict bar for Pythonic clarity, type hints, and maintainability.
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent

--- a/agents/review/kieran-rails-reviewer.md
+++ b/agents/review/kieran-rails-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: kieran-rails-reviewer
 description: Conditional code-review persona, selected when the diff touches Rails application code. Reviews Rails changes with Kieran's strict bar for clarity, conventions, and maintainability.
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent

--- a/agents/review/kieran-typescript-reviewer.md
+++ b/agents/review/kieran-typescript-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: kieran-typescript-reviewer
 description: Conditional code-review persona, selected when the diff touches TypeScript code. Reviews changes with Kieran's strict bar for type safety, clarity, and maintainability.
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent

--- a/agents/review/maintainability-reviewer.md
+++ b/agents/review/maintainability-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: maintainability-reviewer
 description: Always-on code-review persona. Reviews code for premature abstraction, unnecessary indirection, dead code, coupling between unrelated modules, and naming that obscures intent.
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent

--- a/agents/review/pattern-recognition-specialist.md
+++ b/agents/review/pattern-recognition-specialist.md
@@ -1,7 +1,6 @@
 ---
 name: pattern-recognition-specialist
 description: "Analyzes code for design patterns, anti-patterns, naming conventions, and duplication. Use when checking codebase consistency or verifying new code follows established patterns."
-model: inherit
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/agents/review/performance-oracle.md
+++ b/agents/review/performance-oracle.md
@@ -1,7 +1,6 @@
 ---
 name: performance-oracle
 description: "Analyzes code for performance bottlenecks, algorithmic complexity, database queries, memory usage, and scalability. Use after implementing features or when performance concerns arise."
-model: inherit
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/agents/review/performance-reviewer.md
+++ b/agents/review/performance-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: performance-reviewer
 description: Conditional code-review persona, selected when the diff touches database queries, loop-heavy data transforms, caching layers, or I/O-intensive paths. Reviews code for runtime performance and scalability issues.
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent

--- a/agents/review/previous-comments-reviewer.md
+++ b/agents/review/previous-comments-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: previous-comments-reviewer
 description: Conditional code-review persona, selected when reviewing a PR that has existing review comments or review threads. Checks whether prior feedback has been addressed in the current diff.
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: yellow
 

--- a/agents/review/project-standards-reviewer.md
+++ b/agents/review/project-standards-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: project-standards-reviewer
 description: Always-on code-review persona. Audits changes against the project's own AGENTS.md standards -- frontmatter rules, reference inclusion, naming conventions, cross-platform portability, and tool selection policies.
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 

--- a/agents/review/reliability-reviewer.md
+++ b/agents/review/reliability-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: reliability-reviewer
 description: Conditional code-review persona, selected when the diff touches error handling, retries, circuit breakers, timeouts, health checks, background jobs, or async handlers. Reviews code for production reliability and failure modes.
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent

--- a/agents/review/schema-drift-detector.md
+++ b/agents/review/schema-drift-detector.md
@@ -1,7 +1,6 @@
 ---
 name: schema-drift-detector
 description: "Detects unrelated schema.rb changes in PRs by cross-referencing against included migrations. Use when reviewing PRs with database schema changes."
-model: inherit
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/agents/review/security-reviewer.md
+++ b/agents/review/security-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: security-reviewer
 description: Conditional code-review persona, selected when the diff touches auth middleware, public endpoints, user input handling, or permission checks. Reviews code for exploitable vulnerabilities.
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 mode: subagent

--- a/agents/review/security-sentinel.md
+++ b/agents/review/security-sentinel.md
@@ -1,7 +1,6 @@
 ---
 name: security-sentinel
 description: "Performs security audits for vulnerabilities, input validation, auth/authz, hardcoded secrets, and OWASP compliance. Use when reviewing code for security issues or before deployment."
-model: inherit
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/agents/review/testing-reviewer.md
+++ b/agents/review/testing-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: testing-reviewer
 description: Always-on code-review persona. Reviews code for test coverage gaps, weak assertions, brittle implementation-coupled tests, and missing edge case coverage.
-model: inherit
 tools: Read, Grep, Glob, Bash
 color: blue
 

--- a/agents/workflow/bug-reproduction-validator.md
+++ b/agents/workflow/bug-reproduction-validator.md
@@ -1,7 +1,6 @@
 ---
 name: bug-reproduction-validator
 description: Systematically reproduces and validates bug reports to confirm whether reported behavior is an actual bug. Use when you receive a bug report or issue that needs verification.
-model: inherit
 mode: subagent
 temperature: 0.1
 ---

--- a/agents/workflow/lint.md
+++ b/agents/workflow/lint.md
@@ -1,7 +1,6 @@
 ---
 name: lint
 description: Use this agent when you need to run linting and code quality checks on Ruby and ERB files. Run before pushing to origin.
-model: inherit
 color: yellow
 mode: subagent
 temperature: 0.1

--- a/agents/workflow/pr-comment-resolver.md
+++ b/agents/workflow/pr-comment-resolver.md
@@ -2,7 +2,6 @@
 name: pr-comment-resolver
 description: "Evaluates and resolves one or more related PR review threads -- assesses validity, implements fixes, and returns structured summaries with reply text. Spawned by the resolve-pr-feedback skill."
 color: blue
-model: inherit
 ---
 
 You resolve PR review threads. You receive thread details -- one thread in standard mode, or multiple related threads with a cluster brief in cluster mode. Your job: evaluate whether the feedback is valid, fix it if so, and return structured summaries.

--- a/agents/workflow/spec-flow-analyzer.md
+++ b/agents/workflow/spec-flow-analyzer.md
@@ -1,7 +1,6 @@
 ---
 name: spec-flow-analyzer
 description: "Analyzes specifications and feature descriptions for user flow completeness and gap identification. Use when a spec, plan, or feature description needs flow analysis, edge case discovery, or requirements validation."
-model: inherit
 ---
 
 Analyze specifications, plans, and feature descriptions from the end user's perspective. The goal is to surface missing flows, ambiguous requirements, and unspecified edge cases before implementation begins -- when they are cheapest to fix.

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -709,11 +709,12 @@ export function checkAgentModel(
     const content = readFileSafe(path.join(rootDir, relPath))
     if (content === null) continue
     const parsed = parseFrontmatter(content)
-    const model = isRecord(parsed.data) ? parsed.data.model : undefined
-    if (model !== 'inherit') {
+    if (!isRecord(parsed.data)) continue
+    if (Object.hasOwn(parsed.data, 'model')) {
       violations.push({
         file: relPath,
-        message: 'Bundled agents must declare model: inherit.',
+        message:
+          "Bundled agents must omit the `model` field. OpenCode subagents inherit the invoking primary agent's model when `model` is unset (per https://opencode.ai/docs/agents/). The literal `model: inherit` was undocumented and produced ProviderModelNotFoundError on OpenCode older than ~v1.13.x (pre sst/opencode#17888).",
       })
     }
   }

--- a/skills/writing-systematic-skills/SKILL.md
+++ b/skills/writing-systematic-skills/SKILL.md
@@ -27,7 +27,7 @@ Systematic adds repository-specific constraints:
 
 - Runtime-recognized frontmatter fields are fixed by the skill loader.
 - Skill sub-files live in a small set of conventional directories.
-- Bundled agents must use provider-portable model defaults.
+- Bundled agents omit the `model` field; subagents inherit the invoking primary agent's model.
 - Content-integrity enforces the mechanical parts in CI.
 
 For worked examples and judgment calls, read `references/foundation-conventions.md`.
@@ -76,13 +76,17 @@ Keep the main `SKILL.md` small enough to decide whether and how to proceed. Move
 
 ## Identity Defaults
 
-Bundled agents must declare:
+Bundled agents must omit the `model` field entirely:
 
 ```yaml
-model: inherit
+---
+name: example-agent
+description: ...
+# no `model:` line
+---
 ```
 
-Hardcoded provider model IDs break users who do not use that provider. Use `model: inherit` unless a future design explicitly proves a provider-specific dependency and documents the tradeoff.
+Per [OpenCode's agent docs](https://opencode.ai/docs/agents/), subagents with no `model` inherit the model of the primary agent that invoked them — which is the desired portable behavior. Do **not** declare `model: inherit`: that literal value is undocumented and produces `ProviderModelNotFoundError` on OpenCode older than ~v1.13.x (pre [sst/opencode#17888](https://github.com/sst/opencode/pull/17888)). Hardcoded provider model IDs (`anthropic/...`, `openai/...`, etc.) are also banned because they break users on other providers.
 
 For agent or API attribution, `ai:systematic` is the machine ID used by Systematic-owned operations, such as Proof's `by` field and `X-Agent-Id` header. It is not a skill cross-reference convention.
 
@@ -99,7 +103,7 @@ The gate checks:
 - Skill frontmatter is present and uses only runtime-recognized fields.
 - Required `name` and `description` fields are non-empty.
 - Banned frontmatter such as `preconditions` is absent.
-- Bundled agents use `model: inherit`.
+- Bundled agents omit the `model` field.
 - Skill references to `references/`, `scripts/`, `assets/`, and `templates/` resolve on disk.
 
 If the gate fails, fix the content rather than broadening the validator unless the runtime loader contract has actually changed.
@@ -110,6 +114,6 @@ If the gate fails, fix the content rather than broadening the validator unless t
 |---|---|
 | Adding a new frontmatter field because it reads well | Add body prose instead, unless the runtime loader consumes the field. |
 | Summarizing the whole workflow in `description` | Describe trigger conditions only. |
-| Adding provider-specific agent models | Use `model: inherit`. |
+| Adding any `model` field to a bundled agent | Omit the field; subagents inherit from the invoking primary agent. |
 | Linking to a non-existent reference file | Create the file or remove the link. |
 | Duplicating the general writing-skills guidance | Link to the foundation and document only the Systematic delta. |

--- a/skills/writing-systematic-skills/references/foundation-conventions.md
+++ b/skills/writing-systematic-skills/references/foundation-conventions.md
@@ -18,7 +18,7 @@ Systematic skill frontmatter mirrors what the runtime loader actually reads. Do 
 | `metadata` | No | String-only metadata map. Keep it boring. | `metadata: { owner: systematic }` |
 | `user-invocable` | No | Direct user invocation should be explicitly advertised or suppressed. | `user-invocable: false` |
 | `agent` | No | A loader-supported companion agent is required. | `agent: general` |
-| `model` | No | A skill-level model choice is justified. Prefer inheritance elsewhere. | `model: inherit` |
+| `model` | No | A skill-level model choice is justified for *skill execution* (not bundled agents — see below). | `model: anthropic/claude-haiku-4-5` |
 | `context` | No | Forked execution is required. `fork` derives subtask behavior at runtime. | `context: fork` |
 | `subtask` | No | Explicit forked-subtask dispatch marker. | `subtask: true` |
 
@@ -106,15 +106,21 @@ Avoid ambiguous references such as "the conventions doc". They are harder for ag
 
 ### Bundled Agent Model
 
-Bundled agents must use:
+Bundled agents must omit the `model` field entirely:
 
 ```yaml
-model: inherit
+---
+name: example-agent
+description: ...
+# no `model:` line
+---
 ```
 
-This keeps Systematic provider-portable. Hardcoded provider IDs make an agent unusable for users on other providers and are almost never worth the lock-in.
+Per [OpenCode's agent docs](https://opencode.ai/docs/agents/): **"If you don't specify a model, primary agents use the model globally configured while subagents will use the model of the primary agent that invoked the subagent."** All bundled Systematic agents are subagents, so omitting `model` gives the desired portable inheritance behavior.
 
-If a future agent truly depends on a specific provider, document the constraint in the plan and get explicit review before adding the hardcoded model.
+Do **not** declare `model: inherit`. That literal value is undocumented and was treated as a real provider/model string by `Provider.parseModel()` until [sst/opencode#17888](https://github.com/sst/opencode/pull/17888) landed in mid-March 2026 — producing `ProviderModelNotFoundError` on every subagent invocation for anyone on an older OpenCode. Omitting the field works on every OpenCode version and is what the docs canonically describe.
+
+Hardcoded provider IDs (`anthropic/claude-...`, `openai/gpt-...`, etc.) are also banned because they make an agent unusable for users on other providers. If a future agent truly depends on a specific provider, document the constraint in the plan and get explicit review before adding the hardcoded model.
 
 ### Machine ID
 

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -52,10 +52,12 @@ function writeAllowlist(root: string, exemptions: AllowlistEntry[]): void {
 }
 
 function writeAgent(root: string, category: string, name: string): void {
+  // Bundled agents must omit the `model` field per content-integrity gate;
+  // OpenCode subagents inherit the invoking primary agent's model when unset.
   writeFile(
     root,
     `agents/${category}/${name}.md`,
-    `---\nname: ${name}\nmodel: inherit\n---\nagent body`,
+    `---\nname: ${name}\n---\nagent body`,
   )
 }
 
@@ -663,7 +665,7 @@ describe('checkFrontmatter', () => {
           '  owner: systematic',
           'user-invocable: true',
           'agent: general',
-          'model: inherit',
+          'model: anthropic/claude-haiku-4-5',
           'context: fork',
           'subtask: true',
           '---',
@@ -843,7 +845,7 @@ describe('checkFrontmatter', () => {
 })
 
 describe('checkAgentModel', () => {
-  test('allows agents with model inherit', () => {
+  test('allows agents with model field omitted', () => {
     const root = makeFixtureRepo()
     try {
       writeAgent(root, 'research', 'a')
@@ -854,13 +856,13 @@ describe('checkAgentModel', () => {
     }
   })
 
-  test('flags missing, non-inherit, empty, and null model values', () => {
+  test('flags any present model value (including inherit, hardcoded, empty, null)', () => {
     const root = makeFixtureRepo()
     try {
       writeFile(
         root,
-        'agents/research/missing.md',
-        '---\nname: missing\n---\nbody',
+        'agents/research/inherit.md',
+        '---\nname: inherit\nmodel: inherit\n---\nbody',
       )
       writeFile(
         root,
@@ -882,18 +884,20 @@ describe('checkAgentModel', () => {
       expect(violations.map((v) => v.file).sort()).toEqual([
         'agents/research/empty.md',
         'agents/research/hardcoded.md',
-        'agents/research/missing.md',
+        'agents/research/inherit.md',
         'agents/research/null.md',
       ])
       expect(
-        violations.every((v) => v.message.includes('model: inherit')),
+        violations.every((v) =>
+          v.message.includes('Bundled agents must omit the `model` field'),
+        ),
       ).toBe(true)
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }
   })
 
-  test('flags non-object frontmatter as a missing model', () => {
+  test('ignores non-object frontmatter (no model key to flag)', () => {
     const root = makeFixtureRepo()
     try {
       writeFile(
@@ -903,12 +907,7 @@ describe('checkAgentModel', () => {
       )
 
       const targets = collectScanTargets(root)
-      expect(checkAgentModel(root, targets.markdown)).toEqual([
-        {
-          file: 'agents/research/list.md',
-          message: 'Bundled agents must declare model: inherit.',
-        },
-      ])
+      expect(checkAgentModel(root, targets.markdown)).toEqual([])
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }
@@ -1000,7 +999,11 @@ describe('checkContentIntegrity (top-level)', () => {
         'foo',
         '---\nname: foo\ndescription: Test skill\npreconditions: before use\n---\nbody',
       )
-      writeFile(root, 'agents/research/a.md', '---\nname: a\n---\nagent')
+      writeFile(
+        root,
+        'agents/research/a.md',
+        '---\nname: a\nmodel: inherit\n---\nagent',
+      )
 
       const result = checkContentIntegrity(root)
       expect(result.frontmatterViolations).toHaveLength(1)
@@ -1397,7 +1400,11 @@ describe('CLI', () => {
         'foo',
         '---\nname: foo\ndescription: Test skill\npreconditions: before use\n---\nbody',
       )
-      writeFile(root, 'agents/research/a.md', '---\nname: a\n---\nagent')
+      writeFile(
+        root,
+        'agents/research/a.md',
+        '---\nname: a\nmodel: inherit\n---\nagent',
+      )
 
       const result = Bun.spawnSync(['bun', SCRIPT_PATH, root], {
         cwd: REPO_ROOT,


### PR DESCRIPTION
## Why

OpenCode's documented contract for subagent model resolution is **field-omitted**:

> If you don't specify a model, ... subagents will use the model of the primary agent that invoked the subagent.
> — https://opencode.ai/docs/agents/

The literal value `model: inherit` is **not documented** by OpenCode and historically broke subagent dispatch. Pre-`sst/opencode#17888` (March 2026), `Provider.parseModel("inherit")` returned a non-null structure that defeated the `agent?.model ?? sessionModel` fallback, producing `ProviderModelNotFoundError` on every subagent invocation. The fix special-cases the literal string, but a user on OpenCode older than ~v1.13.x running Systematic v2.x today still gets a hard crash with no breadcrumb pointing at frontmatter.

Field-omitted works on every OpenCode version and matches the documented contract.

## What changes

- **All 50 bundled agents** under `agents/` strip the `model: inherit` line from their frontmatter.
- **Content-integrity gate** (`scripts/content-integrity.ts:701-723`) flips its rule from "require `model: inherit`" to "require the field absent". The new violation message cites the OpenCode docs and the upstream PR so contributors who hit it understand the why.
- **`writing-systematic-skills` spec** (`SKILL.md` + `references/foundation-conventions.md`) reverses the prior guidance and explains the rationale.
- **Root `AGENTS.md`** gains one Conventions bullet so contributors discover the policy at authoring time, not at CI failure.
- **Test fixtures** flip violation expectations: previously the suite asserted "missing/non-inherit/empty/null" as violations; now it asserts "any present `model` value (including the literal `inherit`)" as violations.

## What does NOT change

- The CC→OpenCode converter (`src/lib/converter.ts:310-313`) was already stripping `model: inherit` from output. The conversion path was correct; only the bundled agents and the spec hadn't caught up.
- Orchestrator plugin compatibility is unaffected. `oh-my-openagent` and `oh-my-opencode-slim` route by agent name and don't read frontmatter `model` at all. Their model overrides come from category-config, not agent files.

## Peer convention check

Audited 5 peer OpenCode plugins for bundled-agent `model:` patterns:

| Plugin                      | Bundled agents | `model: inherit` | Explicit model | No model field |
| --------------------------- | -------------- | ---------------- | -------------- | -------------- |
| oh-my-openagent             | 4              | 0                | 0              | **4**          |
| oh-my-opencode-slim         | 1              | 0                | 0              | **1**          |
| opencode-magic-context      | 38             | 0                | 0              | **38**         |
| opencode-copilot-delegate   | 0 (tools-only) | —                | —              | —              |
| compound-engineering-plugin | 53             | **44**           | 7              | 2              |

Field-omitted is the dominant peer convention (43/43 of agents in plugins that actually omit, vs. CEP which is the historical pattern Systematic inherited).

## Verification

| Check                  | Result                                                                                                                       |
| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
| `bun run typecheck`      | ✅                                                                                                                            |
| `bun run lint`           | ✅                                                                                                                            |
| `bun run build`          | ✅                                                                                                                            |
| `bun test tests/unit`    | ✅ 448/448                                                                                                                    |
| Content-integrity gate | ✅ 162 md + 15 ts scanned, 43 exempt hits, 0 violations (the gate now flags any agent declaring a `model` field, including `inherit`) |
| Registry drift         | ✅ 101 components                                                                                                             |
| Node ESM smoke         | ✅                                                                                                                            |

## Backward compatibility

Reversible by single revert if a real-world regression surfaces. The literal `inherit` string still works on post-#17888 OpenCode — this PR removes a deliberately undocumented value, it does not remove behavior.

## Leading indicators to watch

If OpenCode ever changes the field-absent default, the canaries are:

1. Changes to `agent?.model ?? sessionModel` fallback in `sst/opencode` `packages/opencode/src/session/index.ts`
2. Introduction of a `default_subagent_model` or equivalent global config key
3. Wording changes to the "If you don't specify a model..." paragraph at https://opencode.ai/docs/agents/
4. Release notes mentioning "subagent model" / "default model" / "model inheritance"

Refs: https://opencode.ai/docs/agents/, sst/opencode#17888
