### PR TITLE
feat(config): add agent configuration overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,20 @@ Configuration is loaded from multiple locations and merged (later sources overri
 {
   "disabled_skills": ["git-worktree"],
   "disabled_agents": [],
+  "categories": {
+    "review": {
+      "temperature": 0.1,
+      "skills": ["ce:review"]
+    }
+  },
+  "agents": {
+    "security-sentinel": {
+      "model": "anthropic/claude-sonnet-4-5"
+    },
+    "workflow/systematic-implementer": {
+      "steps": 20
+    }
+  },
   "bootstrap": {
     "enabled": true
   }
@@ -307,8 +321,20 @@ Configuration is loaded from multiple locations and merged (later sources overri
 |--------|------|---------|-------------|
 | `disabled_skills` | `string[]` | `[]` | Skills to exclude from registration |
 | `disabled_agents` | `string[]` | `[]` | Agents to exclude from registration |
+| `categories` | `object` | `{}` | Overlay bundled agents by category (`design`, `docs`, `document-review`, `research`, `review`, `workflow`) |
+| `agents` | `object` | `{}` | Overlay exact bundled agents by unique stem or `<category>/<stem>` key |
 | `bootstrap.enabled` | `boolean` | `true` | Inject the `using-systematic` guide into system prompts |
 | `bootstrap.file` | `string` | — | Custom bootstrap file path (overrides default) |
+
+Agent overlays support `model`, `variant`, `temperature`, `top_p`, `permission`, `mode`, `color`, `steps`, `hidden`, exact-agent-only `disable`, and managed `skills`. `skills` is a shortcut that writes OpenCode `permission.skill` rules; it is not a native OpenCode agent field.
+
+Systematic separates config-source precedence from overlay precedence. Config files merge in this order: user config, project config, then `$OPENCODE_CONFIG_DIR/systematic.json` if set. Higher-priority `agents.<key>` and `categories.<id>` entries replace lower-priority entries wholesale, while unrelated keys survive. After the effective config is built, exact `agents` overlays beat category overlays, which beat built-in policy defaults, bundled markdown defaults, and OpenCode inherited defaults.
+
+Bundled agents omit `model` by default so OpenCode model inheritance keeps working. Systematic emits a `model` only when you configure one explicitly; provider-specific zero-config model defaults are intentionally deferred.
+
+Native OpenCode agents with the same emitted key are full replacements. An exact Systematic overlay for that key conflicts, while category overlays skip native replacements and continue applying to other bundled agents. Use one canonical agent key form across config sources (`security-sentinel` or `review/security-sentinel`) because alias collisions fail duplicate-target validation.
+
+Category IDs are V1 public API because broad policy overlays are a core use case; future agent reorganizations must preserve aliases or provide migration warnings. Category overlays also apply to future bundled agents added to that category. V1 does not include an MCP allowlist shortcut.
 
 ### Project-Specific Content
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Configuration is loaded from multiple locations and merged (later sources overri
   "categories": {
     "review": {
       "temperature": 0.1,
-      "skills": ["ce:review"]
+      "steps": 12
     }
   },
   "agents": {
@@ -326,9 +326,9 @@ Configuration is loaded from multiple locations and merged (later sources overri
 | `bootstrap.enabled` | `boolean` | `true` | Inject the `using-systematic` guide into system prompts |
 | `bootstrap.file` | `string` | — | Custom bootstrap file path (overrides default) |
 
-Agent overlays support `model`, `variant`, `temperature`, `top_p`, `permission`, `mode`, `color`, `steps`, `hidden`, exact-agent-only `disable`, and managed `skills`. `skills` is a shortcut that writes OpenCode `permission.skill` rules; it is not a native OpenCode agent field.
+Agent overlays support `model`, `variant`, `temperature`, `top_p`, `permission`, `mode`, `color`, `steps`, `hidden`, exact-agent-only `disable`, and managed `skills`. `skills` uses bundled skill frontmatter names like `ce:review`; it is a shortcut that writes OpenCode `permission.skill` rules, not a native OpenCode agent field. Because `permission` and `skills` control tool access, they are only accepted from user config or `$OPENCODE_CONFIG_DIR/systematic.json`; project config may tune behavior but cannot loosen a user's permission policy.
 
-Systematic separates config-source precedence from overlay precedence. Config files merge in this order: user config, project config, then `$OPENCODE_CONFIG_DIR/systematic.json` if set. Higher-priority `agents.<key>` and `categories.<id>` entries replace lower-priority entries wholesale, while unrelated keys survive. After the effective config is built, exact `agents` overlays beat category overlays, which beat built-in policy defaults, bundled markdown defaults, and OpenCode inherited defaults.
+Systematic separates config-source precedence from overlay precedence. Config files merge in this order: user config, project config, then `$OPENCODE_CONFIG_DIR/systematic.json` if set. Higher-priority `agents.<key>` and `categories.<id>` entries replace lower-priority entries wholesale, while unrelated keys survive. Project overlays are the exception for security fields: same-key project overlays preserve user-level `permission` and `skills` fields instead of erasing them. After the effective config is built, exact `agents` overlays beat category overlays, which beat built-in policy defaults, bundled markdown defaults, and OpenCode inherited defaults.
 
 Bundled agents omit `model` by default so OpenCode model inheritance keeps working. Systematic emits a `model` only when you configure one explicitly; provider-specific zero-config model defaults are intentionally deferred.
 

--- a/docs/plans/2026-05-09-001-feat-agent-model-configuration-plan.md
+++ b/docs/plans/2026-05-09-001-feat-agent-model-configuration-plan.md
@@ -1,0 +1,407 @@
+---
+title: feat: Add Agent Configuration Overlays
+type: feat
+status: active
+date: 2026-05-09
+origin: docs/brainstorms/2026-05-09-agent-model-configuration-requirements.md
+---
+
+# feat: Add Agent Configuration Overlays
+
+## Overview
+
+Add a Systematic config surface for tuning bundled agents without editing bundled markdown or copying native OpenCode agent definitions. The first version adds top-level Systematic `agents` and `categories` overlays, built-in zero-config temperature defaults, strict field validation, and a permission-backed `skills` allowlist shortcut.
+
+The plan replaces the earlier model-only `agent_models` direction. The config surface is broader agent configuration, but it remains a deterministic config-time overlay layer: no presets, runtime model switching, fallback chains, provider probing, or background retry manager.
+
+## Problem Frame
+
+Systematic emits bundled OpenCode agent definitions from `agents/**/*.md`. Bundled agents intentionally omit `model:` frontmatter, preserving provider portability by inheriting the orchestrating agent model. That portability makes specialized workflow tuning awkward: users must either accept inherited model/capability behavior or replace complete native OpenCode agent config and risk drift from bundled prompt/tool metadata (see origin: `docs/brainstorms/2026-05-09-agent-model-configuration-requirements.md`).
+
+Systematic should provide a smaller, safer customization layer for its own bundled agents: markdown remains the default prompt/tool source, built-in policy defaults supply low-risk runtime tuning, category overlays handle broad policy, exact agent overlays handle exceptions, and native OpenCode same-name agents remain full user-owned replacements. The `skills` shortcut is included because per-agent skill visibility is part of the same customization problem: without it, users still have to copy full native agent definitions just to tune skill access.
+
+## Requirements Trace
+
+- R1. Support top-level Systematic `agents` and `categories` maps for bundled-agent overlays.
+- R2. Support both unqualified file-stem agent keys and qualified `<category>/<stem>` keys, with duplicate-target validation. V1 also requires bundled stems to remain globally unique because emitted OpenCode agent keys are stem-only.
+- R3. Treat documented category IDs as public V1 config API.
+- R4. Apply precedence: exact agent overlay, category overlay, built-in defaults, bundled markdown defaults, inherited OpenCode defaults.
+- R5. Across Systematic config sources, higher-priority same-key `agents`/`categories` objects replace lower-priority objects; unrelated keys survive.
+- R6. Enforce a strict V1 field allow-list and reject unsupported fields.
+- R7. Validate explicit `model` strings structurally as `provider/model`; include `variant` only as a normal OpenCode agent field, not as provider availability proof.
+- R8. Define scalar, object, array, and capability allowlist merge semantics.
+- R8a. Allow `disable` only for exact agent overlays.
+- R8b. Add zero-config runtime tuning defaults outside bundled markdown; temperature defaults are in scope and may change zero-config runtime behavior. Provider-specific model defaults are deferred because safe config-hook availability/fallback support was not proven.
+- R9. Include `skills` as a permission-backed shortcut because planning verified inventory and OpenCode `permission.skill` enforcement. Defer `mcps` because V1 should not depend on MCP tool-key naming without a dedicated implementation spike.
+- R10. Fail fast before mutating OpenCode config for invalid overlay keys, fields, values, duplicates, and capability names.
+- R11. Error messages include source config file path and invalid config key path where possible.
+- R12. Exact overlays for known disabled bundled agents are valid no-ops unless a native replacement conflict exists.
+- R13. Native OpenCode same-name agents are full replacements. Exact Systematic overlay for the same key conflicts; category overlays skip native replacements.
+- R14. Bundled agents continue to omit `model:` frontmatter.
+- R15. Overrides apply during OpenCode config generation, not by mutating markdown or generated docs.
+- R16. Documentation covers config shape, field allow-list, precedence, conflict behavior, source precedence, and no-`model:` policy.
+- R17. Documentation warns that category defaults affect future bundled agents in that category.
+
+## Scope Boundaries
+
+- V1 keeps `systematic.json`; it does not add `systematic.jsonc` discovery.
+- V1 does not add named presets, runtime fallback chains, rate-limit failover, retry managers, or model switching.
+- V1 does not attempt provider/model availability detection in the config hook. Explicit user `model` values are structurally validated only; well-shaped but nonexistent provider/model IDs pass Systematic validation and are left for OpenCode runtime behavior.
+- V1 does not emit provider-specific zero-config model defaults. Default `model` remains omitted so OpenCode inheritance still works.
+- V1 does not emit native `agent.skills` or `agent.mcps` fields; OpenCode has no such agent fields.
+- V1 does not include a Systematic `mcps` shortcut. MCP allowlists are deferred until a separate plan can specify stable OpenCode MCP tool-key mapping and permission-rule behavior.
+- V1 does not expose `prompt`, `description`, `options`, `tools`, display metadata beyond `color`/`hidden`, or arbitrary future OpenCode fields.
+- V1 does not cover arbitrary user-defined agents outside Systematic's bundled inventory.
+- V1 does not mutate bundled agent markdown or generated reference docs to add runtime tuning metadata.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/lib/config.ts` loads `systematic.json` from defaults, user config, project config, and `$OPENCODE_CONFIG_DIR`, with custom config highest priority. Current arrays are union-merged and `bootstrap` is shallow-merged.
+- `src/lib/config-handler.ts` discovers bundled agents/skills/commands and mutates OpenCode config in the plugin `config` hook. Current native `config.agent` entries win by object spread.
+- `src/lib/agents.ts` discovers bundled agent files and categories, parses OpenCode-like frontmatter, and currently omits `variant` from `AgentInfo` despite OpenCode supporting it.
+- `src/lib/skills.ts` discovers bundled skills and already has frontmatter validation patterns useful for skill allowlist inventory.
+- `src/lib/validation.ts` contains small type guard helpers; new overlay validation should follow that style but live in a focused module.
+- `src/lib/converter.ts` has `inferTemperature()` heuristics seeded from CEP conversion work: low temperature for review/security/lint/oracle-style agents, moderate for planning/research/architecture, medium for docs/writing, higher for brainstorm/design.
+- `scripts/content-integrity.ts` already rejects bundled agent `model` frontmatter and discovers top-level bundled categories.
+- `tests/unit/config.test.ts`, `tests/unit/config-handler.test.ts`, and `tests/unit/agents.test.ts` provide temp-dir and config-hook testing patterns.
+- `docs/src/content/docs/getting-started/configuration.mdx` is the main manual config documentation surface.
+
+### Institutional Learnings
+
+- Bundled agents must omit `model:` entirely; `model: inherit` is invalid historical baggage.
+- Systematic config priority is `$OPENCODE_CONFIG_DIR/systematic.json` over project `.opencode/systematic.json` over user `~/.config/opencode/systematic.json` over defaults.
+- Content-integrity gates are needed for bundled asset contracts; type/lint checks alone do not catch invalid markdown/frontmatter drift.
+- Plugin config-hook changes must preserve the idempotent plugin registration behavior; duplicate plugin factory calls should still return empty hooks after the first registration.
+- Batch/generator verification should avoid brittle shell iteration patterns and should use a different verification mechanism than mutation.
+
+### External References
+
+- `anomalyco/opencode` `packages/opencode/src/config/agent.ts`: OpenCode `AgentConfig` supports `model`, `variant`, `temperature`, `top_p`, `prompt`, deprecated `tools`, `disable`, `description`, `mode`, `hidden`, `options`, `color`, `steps`, deprecated `maxSteps`, and `permission`. Unknown fields are moved into `options`, so Systematic must not pass arbitrary overlay fields through.
+- `anomalyco/opencode` `packages/opencode/src/agent/agent.ts`: runtime overlays config fields onto agents and merges permissions. `disable: true` removes an agent.
+- `anomalyco/opencode` plugin APIs: the plugin `config(cfg)` hook receives only the mutable config object. It does not cleanly expose provider/model availability during config mutation.
+- `anomalyco/opencode` skill/MCP sources: skills are global via `skills.paths`/`skills.urls`; per-agent skill visibility is enforced through `permission.skill`. MCP servers are global via `cfg.mcp`; per-agent MCP access is controlled through permission rules on MCP tool keys.
+- `oh-my-opencode-slim` demonstrates strict top-level `agents` config, provider-specific defaults, and translation of `skills`/`mcps` allowlists into permissions. It does not safely preflight provider availability during config-hook model selection. Systematic adopts the `skills` permission shortcut pattern but defers MCP shortcut support.
+- `@cortexkit/magic-context` demonstrates explicit model/fallback settings for hidden managed agents and model-not-found retry for owned prompts, but that is outside Systematic V1's static bundled-agent overlay scope.
+
+## Key Technical Decisions
+
+- **Config shape:** Add top-level `agents` and `categories` maps to Systematic config. Do not use `agent_models`.
+- **Effective source merge:** Merge `agents`/`categories` by key across Systematic config sources. Higher-priority same-key objects replace lower-priority same-key objects wholesale; unrelated keys survive.
+- **Agent key model:** Support both unqualified file stems and qualified `<category>/<stem>` IDs as config aliases. V1 keeps emitted OpenCode agent keys as stem-only, so bundled agent stems must remain globally unique. Reject duplicate stems during inventory validation and content integrity. Reject configs that use both key forms for the same target in the effective config.
+- **Category API:** Use top-level bundled category directory names as stable V1 category IDs: `design`, `docs`, `document-review`, `research`, `review`, and `workflow`.
+- **Overlay field allow-list:** Support `model`, `variant`, `temperature`, `top_p`, `permission`, `mode`, `color`, `steps`, `hidden`, exact-agent-only `disable`, and managed `skills` shortcut fields translated into permissions. Exclude `tools` because OpenCode marks it deprecated; users can express tool policy through `permission`.
+- **Built-in policy defaults:** Add zero-config temperature defaults in a default-resolution layer outside bundled markdown. These are intentional policy defaults, not absence-only fillers, and may override bundled markdown temperature values. Do not emit provider-specific default models in V1 because provider/model availability cannot be cleanly verified inside `config(cfg)`. Explicit user `model` config remains supported.
+- **Capability semantics:** Implement `skills` as a managed shortcut for `permission.skill`. Omitted means inherit from weaker layers; an explicit empty array means allow none; `null` is invalid. Unknown/disabled skill names fail fast. Defer `mcps` rather than shipping a shortcut with underspecified MCP tool-key semantics.
+- **Permission ordering:** Normalize permissions from weakest to strongest layer: bundled markdown, built-in defaults, category overlay, exact overlay. OpenCode evaluates the last matching permission rule, so exact-layer rules must be appended after category/default rules. Within a single overlay object, reject configs that set both managed `skills` and explicit `permission.skill`; this avoids ambiguous same-layer ownership of skill visibility.
+- **Permission serialization:** Flatten each layer into ordered permission rules, concatenate weakest-to-strongest, resolve duplicate permission/pattern entries by last match, then rebuild the final permission object in evaluation order. Cross-layer `skills` and explicit `permission.skill` both normalize into the same ordered rule representation; exact-layer rules win because they are appended last.
+- **Native replacement behavior:** Native OpenCode `agent.<key>` with the same emitted bundled agent key is a full user-owned replacement. Exact Systematic `agents.<key>` config for that agent conflicts. Category overlays skip native replacements and apply to remaining Systematic-owned bundled agents.
+- **Pre-mutation validation:** Validate all overlay config, inventories, native conflicts, and capability names before mutating `config.agent`, `config.command`, `config.skills`, or `config.mcp`.
+- **No markdown mutation:** Keep content-integrity enforcement of no bundled `model:` frontmatter; overrides and defaults are config-time only.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Does OpenCode expose provider/model availability in the config hook?** No cleanly supported path was found in `anomalyco/opencode`; V1 defers provider-specific zero-config model defaults and never rewrites or falls back from explicit user `model` values.
+- **Are `skills`/`mcps` native per-agent fields?** No. V1 translates `skills` into `permission.skill` rules and defers `mcps` until MCP permission mapping is specified in a later plan.
+- **Should `tools` be part of the overlay allow-list?** No. OpenCode treats `tools` as deprecated and normalizes it into `permission`; Systematic should expose `permission` directly.
+- **Can `variant`, `steps`, and `hidden` be exposed?** Yes. They are real OpenCode agent config fields in the actual source.
+- **Can `variant` appear without `model`?** Yes. Systematic accepts it as a native OpenCode field, but docs/tests must note it may be ignored by OpenCode when no effective model uses variants.
+- **Should native same-name config overlay bundled agents shallowly?** No. The corrected requirements make native same-name agents full replacements; exact Systematic overlay for the same target conflicts.
+
+### Deferred to Implementation
+
+- **Nearest-name suggestions:** Implement deterministic suggestions only if cheap; otherwise list valid categories and agent keys in errors.
+- **Exact default temperature table:** Seed from `inferTemperature()` but adjust per-agent mappings during implementation if current bundled categories/roles make a more explicit table clearer.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TD
+  A[load Systematic config sources with provenance] --> B[merge agents/categories by source priority]
+  B --> C[discover full bundled agent inventory and category IDs]
+  C --> D[discover enabled bundled skills]
+  D --> E[validate overlay keys, fields, values, aliases, capabilities, native conflicts]
+  E --> F[load bundled agent markdown config]
+  F --> G[partition out native replacements and disabled agents]
+  G --> H[apply built-in temperature defaults]
+  H --> I[apply category overlays]
+  I --> J[apply exact agent overlays]
+  J --> K[assign final OpenCode config once]
+```
+
+Precedence for a Systematic-owned bundled agent is:
+
+1. Exact `agents.<key>` overlay
+2. `categories.<category-id>` overlay
+3. Built-in zero-config defaults
+4. Bundled markdown/frontmatter defaults
+5. OpenCode inherited defaults
+
+Config-source priority is separate: before applying overlays, Systematic first computes effective `agents` and `categories` maps from defaults, user config, project config, and `$OPENCODE_CONFIG_DIR`, replacing same-key objects wholesale at higher priority.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add source-aware overlay config loading**
+
+**Goal:** Extend Systematic config loading with top-level `agents` and `categories`, preserving source provenance and whole-object same-key replacement semantics.
+
+**Requirements:** R1, R5, R10, R11
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `src/lib/config.ts`
+- Test: `tests/unit/config.test.ts`
+
+**Approach:**
+- Add typed optional `agents` and `categories` maps to `SystematicConfig`.
+- Introduce a source-aware config result/helper boundary so the merged `SystematicConfig` can remain simple while overlay validation receives effective overlay entries with their source file path and key path.
+- Represent raw overlay objects as `unknown`/records at config load time; detailed field validation belongs in Unit 2 after inventories exist.
+- Track source file path and key path for each effective `agents.<key>` and `categories.<id>` entry so later validation errors can name the file that supplied the surviving object. Same-key replacement should replace provenance as well as value.
+- Merge config sources in existing priority order. For overlay maps, higher-priority same-key objects replace lower-priority same-key objects wholesale; unrelated keys survive. Alias forms are not canonicalized before source merge; cross-source unqualified/qualified aliases for the same target survive and fail duplicate-target validation, so docs must tell users to use one canonical key form across sources.
+- Preserve existing disabled-list union behavior and `bootstrap` shallow merge behavior.
+- Keep missing config files ignored. Do not add `systematic.jsonc` discovery.
+- Do not change plugin registration/idempotency behavior.
+
+**Patterns to follow:**
+- `src/lib/config.ts` default config and source-priority merge structure.
+- `tests/unit/config.test.ts` temp-dir isolation.
+
+**Test scenarios:**
+- Happy path: user config with `agents.correctness-reviewer.model` loads with source/key provenance.
+- Happy path: user category plus project exact agent both survive when keys differ.
+- Precedence: project `agents.correctness-reviewer` replaces user `agents.correctness-reviewer` wholesale, without retaining lower-priority fields.
+- Precedence: `$OPENCODE_CONFIG_DIR` category object replaces project category object for the same key.
+- Edge case: absent `agents`/`categories` and empty maps are valid no-ops.
+- Error path: `agents`, `categories`, or a same-key overlay entry set to `null`, arrays, or scalars fails with file path and config key path.
+- Error path: higher-priority same-key replacement reports the higher-priority source file in later validation errors, not the lower-priority source.
+- Error path: lower-priority unqualified key plus higher-priority qualified key for the same target fails duplicate-target validation rather than silently overriding across aliases.
+- Non-error path: missing config files remain ignored.
+
+**Verification:**
+- Config tests prove merge priority, same-key replacement, unrelated-key survival, and source provenance.
+
+- [ ] **Unit 2: Add bundled agent overlay inventory and validation**
+
+**Goal:** Validate overlay keys, allowed fields, values, category IDs, alias collisions, and native replacement conflicts against real bundled inventories before config mutation.
+
+**Requirements:** R2, R3, R6, R7, R8a, R10, R11, R12, R13
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `src/lib/agent-overlays.ts`
+- Modify: `src/lib/agents.ts`
+- Test: `tests/unit/agent-overlays.test.ts`
+
+**Approach:**
+- Build a public bundled-agent inventory from direct `agents/<category>/<name>.md` files.
+- Expose both qualified IDs and unqualified aliases when the stem is unique.
+- Reject duplicate bundled stems as an inventory error because V1 emits stem-only OpenCode agent keys.
+- Reject effective configs that use both qualified and unqualified keys for the same bundled agent.
+- Validate category keys against top-level bundled category IDs, not only enabled agents.
+- Validate field allow-list: `model`, `variant`, `temperature`, `top_p`, `permission`, `mode`, `color`, `steps`, `hidden`, exact-agent-only `disable`, and `skills`.
+- Reject `tools`, `prompt`, `description`, `options`, unknown display metadata, and arbitrary unknown fields.
+- Validate scalar values structurally: non-empty `provider/model` strings for `model`, non-empty string for `variant`, finite numbers for sampling fields, positive integer for `steps`, boolean for `hidden`/`disable`, supported mode literals, and OpenCode-compatible color strings. Do not validate provider/model availability and do not normalize shorthand model names.
+- Validate `permission` against OpenCode's current permission shape, including action-or-object rules, rest/custom tool keys, wildcard patterns, and `permission.skill` object form, without interpreting provider/MCP tool-key semantics. Do not reuse `normalizePermission()` if it rejects valid OpenCode permission config.
+- Validate category-level `disable` as invalid.
+- Detect native same-name replacements from the incoming OpenCode `config.agent` map. Exact overlay targeting a native replacement fails; category overlays should later skip those targets.
+- Treat exact overlays for known disabled bundled agents as valid; they become no-ops when application filters disabled agents.
+
+**Patterns to follow:**
+- `src/lib/validation.ts` type guards and normalizers.
+- `src/lib/agents.ts` and `scripts/content-integrity.ts` category discovery style.
+- `tests/unit/agents.test.ts` fixture-based discovery tests.
+
+**Test scenarios:**
+- Happy path: unqualified unique key and qualified key each resolve to the same bundled agent when used alone.
+- Error path: both key forms for the same target in the effective config fail with a duplicate-target error.
+- Error path: duplicate bundled stems fail inventory validation before config application.
+- Happy path: known category ID validates.
+- Error path: unknown category ID lists valid categories.
+- Error path: unknown field, deprecated `tools`, `prompt`, `description`, and `options` are rejected with key path.
+- Error path: `mcps` is rejected as unsupported in V1.
+- Error path: `disable` under `categories.review` is rejected; `disable` under an exact agent is accepted.
+- Error path: malformed `model`, `variant`, `temperature`, `top_p`, `mode`, `steps`, `hidden`, `color`, or `permission` values fail with source path and key path.
+- Native conflict: exact overlay for `correctness-reviewer` fails when incoming OpenCode config already defines `agent.correctness-reviewer`.
+- Native conflict: exact overlay using qualified key `agents.review/correctness-reviewer` also fails when incoming OpenCode config defines `agent.correctness-reviewer`.
+- Native conflict: exact overlay for a disabled bundled agent still fails when the same emitted key is present as a native replacement.
+- Permission path: `permission.read`, `permission.grep`, `permission.skill` object form, wildcard rules, and custom tool keys validate without MCP-specific semantics.
+- Model path: `model: "gpt-4"` and `model: "inherit"` fail structural validation; `model: "openai/gpt-4"` passes even if OpenCode may not have that model configured.
+- Disabled path: exact overlay for a disabled bundled agent validates but records no application target.
+
+**Verification:**
+- Validation tests prove every public error class and key-resolution rule before config-handler integration.
+
+- [ ] **Unit 3: Implement defaults, capability permissions, and overlay application**
+
+**Goal:** Apply built-in defaults, category overlays, exact overlays, and managed capability shortcuts to emitted bundled OpenCode agent config.
+
+**Requirements:** R4, R8, R8b, R9, R12, R13, R14, R15
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `src/lib/agent-overlays.ts`
+- Modify: `src/lib/config-handler.ts`
+- Modify: `src/lib/agents.ts`
+- Test: `tests/unit/agent-overlays.test.ts`
+- Test: `tests/unit/config-handler.test.ts`
+
+**Approach:**
+- Add built-in temperature defaults outside bundled markdown. Prefer an explicit function/table seeded from `inferTemperature()` rather than importing converter-specific behavior directly if that would couple runtime config to conversion internals. Built-in defaults sit above bundled markdown in the precedence stack and override existing markdown temperature values unless a stronger category/exact overlay applies; document this zero-config behavior change and note that OpenCode/runtime providers own unsupported sampling-parameter behavior.
+- Do not emit default `model` values. User-configured explicit `model` values apply normally.
+- Add `variant` parsing/emission support to bundled agent config where relevant because OpenCode supports it.
+- Apply overlays to Systematic-owned bundled agents only: markdown defaults first, built-in policy defaults next, category overlay, then exact overlay.
+- Partition disabled agents and native same-name replacements out of the Systematic-owned target set before applying overlays. Exact overlays targeting native replacements fail during validation; category overlays simply never see those native-owned targets.
+- Implement `skills` as a managed shortcut that writes `permission.skill` rules. `skills: ["ce:review"]` should deny all skills first and then allow the selected skills, ordered so OpenCode's last-match rule produces the allowlist. `skills: []` should deny all skills. Omitted `skills` inherits weaker-layer skill permissions/defaults.
+- Reject any single overlay object that sets both managed `skills` and explicit `permission.skill`; users must choose one authority for skill visibility at that layer.
+- Normalize each layer into ordered permission rules and concatenate weakest-to-strongest so exact overlays override category/default rules under OpenCode's last-match behavior. Cross-layer managed `skills` and explicit `permission.skill` use the same normalized rule representation.
+- Build all bundled agent configs and validation results locally, then assign `config.agent` and related config surfaces only after validation succeeds. Stage cloned copies of every mutated surface, including `config.skills.paths`, and avoid in-place `push` on caller-owned arrays before validation succeeds.
+
+**Patterns to follow:**
+- `src/lib/config-handler.ts` existing bundled agent/skill registration flow.
+- `src/lib/agents.ts` frontmatter-to-AgentConfig mapping.
+- OpenCode permission shape from `anomalyco/opencode` config sources.
+
+**Test scenarios:**
+- Happy path: no user config applies built-in temperature defaults while leaving `model` omitted.
+- Precedence path: a bundled markdown temperature is overridden by the built-in temperature default unless a category/exact overlay provides a stronger value.
+- Happy path: category `review.temperature` applies to review agents.
+- Happy path: exact `agents.correctness-reviewer.temperature` beats `categories.review.temperature`.
+- Happy path: exact explicit `model` emits `model`; unrelated agents still omit `model`.
+- Happy path: `variant`, `top_p`, `mode`, `color`, `steps`, and `hidden` emit correctly when configured.
+- Variant path: `variant` without `model` is accepted and emitted, with docs noting OpenCode may ignore it without an effective variant-capable model.
+- Capability path: `skills: ["ce:review"]` emits exact ordered permission rules that deny all skills and then allow `ce:review`.
+- Capability path: `skills: []` emits deny-all skill permission; omitted `skills` inherits weaker-layer behavior.
+- Capability path: category allows skill A/B and exact allows only A; final permission order allows only A.
+- Capability path: category denies skill A and exact allows A; exact wins through last-match rule order.
+- Capability path: category `skills` plus exact explicit `permission.skill` follows weakest-to-strongest rule ordering; category explicit `permission.skill` plus exact `skills` does the same.
+- Error path: same overlay object with both `skills` and `permission.skill` fails.
+- Error path: unknown or disabled skill names fail before config mutation.
+- Native path: category overlay skips native replacement and still applies to other bundled agents in the category.
+- Disabled path: exact overlay for disabled bundled agent has no emitted config.
+- Atomicity path: invalid overlay leaves `config.agent`, `config.command`, `config.skills.paths`, and `config.mcp` unmodified, including preserving existing array contents, nested object state, and caller-owned references.
+
+**Verification:**
+- Unit tests prove final emitted OpenCode config shape, permission translations, no default model emission, and pre-mutation atomicity.
+
+- [ ] **Unit 4: Add integrity coverage and documentation**
+
+**Goal:** Document the new config surface and guard the bundled-asset contracts that make it safe.
+
+**Requirements:** R14, R15, R16, R17
+
+**Dependencies:** Units 1-3
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/src/content/docs/getting-started/configuration.mdx`
+- Modify: `scripts/content-integrity.ts`
+- Test: `tests/unit/content-integrity.test.ts`
+
+**Approach:**
+- Document `agents` and `categories` examples using repo-accurate category IDs and agent IDs.
+- Explain precedence separately for config-source merging and overlay application.
+- Document native OpenCode same-name replacement conflicts and category-skip behavior.
+- Document that default `model` is omitted unless the user configures it; provider-specific model defaults are intentionally deferred.
+- Document managed `skills` as a permission shortcut, not a native OpenCode agent field. Do not include `mcps` in the V1 config schema or examples; mention it only in an out-of-scope note if needed.
+- Document that category IDs are V1 public API because broad policy overlays are a primary use case; future reorganizations must preserve aliases or provide migration warnings.
+- Document that users should use one canonical agent key form across config sources because cross-source alias collisions fail duplicate-target validation.
+- Add or extend content-integrity checks only where needed: bundled agent `model:` ban stays enforced, and any duplicated bundled agent stems should fail because unqualified config aliases depend on uniqueness.
+- Do not edit generated reference docs directly.
+
+**Patterns to follow:**
+- Existing config docs in `docs/src/content/docs/getting-started/configuration.mdx`.
+- Existing `checkAgentModel()` and explicit-field validation style in `scripts/content-integrity.ts`.
+
+**Test scenarios:**
+- Content-integrity: duplicate bundled agent stems across categories fail with both paths.
+- Content-integrity: existing no-`model:` bundled agent rule still fails a fixture with `model` frontmatter.
+- Docs review expectation: examples use `agents`/`categories`, not `agent_models`, and no generated reference files are hand-edited.
+
+**Verification:**
+- Documentation clearly states config shape, precedence, conflicts, defaults, and capability semantics.
+- Integrity tests cover duplicate stem and no-model contracts.
+
+- [ ] **Unit 5: Add integration coverage and generated artifacts**
+
+**Goal:** Verify the full plugin config hook behavior and generated-artifact drift status.
+
+**Requirements:** R1-R17
+
+**Dependencies:** Units 1-4
+
+**Files:**
+- Modify: `tests/integration/systematic-plugin.test.ts`
+
+**Approach:**
+- Add end-to-end plugin config-hook tests that run through `SystematicPlugin()` or the nearest existing integration harness rather than only pure helpers.
+- Cover exact/category overlays, no-default-model behavior, native exact conflict, native category skip, and capability permission translation at the integration level.
+- No generated artifacts are expected to change from the plan alone. Run docs/registry drift checks; regenerate only if source changes require it.
+- Keep OpenCode plugin default export contract unchanged; do not add named exports from `src/index.ts`.
+
+**Patterns to follow:**
+- Existing integration tests for skill/tool registration and config hook behavior.
+- Existing generated-doc and registry workflows.
+
+**Test scenarios:**
+- Integration: plugin config with exact overlay emits tuned bundled agent.
+- Integration: plugin config with category overlay tunes category members and skips native replacement.
+- Integration: native-replaced category member is partitioned out before overlay application; no intermediate or final Systematic-owned config is produced for that key.
+- Integration: exact overlay plus native same-name agent fails before partial mutation.
+- Integration: no user model config leaves emitted agents without provider-specific default models.
+- Integration: well-shaped but nonexistent explicit `model` passes Systematic validation and is emitted unchanged; OpenCode owns runtime failure behavior.
+- Regression: plugin still exports only a default factory function from built `dist/index.js`.
+
+**Verification:**
+- Full unit/integration test suite, typecheck, lint, content-integrity, and registry drift pass after implementation.
+
+## System-Wide Impact
+
+- **Interaction graph:** `loadConfig()` feeds `createConfigHandler()`, which discovers bundled agents/skills and mutates OpenCode config. Overlay validation must run before any config mutation to avoid partial registration.
+- **Error propagation:** Invalid config should throw with file path and key path. Missing config files remain ignored.
+- **State lifecycle risks:** Plugin config hooks mutate a live object; build local results first and assign once to minimize partial-state bugs.
+- **API surface parity:** Config docs, README examples, content-integrity, and tests must all agree on `agents`/`categories`, not `agent_models`.
+- **Integration coverage:** Pure helper tests are insufficient; at least one integration path should prove final OpenCode config shape.
+- **Unchanged invariants:** Bundled markdown still omits `model:`; `src/index.ts` still exports only the default plugin factory; registry source of truth remains `registry/registry.jsonc`.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Provider-specific defaults break users without that provider | Defer default model emission; inherit unless user explicitly configures `model`. |
+| `skills`/`mcps` become inert pass-through fields | Translate `skills` to permissions; defer `mcps` until a separate plan specifies stable MCP permission mapping. |
+| Dual agent key forms create ambiguous config | Canonical inventory, duplicate-target validation, duplicate-stem integrity gate. |
+| Category defaults surprise users after upgrades | Document category IDs as public API and warn that future agents in a category inherit category defaults. |
+| Native OpenCode config and Systematic overlays fight for ownership | Exact overlay conflicts with native same-name replacement; category overlays skip native replacements. |
+| Config-hook partial mutation leaves broken OpenCode config | Validate first, build local maps, assign once. |
+
+## Documentation / Operational Notes
+
+- This is a minor feature if the implementation preserves inherited model behavior by default.
+- Release notes should say provider-specific zero-config model defaults were researched and deferred because OpenCode does not expose reliable config-hook availability detection.
+- Docs should present `skills` as a permission shortcut, not as a native OpenCode agent field.
+- Docs and tests must omit `mcps` from the V1 config schema rather than marking it “coming soon.”
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-09-agent-model-configuration-requirements.md](../brainstorms/2026-05-09-agent-model-configuration-requirements.md)
+- `src/lib/config.ts`
+- `src/lib/config-handler.ts`
+- `src/lib/agents.ts`
+- `src/lib/skills.ts`
+- `src/lib/validation.ts`
+- `src/lib/converter.ts`
+- `scripts/content-integrity.ts`
+- `docs/src/content/docs/getting-started/configuration.mdx`
+- OpenCode source: `https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/config/agent.ts`
+- OpenCode source: `https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/agent/agent.ts`
+- OpenCode source: `https://github.com/anomalyco/opencode/blob/dev/packages/plugin/src/index.ts`
+- OpenCode source: `https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/config/skills.ts`
+- OpenCode source: `https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/config/mcp.ts`

--- a/docs/plans/2026-05-09-001-feat-agent-model-configuration-plan.md
+++ b/docs/plans/2026-05-09-001-feat-agent-model-configuration-plan.md
@@ -1,7 +1,7 @@
 ---
 title: feat: Add Agent Configuration Overlays
 type: feat
-status: active
+status: completed
 date: 2026-05-09
 origin: docs/brainstorms/2026-05-09-agent-model-configuration-requirements.md
 ---

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -9,10 +9,11 @@ Systematic works out of the box with sensible defaults, but it provides several 
 
 ## Plugin Configuration
 
-You can customize the plugin by creating a configuration file. Systematic looks for configuration in two places:
+You can customize the plugin by creating a configuration file. Systematic looks for configuration in three places:
 
 1.  **Global:** `~/.config/opencode/systematic.json`
-2.  **Project-specific:** `.opencode/systematic.json` (takes precedence)
+2.  **Project-specific:** `.opencode/systematic.json`
+3.  **Custom config directory:** `$OPENCODE_CONFIG_DIR/systematic.json`
 
 ### Disabling Bundled Content
 
@@ -24,6 +25,57 @@ If you want to hide certain bundled skills or agents, you can list them in the `
   "disabled_agents": []
 }
 ```
+
+### Bundled Agent Overlays
+
+Use top-level `agents` and `categories` maps to tune bundled Systematic agents without copying their markdown files into native OpenCode agent definitions.
+
+```jsonc
+{
+  "categories": {
+    // Applies to bundled agents in agents/review/*.md unless that agent has
+    // been replaced by a native OpenCode agent with the same emitted key.
+    "review": {
+      "temperature": 0.1,
+      "skills": ["ce:review"]
+    }
+  },
+  "agents": {
+    // Unqualified unique stem form.
+    "security-sentinel": {
+      "model": "anthropic/claude-sonnet-4-5",
+      "variant": "thinking",
+      "steps": 20
+    },
+
+    // Qualified form for the same inventory model: <category>/<agent-stem>.
+    "workflow/systematic-implementer": {
+      "mode": "subagent",
+      "color": "cyan"
+    }
+  }
+}
+```
+
+Valid category IDs are `design`, `docs`, `document-review`, `research`, `review`, and `workflow`. These IDs are V1 public API because broad policy overlays are a primary use case; future reorganizations must preserve aliases or ship migration warnings. Category overlays also apply to future bundled agents added to that category, so use them for policies you want to inherit broadly.
+
+Exact agent overlays accept the unique file stem (`security-sentinel`) or the qualified key (`review/security-sentinel`). Pick one canonical form across all config sources. Systematic merges config sources before resolving aliases, so cross-source alias collisions like user `agents.security-sentinel` plus project `agents.review/security-sentinel` fail duplicate-target validation instead of silently overriding.
+
+Supported overlay fields are `model`, `variant`, `temperature`, `top_p`, `permission`, `mode`, `color`, `steps`, `hidden`, exact-agent-only `disable`, and `skills`.
+
+`skills` is a Systematic-managed shortcut that writes OpenCode `permission.skill` rules. It is not a native OpenCode agent field. Systematic does not expose an `mcps` shortcut in V1; MCP-specific permission mapping is out of scope for this config surface.
+
+Bundled agent markdown intentionally omits `model`. By default, emitted bundled agents also omit `model` so OpenCode inheritance keeps working. Systematic only emits a model when you configure `agents.<key>.model`; provider-specific zero-config model defaults are intentionally deferred.
+
+Overlay application precedence for a Systematic-owned bundled agent is strongest first:
+
+1. Exact `agents.<key>` overlay
+2. `categories.<category-id>` overlay
+3. Built-in Systematic policy defaults, such as temperature defaults
+4. Bundled markdown/frontmatter defaults
+5. OpenCode inherited defaults
+
+Native OpenCode agents with the same emitted key are full replacements. If `config.agent.security-sentinel` already exists in OpenCode config, `agents.security-sentinel` or `agents.review/security-sentinel` conflicts because ownership would be ambiguous. Category overlays skip native replacements and continue applying to the remaining Systematic-owned bundled agents in that category.
 
 ## Project-Specific Content
 
@@ -50,11 +102,14 @@ If you create a project-specific asset with the same name as a bundled one, your
 
 Systematic resolves configuration and content in the following order (highest priority first):
 
-1.  **Project-level assets:** Files in `.opencode/`
-2.  **Project-level config:** `.opencode/systematic.json`
-3.  **User-level assets:** Files in `~/.config/opencode/`
-4.  **User-level config:** `~/.config/opencode/systematic.json`
-5.  **Bundled assets:** Content shipped with the plugin package
+1.  **Custom config directory:** `$OPENCODE_CONFIG_DIR/systematic.json` and assets under `$OPENCODE_CONFIG_DIR/systematic/`
+2.  **Project-level assets:** Files in `.opencode/`
+3.  **Project-level config:** `.opencode/systematic.json`
+4.  **User-level assets:** Files in `~/.config/opencode/`
+5.  **User-level config:** `~/.config/opencode/systematic.json`
+6.  **Bundled assets:** Content shipped with the plugin package
+
+Config-source merge precedence is separate from overlay application precedence. Across Systematic config files, `disabled_*` arrays are union-merged, `bootstrap` is shallow-merged, and top-level `agents`/`categories` maps merge by key. A higher-priority source replaces the whole object for the same `agents.<key>` or `categories.<id>` entry; unrelated keys survive. After that effective config is built, Systematic applies category and exact overlays to bundled agents using the overlay precedence above.
 
 ## Advanced Configuration
 
@@ -64,8 +119,19 @@ The Systematic configuration file is parsed as JSONC, meaning you can include co
 {
   // Disable git-worktree as we use a different branching model
   "disabled_skills": ["git-worktree"],
-  
-  // Custom agents are added in .opencode/agents/
-  "disabled_agents": []
+
+  // Custom agents are added in .opencode/agents/; bundled agents can also be
+  // tuned with overlays instead of copied.
+  "disabled_agents": [],
+  "categories": {
+    "research": {
+      "temperature": 0.2
+    }
+  },
+  "agents": {
+    "repo-research-analyst": {
+      "model": "anthropic/claude-sonnet-4-5"
+    }
+  }
 }
 ```

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -37,7 +37,7 @@ Use top-level `agents` and `categories` maps to tune bundled Systematic agents w
     // been replaced by a native OpenCode agent with the same emitted key.
     "review": {
       "temperature": 0.1,
-      "skills": ["ce:review"]
+      "steps": 12
     }
   },
   "agents": {
@@ -63,7 +63,7 @@ Exact agent overlays accept the unique file stem (`security-sentinel`) or the qu
 
 Supported overlay fields are `model`, `variant`, `temperature`, `top_p`, `permission`, `mode`, `color`, `steps`, `hidden`, exact-agent-only `disable`, and `skills`.
 
-`skills` is a Systematic-managed shortcut that writes OpenCode `permission.skill` rules. It is not a native OpenCode agent field. Systematic does not expose an `mcps` shortcut in V1; MCP-specific permission mapping is out of scope for this config surface.
+`skills` is a Systematic-managed shortcut that writes OpenCode `permission.skill` rules using bundled skill frontmatter names such as `ce:review`. It is not a native OpenCode agent field. Because `permission` and `skills` control tool access, they are accepted only from user config or `$OPENCODE_CONFIG_DIR/systematic.json`; project config may tune agent behavior but cannot loosen a user's permission policy. Systematic does not expose an `mcps` shortcut in V1; MCP-specific permission mapping is out of scope for this config surface.
 
 Bundled agent markdown intentionally omits `model`. By default, emitted bundled agents also omit `model` so OpenCode inheritance keeps working. Systematic only emits a model when you configure `agents.<key>.model`; provider-specific zero-config model defaults are intentionally deferred.
 
@@ -109,7 +109,7 @@ Systematic resolves configuration and content in the following order (highest pr
 5.  **User-level config:** `~/.config/opencode/systematic.json`
 6.  **Bundled assets:** Content shipped with the plugin package
 
-Config-source merge precedence is separate from overlay application precedence. Across Systematic config files, `disabled_*` arrays are union-merged, `bootstrap` is shallow-merged, and top-level `agents`/`categories` maps merge by key. A higher-priority source replaces the whole object for the same `agents.<key>` or `categories.<id>` entry; unrelated keys survive. After that effective config is built, Systematic applies category and exact overlays to bundled agents using the overlay precedence above.
+Config-source merge precedence is separate from overlay application precedence. Across Systematic config files, `disabled_*` arrays are union-merged, `bootstrap` is shallow-merged, and top-level `agents`/`categories` maps merge by key. A higher-priority source replaces the whole object for the same `agents.<key>` or `categories.<id>` entry; unrelated keys survive. Project overlays are the exception for security fields: they cannot define `permission` or `skills`, and same-key project overlays preserve user-level `permission`/`skills` fields instead of erasing them. After that effective config is built, Systematic applies category and exact overlays to bundled agents using the overlay precedence above.
 
 ## Advanced Configuration
 

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -155,6 +155,12 @@ export interface AgentModelViolation {
   message: string
 }
 
+export interface AgentStemViolation {
+  stem: string
+  files: string[]
+  message: string
+}
+
 export interface CheckResult {
   rootDir: string
   categories: string[]
@@ -164,6 +170,7 @@ export interface CheckResult {
   bannedPatterns: BannedPatternHit[]
   frontmatterViolations: FrontmatterViolation[]
   agentModelViolations: AgentModelViolation[]
+  agentStemViolations: AgentStemViolation[]
   exemptHits: ExemptHit[]
   scanStats: {
     markdownFiles: number
@@ -722,6 +729,34 @@ export function checkAgentModel(
   return violations
 }
 
+export function checkAgentStemUniqueness(
+  rootDir: string,
+  markdownFiles: readonly string[],
+): AgentStemViolation[] {
+  const filesByStem = new Map<string, string[]>()
+
+  for (const relPath of markdownFiles) {
+    if (!isAgentFile(relPath)) continue
+    if (!fs.existsSync(path.join(rootDir, relPath))) continue
+
+    const stem = path.basename(relPath, '.md')
+    const files = filesByStem.get(stem) ?? []
+    files.push(relPath)
+    filesByStem.set(stem, files)
+  }
+
+  return [...filesByStem.entries()]
+    .filter(([, files]) => files.length > 1)
+    .map(([stem, files]) => ({
+      stem,
+      files: [...files].sort(),
+      message:
+        `Duplicate bundled agent stem \`${stem}\` found in ${files.length} files. ` +
+        'V1 emits stem-only OpenCode agent keys, so bundled agent filenames must be globally unique across categories.',
+    }))
+    .sort((a, b) => a.stem.localeCompare(b.stem))
+}
+
 function isAgentFile(relPath: string): boolean {
   const parts = relPath.split('/')
   return (
@@ -836,6 +871,10 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
   const brokenSubfileRefs = checkSubfileReferences(rootDir, targets.markdown)
   const frontmatterViolations = checkFrontmatter(rootDir, targets.markdown)
   const agentModelViolations = checkAgentModel(rootDir, targets.markdown)
+  const agentStemViolations = checkAgentStemUniqueness(
+    rootDir,
+    targets.markdown,
+  )
   const { hits: bannedPatterns, exempt: exemptHits } = checkBannedPatterns(
     rootDir,
     allScannedFiles,
@@ -851,6 +890,7 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     bannedPatterns,
     frontmatterViolations,
     agentModelViolations,
+    agentStemViolations,
     exemptHits,
     scanStats: {
       markdownFiles: targets.markdown.length,
@@ -890,6 +930,7 @@ function printResult(result: CheckResult, verbose: boolean): void {
   printBannedPatterns(result.bannedPatterns)
   printFrontmatterViolations(result.frontmatterViolations)
   printAgentModelViolations(result.agentModelViolations)
+  printAgentStemViolations(result.agentStemViolations)
 
   if (totalViolations(result) === 0) {
     process.stdout.write(
@@ -906,6 +947,7 @@ function printResult(result: CheckResult, verbose: boolean): void {
         `scanStats: ${result.scanStats.markdownFiles} md + ${result.scanStats.typescriptFiles} ts\n` +
         `frontmatterViolations: ${result.frontmatterViolations.length}\n` +
         `agentModelViolations: ${result.agentModelViolations.length}\n` +
+        `agentStemViolations: ${result.agentStemViolations.length}\n` +
         `exemptHits: ${result.exemptHits.length}\n`,
     )
   }
@@ -965,13 +1007,29 @@ function printAgentModelViolations(
   }
 }
 
+function printAgentStemViolations(
+  violations: readonly AgentStemViolation[],
+): void {
+  if (violations.length === 0) return
+  process.stderr.write(
+    `\nDuplicate bundled agent stems (${violations.length}):\n`,
+  )
+  for (const v of violations) {
+    process.stderr.write(`  ${v.stem}  ${v.message}\n`)
+    for (const file of v.files) {
+      process.stderr.write(`    ${file}\n`)
+    }
+  }
+}
+
 function totalViolations(result: CheckResult): number {
   return (
     result.phantomRefs.length +
     result.brokenSubfileRefs.length +
     result.bannedPatterns.length +
     result.frontmatterViolations.length +
-    result.agentModelViolations.length
+    result.agentModelViolations.length +
+    result.agentStemViolations.length
   )
 }
 

--- a/src/lib/agent-overlays.ts
+++ b/src/lib/agent-overlays.ts
@@ -1,0 +1,473 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { SourcedOverlayConfigMap } from './config.js'
+import { isAgentMode, isPermissionSetting, isRecord } from './validation.js'
+
+export interface BundledAgentInventoryEntry {
+  id: string
+  key: string
+  category: string
+  file: string
+  disabled: boolean
+}
+
+export interface BundledAgentInventory {
+  agentsByQualifiedId: Record<string, BundledAgentInventoryEntry>
+  aliases: Record<string, string>
+  categories: string[]
+}
+
+export interface ValidatedAgentOverlay {
+  key: string
+  target: BundledAgentInventoryEntry
+  value: Record<string, unknown>
+  sourcePath: string
+  keyPath: string
+}
+
+export interface ValidatedCategoryOverlay {
+  key: string
+  value: Record<string, unknown>
+  sourcePath: string
+  keyPath: string
+}
+
+export interface ValidatedAgentOverlays {
+  agents: ValidatedAgentOverlay[]
+  categories: ValidatedCategoryOverlay[]
+}
+
+export interface ValidateAgentOverlaysOptions {
+  inventory: BundledAgentInventory
+  overlays: SourcedOverlayConfigMap
+  nativeAgents?: Record<string, unknown>
+}
+
+const ALLOWED_OVERLAY_FIELDS = new Set([
+  'model',
+  'variant',
+  'temperature',
+  'top_p',
+  'permission',
+  'mode',
+  'color',
+  'steps',
+  'hidden',
+  'disable',
+  'skills',
+])
+
+export function buildBundledAgentInventory(
+  agentsDir: string,
+  disabledAgents: string[],
+): BundledAgentInventory {
+  const categories = readCategoryDirs(agentsDir)
+  const agentsByQualifiedId: Record<string, BundledAgentInventoryEntry> = {}
+  const stemCategories = new Map<string, string[]>()
+  const disabledSet = new Set(disabledAgents)
+
+  for (const category of categories) {
+    for (const fileName of readMarkdownFiles(path.join(agentsDir, category))) {
+      const key = fileName.replace(/\.md$/, '')
+      const id = `${category}/${key}`
+      agentsByQualifiedId[id] = {
+        id,
+        key,
+        category,
+        file: path.join(agentsDir, category, fileName),
+        disabled: disabledSet.has(key) || disabledSet.has(id),
+      }
+
+      const existing = stemCategories.get(key) ?? []
+      existing.push(category)
+      stemCategories.set(key, existing)
+    }
+  }
+
+  const duplicateStems = Array.from(stemCategories.entries()).filter(
+    ([, seenCategories]) => seenCategories.length > 1,
+  )
+  if (duplicateStems.length > 0) {
+    const details = duplicateStems
+      .map(
+        ([stem, seenCategories]) =>
+          `Duplicate bundled agent stem "${stem}" in categories: ${seenCategories.join(', ')}`,
+      )
+      .join('; ')
+    throw new Error(details)
+  }
+
+  const aliases: Record<string, string> = {}
+  for (const entry of Object.values(agentsByQualifiedId)) {
+    aliases[entry.id] = entry.id
+    aliases[entry.key] = entry.id
+  }
+
+  return { agentsByQualifiedId, aliases, categories }
+}
+
+export function validateAgentOverlays({
+  inventory,
+  overlays,
+  nativeAgents = {},
+}: ValidateAgentOverlaysOptions): ValidatedAgentOverlays {
+  const agents = validateExactAgentOverlays(inventory, overlays, nativeAgents)
+  const categories = validateCategoryOverlays(inventory, overlays)
+
+  return { agents, categories }
+}
+
+function validateExactAgentOverlays(
+  inventory: BundledAgentInventory,
+  overlays: SourcedOverlayConfigMap,
+  nativeAgents: Record<string, unknown>,
+): ValidatedAgentOverlay[] {
+  const result: ValidatedAgentOverlay[] = []
+  const seenTargets = new Map<string, string>()
+
+  for (const [key, overlay] of Object.entries(overlays.agents)) {
+    const targetId = inventory.aliases[key]
+    if (!targetId) {
+      throwConfigError(
+        overlay.sourcePath,
+        overlay.keyPath,
+        `unknown bundled agent. Valid agents: ${validAgentKeys(inventory).join(', ')}`,
+      )
+    }
+
+    const previousKeyPath = seenTargets.get(targetId)
+    if (previousKeyPath) {
+      throwConfigError(
+        overlay.sourcePath,
+        overlay.keyPath,
+        `Duplicate Systematic agent overlay target "${targetId}" from ${previousKeyPath} and ${overlay.keyPath}`,
+      )
+    }
+    seenTargets.set(targetId, overlay.keyPath)
+
+    const target = inventory.agentsByQualifiedId[targetId]
+    if (!target) {
+      throwConfigError(
+        overlay.sourcePath,
+        overlay.keyPath,
+        `unknown bundled agent target "${targetId}"`,
+      )
+    }
+
+    if (Object.hasOwn(nativeAgents, target.key)) {
+      throwConfigError(
+        overlay.sourcePath,
+        overlay.keyPath,
+        `conflicts with native OpenCode agent.${target.key}; native agents are replacements for bundled agents`,
+      )
+    }
+
+    validateOverlayFields(overlay, 'agent')
+    result.push({
+      key,
+      target,
+      value: overlay.value,
+      sourcePath: overlay.sourcePath,
+      keyPath: overlay.keyPath,
+    })
+  }
+
+  return result
+}
+
+function validateCategoryOverlays(
+  inventory: BundledAgentInventory,
+  overlays: SourcedOverlayConfigMap,
+): ValidatedCategoryOverlay[] {
+  const categories = new Set(inventory.categories)
+  const result: ValidatedCategoryOverlay[] = []
+
+  for (const [key, overlay] of Object.entries(overlays.categories)) {
+    if (!categories.has(key)) {
+      throwConfigError(
+        overlay.sourcePath,
+        overlay.keyPath,
+        `unknown bundled agent category. Valid categories: ${inventory.categories.join(', ')}`,
+      )
+    }
+
+    validateOverlayFields(overlay, 'category')
+    result.push({
+      key,
+      value: overlay.value,
+      sourcePath: overlay.sourcePath,
+      keyPath: overlay.keyPath,
+    })
+  }
+
+  return result
+}
+
+function validateOverlayFields(
+  overlay: {
+    value: Record<string, unknown>
+    sourcePath: string
+    keyPath: string
+  },
+  targetType: 'agent' | 'category',
+): void {
+  for (const [field, value] of Object.entries(overlay.value)) {
+    const keyPath = `${overlay.keyPath}.${field}`
+    if (!ALLOWED_OVERLAY_FIELDS.has(field)) {
+      throwConfigError(
+        overlay.sourcePath,
+        keyPath,
+        `unsupported agent overlay field "${field}"`,
+      )
+    }
+
+    if (targetType === 'category' && field === 'disable') {
+      throwConfigError(
+        overlay.sourcePath,
+        keyPath,
+        'disable is only valid for exact agent overlays',
+      )
+    }
+
+    validateOverlayFieldValue(overlay.sourcePath, keyPath, field, value)
+  }
+}
+
+function validateOverlayFieldValue(
+  sourcePath: string,
+  keyPath: string,
+  field: string,
+  value: unknown,
+): void {
+  switch (field) {
+    case 'model':
+      validateModel(sourcePath, keyPath, value)
+      return
+    case 'variant':
+      validateNonEmptyString(sourcePath, keyPath, value)
+      return
+    case 'temperature':
+    case 'top_p':
+      validateFiniteNumber(sourcePath, keyPath, value)
+      return
+    case 'permission':
+      validatePermission(sourcePath, keyPath, value)
+      return
+    case 'mode':
+      validateMode(sourcePath, keyPath, value)
+      return
+    case 'color':
+      validateColor(sourcePath, keyPath, value)
+      return
+    case 'steps':
+      validatePositiveInteger(sourcePath, keyPath, value)
+      return
+    case 'hidden':
+    case 'disable':
+      validateBoolean(sourcePath, keyPath, value)
+      return
+    case 'skills':
+      validateSkills(sourcePath, keyPath, value)
+      return
+  }
+}
+
+function validateModel(
+  sourcePath: string,
+  keyPath: string,
+  value: unknown,
+): void {
+  if (typeof value !== 'string') {
+    throwConfigError(sourcePath, keyPath, 'must be a provider/model string')
+  }
+
+  const trimmed = value.trim()
+  const slashIndex = trimmed.indexOf('/')
+  if (trimmed === '' || slashIndex <= 0 || slashIndex === trimmed.length - 1) {
+    throwConfigError(sourcePath, keyPath, 'must be a provider/model string')
+  }
+}
+
+function validateNonEmptyString(
+  sourcePath: string,
+  keyPath: string,
+  value: unknown,
+): void {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throwConfigError(sourcePath, keyPath, 'must be a non-empty string')
+  }
+}
+
+function validateFiniteNumber(
+  sourcePath: string,
+  keyPath: string,
+  value: unknown,
+): void {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throwConfigError(sourcePath, keyPath, 'must be a finite number')
+  }
+}
+
+function validatePositiveInteger(
+  sourcePath: string,
+  keyPath: string,
+  value: unknown,
+): void {
+  if (!Number.isInteger(value) || (value as number) < 1) {
+    throwConfigError(sourcePath, keyPath, 'must be a positive integer')
+  }
+}
+
+function validateBoolean(
+  sourcePath: string,
+  keyPath: string,
+  value: unknown,
+): void {
+  if (typeof value !== 'boolean') {
+    throwConfigError(sourcePath, keyPath, 'must be a boolean')
+  }
+}
+
+function validateMode(
+  sourcePath: string,
+  keyPath: string,
+  value: unknown,
+): void {
+  if (!isAgentMode(value)) {
+    throwConfigError(
+      sourcePath,
+      keyPath,
+      'must be one of: subagent, primary, all',
+    )
+  }
+}
+
+function validateColor(
+  sourcePath: string,
+  keyPath: string,
+  value: unknown,
+): void {
+  if (typeof value !== 'string' || !isOpenCodeColor(value.trim())) {
+    throwConfigError(
+      sourcePath,
+      keyPath,
+      'must be an OpenCode-compatible color string',
+    )
+  }
+}
+
+function isOpenCodeColor(value: string): boolean {
+  if (value === '') return false
+  if (/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(value)) return true
+  return /^[a-zA-Z][a-zA-Z0-9-]*$/.test(value)
+}
+
+function validateSkills(
+  sourcePath: string,
+  keyPath: string,
+  value: unknown,
+): void {
+  if (
+    !Array.isArray(value) ||
+    !value.every((skill) => typeof skill === 'string' && skill.trim() !== '')
+  ) {
+    throwConfigError(
+      sourcePath,
+      keyPath,
+      'must be an array of non-empty strings',
+    )
+  }
+}
+
+function validatePermission(
+  sourcePath: string,
+  keyPath: string,
+  value: unknown,
+): void {
+  if (!isRecord(value)) {
+    throwConfigError(sourcePath, keyPath, 'must be an object')
+  }
+
+  for (const [toolKey, rule] of Object.entries(value)) {
+    if (toolKey.trim() === '') {
+      throwConfigError(
+        sourcePath,
+        `${keyPath}.${toolKey}`,
+        'must use a non-empty tool key',
+      )
+    }
+
+    validatePermissionRule(sourcePath, `${keyPath}.${toolKey}`, rule)
+  }
+}
+
+function validatePermissionRule(
+  sourcePath: string,
+  keyPath: string,
+  value: unknown,
+): void {
+  if (isPermissionSetting(value)) return
+
+  if (!isRecord(value)) {
+    throwConfigError(
+      sourcePath,
+      keyPath,
+      'must be ask, allow, deny, or an object of pattern rules',
+    )
+  }
+
+  for (const [pattern, setting] of Object.entries(value)) {
+    if (pattern.trim() === '') {
+      throwConfigError(
+        sourcePath,
+        `${keyPath}.${pattern}`,
+        'must use a non-empty permission pattern',
+      )
+    }
+    if (!isPermissionSetting(setting)) {
+      throwConfigError(
+        sourcePath,
+        `${keyPath}.${pattern}`,
+        'must be ask, allow, or deny',
+      )
+    }
+  }
+}
+
+function readCategoryDirs(agentsDir: string): string[] {
+  try {
+    return fs
+      .readdirSync(agentsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+function readMarkdownFiles(categoryDir: string): string[] {
+  try {
+    return fs
+      .readdirSync(categoryDir, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+      .map((entry) => entry.name)
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+function validAgentKeys(inventory: BundledAgentInventory): string[] {
+  return Object.keys(inventory.aliases).sort()
+}
+
+function throwConfigError(
+  sourcePath: string,
+  keyPath: string,
+  message: string,
+): never {
+  throw new Error(
+    `Invalid Systematic config in ${sourcePath}: ${keyPath} ${message}`,
+  )
+}

--- a/src/lib/agent-overlays.ts
+++ b/src/lib/agent-overlays.ts
@@ -41,6 +41,12 @@ export interface ValidateAgentOverlaysOptions {
   inventory: BundledAgentInventory
   overlays: SourcedOverlayConfigMap
   nativeAgents?: Record<string, unknown>
+  enabledSkills?: string[]
+}
+
+export interface ResolvedAgentOverlaySet {
+  agentsByTargetId: Map<string, ValidatedAgentOverlay>
+  categoriesByKey: Map<string, ValidatedCategoryOverlay>
 }
 
 const ALLOWED_OVERLAY_FIELDS = new Set([
@@ -110,17 +116,64 @@ export function validateAgentOverlays({
   inventory,
   overlays,
   nativeAgents = {},
+  enabledSkills,
 }: ValidateAgentOverlaysOptions): ValidatedAgentOverlays {
-  const agents = validateExactAgentOverlays(inventory, overlays, nativeAgents)
-  const categories = validateCategoryOverlays(inventory, overlays)
+  const skillSet = enabledSkills ? new Set(enabledSkills) : undefined
+  const agents = validateExactAgentOverlays(
+    inventory,
+    overlays,
+    nativeAgents,
+    skillSet,
+  )
+  const categories = validateCategoryOverlays(inventory, overlays, skillSet)
 
   return { agents, categories }
+}
+
+export function resolveAgentOverlaySet(
+  overlays: ValidatedAgentOverlays,
+): ResolvedAgentOverlaySet {
+  return {
+    agentsByTargetId: new Map(
+      overlays.agents.map((overlay) => [overlay.target.id, overlay]),
+    ),
+    categoriesByKey: new Map(
+      overlays.categories.map((overlay) => [overlay.key, overlay]),
+    ),
+  }
+}
+
+export function inferBuiltInTemperature(
+  name: string,
+  description?: string,
+): number {
+  const sample = `${name} ${description ?? ''}`.toLowerCase()
+  if (
+    /(review|audit|security|sentinel|oracle|lint|verification|guardian)/.test(
+      sample,
+    )
+  ) {
+    return 0.1
+  }
+  if (
+    /(plan|planning|architecture|strategist|analysis|research)/.test(sample)
+  ) {
+    return 0.2
+  }
+  if (/(doc|readme|changelog|editor|writer)/.test(sample)) {
+    return 0.3
+  }
+  if (/(brainstorm|creative|ideate|design|concept)/.test(sample)) {
+    return 0.6
+  }
+  return 0.3
 }
 
 function validateExactAgentOverlays(
   inventory: BundledAgentInventory,
   overlays: SourcedOverlayConfigMap,
   nativeAgents: Record<string, unknown>,
+  enabledSkills: Set<string> | undefined,
 ): ValidatedAgentOverlay[] {
   const result: ValidatedAgentOverlay[] = []
   const seenTargets = new Map<string, string>()
@@ -162,7 +215,7 @@ function validateExactAgentOverlays(
       )
     }
 
-    validateOverlayFields(overlay, 'agent')
+    validateOverlayFields(overlay, 'agent', enabledSkills)
     result.push({
       key,
       target,
@@ -178,6 +231,7 @@ function validateExactAgentOverlays(
 function validateCategoryOverlays(
   inventory: BundledAgentInventory,
   overlays: SourcedOverlayConfigMap,
+  enabledSkills: Set<string> | undefined,
 ): ValidatedCategoryOverlay[] {
   const categories = new Set(inventory.categories)
   const result: ValidatedCategoryOverlay[] = []
@@ -191,7 +245,7 @@ function validateCategoryOverlays(
       )
     }
 
-    validateOverlayFields(overlay, 'category')
+    validateOverlayFields(overlay, 'category', enabledSkills)
     result.push({
       key,
       value: overlay.value,
@@ -210,7 +264,19 @@ function validateOverlayFields(
     keyPath: string
   },
   targetType: 'agent' | 'category',
+  enabledSkills: Set<string> | undefined,
 ): void {
+  if (
+    Object.hasOwn(overlay.value, 'skills') &&
+    hasPermissionSkill(overlay.value.permission)
+  ) {
+    throwConfigError(
+      overlay.sourcePath,
+      overlay.keyPath,
+      'cannot set both skills and permission.skill in the same overlay object',
+    )
+  }
+
   for (const [field, value] of Object.entries(overlay.value)) {
     const keyPath = `${overlay.keyPath}.${field}`
     if (!ALLOWED_OVERLAY_FIELDS.has(field)) {
@@ -229,8 +295,18 @@ function validateOverlayFields(
       )
     }
 
-    validateOverlayFieldValue(overlay.sourcePath, keyPath, field, value)
+    validateOverlayFieldValue(
+      overlay.sourcePath,
+      keyPath,
+      field,
+      value,
+      enabledSkills,
+    )
   }
+}
+
+function hasPermissionSkill(permission: unknown): boolean {
+  return isRecord(permission) && Object.hasOwn(permission, 'skill')
 }
 
 function validateOverlayFieldValue(
@@ -238,6 +314,7 @@ function validateOverlayFieldValue(
   keyPath: string,
   field: string,
   value: unknown,
+  enabledSkills: Set<string> | undefined,
 ): void {
   switch (field) {
     case 'model':
@@ -267,7 +344,7 @@ function validateOverlayFieldValue(
       validateBoolean(sourcePath, keyPath, value)
       return
     case 'skills':
-      validateSkills(sourcePath, keyPath, value)
+      validateSkills(sourcePath, keyPath, value, enabledSkills)
       return
   }
 }
@@ -366,6 +443,7 @@ function validateSkills(
   sourcePath: string,
   keyPath: string,
   value: unknown,
+  enabledSkills: Set<string> | undefined,
 ): void {
   if (
     !Array.isArray(value) ||
@@ -376,6 +454,18 @@ function validateSkills(
       keyPath,
       'must be an array of non-empty strings',
     )
+  }
+
+  if (!enabledSkills) return
+
+  for (const skill of value) {
+    if (!enabledSkills.has(skill)) {
+      throwConfigError(
+        sourcePath,
+        keyPath,
+        `unknown or disabled skill "${skill}"`,
+      )
+    }
   }
 }
 

--- a/src/lib/agent-overlays.ts
+++ b/src/lib/agent-overlays.ts
@@ -324,8 +324,10 @@ function validateOverlayFieldValue(
       validateNonEmptyString(sourcePath, keyPath, value)
       return
     case 'temperature':
+      validateTemperature(sourcePath, keyPath, value)
+      return
     case 'top_p':
-      validateFiniteNumber(sourcePath, keyPath, value)
+      validateTopP(sourcePath, keyPath, value)
       return
     case 'permission':
       validatePermission(sourcePath, keyPath, value)
@@ -358,9 +360,12 @@ function validateModel(
     throwConfigError(sourcePath, keyPath, 'must be a provider/model string')
   }
 
-  const trimmed = value.trim()
-  const slashIndex = trimmed.indexOf('/')
-  if (trimmed === '' || slashIndex <= 0 || slashIndex === trimmed.length - 1) {
+  if (value !== value.trim() || /\s/.test(value)) {
+    throwConfigError(sourcePath, keyPath, 'must be a provider/model string')
+  }
+
+  const slashIndex = value.indexOf('/')
+  if (value === '' || slashIndex <= 0 || slashIndex === value.length - 1) {
     throwConfigError(sourcePath, keyPath, 'must be a provider/model string')
   }
 }
@@ -370,18 +375,37 @@ function validateNonEmptyString(
   keyPath: string,
   value: unknown,
 ): void {
-  if (typeof value !== 'string' || value.trim() === '') {
+  if (typeof value !== 'string' || value === '' || value !== value.trim()) {
     throwConfigError(sourcePath, keyPath, 'must be a non-empty string')
   }
 }
 
-function validateFiniteNumber(
+function validateTemperature(
   sourcePath: string,
   keyPath: string,
   value: unknown,
 ): void {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throwConfigError(sourcePath, keyPath, 'must be a finite number')
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throwConfigError(
+      sourcePath,
+      keyPath,
+      'must be a non-negative finite number',
+    )
+  }
+}
+
+function validateTopP(
+  sourcePath: string,
+  keyPath: string,
+  value: unknown,
+): void {
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    value < 0 ||
+    value > 1
+  ) {
+    throwConfigError(sourcePath, keyPath, 'must be a number from 0 to 1')
   }
 }
 
@@ -424,7 +448,11 @@ function validateColor(
   keyPath: string,
   value: unknown,
 ): void {
-  if (typeof value !== 'string' || !isOpenCodeColor(value.trim())) {
+  if (
+    typeof value !== 'string' ||
+    value !== value.trim() ||
+    !isOpenCodeColor(value)
+  ) {
     throwConfigError(
       sourcePath,
       keyPath,
@@ -447,7 +475,10 @@ function validateSkills(
 ): void {
   if (
     !Array.isArray(value) ||
-    !value.every((skill) => typeof skill === 'string' && skill.trim() !== '')
+    !value.every(
+      (skill) =>
+        typeof skill === 'string' && skill !== '' && skill === skill.trim(),
+    )
   ) {
     throwConfigError(
       sourcePath,

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -20,6 +20,8 @@ export interface AgentFrontmatter {
   prompt: string
   /** Model to use (provider/model format) */
   model?: string
+  /** Model variant to use */
+  variant?: string
   /** Temperature for generation */
   temperature?: number
   /** Top-p sampling */
@@ -72,6 +74,7 @@ export function extractAgentFrontmatter(content: string): AgentFrontmatter {
     description: extractString(data, 'description'),
     prompt: body.trim(),
     model: extractNonEmptyString(data, 'model'),
+    variant: extractNonEmptyString(data, 'variant'),
     temperature: extractNumber(data, 'temperature'),
     top_p: extractNumber(data, 'top_p'),
     tools: isToolsMap(data.tools) ? data.tools : undefined,

--- a/src/lib/config-handler.ts
+++ b/src/lib/config-handler.ts
@@ -1,12 +1,20 @@
 import type { Config } from '@opencode-ai/plugin'
 import type { AgentConfig } from '@opencode-ai/sdk'
+import {
+  buildBundledAgentInventory,
+  inferBuiltInTemperature,
+  type ResolvedAgentOverlaySet,
+  resolveAgentOverlaySet,
+  validateAgentOverlays,
+} from './agent-overlays.js'
 import { extractAgentFrontmatter, findAgentsInDir } from './agents.js'
 import { extractCommandFrontmatter, findCommandsInDir } from './commands.js'
-import { loadConfig } from './config.js'
+import { loadConfigWithSources } from './config.js'
 import { convertFileWithCache } from './converter.js'
 import { parseFrontmatter } from './frontmatter.js'
 import { type LoadedSkill, loadSkill } from './skill-loader.js'
 import { findSkillsInDir } from './skills.js'
+import { isRecord, type PermissionSetting } from './validation.js'
 
 export interface ConfigHandlerDeps {
   directory: string
@@ -54,6 +62,7 @@ function loadAgentAsConfig(agentInfo: {
       description,
       prompt,
       model,
+      variant,
       temperature,
       top_p,
       tools,
@@ -71,6 +80,7 @@ function loadAgentAsConfig(agentInfo: {
     }
 
     if (model !== undefined) config.model = model
+    if (variant !== undefined) config.variant = variant
     if (temperature !== undefined) config.temperature = temperature
     if (top_p !== undefined) config.top_p = top_p
     if (tools !== undefined) config.tools = tools
@@ -143,20 +153,177 @@ function loadSkillAsCommand(loaded: LoadedSkill): CommandConfig {
 function collectAgents(
   dir: string,
   disabledAgents: string[],
+  nativeAgents: Record<string, unknown>,
+  overlays: ResolvedAgentOverlaySet,
 ): NonNullable<Config['agent']> {
   const agents: NonNullable<Config['agent']> = {}
   const agentList = findAgentsInDir(dir)
+  const disabledSet = new Set(disabledAgents)
 
   for (const agentInfo of agentList) {
-    if (disabledAgents.includes(agentInfo.name)) continue
+    const id = agentInfo.category
+      ? `${agentInfo.category}/${agentInfo.name}`
+      : agentInfo.name
+    if (disabledSet.has(agentInfo.name) || disabledSet.has(id)) continue
+    if (Object.hasOwn(nativeAgents, agentInfo.name)) continue
+
+    const exactOverlay = overlays.agentsByTargetId.get(id)
+    if (exactOverlay?.value.disable === true) continue
 
     const config = loadAgentAsConfig(agentInfo)
     if (config) {
-      agents[agentInfo.name] = config
+      agents[agentInfo.name] = applyAgentOverlays(config, agentInfo, overlays)
     }
   }
 
   return agents
+}
+
+function applyAgentOverlays(
+  config: AgentConfig,
+  agentInfo: { name: string; category?: string },
+  overlays: ResolvedAgentOverlaySet,
+): AgentConfig {
+  const id = agentInfo.category
+    ? `${agentInfo.category}/${agentInfo.name}`
+    : agentInfo.name
+  const categoryOverlay = agentInfo.category
+    ? overlays.categoriesByKey.get(agentInfo.category)
+    : undefined
+  const exactOverlay = overlays.agentsByTargetId.get(id)
+  const result: AgentConfig = { ...config }
+  const permissionRules = createPermissionRuleAccumulator()
+  const hasPermissionOverlay =
+    overlayControlsPermission(categoryOverlay?.value) ||
+    overlayControlsPermission(exactOverlay?.value)
+
+  if (hasPermissionOverlay && isRecord(config.permission)) {
+    addPermissionRules(permissionRules, config.permission)
+  }
+
+  result.temperature = inferBuiltInTemperature(
+    agentInfo.name,
+    result.description,
+  )
+
+  if (categoryOverlay) {
+    applyOverlayObject(result, categoryOverlay.value, permissionRules)
+  }
+  if (exactOverlay) {
+    applyOverlayObject(result, exactOverlay.value, permissionRules)
+  }
+
+  if (hasPermissionOverlay) {
+    const permission = permissionFromRules(permissionRules)
+    if (permission) {
+      result.permission = permission as AgentConfig['permission']
+    } else {
+      delete result.permission
+    }
+  }
+
+  return result
+}
+
+function overlayControlsPermission(
+  overlay: Record<string, unknown> | undefined,
+): boolean {
+  return (
+    overlay !== undefined &&
+    (Object.hasOwn(overlay, 'permission') || Object.hasOwn(overlay, 'skills'))
+  )
+}
+
+const OVERLAY_ASSIGN_FIELDS = [
+  'model',
+  'variant',
+  'temperature',
+  'top_p',
+  'mode',
+  'color',
+  'steps',
+  'hidden',
+] as const
+
+function applyOverlayObject(
+  target: AgentConfig,
+  overlay: Record<string, unknown>,
+  permissionRules: PermissionRuleAccumulator,
+): void {
+  for (const field of OVERLAY_ASSIGN_FIELDS) {
+    if (Object.hasOwn(overlay, field)) {
+      ;(target as Record<string, unknown>)[field] = overlay[field]
+    }
+  }
+
+  if (isRecord(overlay.permission)) {
+    addPermissionRules(permissionRules, overlay.permission)
+  }
+  if (Array.isArray(overlay.skills)) {
+    addManagedSkillRules(permissionRules, overlay.skills)
+  }
+}
+
+type PermissionRuleAccumulator = Map<string, Map<string, PermissionSetting>>
+
+function createPermissionRuleAccumulator(): PermissionRuleAccumulator {
+  return new Map<string, Map<string, PermissionSetting>>()
+}
+
+function addPermissionRules(
+  accumulator: PermissionRuleAccumulator,
+  permission: Record<string, unknown>,
+): void {
+  for (const [tool, rule] of Object.entries(permission)) {
+    if (isPermissionSettingValue(rule)) {
+      setPermissionRule(accumulator, tool, '*', rule)
+      continue
+    }
+    if (!isRecord(rule)) continue
+    for (const [pattern, setting] of Object.entries(rule)) {
+      if (isPermissionSettingValue(setting)) {
+        setPermissionRule(accumulator, tool, pattern, setting)
+      }
+    }
+  }
+}
+
+function addManagedSkillRules(
+  accumulator: PermissionRuleAccumulator,
+  skills: unknown[],
+): void {
+  setPermissionRule(accumulator, 'skill', '*', 'deny')
+  for (const skill of skills) {
+    if (typeof skill === 'string') {
+      setPermissionRule(accumulator, 'skill', skill, 'allow')
+    }
+  }
+}
+
+function permissionFromRules(
+  accumulator: PermissionRuleAccumulator,
+): Record<string, Record<string, PermissionSetting>> | undefined {
+  const permission: Record<string, Record<string, PermissionSetting>> = {}
+  for (const [tool, rules] of accumulator) {
+    permission[tool] = Object.fromEntries(rules)
+  }
+  return Object.keys(permission).length > 0 ? permission : undefined
+}
+
+function setPermissionRule(
+  accumulator: PermissionRuleAccumulator,
+  tool: string,
+  pattern: string,
+  setting: PermissionSetting,
+): void {
+  const rules = accumulator.get(tool) ?? new Map<string, PermissionSetting>()
+  if (rules.has(pattern)) rules.delete(pattern)
+  rules.set(pattern, setting)
+  accumulator.set(tool, rules)
+}
+
+function isPermissionSettingValue(value: unknown): value is PermissionSetting {
+  return value === 'ask' || value === 'allow' || value === 'deny'
 }
 
 /**
@@ -210,6 +377,16 @@ function collectSkillsAsCommands(
   return commands
 }
 
+function collectEnabledSkillNames(
+  dir: string,
+  disabledSkills: string[],
+): string[] {
+  const disabledSet = new Set(disabledSkills)
+  return findSkillsInDir(dir)
+    .filter((skillInfo) => !disabledSet.has(skillInfo.name))
+    .map((skillInfo) => skillInfo.name)
+}
+
 /**
  * Create the config hook handler for the Systematic plugin.
  *
@@ -224,11 +401,36 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     deps
 
   return async (config: Config): Promise<void> => {
-    const systematicConfig = loadConfig(directory)
+    const { config: systematicConfig, overlays } =
+      loadConfigWithSources(directory)
+    const existingAgents = { ...(config.agent ?? {}) }
+    const existingCommands = { ...(config.command ?? {}) }
+
+    const bundledSkills = collectSkillsAsCommands(
+      bundledSkillsDir,
+      systematicConfig.disabled_skills,
+    )
+    const enabledSkillNames = collectEnabledSkillNames(
+      bundledSkillsDir,
+      systematicConfig.disabled_skills,
+    )
+    const inventory = buildBundledAgentInventory(
+      bundledAgentsDir,
+      systematicConfig.disabled_agents,
+    )
+    const validatedOverlays = validateAgentOverlays({
+      inventory,
+      overlays,
+      nativeAgents: existingAgents,
+      enabledSkills: enabledSkillNames,
+    })
+    const resolvedOverlays = resolveAgentOverlaySet(validatedOverlays)
 
     const bundledAgents = collectAgents(
       bundledAgentsDir,
       systematicConfig.disabled_agents,
+      existingAgents,
+      resolvedOverlays,
     )
 
     const bundledCommands = collectCommands(
@@ -236,18 +438,11 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
       systematicConfig.disabled_commands,
     )
 
-    const bundledSkills = collectSkillsAsCommands(
-      bundledSkillsDir,
-      systematicConfig.disabled_skills,
-    )
-
-    const existingAgents = config.agent ?? {}
     config.agent = {
       ...bundledAgents,
       ...existingAgents,
     }
 
-    const existingCommands = config.command ?? {}
     config.command = {
       ...bundledCommands,
       ...bundledSkills,
@@ -267,9 +462,12 @@ type ConfigWithSkills = Config & {
 /** Register a directory for OpenCode's native skill discovery (`skill` tool). */
 export function registerSkillsPaths(config: Config, skillsDir: string): void {
   const extended = config as ConfigWithSkills
-  extended.skills ??= {}
-  extended.skills.paths ??= []
-  if (!extended.skills.paths.includes(skillsDir)) {
-    extended.skills.paths.push(skillsDir)
+  const paths = extended.skills?.paths ?? []
+  const nextPaths = paths.includes(skillsDir)
+    ? [...paths]
+    : [...paths, skillsDir]
+  extended.skills = {
+    ...extended.skills,
+    paths: nextPaths,
   }
 }

--- a/src/lib/config-handler.ts
+++ b/src/lib/config-handler.ts
@@ -393,8 +393,9 @@ function collectEnabledSkillNames(
  * This follows the pattern used by oh-my-opencode to inject bundled agents,
  * skills (as commands), and commands into OpenCode's configuration.
  *
- * Only bundled content is loaded. User/project overrides are not supported.
- * Existing OpenCode config is preserved and takes precedence.
+ * Bundled content is loaded and then tuned with Systematic agent overlays.
+ * Existing native OpenCode agents with the same emitted key are preserved as
+ * replacements for bundled agents.
  */
 export function createConfigHandler(deps: ConfigHandlerDeps) {
   const { directory, bundledSkillsDir, bundledAgentsDir, bundledCommandsDir } =

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -8,11 +8,33 @@ export interface BootstrapConfig {
   file?: string
 }
 
+export type OverlayConfig = Record<string, unknown>
+
+export type OverlayConfigMap = Record<string, OverlayConfig>
+
+export interface SourcedOverlayConfig {
+  value: OverlayConfig
+  sourcePath: string
+  keyPath: string
+}
+
+export interface SourcedOverlayConfigMap {
+  agents: Record<string, SourcedOverlayConfig>
+  categories: Record<string, SourcedOverlayConfig>
+}
+
+export interface SourceAwareConfigResult {
+  config: SystematicConfig
+  overlays: SourcedOverlayConfigMap
+}
+
 export interface SystematicConfig {
   disabled_skills: string[]
   disabled_agents: string[]
   disabled_commands: string[]
   bootstrap: BootstrapConfig
+  agents?: OverlayConfigMap
+  categories?: OverlayConfigMap
 }
 
 export const DEFAULT_CONFIG: SystematicConfig = {
@@ -22,16 +44,42 @@ export const DEFAULT_CONFIG: SystematicConfig = {
   bootstrap: {
     enabled: true,
   },
+  agents: {},
+  categories: {},
 }
 
-function loadJsoncFile<T>(filePath: string): T | null {
+interface RawSystematicConfig
+  extends Omit<Partial<SystematicConfig>, 'agents' | 'categories'> {
+  agents?: unknown
+  categories?: unknown
+}
+
+interface ConfigSource {
+  path: string
+  config: RawSystematicConfig
+}
+
+function loadJsoncFile(filePath: string): RawSystematicConfig | null {
   try {
     if (!fs.existsSync(filePath)) return null
     const content = fs.readFileSync(filePath, 'utf-8')
-    return parseJsonc(content) as T
+    const parsed = parseJsonc(content) as unknown
+    if (!isRecord(parsed)) return null
+    return parsed as RawSystematicConfig
   } catch {
     return null
   }
+}
+
+function loadConfigSource(filePath: string): ConfigSource | null {
+  const config = loadJsoncFile(filePath)
+  if (!config) return null
+
+  return { path: filePath, config }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 function mergeArraysUnique<T>(
@@ -45,15 +93,27 @@ function mergeArraysUnique<T>(
 }
 
 export function loadConfig(projectDir: string): SystematicConfig {
+  return loadConfigWithSources(projectDir).config
+}
+
+export function loadConfigWithSources(
+  projectDir: string,
+): SourceAwareConfigResult {
   const paths = getConfigPaths(projectDir)
 
-  const userConfig = loadJsoncFile<Partial<SystematicConfig>>(paths.userConfig)
-  const projectConfig = loadJsoncFile<Partial<SystematicConfig>>(
-    paths.projectConfig,
-  )
-  const customConfig = paths.customConfig
-    ? loadJsoncFile<Partial<SystematicConfig>>(paths.customConfig)
+  const userSource = loadConfigSource(paths.userConfig)
+  const projectSource = loadConfigSource(paths.projectConfig)
+  const customSource = paths.customConfig
+    ? loadConfigSource(paths.customConfig)
     : null
+  const sources = [userSource, projectSource, customSource].filter(
+    (source): source is ConfigSource => source !== null,
+  )
+
+  const overlays = mergeOverlaySources(sources)
+  const userConfig = userSource?.config
+  const projectConfig = projectSource?.config
+  const customConfig = customSource?.config
 
   const result: SystematicConfig = {
     disabled_skills: mergeArraysUnique(
@@ -92,9 +152,69 @@ export function loadConfig(projectDir: string): SystematicConfig {
       ...projectConfig?.bootstrap,
       ...customConfig?.bootstrap,
     },
+    agents: overlayValues(overlays.agents),
+    categories: overlayValues(overlays.categories),
+  }
+
+  return { config: result, overlays }
+}
+
+function mergeOverlaySources(sources: ConfigSource[]): SourcedOverlayConfigMap {
+  const result: SourcedOverlayConfigMap = {
+    agents: {},
+    categories: {},
+  }
+
+  for (const source of sources) {
+    mergeOverlayMap(result.agents, source, 'agents')
+    mergeOverlayMap(result.categories, source, 'categories')
   }
 
   return result
+}
+
+function mergeOverlayMap(
+  target: Record<string, SourcedOverlayConfig>,
+  source: ConfigSource,
+  mapKey: 'agents' | 'categories',
+): void {
+  const overlayMap = source.config[mapKey]
+  if (overlayMap === undefined) return
+
+  if (!isRecord(overlayMap)) {
+    throwInvalidOverlay(source.path, mapKey)
+  }
+
+  for (const [key, value] of Object.entries(overlayMap)) {
+    const keyPath = `${mapKey}.${key}`
+    if (!isRecord(value)) {
+      throwInvalidOverlay(source.path, keyPath)
+    }
+
+    target[key] = {
+      value,
+      sourcePath: source.path,
+      keyPath,
+    }
+  }
+}
+
+function overlayValues(
+  overlays: Record<string, SourcedOverlayConfig>,
+): OverlayConfigMap {
+  const result: OverlayConfigMap = {}
+
+  for (const [key, overlay] of Object.entries(overlays)) {
+    result[key] = overlay.value
+  }
+
+  return result
+}
+
+function throwInvalidOverlay(sourcePath: string, keyPath: string): never {
+  throw new Error(
+    `Invalid Systematic config in ${sourcePath}: ${keyPath} must be an object`,
+  )
 }
 
 export function getConfigPaths(projectDir: string) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,7 +1,11 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { parse as parseJsonc } from 'jsonc-parser'
+import {
+  type ParseError,
+  parse as parseJsonc,
+  printParseErrorCode,
+} from 'jsonc-parser'
 
 export interface BootstrapConfig {
   enabled: boolean
@@ -57,25 +61,56 @@ interface RawSystematicConfig
 interface ConfigSource {
   path: string
   config: RawSystematicConfig
+  trust: 'user' | 'project' | 'custom'
+}
+
+const SECURITY_OVERLAY_FIELDS = new Set(['permission', 'skills'])
+
+function isErrorWithCode(error: unknown): error is Error & { code?: unknown } {
+  return error instanceof Error && 'code' in error
 }
 
 function loadJsoncFile(filePath: string): RawSystematicConfig | null {
+  let content: string
   try {
-    if (!fs.existsSync(filePath)) return null
-    const content = fs.readFileSync(filePath, 'utf-8')
-    const parsed = parseJsonc(content) as unknown
-    if (!isRecord(parsed)) return null
-    return parsed as RawSystematicConfig
-  } catch {
-    return null
+    content = fs.readFileSync(filePath, 'utf-8')
+  } catch (error) {
+    if (isErrorWithCode(error) && error.code === 'ENOENT') return null
+    throw new Error(
+      `Invalid Systematic config in ${filePath}: unable to read file`,
+      { cause: error },
+    )
   }
+
+  const errors: ParseError[] = []
+  const parsed = parseJsonc(content, errors) as unknown
+  if (errors.length > 0) {
+    const error = errors[0]
+    const message = error
+      ? `${printParseErrorCode(error.error)} at offset ${error.offset}`
+      : 'unknown parse error'
+    throw new Error(
+      `Invalid Systematic config in ${filePath}: JSONC parse error: ${message}`,
+    )
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error(
+      `Invalid Systematic config in ${filePath}: root must be an object`,
+    )
+  }
+
+  return parsed as RawSystematicConfig
 }
 
-function loadConfigSource(filePath: string): ConfigSource | null {
+function loadConfigSource(
+  filePath: string,
+  trust: ConfigSource['trust'],
+): ConfigSource | null {
   const config = loadJsoncFile(filePath)
   if (!config) return null
 
-  return { path: filePath, config }
+  return { path: filePath, config, trust }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -101,10 +136,10 @@ export function loadConfigWithSources(
 ): SourceAwareConfigResult {
   const paths = getConfigPaths(projectDir)
 
-  const userSource = loadConfigSource(paths.userConfig)
-  const projectSource = loadConfigSource(paths.projectConfig)
+  const userSource = loadConfigSource(paths.userConfig, 'user')
+  const projectSource = loadConfigSource(paths.projectConfig, 'project')
   const customSource = paths.customConfig
-    ? loadConfigSource(paths.customConfig)
+    ? loadConfigSource(paths.customConfig, 'custom')
     : null
   const sources = [userSource, projectSource, customSource].filter(
     (source): source is ConfigSource => source !== null,
@@ -191,12 +226,49 @@ function mergeOverlayMap(
       throwInvalidOverlay(source.path, keyPath)
     }
 
+    if (source.trust === 'project') {
+      rejectProjectSecurityOverlay(source.path, keyPath, value)
+    }
+
+    const previous = target[key]
+    const nextValue =
+      source.trust === 'project' && previous
+        ? preserveSecurityFields(previous.value, value)
+        : value
+
     target[key] = {
-      value,
+      value: nextValue,
       sourcePath: source.path,
       keyPath,
     }
   }
+}
+
+function rejectProjectSecurityOverlay(
+  sourcePath: string,
+  keyPath: string,
+  value: Record<string, unknown>,
+): void {
+  for (const field of SECURITY_OVERLAY_FIELDS) {
+    if (Object.hasOwn(value, field)) {
+      throw new Error(
+        `Invalid Systematic config in ${sourcePath}: ${keyPath}.${field} is only valid in user config or OPENCODE_CONFIG_DIR config`,
+      )
+    }
+  }
+}
+
+function preserveSecurityFields(
+  previous: OverlayConfig,
+  next: OverlayConfig,
+): OverlayConfig {
+  const result: OverlayConfig = { ...next }
+  for (const field of SECURITY_OVERLAY_FIELDS) {
+    if (Object.hasOwn(previous, field)) {
+      result[field] = previous[field]
+    }
+  }
+  return result
 }
 
 function overlayValues(

--- a/tests/integration/opencode.test.ts
+++ b/tests/integration/opencode.test.ts
@@ -2,6 +2,9 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import type { Config, PluginInput } from '@opencode-ai/plugin'
+import SystematicPlugin from '../../src/index.ts'
+import { _resetPluginSingleton } from '../../src/lib/plugin-singleton.ts'
 
 const OPENCODE_AVAILABLE = (() => {
   const result = Bun.spawnSync(['which', 'opencode'])
@@ -14,6 +17,12 @@ const RETRY_DELAY_MS = 3_000
 const OPENCODE_TEST_MODEL = 'opencode/big-pickle'
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '../..')
+
+type AgentConfig = NonNullable<Config['agent']>[string]
+
+function skillPermission(agent: AgentConfig | undefined): unknown {
+  return (agent?.permission as { skill?: unknown } | undefined)?.skill
+}
 
 interface OpencodeResult {
   stdout: string
@@ -92,6 +101,189 @@ function expectSetupSkillLoaded(result: OpencodeResult): void {
   expect(result.stderr).toMatch(/setup/)
   expect(result.stdout).toMatch(/ce:review/i)
 }
+
+describe('SystematicPlugin config hook integration', () => {
+  let tempDir: string
+  let projectDir: string
+
+  beforeEach(() => {
+    _resetPluginSingleton()
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'systematic-plugin-'))
+    projectDir = path.join(tempDir, 'project')
+    fs.mkdirSync(projectDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    _resetPluginSingleton()
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  function writeSystematicConfig(config: Record<string, unknown>): void {
+    fs.mkdirSync(path.join(projectDir, '.opencode'), { recursive: true })
+    fs.writeFileSync(
+      path.join(projectDir, '.opencode/systematic.json'),
+      JSON.stringify(config),
+    )
+  }
+
+  async function runConfigHook(config: Config): Promise<void> {
+    const hooks = await SystematicPlugin({
+      directory: projectDir,
+      client: {
+        app: {
+          log: async () => {},
+        },
+      },
+    } as unknown as PluginInput)
+
+    expect(hooks.config).toBeDefined()
+    await hooks.config?.(config)
+  }
+
+  test('exact overlay emits a tuned bundled agent', async () => {
+    writeSystematicConfig({
+      agents: {
+        'correctness-reviewer': {
+          model: 'openrouter/anthropic/claude-sonnet-4',
+          temperature: 0.33,
+          top_p: 0.8,
+          mode: 'subagent',
+        },
+      },
+    })
+
+    const config: Config = {}
+    await runConfigHook(config)
+
+    expect(config.agent?.['correctness-reviewer']).toMatchObject({
+      model: 'openrouter/anthropic/claude-sonnet-4',
+      temperature: 0.33,
+      top_p: 0.8,
+      mode: 'subagent',
+    })
+    expect(config.agent?.['correctness-reviewer']?.description).toContain(
+      '(Correctness-Reviewer - Systematic)',
+    )
+  })
+
+  test('category overlay tunes category members and skips native replacements', async () => {
+    writeSystematicConfig({
+      categories: {
+        review: {
+          temperature: 0.21,
+          skills: ['ce:review'],
+        },
+      },
+    })
+
+    const config: Config = {
+      agent: {
+        'security-reviewer': {
+          description: 'Native security reviewer',
+          prompt: 'Native prompt',
+        },
+      },
+    }
+    await runConfigHook(config)
+
+    expect(config.agent?.['correctness-reviewer']?.temperature).toBe(0.21)
+    expect(skillPermission(config.agent?.['correctness-reviewer'])).toEqual({
+      '*': 'deny',
+      'ce:review': 'allow',
+    })
+    expect(config.agent?.['security-reviewer']).toEqual({
+      description: 'Native security reviewer',
+      prompt: 'Native prompt',
+    })
+  })
+
+  test('native-replaced category member is partitioned out before overlay application', async () => {
+    writeSystematicConfig({
+      categories: {
+        review: {
+          temperature: 0.44,
+          color: '#123abc',
+          skills: ['ce:review'],
+        },
+      },
+    })
+
+    const nativeSecurityReviewer = {
+      description: 'Native owns this key',
+      prompt: 'Native prompt',
+    }
+    const config: Config = {
+      agent: {
+        'security-reviewer': nativeSecurityReviewer,
+      },
+    }
+    await runConfigHook(config)
+
+    expect(config.agent?.['security-reviewer']).toBe(nativeSecurityReviewer)
+    expect(config.agent?.['security-reviewer']?.temperature).toBeUndefined()
+    expect(config.agent?.['security-reviewer']?.color).toBeUndefined()
+    expect(config.agent?.['security-reviewer']?.permission).toBeUndefined()
+    expect(config.agent?.['security-reviewer']?.description).not.toContain(
+      'Systematic',
+    )
+  })
+
+  test('exact overlay plus native same-name agent fails before partial mutation', async () => {
+    writeSystematicConfig({
+      agents: {
+        'correctness-reviewer': { temperature: 0.11 },
+      },
+    })
+
+    const config: Config = {
+      agent: {
+        'correctness-reviewer': {
+          description: 'Native correctness reviewer',
+          prompt: 'Native prompt',
+        },
+      },
+      command: {
+        native: {
+          description: 'Native command',
+          template: 'Native template',
+        },
+      },
+    }
+    const before = structuredClone(config)
+
+    await expect(runConfigHook(config)).rejects.toThrow(/native/i)
+    expect(config).toEqual(before)
+  })
+
+  test('no user model config leaves emitted bundled agents without default models', async () => {
+    const config: Config = {}
+    await runConfigHook(config)
+
+    const modeledAgents = Object.entries(config.agent ?? {}).filter(
+      ([, agent]) => agent?.model !== undefined,
+    )
+
+    expect(modeledAgents).toEqual([])
+    expect(config.agent?.['correctness-reviewer']?.temperature).toBeDefined()
+  })
+
+  test('well-shaped nonexistent explicit model passes validation and emits unchanged', async () => {
+    writeSystematicConfig({
+      agents: {
+        'correctness-reviewer': {
+          model: 'nonexistent-provider/nonexistent-model',
+        },
+      },
+    })
+
+    const config: Config = {}
+    await runConfigHook(config)
+
+    expect(config.agent?.['correctness-reviewer']?.model).toBe(
+      'nonexistent-provider/nonexistent-model',
+    )
+  })
+})
 
 describe.skipIf(!OPENCODE_AVAILABLE)('opencode integration', () => {
   let testEnv: {

--- a/tests/integration/opencode.test.ts
+++ b/tests/integration/opencode.test.ts
@@ -115,6 +115,7 @@ describe('SystematicPlugin config hook integration', () => {
 
   afterEach(() => {
     _resetPluginSingleton()
+    delete process.env.OPENCODE_CONFIG_DIR
     fs.rmSync(tempDir, { recursive: true, force: true })
   })
 
@@ -122,6 +123,16 @@ describe('SystematicPlugin config hook integration', () => {
     fs.mkdirSync(path.join(projectDir, '.opencode'), { recursive: true })
     fs.writeFileSync(
       path.join(projectDir, '.opencode/systematic.json'),
+      JSON.stringify(config),
+    )
+  }
+
+  function writeCustomSystematicConfig(config: Record<string, unknown>): void {
+    const customDir = path.join(tempDir, 'custom-config')
+    process.env.OPENCODE_CONFIG_DIR = customDir
+    fs.mkdirSync(customDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(customDir, 'systematic.json'),
       JSON.stringify(config),
     )
   }
@@ -167,7 +178,7 @@ describe('SystematicPlugin config hook integration', () => {
   })
 
   test('category overlay tunes category members and skips native replacements', async () => {
-    writeSystematicConfig({
+    writeCustomSystematicConfig({
       categories: {
         review: {
           temperature: 0.21,
@@ -198,7 +209,7 @@ describe('SystematicPlugin config hook integration', () => {
   })
 
   test('native-replaced category member is partitioned out before overlay application', async () => {
-    writeSystematicConfig({
+    writeCustomSystematicConfig({
       categories: {
         review: {
           temperature: 0.44,

--- a/tests/unit/agent-overlays.test.ts
+++ b/tests/unit/agent-overlays.test.ts
@@ -347,6 +347,47 @@ describe('validateAgentOverlays', () => {
     ).not.toThrow()
   })
 
+  test('rejects same overlay object with managed skills and explicit permission.skill', () => {
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {
+            'correctness-reviewer': source('agents', 'correctness-reviewer', {
+              skills: ['ce:review'],
+              permission: { skill: { '*': 'deny' } },
+            }),
+          },
+          categories: {},
+        },
+        nativeAgents: {},
+        enabledSkills: ['ce:review'],
+      }),
+    ).toThrow(
+      /agents\.correctness-reviewer.*cannot set both skills and permission\.skill/,
+    )
+  })
+
+  test('rejects unknown or disabled managed skill names', () => {
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {
+            'correctness-reviewer': source('agents', 'correctness-reviewer', {
+              skills: ['missing-skill'],
+            }),
+          },
+          categories: {},
+        },
+        nativeAgents: {},
+        enabledSkills: ['ce:review'],
+      }),
+    ).toThrow(
+      /agents\.correctness-reviewer\.skills.*unknown or disabled skill "missing-skill"/,
+    )
+  })
+
   test('model requires provider/model and does not normalize shorthand', () => {
     for (const model of ['gpt-4', 'inherit']) {
       expect(() =>

--- a/tests/unit/agent-overlays.test.ts
+++ b/tests/unit/agent-overlays.test.ts
@@ -243,12 +243,17 @@ describe('validateAgentOverlays', () => {
     const invalidCases: Array<[string, unknown]> = [
       ['model', 'gpt-4'],
       ['model', 'inherit'],
+      ['model', ' openai/gpt-4'],
       ['variant', ''],
+      ['variant', ' small'],
       ['temperature', Number.NaN],
+      ['temperature', -0.1],
       ['top_p', Number.POSITIVE_INFINITY],
+      ['top_p', 1.1],
       ['mode', 'background'],
       ['steps', 0],
       ['hidden', 'true'],
+      ['color', ' cyan'],
       ['color', 'not a color'],
       ['permission', { read: 'maybe' }],
     ]
@@ -386,6 +391,22 @@ describe('validateAgentOverlays', () => {
     ).toThrow(
       /agents\.correctness-reviewer\.skills.*unknown or disabled skill "missing-skill"/,
     )
+
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {
+            'correctness-reviewer': source('agents', 'correctness-reviewer', {
+              skills: [' ce:review'],
+            }),
+          },
+          categories: {},
+        },
+        nativeAgents: {},
+        enabledSkills: ['ce:review'],
+      }),
+    ).toThrow(/agents\.correctness-reviewer\.skills/)
   })
 
   test('model requires provider/model and does not normalize shorthand', () => {

--- a/tests/unit/agent-overlays.test.ts
+++ b/tests/unit/agent-overlays.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  type BundledAgentInventory,
+  buildBundledAgentInventory,
+  validateAgentOverlays,
+} from '../../src/lib/agent-overlays.js'
+import type { SourcedOverlayConfig } from '../../src/lib/config.js'
+
+function withTempDir(run: (dir: string) => void): void {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'systematic-overlays-'))
+  try {
+    run(dir)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+function createAgent(root: string, category: string, stem: string): void {
+  const categoryDir = path.join(root, category)
+  fs.mkdirSync(categoryDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(categoryDir, `${stem}.md`),
+    `---\nname: ${stem}\ndescription: ${stem}\n---\nPrompt`,
+  )
+}
+
+function source(
+  mapKey: 'agents' | 'categories',
+  key: string,
+  value: Record<string, unknown>,
+): SourcedOverlayConfig {
+  return {
+    value,
+    sourcePath: '/tmp/systematic.json',
+    keyPath: `${mapKey}.${key}`,
+  }
+}
+
+function createInventory(): BundledAgentInventory {
+  return {
+    agentsByQualifiedId: {
+      'review/correctness-reviewer': {
+        id: 'review/correctness-reviewer',
+        key: 'correctness-reviewer',
+        category: 'review',
+        file: '/agents/review/correctness-reviewer.md',
+        disabled: false,
+      },
+      'workflow/disabled-helper': {
+        id: 'workflow/disabled-helper',
+        key: 'disabled-helper',
+        category: 'workflow',
+        file: '/agents/workflow/disabled-helper.md',
+        disabled: true,
+      },
+    },
+    aliases: {
+      'correctness-reviewer': 'review/correctness-reviewer',
+      'review/correctness-reviewer': 'review/correctness-reviewer',
+      'disabled-helper': 'workflow/disabled-helper',
+      'workflow/disabled-helper': 'workflow/disabled-helper',
+    },
+    categories: ['review', 'workflow'],
+  }
+}
+
+describe('buildBundledAgentInventory', () => {
+  test('builds direct category inventory with qualified ids and unique aliases', () => {
+    withTempDir((dir) => {
+      createAgent(dir, 'review', 'correctness-reviewer')
+
+      const inventory = buildBundledAgentInventory(dir, [])
+
+      expect(inventory.categories).toEqual(['review'])
+      expect(inventory.aliases['correctness-reviewer']).toBe(
+        'review/correctness-reviewer',
+      )
+      expect(inventory.aliases['review/correctness-reviewer']).toBe(
+        'review/correctness-reviewer',
+      )
+    })
+  })
+
+  test('rejects duplicate bundled stems before config application', () => {
+    withTempDir((dir) => {
+      createAgent(dir, 'review', 'shared')
+      createAgent(dir, 'workflow', 'shared')
+
+      expect(() => buildBundledAgentInventory(dir, [])).toThrow(
+        /Duplicate bundled agent stem "shared"/,
+      )
+    })
+  })
+})
+
+describe('validateAgentOverlays', () => {
+  test('unqualified unique key and qualified key each resolve to same bundled agent when used alone', () => {
+    const inventory = createInventory()
+
+    const unqualified = validateAgentOverlays({
+      inventory,
+      overlays: {
+        agents: {
+          'correctness-reviewer': source('agents', 'correctness-reviewer', {
+            model: 'openai/gpt-4',
+          }),
+        },
+        categories: {},
+      },
+      nativeAgents: {},
+    })
+    const qualified = validateAgentOverlays({
+      inventory,
+      overlays: {
+        agents: {
+          'review/correctness-reviewer': source(
+            'agents',
+            'review/correctness-reviewer',
+            { model: 'openai/gpt-4' },
+          ),
+        },
+        categories: {},
+      },
+      nativeAgents: {},
+    })
+
+    expect(unqualified.agents[0]?.target.id).toBe('review/correctness-reviewer')
+    expect(qualified.agents[0]?.target.id).toBe('review/correctness-reviewer')
+  })
+
+  test('both key forms for same target fail duplicate-target validation', () => {
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {
+            'correctness-reviewer': source('agents', 'correctness-reviewer', {
+              model: 'openai/gpt-4',
+            }),
+            'review/correctness-reviewer': source(
+              'agents',
+              'review/correctness-reviewer',
+              { temperature: 0.2 },
+            ),
+          },
+          categories: {},
+        },
+        nativeAgents: {},
+      }),
+    ).toThrow(
+      /Duplicate Systematic agent overlay target.*agents\.correctness-reviewer.*agents\.review\/correctness-reviewer/s,
+    )
+  })
+
+  test('known category validates and unknown category lists valid categories', () => {
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {},
+          categories: {
+            review: source('categories', 'review', { temperature: 0.2 }),
+          },
+        },
+        nativeAgents: {},
+      }),
+    ).not.toThrow()
+
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {},
+          categories: {
+            unknown: source('categories', 'unknown', { temperature: 0.2 }),
+          },
+        },
+        nativeAgents: {},
+      }),
+    ).toThrow(/categories\.unknown.*Valid categories: review, workflow/)
+  })
+
+  test('rejects unknown and unsupported fields with key path', () => {
+    for (const field of [
+      'unknown',
+      'tools',
+      'prompt',
+      'description',
+      'options',
+      'mcps',
+    ]) {
+      expect(() =>
+        validateAgentOverlays({
+          inventory: createInventory(),
+          overlays: {
+            agents: {
+              'correctness-reviewer': source('agents', 'correctness-reviewer', {
+                [field]: true,
+              }),
+            },
+            categories: {},
+          },
+          nativeAgents: {},
+        }),
+      ).toThrow(new RegExp(`agents\\.correctness-reviewer\\.${field}`))
+    }
+  })
+
+  test('rejects category disable but accepts exact disable', () => {
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {},
+          categories: {
+            review: source('categories', 'review', { disable: true }),
+          },
+        },
+        nativeAgents: {},
+      }),
+    ).toThrow(/categories\.review\.disable/)
+
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {
+            'correctness-reviewer': source('agents', 'correctness-reviewer', {
+              disable: true,
+            }),
+          },
+          categories: {},
+        },
+        nativeAgents: {},
+      }),
+    ).not.toThrow()
+  })
+
+  test('malformed scalar fields and permission fail with source path and key path', () => {
+    const invalidCases: Array<[string, unknown]> = [
+      ['model', 'gpt-4'],
+      ['model', 'inherit'],
+      ['variant', ''],
+      ['temperature', Number.NaN],
+      ['top_p', Number.POSITIVE_INFINITY],
+      ['mode', 'background'],
+      ['steps', 0],
+      ['hidden', 'true'],
+      ['color', 'not a color'],
+      ['permission', { read: 'maybe' }],
+    ]
+
+    for (const [field, value] of invalidCases) {
+      expect(() =>
+        validateAgentOverlays({
+          inventory: createInventory(),
+          overlays: {
+            agents: {
+              'correctness-reviewer': source('agents', 'correctness-reviewer', {
+                [field]: value,
+              }),
+            },
+            categories: {},
+          },
+          nativeAgents: {},
+        }),
+      ).toThrow(
+        new RegExp(
+          `/tmp/systematic\\.json.*agents\\.correctness-reviewer\\.${field}`,
+        ),
+      )
+    }
+  })
+
+  test('native replacement conflicts with exact unqualified and qualified overlays', () => {
+    for (const key of ['correctness-reviewer', 'review/correctness-reviewer']) {
+      expect(() =>
+        validateAgentOverlays({
+          inventory: createInventory(),
+          overlays: {
+            agents: {
+              [key]: source('agents', key, { model: 'openai/gpt-4' }),
+            },
+            categories: {},
+          },
+          nativeAgents: { 'correctness-reviewer': { prompt: 'native' } },
+        }),
+      ).toThrow(/native OpenCode agent\.correctness-reviewer/)
+    }
+  })
+
+  test('disabled exact overlay validates unless same emitted key is native replacement', () => {
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {
+            'disabled-helper': source('agents', 'disabled-helper', {
+              model: 'openai/gpt-4',
+            }),
+          },
+          categories: {},
+        },
+        nativeAgents: {},
+      }),
+    ).not.toThrow()
+
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {
+            'disabled-helper': source('agents', 'disabled-helper', {
+              model: 'openai/gpt-4',
+            }),
+          },
+          categories: {},
+        },
+        nativeAgents: { 'disabled-helper': { prompt: 'native' } },
+      }),
+    ).toThrow(/native OpenCode agent\.disabled-helper/)
+  })
+
+  test('validates OpenCode permission shapes without MCP/provider semantics', () => {
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {
+            'correctness-reviewer': source('agents', 'correctness-reviewer', {
+              permission: {
+                read: 'allow',
+                grep: { '**/*.ts': 'allow' },
+                skill: { 'ce:*': 'allow' },
+                bash: { '*': 'ask' },
+                'custom.tool': { 'provider/*': 'deny' },
+              },
+            }),
+          },
+          categories: {},
+        },
+        nativeAgents: {},
+      }),
+    ).not.toThrow()
+  })
+
+  test('model requires provider/model and does not normalize shorthand', () => {
+    for (const model of ['gpt-4', 'inherit']) {
+      expect(() =>
+        validateAgentOverlays({
+          inventory: createInventory(),
+          overlays: {
+            agents: {
+              'correctness-reviewer': source('agents', 'correctness-reviewer', {
+                model,
+              }),
+            },
+            categories: {},
+          },
+          nativeAgents: {},
+        }),
+      ).toThrow(/agents\.correctness-reviewer\.model/)
+    }
+
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {
+            'correctness-reviewer': source('agents', 'correctness-reviewer', {
+              model: 'openai/gpt-4',
+            }),
+          },
+          categories: {},
+        },
+        nativeAgents: {},
+      }),
+    ).not.toThrow()
+
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {
+            'correctness-reviewer': source('agents', 'correctness-reviewer', {
+              model: 'openrouter/anthropic/claude-sonnet-4',
+            }),
+          },
+          categories: {},
+        },
+        nativeAgents: {},
+      }),
+    ).not.toThrow()
+  })
+})

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -69,6 +69,24 @@ Skill content for ${name}.`,
     )
   }
 
+  function createCategorizedAgent(
+    category: string,
+    name: string,
+    frontmatterOrDescription: string | Record<string, unknown>,
+  ): void {
+    const categoryDir = path.join(bundledDir, 'agents', category)
+    fs.mkdirSync(categoryDir, { recursive: true })
+    createAgent(categoryDir, name, frontmatterOrDescription)
+  }
+
+  function writeSystematicConfig(value: Record<string, unknown>): void {
+    fs.mkdirSync(path.join(projectDir, '.opencode'), { recursive: true })
+    fs.writeFileSync(
+      path.join(projectDir, '.opencode/systematic.json'),
+      JSON.stringify(value),
+    )
+  }
+
   function createCommand(dir: string, name: string, description: string): void {
     fs.writeFileSync(
       path.join(dir, `${name}.md`),
@@ -452,7 +470,7 @@ Skill content for ce:plan.`,
       expect(agent).toBeDefined()
       expect(agent?.description).toBe('A full agent (Full-Agent - Systematic)')
       expect(agent?.model).toBe('openai/gpt-4')
-      expect(agent?.temperature).toBe(0.7)
+      expect(agent?.temperature).toBe(0.3)
       expect(agent?.top_p).toBe(1)
       expect(agent?.steps).toBe(10)
       expect(agent?.color).toBe('#ff0000')
@@ -643,6 +661,380 @@ model: gpt-4
 
       expect(config.command?.['systematic:routed-skill']?.agent).toBe('oracle')
       expect(config.command?.['systematic:routed-skill']?.model).toBe('gpt-4')
+    })
+
+    test('applies built-in temperature defaults without emitting default model', async () => {
+      createCategorizedAgent('review', 'correctness-reviewer', {
+        name: 'correctness-reviewer',
+        description: 'Reviews correctness',
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.['correctness-reviewer']?.temperature).toBe(0.1)
+      expect(config.agent?.['correctness-reviewer']?.model).toBeUndefined()
+    })
+
+    test('built-in temperature overrides bundled markdown unless category or exact overlay is stronger', async () => {
+      createCategorizedAgent('review', 'correctness-reviewer', {
+        name: 'correctness-reviewer',
+        description: 'Reviews correctness',
+        temperature: 0.9,
+      })
+      createCategorizedAgent('review', 'security-reviewer', {
+        name: 'security-reviewer',
+        description: 'Security reviewer',
+        temperature: 0.9,
+      })
+      writeSystematicConfig({
+        categories: { review: { temperature: 0.25 } },
+        agents: { 'correctness-reviewer': { temperature: 0.05 } },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.['correctness-reviewer']?.temperature).toBe(0.05)
+      expect(config.agent?.['security-reviewer']?.temperature).toBe(0.25)
+    })
+
+    test('emits exact configured model and supported overlay fields including variant', async () => {
+      createCategorizedAgent('review', 'correctness-reviewer', {
+        name: 'correctness-reviewer',
+        description: 'Reviews correctness',
+      })
+      createCategorizedAgent('review', 'other-reviewer', {
+        name: 'other-reviewer',
+        description: 'Other reviewer',
+      })
+      writeSystematicConfig({
+        agents: {
+          'correctness-reviewer': {
+            model: 'openrouter/anthropic/claude-sonnet-4',
+            variant: 'large-context',
+            top_p: 0.8,
+            mode: 'subagent',
+            color: '#123abc',
+            steps: 12,
+            hidden: true,
+          },
+        },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      const agent = config.agent?.['correctness-reviewer']
+      expect(agent?.model).toBe('openrouter/anthropic/claude-sonnet-4')
+      expect(agent?.variant).toBe('large-context')
+      expect(agent?.top_p).toBe(0.8)
+      expect(agent?.mode).toBe('subagent')
+      expect(agent?.color).toBe('#123abc')
+      expect(agent?.steps).toBe(12)
+      expect(agent?.hidden).toBe(true)
+      expect(config.agent?.['other-reviewer']?.model).toBeUndefined()
+    })
+
+    test('accepts and emits variant without model', async () => {
+      createCategorizedAgent('review', 'correctness-reviewer', {
+        name: 'correctness-reviewer',
+        description: 'Reviews correctness',
+      })
+      writeSystematicConfig({
+        agents: { 'correctness-reviewer': { variant: 'small' } },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.['correctness-reviewer']?.variant).toBe('small')
+      expect(config.agent?.['correctness-reviewer']?.model).toBeUndefined()
+    })
+
+    test('managed skills shortcut emits ordered deny-all then allow-selected rules', async () => {
+      createSkill(path.join(bundledDir, 'skills'), 'ce:review', 'Review skill')
+      createCategorizedAgent('review', 'correctness-reviewer', {
+        name: 'correctness-reviewer',
+        description: 'Reviews correctness',
+      })
+      writeSystematicConfig({
+        agents: { 'correctness-reviewer': { skills: ['ce:review'] } },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.['correctness-reviewer']?.permission?.skill).toEqual(
+        {
+          '*': 'deny',
+          'ce:review': 'allow',
+        },
+      )
+    })
+
+    test('managed empty skills emits deny-all and omitted skills inherit weaker behavior', async () => {
+      createSkill(path.join(bundledDir, 'skills'), 'ce:review', 'Review skill')
+      createCategorizedAgent('review', 'correctness-reviewer', {
+        name: 'correctness-reviewer',
+        description: 'Reviews correctness',
+      })
+      createCategorizedAgent('review', 'security-reviewer', {
+        name: 'security-reviewer',
+        description: 'Security reviewer',
+      })
+      writeSystematicConfig({
+        categories: { review: { skills: ['ce:review'] } },
+        agents: { 'correctness-reviewer': { skills: [] } },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.['correctness-reviewer']?.permission?.skill).toEqual(
+        {
+          'ce:review': 'allow',
+          '*': 'deny',
+        },
+      )
+      expect(config.agent?.['security-reviewer']?.permission?.skill).toEqual({
+        '*': 'deny',
+        'ce:review': 'allow',
+      })
+    })
+
+    test('permission rules concatenate weakest to strongest so exact skills override category skills', async () => {
+      createSkill(path.join(bundledDir, 'skills'), 'skill-a', 'Skill A')
+      createSkill(path.join(bundledDir, 'skills'), 'skill-b', 'Skill B')
+      createCategorizedAgent('review', 'correctness-reviewer', {
+        name: 'correctness-reviewer',
+        description: 'Reviews correctness',
+      })
+      writeSystematicConfig({
+        categories: {
+          review: { skills: ['skill-a', 'skill-b'] },
+        },
+        agents: { 'correctness-reviewer': { skills: ['skill-a'] } },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.['correctness-reviewer']?.permission?.skill).toEqual(
+        {
+          'skill-b': 'allow',
+          '*': 'deny',
+          'skill-a': 'allow',
+        },
+      )
+    })
+
+    test('exact permission.skill can override category skills and exact skills can override category permission.skill', async () => {
+      createSkill(path.join(bundledDir, 'skills'), 'skill-a', 'Skill A')
+      createCategorizedAgent('review', 'explicit-exact', {
+        name: 'explicit-exact',
+        description: 'Explicit exact',
+      })
+      createCategorizedAgent('review', 'managed-exact', {
+        name: 'managed-exact',
+        description: 'Managed exact',
+      })
+      writeSystematicConfig({
+        categories: {
+          review: {
+            skills: ['skill-a'],
+            permission: { bash: 'deny' },
+          },
+        },
+        agents: {
+          'explicit-exact': {
+            permission: { skill: { 'skill-a': 'deny' } },
+          },
+          'managed-exact': { skills: ['skill-a'] },
+        },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.['explicit-exact']?.permission?.skill).toEqual({
+        '*': 'deny',
+        'skill-a': 'deny',
+      })
+      expect(config.agent?.['explicit-exact']?.permission?.bash).toEqual({
+        '*': 'deny',
+      })
+      expect(config.agent?.['managed-exact']?.permission?.skill).toEqual({
+        '*': 'deny',
+        'skill-a': 'allow',
+      })
+    })
+
+    test('exact managed skills override category permission.skill denial through last-match order', async () => {
+      createSkill(path.join(bundledDir, 'skills'), 'skill-a', 'Skill A')
+      createCategorizedAgent('review', 'managed-exact', {
+        name: 'managed-exact',
+        description: 'Managed exact',
+      })
+      writeSystematicConfig({
+        categories: {
+          review: {
+            permission: { skill: { 'skill-a': 'deny' } },
+          },
+        },
+        agents: {
+          'managed-exact': { skills: ['skill-a'] },
+        },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.['managed-exact']?.permission?.skill).toEqual({
+        '*': 'deny',
+        'skill-a': 'allow',
+      })
+    })
+
+    test('category overlay skips native replacement and applies to other bundled agents', async () => {
+      createCategorizedAgent('review', 'native-replacement', {
+        name: 'native-replacement',
+        description: 'Native replacement',
+      })
+      createCategorizedAgent('review', 'other-reviewer', {
+        name: 'other-reviewer',
+        description: 'Other reviewer',
+      })
+      writeSystematicConfig({ categories: { review: { temperature: 0.22 } } })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {
+        agent: {
+          'native-replacement': { description: 'Native', prompt: 'Native' },
+        },
+      }
+      await handler(config)
+
+      expect(config.agent?.['native-replacement']?.description).toBe('Native')
+      expect(config.agent?.['other-reviewer']?.temperature).toBe(0.22)
+    })
+
+    test('disabled exact overlay has no emitted config', async () => {
+      createCategorizedAgent('workflow', 'helper', {
+        name: 'helper',
+        description: 'Helper',
+      })
+      writeSystematicConfig({ agents: { helper: { disable: true } } })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.helper).toBeUndefined()
+    })
+
+    test('invalid overlay leaves config surfaces unmodified', async () => {
+      createCategorizedAgent('review', 'correctness-reviewer', {
+        name: 'correctness-reviewer',
+        description: 'Reviews correctness',
+      })
+      writeSystematicConfig({
+        agents: { 'correctness-reviewer': { skills: ['missing-skill'] } },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config = {
+        agent: { native: { description: 'Native', prompt: 'Native' } },
+        command: { native: { description: 'Native', template: 'Native' } },
+        skills: { paths: ['/existing/skills'] },
+        mcp: { local: { type: 'local', command: ['echo'] } },
+      } as unknown as Config
+      const before = structuredClone(config)
+
+      await expect(handler(config)).rejects.toThrow(/missing-skill/)
+
+      expect(config).toEqual(before)
     })
   })
 })

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -35,6 +35,7 @@ describe('config-handler', () => {
   })
 
   afterEach(() => {
+    delete process.env.OPENCODE_CONFIG_DIR
     fs.rmSync(testDir, { recursive: true, force: true })
   })
 
@@ -83,6 +84,16 @@ Skill content for ${name}.`,
     fs.mkdirSync(path.join(projectDir, '.opencode'), { recursive: true })
     fs.writeFileSync(
       path.join(projectDir, '.opencode/systematic.json'),
+      JSON.stringify(value),
+    )
+  }
+
+  function writeCustomSystematicConfig(value: Record<string, unknown>): void {
+    const customDir = path.join(testDir, 'custom-config')
+    process.env.OPENCODE_CONFIG_DIR = customDir
+    fs.mkdirSync(customDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(customDir, 'systematic.json'),
       JSON.stringify(value),
     )
   }
@@ -786,7 +797,7 @@ model: gpt-4
         name: 'correctness-reviewer',
         description: 'Reviews correctness',
       })
-      writeSystematicConfig({
+      writeCustomSystematicConfig({
         agents: { 'correctness-reviewer': { skills: ['ce:review'] } },
       })
 
@@ -818,7 +829,7 @@ model: gpt-4
         name: 'security-reviewer',
         description: 'Security reviewer',
       })
-      writeSystematicConfig({
+      writeCustomSystematicConfig({
         categories: { review: { skills: ['ce:review'] } },
         agents: { 'correctness-reviewer': { skills: [] } },
       })
@@ -852,7 +863,7 @@ model: gpt-4
         name: 'correctness-reviewer',
         description: 'Reviews correctness',
       })
-      writeSystematicConfig({
+      writeCustomSystematicConfig({
         categories: {
           review: { skills: ['skill-a', 'skill-b'] },
         },
@@ -888,7 +899,7 @@ model: gpt-4
         name: 'managed-exact',
         description: 'Managed exact',
       })
-      writeSystematicConfig({
+      writeCustomSystematicConfig({
         categories: {
           review: {
             skills: ['skill-a'],
@@ -932,7 +943,7 @@ model: gpt-4
         name: 'managed-exact',
         description: 'Managed exact',
       })
-      writeSystematicConfig({
+      writeCustomSystematicConfig({
         categories: {
           review: {
             permission: { skill: { 'skill-a': 'deny' } },
@@ -1013,7 +1024,7 @@ model: gpt-4
         name: 'correctness-reviewer',
         description: 'Reviews correctness',
       })
-      writeSystematicConfig({
+      writeCustomSystematicConfig({
         agents: { 'correctness-reviewer': { skills: ['missing-skill'] } },
       })
 

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_CONFIG,
   getConfigPaths,
   loadConfig,
+  loadConfigWithSources,
 } from '../../src/lib/config.ts'
 
 // Avoid TOCTOU (time-of-check-time-of-use) race conditions
@@ -418,6 +419,249 @@ describe('config', () => {
       test('ignores project config if it does not exist', () => {
         const result = loadConfig(testDir)
         expect(result).toEqual(DEFAULT_CONFIG)
+      })
+    })
+
+    describe('agent and category overlays', () => {
+      test('loads a user agent overlay with source and key provenance', () => {
+        const userConfigDir = path.join(os.homedir(), '.config/opencode')
+        const userConfigPath = path.join(userConfigDir, 'systematic.json')
+        const userConfigBackup = tryReadFile(userConfigPath)
+
+        try {
+          fs.mkdirSync(userConfigDir, { recursive: true })
+          fs.writeFileSync(
+            userConfigPath,
+            JSON.stringify({
+              agents: {
+                'correctness-reviewer': { model: 'openai/gpt-5' },
+              },
+            }),
+          )
+
+          const result = loadConfigWithSources(testDir)
+
+          expect(result.config.agents).toEqual({
+            'correctness-reviewer': { model: 'openai/gpt-5' },
+          })
+          expect(result.overlays.agents['correctness-reviewer']).toEqual({
+            value: { model: 'openai/gpt-5' },
+            sourcePath: userConfigPath,
+            keyPath: 'agents.correctness-reviewer',
+          })
+        } finally {
+          if (userConfigBackup !== null) {
+            fs.writeFileSync(userConfigPath, userConfigBackup)
+          } else {
+            tryUnlink(userConfigPath)
+          }
+        }
+      })
+
+      test('preserves unrelated user category and project agent overlays', () => {
+        const userConfigDir = path.join(os.homedir(), '.config/opencode')
+        const userConfigPath = path.join(userConfigDir, 'systematic.json')
+        const userConfigBackup = tryReadFile(userConfigPath)
+
+        try {
+          fs.mkdirSync(userConfigDir, { recursive: true })
+          fs.writeFileSync(
+            userConfigPath,
+            JSON.stringify({ categories: { review: { temperature: 0.2 } } }),
+          )
+
+          const projectConfigDir = path.join(testDir, '.opencode')
+          fs.mkdirSync(projectConfigDir)
+          fs.writeFileSync(
+            path.join(projectConfigDir, 'systematic.json'),
+            JSON.stringify({
+              agents: {
+                'correctness-reviewer': { model: 'anthropic/claude-sonnet-4' },
+              },
+            }),
+          )
+
+          const result = loadConfigWithSources(testDir)
+
+          expect(result.config.categories).toEqual({
+            review: { temperature: 0.2 },
+          })
+          expect(result.config.agents).toEqual({
+            'correctness-reviewer': { model: 'anthropic/claude-sonnet-4' },
+          })
+        } finally {
+          if (userConfigBackup !== null) {
+            fs.writeFileSync(userConfigPath, userConfigBackup)
+          } else {
+            tryUnlink(userConfigPath)
+          }
+        }
+      })
+
+      test('project agent overlay replaces user same-key overlay wholesale', () => {
+        const userConfigDir = path.join(os.homedir(), '.config/opencode')
+        const userConfigPath = path.join(userConfigDir, 'systematic.json')
+        const userConfigBackup = tryReadFile(userConfigPath)
+
+        try {
+          fs.mkdirSync(userConfigDir, { recursive: true })
+          fs.writeFileSync(
+            userConfigPath,
+            JSON.stringify({
+              agents: {
+                'correctness-reviewer': {
+                  model: 'openai/gpt-5',
+                  temperature: 0.1,
+                },
+              },
+            }),
+          )
+
+          const projectConfigDir = path.join(testDir, '.opencode')
+          fs.mkdirSync(projectConfigDir)
+          const projectConfigPath = path.join(
+            projectConfigDir,
+            'systematic.json',
+          )
+          fs.writeFileSync(
+            projectConfigPath,
+            JSON.stringify({
+              agents: {
+                'correctness-reviewer': { model: 'anthropic/claude-sonnet-4' },
+              },
+            }),
+          )
+
+          const result = loadConfigWithSources(testDir)
+
+          expect(result.config.agents).toEqual({
+            'correctness-reviewer': { model: 'anthropic/claude-sonnet-4' },
+          })
+          expect(
+            result.overlays.agents['correctness-reviewer']?.sourcePath,
+          ).toBe(projectConfigPath)
+        } finally {
+          if (userConfigBackup !== null) {
+            fs.writeFileSync(userConfigPath, userConfigBackup)
+          } else {
+            tryUnlink(userConfigPath)
+          }
+        }
+      })
+
+      test('custom config category overlay replaces project same-key overlay', () => {
+        const customDir = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'systematic-custom-'),
+        )
+        process.env.OPENCODE_CONFIG_DIR = customDir
+
+        try {
+          const projectConfigDir = path.join(testDir, '.opencode')
+          fs.mkdirSync(projectConfigDir)
+          fs.writeFileSync(
+            path.join(projectConfigDir, 'systematic.json'),
+            JSON.stringify({
+              categories: {
+                review: { model: 'openai/gpt-5', temperature: 0.1 },
+              },
+            }),
+          )
+
+          const customConfigPath = path.join(customDir, 'systematic.json')
+          fs.writeFileSync(
+            customConfigPath,
+            JSON.stringify({ categories: { review: { temperature: 0.7 } } }),
+          )
+
+          const result = loadConfigWithSources(testDir)
+
+          expect(result.config.categories).toEqual({
+            review: { temperature: 0.7 },
+          })
+          expect(result.overlays.categories.review?.sourcePath).toBe(
+            customConfigPath,
+          )
+        } finally {
+          delete process.env.OPENCODE_CONFIG_DIR
+          fs.rmSync(customDir, { recursive: true, force: true })
+        }
+      })
+
+      test('absent and empty overlay maps are valid no-ops', () => {
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        fs.writeFileSync(
+          path.join(projectConfigDir, 'systematic.json'),
+          JSON.stringify({ agents: {}, categories: {} }),
+        )
+
+        const result = loadConfigWithSources(testDir)
+
+        expect(result.config.agents).toEqual({})
+        expect(result.config.categories).toEqual({})
+        expect(result.overlays.agents).toEqual({})
+        expect(result.overlays.categories).toEqual({})
+      })
+
+      test.each([
+        ['agents container', { agents: null }, 'agents'],
+        ['categories container', { categories: [] }, 'categories'],
+        [
+          'agent entry',
+          { agents: { 'correctness-reviewer': 'openai/gpt-5' } },
+          'agents.correctness-reviewer',
+        ],
+        [
+          'category entry',
+          { categories: { review: null } },
+          'categories.review',
+        ],
+      ])('rejects invalid %s overlay values', (_name, config, keyPath) => {
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        const projectConfigPath = path.join(projectConfigDir, 'systematic.json')
+        fs.writeFileSync(projectConfigPath, JSON.stringify(config))
+
+        expect(() => loadConfigWithSources(testDir)).toThrow(projectConfigPath)
+        expect(() => loadConfigWithSources(testDir)).toThrow(keyPath)
+      })
+
+      test('preserves unqualified and qualified alias keys across source priorities', () => {
+        const userConfigDir = path.join(os.homedir(), '.config/opencode')
+        const userConfigPath = path.join(userConfigDir, 'systematic.json')
+        const userConfigBackup = tryReadFile(userConfigPath)
+
+        try {
+          fs.mkdirSync(userConfigDir, { recursive: true })
+          fs.writeFileSync(
+            userConfigPath,
+            JSON.stringify({
+              agents: { 'correctness-reviewer': { temperature: 0.1 } },
+            }),
+          )
+
+          const projectConfigDir = path.join(testDir, '.opencode')
+          fs.mkdirSync(projectConfigDir)
+          fs.writeFileSync(
+            path.join(projectConfigDir, 'systematic.json'),
+            JSON.stringify({
+              agents: { 'review/correctness-reviewer': { temperature: 0.2 } },
+            }),
+          )
+
+          const result = loadConfigWithSources(testDir)
+
+          expect(result.config.agents).toEqual({
+            'correctness-reviewer': { temperature: 0.1 },
+            'review/correctness-reviewer': { temperature: 0.2 },
+          })
+        } finally {
+          if (userConfigBackup !== null) {
+            fs.writeFileSync(userConfigPath, userConfigBackup)
+          } else {
+            tryUnlink(userConfigPath)
+          }
+        }
       })
     })
   })

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -404,16 +404,14 @@ describe('config', () => {
     })
 
     describe('malformed configs', () => {
-      test('ignores project config if it has invalid JSON', () => {
+      test('fails fast when project config has invalid JSONC', () => {
         const projectConfigDir = path.join(testDir, '.opencode')
         fs.mkdirSync(projectConfigDir)
-        fs.writeFileSync(
-          path.join(projectConfigDir, 'systematic.json'),
-          '{invalid json',
-        )
+        const projectConfigPath = path.join(projectConfigDir, 'systematic.json')
+        fs.writeFileSync(projectConfigPath, '{invalid json')
 
-        const result = loadConfig(testDir)
-        expect(result).toEqual(DEFAULT_CONFIG)
+        expect(() => loadConfig(testDir)).toThrow(projectConfigPath)
+        expect(() => loadConfig(testDir)).toThrow(/parse error/i)
       })
 
       test('ignores project config if it does not exist', () => {
@@ -540,6 +538,86 @@ describe('config', () => {
           expect(
             result.overlays.agents['correctness-reviewer']?.sourcePath,
           ).toBe(projectConfigPath)
+        } finally {
+          if (userConfigBackup !== null) {
+            fs.writeFileSync(userConfigPath, userConfigBackup)
+          } else {
+            tryUnlink(userConfigPath)
+          }
+        }
+      })
+
+      test('project overlays cannot configure permission or managed skills', () => {
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        const projectConfigPath = path.join(projectConfigDir, 'systematic.json')
+
+        for (const config of [
+          {
+            agents: {
+              'correctness-reviewer': { permission: { bash: 'allow' } },
+            },
+          },
+          { categories: { review: { skills: ['ce:review'] } } },
+        ]) {
+          fs.writeFileSync(projectConfigPath, JSON.stringify(config))
+
+          expect(() => loadConfigWithSources(testDir)).toThrow(
+            projectConfigPath,
+          )
+          expect(() => loadConfigWithSources(testDir)).toThrow(
+            /only valid in user config or OPENCODE_CONFIG_DIR config/,
+          )
+        }
+      })
+
+      test('project same-key overlays preserve user permission policy fields', () => {
+        const userConfigDir = path.join(os.homedir(), '.config/opencode')
+        const userConfigPath = path.join(userConfigDir, 'systematic.json')
+        const userConfigBackup = tryReadFile(userConfigPath)
+
+        try {
+          fs.mkdirSync(userConfigDir, { recursive: true })
+          fs.writeFileSync(
+            userConfigPath,
+            JSON.stringify({
+              categories: {
+                review: {
+                  permission: { bash: 'deny' },
+                  skills: ['ce:review'],
+                  temperature: 0.1,
+                },
+              },
+              agents: {
+                'correctness-reviewer': {
+                  permission: { read: 'deny' },
+                  temperature: 0.1,
+                },
+              },
+            }),
+          )
+
+          const projectConfigDir = path.join(testDir, '.opencode')
+          fs.mkdirSync(projectConfigDir)
+          fs.writeFileSync(
+            path.join(projectConfigDir, 'systematic.json'),
+            JSON.stringify({
+              categories: { review: { temperature: 0.4 } },
+              agents: { 'correctness-reviewer': { model: 'openai/gpt-5' } },
+            }),
+          )
+
+          const result = loadConfigWithSources(testDir)
+
+          expect(result.config.categories?.review).toEqual({
+            temperature: 0.4,
+            permission: { bash: 'deny' },
+            skills: ['ce:review'],
+          })
+          expect(result.config.agents?.['correctness-reviewer']).toEqual({
+            model: 'openai/gpt-5',
+            permission: { read: 'deny' },
+          })
         } finally {
           if (userConfigBackup !== null) {
             fs.writeFileSync(userConfigPath, userConfigBackup)

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -7,6 +7,7 @@ import {
   type AllowlistEntry,
   BANNED_PATTERNS,
   checkAgentModel,
+  checkAgentStemUniqueness,
   checkBannedPatterns,
   checkContentIntegrity,
   checkFrontmatter,
@@ -927,6 +928,42 @@ describe('checkAgentModel', () => {
   })
 })
 
+describe('checkAgentStemUniqueness', () => {
+  test('flags duplicate bundled agent stems across categories with both paths', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAgent(root, 'research', 'duplicate-reviewer')
+      writeAgent(root, 'review', 'duplicate-reviewer')
+
+      const targets = collectScanTargets(root)
+      const violations = checkAgentStemUniqueness(root, targets.markdown)
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0]?.stem).toBe('duplicate-reviewer')
+      expect(violations[0]?.files.sort()).toEqual([
+        'agents/research/duplicate-reviewer.md',
+        'agents/review/duplicate-reviewer.md',
+      ])
+      expect(violations[0]?.message).toContain('stem-only OpenCode agent keys')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('allows unique bundled agent stems across categories', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAgent(root, 'research', 'repo-research-analyst')
+      writeAgent(root, 'review', 'security-sentinel')
+
+      const targets = collectScanTargets(root)
+      expect(checkAgentStemUniqueness(root, targets.markdown)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
 describe('checkContentIntegrity (top-level)', () => {
   test('clean repo with no violations returns empty arrays', () => {
     const root = makeFixtureRepo()
@@ -941,6 +978,7 @@ describe('checkContentIntegrity (top-level)', () => {
       expect(result.bannedPatterns).toEqual([])
       expect(result.frontmatterViolations).toEqual([])
       expect(result.agentModelViolations).toEqual([])
+      expect(result.agentStemViolations).toEqual([])
       expect(result.scanStats.markdownFiles).toBe(2) // SKILL.md + agent a.md
       expect(result.scanStats.typescriptFiles).toBe(1)
       expect(result.categories).toEqual(['research'])
@@ -1010,6 +1048,24 @@ describe('checkContentIntegrity (top-level)', () => {
       expect(result.frontmatterViolations[0]?.rule).toBe('banned-field')
       expect(result.agentModelViolations).toHaveLength(1)
       expect(result.agentModelViolations[0]?.file).toBe('agents/research/a.md')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('exposes duplicate bundled agent stem violations in one pass', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAgent(root, 'research', 'same-stem')
+      writeAgent(root, 'review', 'same-stem')
+
+      const result = checkContentIntegrity(root)
+
+      expect(result.agentStemViolations).toHaveLength(1)
+      expect(result.agentStemViolations[0]?.files.sort()).toEqual([
+        'agents/research/same-stem.md',
+        'agents/review/same-stem.md',
+      ])
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }
@@ -1293,11 +1349,19 @@ describe('integration: real repo', () => {
       throw new Error(`Agent model violations in repo:\n  ${details}`)
     }
 
+    if (result.agentStemViolations.length > 0) {
+      const details = result.agentStemViolations
+        .map((v) => `${v.stem}  ${v.files.join(', ')}`)
+        .join('\n  ')
+      throw new Error(`Duplicate bundled agent stems in repo:\n  ${details}`)
+    }
+
     expect(result.phantomRefs).toEqual([])
     expect(result.brokenSubfileRefs).toEqual([])
     expect(result.bannedPatterns).toEqual([])
     expect(result.frontmatterViolations).toEqual([])
     expect(result.agentModelViolations).toEqual([])
+    expect(result.agentStemViolations).toEqual([])
     expect(result.allowlistWarnings).toEqual([])
     expect(result.scanStats.markdownFiles).toBeGreaterThan(0)
     expect(result.scanStats.typescriptFiles).toBeGreaterThan(0)


### PR DESCRIPTION
## Summary

- Add top-level `agents` and `categories` overlays for bundled Systematic agents.
- Keep bundled agent markdown model-free while allowing exact-agent and category-level runtime tuning.
- Add strict overlay validation, source-aware error reporting, built-in temperature defaults, and duplicate agent-stem integrity checks.
- Add a permission-backed `skills` allowlist shortcut with high-trust source protection for permission-affecting overlays.
- Document the new config surface in the README and configuration guide.

## Testing

- `bun run typecheck`
- `bun run build`
- `bun run lint`
- `bun test`
- `bun run docs:build`
- `bun scripts/content-integrity.ts`
- `bun run registry:drift`
- `bun run registry:validate`
- Scoped taxonomy/diff checks for shipped source files

## Post-Deploy Monitoring & Validation

No persistent service runtime is affected. After merge and release:

- Watch GitHub Actions build/release jobs for package smoke-test failures.
- Search new issues and PR comments for `agents`, `categories`, `permission`, `skills`, `agent overlays`, and `duplicate agent stem`.
- Healthy signals: plugin loads successfully, `systematic_skill` remains available, overlay tests pass in CI, and registry drift remains clean.
- Failure signals: valid configs fail parsing, bundled agents disappear unexpectedly, or permission overlays grant/deny skills contrary to config.
- Mitigation trigger: revert the PR or remove the affected overlay config from `systematic.json` until a patch is available.
- Validation window: first release cycle after merge.
