### PR TITLE
fix(config): harden agent overlay trust boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Configuration is loaded from multiple locations and merged (later sources overri
   },
   "agents": {
     "security-sentinel": {
-      "model": "anthropic/claude-sonnet-4-5"
+      "variant": "thinking"
     },
     "workflow/systematic-implementer": {
       "steps": 20
@@ -326,11 +326,11 @@ Configuration is loaded from multiple locations and merged (later sources overri
 | `bootstrap.enabled` | `boolean` | `true` | Inject the `using-systematic` guide into system prompts |
 | `bootstrap.file` | `string` | — | Custom bootstrap file path (overrides default) |
 
-Agent overlays support `model`, `variant`, `temperature`, `top_p`, `permission`, `mode`, `color`, `steps`, `hidden`, exact-agent-only `disable`, and managed `skills`. `skills` uses bundled skill frontmatter names like `ce:review`; it is a shortcut that writes OpenCode `permission.skill` rules, not a native OpenCode agent field. Because `permission` and `skills` control tool access, they are only accepted from user config or `$OPENCODE_CONFIG_DIR/systematic.json`; project config may tune behavior but cannot loosen a user's permission policy.
+Agent overlays support `model`, `variant`, `temperature`, `top_p`, `permission`, `mode`, `color`, `steps`, `hidden`, exact-agent-only `disable`, and managed `skills`. `color` accepts `#RGB`, `#RRGGBB`, or OpenCode named color tokens matching `[a-zA-Z][a-zA-Z0-9-]*`; whitespace/freeform numeric strings are rejected. `skills` uses bundled skill frontmatter names like `ce:review`; it is a shortcut that writes OpenCode `permission.skill` rules, not a native OpenCode agent field. Because `model` controls provider routing/cost/privacy and `permission`/`skills` control tool access, those fields are only accepted from user config or `$OPENCODE_CONFIG_DIR/systematic.json`. Project config may tune non-sensitive presentation and runtime fields such as `variant`, `temperature`, `top_p`, `mode`, `color`, `steps`, `hidden`, or exact-agent `disable`, but it cannot choose model/provider routing or loosen permission/capability policy.
 
-Systematic separates config-source precedence from overlay precedence. Config files merge in this order: user config, project config, then `$OPENCODE_CONFIG_DIR/systematic.json` if set. Higher-priority `agents.<key>` and `categories.<id>` entries replace lower-priority entries wholesale, while unrelated keys survive. Project overlays are the exception for security fields: same-key project overlays preserve user-level `permission` and `skills` fields instead of erasing them. After the effective config is built, exact `agents` overlays beat category overlays, which beat built-in policy defaults, bundled markdown defaults, and OpenCode inherited defaults.
+Systematic separates config-source precedence from overlay precedence. Config files merge in this order: user config, project config, then `$OPENCODE_CONFIG_DIR/systematic.json` if set. Higher-priority `agents.<key>` and `categories.<id>` entries replace lower-priority entries wholesale, while unrelated keys survive. Project overlays are the exception for trust-sensitive fields: same-key project overlays preserve user-level `model`, `permission`, and `skills` fields instead of erasing them. After the effective config is built, exact `agents` overlays beat category overlays, which beat built-in policy defaults, bundled markdown defaults, and OpenCode inherited defaults.
 
-Bundled agents omit `model` by default so OpenCode model inheritance keeps working. Systematic emits a `model` only when you configure one explicitly; provider-specific zero-config model defaults are intentionally deferred.
+Bundled agents omit `model` by default so OpenCode model inheritance keeps working. Systematic emits a `model` only when you configure one explicitly in user or custom config; provider-specific zero-config model defaults are intentionally deferred.
 
 Native OpenCode agents with the same emitted key are full replacements. An exact Systematic overlay for that key conflicts, while category overlays skip native replacements and continue applying to other bundled agents. Use one canonical agent key form across config sources (`security-sentinel` or `review/security-sentinel`) because alias collisions fail duplicate-target validation.
 

--- a/docs/plans/2026-05-09-002-feat-provider-model-mcp-overlays-plan.md
+++ b/docs/plans/2026-05-09-002-feat-provider-model-mcp-overlays-plan.md
@@ -1,0 +1,443 @@
+---
+title: feat: Add Provider Model Defaults and MCP Overlays
+type: feat
+status: active
+date: 2026-05-09
+origin: docs/plans/2026-05-09-001-feat-agent-model-configuration-plan.md
+---
+
+# feat: Add Provider Model Defaults and MCP Overlays
+
+## Overview
+
+Build the deferred second layer on top of merged agent configuration overlays through separate, safer follow-up PRs:
+
+1. harden the overlay foundation from PR #343 review findings,
+2. add explicit opt-in provider-aware model defaults,
+3. spike MCP tool inventory access before implementing any MCP allowlist shortcut,
+4. implement MCP overlays only if the spike proves final OpenCode MCP tool keys are mechanically available.
+
+The first overlay PR intentionally shipped without provider-specific zero-config model defaults or `mcps` shortcuts because the safe OpenCode mapping was not proven at planning time. Follow-up research against OpenCode source clarifies some constraints: plugin `config(cfg)` runs after provider hooks/config assembly, permission rules are evaluated with last-match semantics, and MCP executable tool keys come from `mcp.tools()` as sanitized `<server>_<tool>` keys. It does **not** prove that Systematic's config hook can access final MCP tool inventory; that remains a blocking spike before any MCP permission emission.
+
+## Problem Frame
+
+Systematic users can now tune bundled agents through top-level `agents` and `categories` overlays, but two high-value knobs remain deferred:
+
+- Provider-specific model defaults can specialize agents, but silently emitting model choices because a provider exists would surprise users and may change cost, privacy, latency, and data-routing behavior.
+- MCP allowlists can narrow agent capabilities, but they must map to real OpenCode permission keys rather than inert metadata or guessed server-prefix patterns.
+
+The follow-up should add these only where user intent is explicit and the runtime contract is mechanical and testable. It should also fold in the approved non-blocking concerns from PR #343 while the overlay code is still fresh.
+
+## Requirements Trace
+
+- R1. Preserve bundled agent markdown portability: no `model:` frontmatter in bundled agent files.
+- R2. Treat model selection as trust-sensitive because it affects cost, privacy, data routing, and provider choice.
+- R3. Project `.opencode/systematic.json` must not be able to set or erase higher-trust `model`, `permission`, `skills`, `mcps`, or provider-default policy fields.
+- R4. Provider-specific built-in model defaults must be explicit opt-in through a Systematic config surface; configured OpenCode providers alone are not consent.
+- R5. Provider defaults may emit model values only when the selected provider is configured in OpenCode config and has a known Systematic model-default table.
+- R6. Ambiguous provider situations must fail closed: when more than one candidate provider is configured and no explicit Systematic provider-default selection exists, omit built-in model defaults and inherit.
+- R7. Explicit user/custom `agents.<key>.model` and `categories.<id>.model` remain structurally validated but not availability-validated; OpenCode owns runtime behavior for explicit user choices.
+- R8. Add `mcps` as a Systematic-managed capability shortcut only if implementation can access or derive final OpenCode MCP tool keys mechanically before emitting config.
+- R9. If final MCP tool keys are unavailable during config handling, defer MCP overlays rather than emitting wildcard or guessed prefix rules.
+- R10. `mcps` semantics, if shipped, are restrictive allowlists: omitted means inherit weaker behavior, `mcps: []` means deny configured MCP tools, and `mcps: ["server"]` means only the listed servers' tools are allowed from that layer.
+- R11. MCP overlays, if shipped, must be security-sensitive like `permission` and `skills`; project config must not loosen or erase higher-trust MCP policy.
+- R12. Preserve permission rule ordering: weaker layers first, stronger layers later, because OpenCode permission evaluation uses last matching rule.
+- R13. Validate unknown MCP server names, disabled MCP servers, sanitized key collisions, malformed overlay values, and cross-layer permission conflicts before mutating OpenCode config.
+- R14. Keep docs explicit that provider defaults and MCP overlays are configuration-time conveniences, not bundled frontmatter, runtime fallback chains, or native `agent.mcps` fields.
+- R15. Address PR #343 non-blocking hardening where cheap: color validation/docs, temperature default tests, permission-ordering comments, and category `hidden` coverage.
+
+## Scope Boundaries
+
+- No runtime fallback manager, retry chain, or provider failover orchestration.
+- No provider default emitted solely from provider detection; explicit Systematic opt-in is required.
+- No MCP server installation or bundling. Users still configure MCP servers in OpenCode.
+- No MCP overlay implementation unless final MCP tool keys are mechanically available during config handling or through a stable OpenCode API.
+- No wildcard/prefix MCP permission grants unless a proof test shows OpenCode permission semantics make them safe against key collisions and future-tool privilege expansion.
+- No native bundled agent `model:` frontmatter.
+- No prompt/description/options overlay expansion.
+- No attempt to validate explicit user model IDs against live provider APIs.
+
+### Deferred to Separate Tasks
+
+- Runtime model fallback chains: separate design if OpenCode exposes a first-class fallback config surface.
+- MCP tool-level allowlists: this plan only considers whole-server allowlists after final tool-key inventory is available.
+- MCP overlays themselves are deferred if the spike cannot prove safe inventory access.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/lib/agent-overlays.ts` owns overlay field validation, bundled-agent inventory, exact/category resolution, and built-in temperature defaults.
+- `src/lib/config-handler.ts` applies overlays to OpenCode `config.agent` and translates managed `skills` into `permission.skill` rules.
+- `src/lib/config.ts` merges sourced `agents`/`categories` overlays and protects security-sensitive overlay fields from project config.
+- `scripts/content-integrity.ts` enforces bundled agent `model:` bans and duplicate bundled agent stem checks.
+- `tests/unit/agent-overlays.test.ts`, `tests/unit/config-handler.test.ts`, and `tests/unit/config.test.ts` cover overlay validation, permission ordering, and source trust behavior.
+
+### Institutional Learnings
+
+- Bundled agents must stay model-free; hard-coded frontmatter `model` values hurt portability and have broken older OpenCode versions.
+- Config-hook logic must be non-destructive and singleton-safe; overlay mutation should stage local copies and assign only after validation succeeds.
+- Prompt-only capability policy is insufficient. Permission-affecting behavior needs explicit OpenCode permission rules and tests.
+- MCP references must resolve to configured capabilities rather than markdown references or assumed servers.
+
+### OpenCode Source Findings
+
+- Plugin config hooks run after provider hooks/config assembly, so `cfg.provider` can be inspected during `config(cfg)`. This is not consent to select a model provider.
+- OpenCode agent config supports `model` and `permission`; runtime agent models are provider/model pairs.
+- Permission config normalizes shorthand into rules; runtime evaluation uses wildcard matching and `findLast`, so later rules override earlier rules.
+- OpenCode MCP tool execution uses the final `mcp.tools()` key map. Exposed keys are sanitized as `<server>_<tool>` with non-alphanumeric, non-underscore, non-hyphen characters converted to `_`.
+- OpenCode source also has an internal MCP cache path using `server:tool`; permission mapping should target the final `mcp.tools()` key only if Systematic can access that final map or reproduce it with proven inputs.
+
+### Fro Bot PR #343 Non-Blocking Concerns
+
+- `isOpenCodeColor` accepts any alphabetic-starting string and may accept invalid-looking values.
+- `validatePositiveInteger` has an unnecessary cast.
+- Alias collisions across sources are intentionally caught at plugin load, but this should remain documented behavior.
+- `inferBuiltInTemperature` is implicit regex behavior and lacks branch tests.
+- Permission ordering relies on Map insertion order; this is correct but deserves a maintenance comment.
+- Missing tests: temperature branches, color edge cases, and category `hidden` acceptance.
+
+## Key Technical Decisions
+
+- **Split delivery into separate PRs.** Hardening, provider defaults, MCP spike, and MCP implementation have different risk profiles and should not block each other.
+- **Model routing is trust-sensitive.** Add `model` and provider-default policy fields to the protected overlay field set so project config cannot steer provider/model choices without user/custom config consent.
+- **Provider defaults are explicit opt-in.** Add a small Systematic config surface such as `agent_defaults.model_provider: "openai"` to select a provider for built-in agent model defaults. Exact final naming can change during implementation, but the config must be top-level, source-aware, and protected from project config.
+- **No automatic provider choice from detection alone.** Provider detection only validates that an explicitly selected provider appears configured. Multiple configured providers are not resolved by preference order unless the user/custom config selects one.
+- **Explicit model overlays remain pass-through.** User/custom model overlays are structurally validated and emitted unchanged; Systematic does not ping provider APIs or rewrite explicit values.
+- **MCP overlays require a spike gate.** Do not implement `mcps` until a spike proves access to final MCP tool keys or a stable equivalent during config handling.
+- **No wildcard MCP grants by default.** Prefix/wildcard rules can expand privileges via future tools or sanitized key collisions. Prefer enumerated concrete keys; if enumeration is impossible, defer.
+- **MCP overlays are restrictive allowlists.** If shipped, `mcps` should deny all configured MCP tool keys first, then allow concrete keys for selected servers, ordered so stronger layers win.
+- **Same-layer and cross-layer policy conflicts need explicit rules.** Reject same-overlay ambiguity between managed `mcps` and explicit MCP tool permissions. Define and test cross-layer ordering for explicit permissions versus managed shortcuts.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Can provider configuration be inspected in the plugin config hook?** Yes, OpenCode source shows provider hooks/config are applied before plugin `config(cfg)`, so configured provider IDs can be inspected. This does not justify implicit model defaults.
+- **Which MCP key shape should permissions target?** Target the final `mcp.tools()` output key, sanitized as `<server>_<tool>`, but only if final keys are actually available or derivable with collision checks.
+- **Do permission rules support override ordering?** Yes, runtime evaluation uses last matching rule.
+- **Should provider defaults and MCP overlays ship together?** No. They are independent and should be split to avoid coupling lower-risk model-default work to security-sensitive MCP work.
+
+### Deferred to Implementation
+
+- **Exact OpenCode `cfg.provider` object shape:** Confirm against installed types/source during implementation and keep model-default inference conservative.
+- **Exact protected config field shape:** Choose final field names for provider-default opt-in while preserving the policy in this plan.
+- **MCP inventory feasibility:** Prove whether final `mcp.tools()` keys are accessible or mechanically derivable during config handling. If not, stop before implementing `mcps`.
+- **Default model table:** Define a small provider/model table during provider-default implementation, with tests and docs. Keep the first table conservative.
+
+## Phased Delivery
+
+### PR 1: Overlay hardening
+
+Addresses Fro Bot NBCs and trust-boundary tightening with minimal product surface change.
+
+### PR 2: Explicit provider model defaults
+
+Adds opt-in provider-default policy and built-in model table without MCP changes.
+
+### PR 3: MCP inventory spike
+
+Proves or disproves safe access to final MCP tool keys and permission matching behavior.
+
+### PR 4: MCP overlays, only if PR 3 succeeds
+
+Implements restrictive `mcps` allowlists using concrete MCP tool keys and collision-safe validation.
+
+## Implementation Units
+
+- [ ] **Unit 1: Harden existing overlay validators and trust fields**
+
+**Goal:** Address PR #343 non-blocking concerns and protect model-routing fields from project config.
+
+**Requirements:** R2, R3, R15
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `src/lib/agent-overlays.ts`
+- Modify: `src/lib/config-handler.ts`
+- Modify: `src/lib/config.ts`
+- Modify: `README.md`
+- Modify: `docs/src/content/docs/getting-started/configuration.mdx`
+- Test: `tests/unit/agent-overlays.test.ts`
+- Test: `tests/unit/config-handler.test.ts`
+- Test: `tests/unit/config.test.ts`
+
+**Approach:**
+- Remove the unnecessary numeric cast in positive integer validation.
+- Add an inline comment around `permissionFromRules`/`setPermissionRule` documenting the Map insertion-order contract and OpenCode last-match permission semantics.
+- Add branch coverage for `inferBuiltInTemperature` values: low review/security, planning/research, docs/writing, creative/design, and fallback.
+- Add color edge-case tests. If tightening validation, keep it aligned with OpenCode accepted values; otherwise document the intentionally permissive name behavior in code and docs.
+- Add category-level `hidden` acceptance coverage.
+- Add `model` to the protected overlay fields in `src/lib/config.ts`, preserving higher-trust model policy across project same-key overlays and rejecting project-level model overlays.
+- Document that project config can tune non-sensitive presentation/runtime fields but cannot choose model/provider or permission/capability policy.
+
+**Patterns to follow:**
+- Existing tests in `tests/unit/agent-overlays.test.ts` for validation error messages and accepted fields.
+- Existing source-trust tests in `tests/unit/config.test.ts`.
+- Existing permission ordering tests in `tests/unit/config-handler.test.ts`.
+
+**Test scenarios:**
+- Happy path: `hidden` is accepted in a category overlay.
+- Edge case: color rejects empty, whitespace-prefixed, and purely numeric values.
+- Edge case: all temperature heuristic branches return expected values.
+- Security path: project config containing `model` is rejected.
+- Security path: project same-key overlay cannot erase user/custom `model` policy.
+- Maintenance path: permission ordering test still proves stronger rules win.
+
+**Verification:**
+- Overlay unit tests cover Fro Bot's missing-test list.
+- Project config cannot steer model/provider routing.
+- Bundled agent `model:` content-integrity ban remains intact.
+
+- [ ] **Unit 2: Add explicit provider-default opt-in**
+
+**Goal:** Add provider-aware built-in model defaults without silent zero-config provider selection.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7, R14
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `src/lib/agent-overlays.ts`
+- Modify: `src/lib/config-handler.ts`
+- Modify: `src/lib/config.ts`
+- Test: `tests/unit/agent-overlays.test.ts`
+- Test: `tests/unit/config-handler.test.ts`
+- Test: `tests/unit/config.test.ts`
+
+**Approach:**
+- Add a source-aware Systematic provider-default config surface, tentatively `agent_defaults.model_provider`.
+- Protect the provider-default field from project config, same as `model`, `permission`, `skills`, and later `mcps`.
+- Add a provider-default resolver beside `inferBuiltInTemperature`, but keep it separate so temperature defaults remain provider-independent.
+- Emit built-in model defaults only when user/custom config explicitly selects a provider and OpenCode config contains that provider.
+- Preserve precedence: explicit exact overlay model > explicit category overlay model > safe opt-in provider default > markdown/inheritance.
+- Omit model defaults when the selected provider is absent, when provider config shape is unknown, or when no provider-default policy is set.
+- Do not rewrite explicit user model values and do not probe remote provider APIs.
+
+**Patterns to follow:**
+- `inferBuiltInTemperature` and overlay application flow in `src/lib/agent-overlays.ts` and `src/lib/config-handler.ts`.
+- Source-aware overlay merge logic in `src/lib/config.ts`.
+
+**Test scenarios:**
+- Happy path: user/custom config selects provider `openai`, OpenCode config contains `provider.openai`, and an agent with no explicit model receives a known built-in model default.
+- Happy path: exact agent `model` overrides category and provider defaults.
+- Happy path: category `model` overrides provider defaults.
+- Edge case: no provider-default policy leaves `model` omitted even when OpenCode has configured providers.
+- Edge case: selected provider missing from OpenCode config leaves `model` omitted or fails with a clear validation error; choose one behavior and document it before implementation.
+- Edge case: multiple providers configured without explicit provider-default policy leaves `model` omitted.
+- Security path: project config cannot set or erase provider-default policy.
+- Error path: malformed explicit model still fails structural validation.
+- Integration: emitted agent config never comes from bundled agent frontmatter.
+
+**Verification:**
+- Zero-config environments still inherit models.
+- Provider defaults require explicit user/custom opt-in.
+- Bundled agent `model:` content-integrity ban remains intact.
+
+- [ ] **Unit 3: Document provider model defaults**
+
+**Goal:** Update docs for explicit provider-default behavior before starting MCP work.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7, R14
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/src/content/docs/getting-started/configuration.mdx`
+
+**Approach:**
+- Document provider-aware model defaults as opt-in and conservative.
+- Document that configured OpenCode providers alone do not change model inheritance.
+- Document that explicit user/custom model overlays are passed through structurally and may still fail at OpenCode runtime if the provider/model is unavailable.
+- Document project-config restrictions for `model`, provider defaults, `permission`, and `skills`.
+
+**Patterns to follow:**
+- Existing agent overlay docs added by PR #343.
+
+**Test scenarios:**
+- Test expectation: none -- documentation-only changes. Existing docs build verifies syntax and generated site integrity.
+
+**Verification:**
+- Docs clearly distinguish inherited models, opt-in provider defaults, and explicit user overrides.
+
+- [ ] **Unit 4: Spike MCP tool-key inventory and permission safety**
+
+**Goal:** Prove whether MCP overlays can be implemented safely in Systematic's config hook.
+
+**Requirements:** R8, R9, R10, R11, R12, R13, R14
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `tests/manual/mcp-permission-key-probe.ts` *(or equivalent manual probe artifact if automated tests are impractical)*
+- Modify: `docs/plans/2026-05-09-002-feat-provider-model-mcp-overlays-plan.md` *(only to record spike result before continuing)*
+
+**Approach:**
+- Verify whether the plugin `config(cfg)` hook can access final MCP tool keys or only server definitions.
+- Verify the installed OpenCode permission evaluator accepts the intended concrete tool keys and last-match rule ordering.
+- Verify sanitized key collisions can be detected before emitting permissions.
+- Verify disabled MCP servers are distinguishable and should be rejected or treated as absent.
+- Do not implement `mcps` overlay support in this unit.
+
+**Patterns to follow:**
+- Manual probe style from `tests/manual/companion-aware-probe.ts`.
+- Existing empirical probe workflow in project memories for OpenCode plugin behavior.
+
+**Test scenarios:**
+- Spike path: configured MCP server with known tools exposes final keys available to plugin code, or proves they are unavailable.
+- Spike path: disabled server is distinguishable from enabled server.
+- Spike path: two sanitized names that would collide are detected or proven impossible through OpenCode validation.
+- Spike path: permission evaluator uses last matching rule for concrete MCP tool keys.
+
+**Verification:**
+- If final tool keys are available or mechanically derivable, document the exact source and continue to Unit 5.
+- If final tool keys are not available, stop: leave `mcps` deferred and do not ship guessed wildcard behavior.
+
+- [ ] **Unit 5: Add MCP server allowlist overlays**
+
+**Goal:** Support restrictive `mcps` overlays by translating configured MCP server allowlists into permission rules for concrete final OpenCode MCP tool keys.
+
+**Requirements:** R8, R10, R11, R12, R13, R14
+
+**Dependencies:** Unit 4 succeeds
+
+**Files:**
+- Modify: `src/lib/agent-overlays.ts`
+- Modify: `src/lib/config-handler.ts`
+- Modify: `src/lib/config.ts`
+- Test: `tests/unit/agent-overlays.test.ts`
+- Test: `tests/unit/config-handler.test.ts`
+- Test: `tests/unit/config.test.ts`
+
+**Approach:**
+- Add `mcps` to the overlay allow-list as an array of configured MCP server IDs only after the spike proves final key inventory.
+- Build MCP inventory from the proven source, not from guessed server prefixes.
+- Reject disabled MCP servers and unknown MCP server IDs.
+- Detect sanitized key collisions before emitting rules.
+- Translate `mcps` into concrete permission rules for final MCP tool keys. Deny all configured MCP tool keys first, then allow keys for selected server IDs.
+- Preserve weaker-to-stronger layer ordering so exact overlays override category/default rules.
+- Reject same-overlay ambiguity where an overlay sets both managed `mcps` and explicit permission entries targeting MCP tool keys.
+- Define and test cross-layer behavior for managed `mcps` versus explicit MCP permissions. Explicit higher-trust user/custom denies must not be silently loosened by generated rules.
+- Add `mcps` to protected overlay fields so project config cannot set or erase MCP policy.
+
+**Patterns to follow:**
+- Managed `skills` shortcut in `src/lib/config-handler.ts`.
+- Project security overlay restrictions in `src/lib/config.ts`.
+- Spike results from Unit 4.
+
+**Test scenarios:**
+- Happy path: `mcps: ["context7"]` emits deny rules for configured MCP keys followed by allows for concrete `context7` tool keys.
+- Happy path: category allows MCP A/B and exact allows only A; exact-layer rules win by order.
+- Edge case: empty `mcps: []` denies all configured MCP tool keys.
+- Edge case: omitted `mcps` inherits weaker-layer MCP rules.
+- Edge case: disabled MCP server is rejected or treated as absent according to Unit 4 decision.
+- Error path: unknown MCP server ID fails before mutating config.
+- Error path: sanitized key collision fails fast.
+- Error path: project config containing `mcps` is rejected.
+- Error path: project same-key overlay cannot erase user/custom `mcps` policy.
+- Error path: same overlay object with managed `mcps` and explicit MCP tool permission fails.
+- Error path: cross-layer explicit deny is not loosened by lower-trust or weaker-layer managed `mcps`.
+- Integration: invalid MCP overlay leaves `config.agent`, `config.command`, `config.skills.paths`, and `config.mcp` unmodified.
+
+**Verification:**
+- Unit and integration tests prove MCP overlay emission uses concrete final MCP tool keys and last-match ordering.
+- No `agent.mcps` field is emitted.
+
+- [ ] **Unit 6: Document MCP overlays**
+
+**Goal:** Update docs for restrictive MCP allowlists only if MCP overlays ship.
+
+**Requirements:** R8, R10, R11, R12, R13, R14
+
+**Dependencies:** Unit 5
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/src/content/docs/getting-started/configuration.mdx`
+
+**Approach:**
+- Document `mcps` as a Systematic permission shortcut, not a native OpenCode agent field.
+- Show examples for omitted `mcps`, `mcps: []`, and `mcps: ["context7"]`.
+- Make restrictive semantics explicit: selected servers narrow available MCP tools at that layer.
+- Document project-config restrictions for `mcps`.
+- Document that MCP servers must already be configured in OpenCode.
+
+**Patterns to follow:**
+- Existing agent overlay and skills allowlist docs.
+
+**Test scenarios:**
+- Test expectation: none -- documentation-only changes. Existing docs build verifies syntax and generated site integrity.
+
+**Verification:**
+- Docs do not imply Systematic installs MCP servers or emits native `agent.mcps` fields.
+
+- [ ] **Unit 7: Final integrity and release safety checks**
+
+**Goal:** Ensure each shipped PR preserves package invariants.
+
+**Requirements:** R1, R3, R11, R12, R13, R14
+
+**Dependencies:** Relevant implementation/docs units for each PR
+
+**Files:**
+- Modify: `scripts/content-integrity.ts` *(only if new static invariants need checks)*
+- Test: `tests/unit/content-integrity.test.ts` *(only if integrity checks change)*
+
+**Approach:**
+- Keep the bundled-agent `model:` ban unchanged.
+- Add content-integrity coverage only for static invariants that cannot be caught by runtime tests.
+- Run the full project verification suite and docs/registry drift checks for each PR.
+
+**Patterns to follow:**
+- Existing content-integrity checks for model bans and duplicate agent stems.
+
+**Test scenarios:**
+- Content-integrity path: bundled agent `model:` remains rejected.
+- Content-integrity path: any new static invariant introduced by this follow-up has a failing fixture/test.
+
+**Verification:**
+- Build, typecheck, lint, tests, docs build, content integrity, registry drift, and registry validation all pass.
+
+## System-Wide Impact
+
+- **Interaction graph:** Systematic config loading feeds overlay validation, bundled agent emission, and OpenCode permission evaluation. Provider defaults depend on source-aware Systematic config plus incoming OpenCode provider config. MCP overlay behavior depends on final MCP tool inventory if available.
+- **Error propagation:** Invalid overlay config should fail fast during plugin config handling with source-path and key-path context. Explicit user model availability remains an OpenCode runtime concern.
+- **State lifecycle risks:** Config mutation must remain atomic; invalid provider/MCP overlays must not partially mutate `config.agent`, `config.command`, `config.skills`, or `config.mcp`.
+- **API surface parity:** Exact agent overlays and category overlays need matching behavior for `model` and `mcps`, except exact-only fields such as `disable` remain exact-only.
+- **Integration coverage:** Unit tests should cover validation, but config-handler tests must prove emitted OpenCode config shape and permission ordering. MCP needs a spike/probe before unit tests can safely assert emitted permissions.
+- **Unchanged invariants:** Bundled agents remain model-free; project config remains lower trust for provider/model and permission-affecting fields; registry generation should not change unless docs/assets inputs change.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Provider defaults surprise users by changing model inheritance | Require explicit user/custom provider-default opt-in; configured providers alone do not select models. |
+| Project config routes prompts to a different provider | Treat `model` and provider-default policy as protected fields. |
+| Provider config shape differs across OpenCode versions | Keep resolver conservative and covered by tests; unknown shapes produce no default. |
+| Multiple configured providers create arbitrary selection | Omit model defaults unless user/custom config chooses a provider. |
+| MCP key mapping is unavailable in config hook | Spike first; if final keys are unavailable, keep `mcps` deferred. |
+| Wildcard MCP grants expand privileges through future tools | Prefer enumerated concrete keys; do not ship guessed prefix grants. |
+| Sanitized MCP key collisions cross server boundaries | Detect collisions before emitting rules. |
+| Permission order regresses | Add explicit comments and tests around last-match semantics. |
+| Temperature heuristics stay too implicit | Add branch tests and an inline reference table/comment. |
+
+## Documentation / Operational Notes
+
+- This is a developer-facing config feature with no persistent production service.
+- Provider-default PR notes should emphasize explicit opt-in and project-config restrictions.
+- MCP PR notes should emphasize restrictive allowlist semantics and that MCP servers must already be configured in OpenCode.
+- PR descriptions should include post-merge validation notes to watch plugin load failures, overlay config issues, provider routing surprises, and MCP permission reports in GitHub issues/PR comments.
+
+## Sources & References
+
+- Origin plan: `docs/plans/2026-05-09-001-feat-agent-model-configuration-plan.md`
+- Merged PR: https://github.com/marcusrbrown/systematic/pull/343
+- Fro Bot review: https://github.com/marcusrbrown/systematic/pull/343#pullrequestreview-4257599753
+- Related code: `src/lib/agent-overlays.ts`
+- Related code: `src/lib/config-handler.ts`
+- Related code: `src/lib/config.ts`
+- Related tests: `tests/unit/agent-overlays.test.ts`
+- Related tests: `tests/unit/config-handler.test.ts`
+- Related tests: `tests/unit/config.test.ts`

--- a/docs/plans/2026-05-09-002-feat-provider-model-mcp-overlays-plan.md
+++ b/docs/plans/2026-05-09-002-feat-provider-model-mcp-overlays-plan.md
@@ -103,7 +103,7 @@ These are source-configured defaults for the next PR. They should live in one au
 | `review` | `anthropic/claude-opus-4.7` | `openai/gpt-5.5`, `opencode-go/deepseek-v4-pro`, `google/gemini-3.1-pro` | Code/security review and adversarial reasoning favor highest signal, with OpenCode Go coding-model fallback. |
 | `workflow` | `openai/gpt-5.4-mini` | `opencode-go/deepseek-v4-flash`, `opencode/gpt-5-nano`, `google/gemini-3-flash` | Orchestration should start cheap/fast and tolerate transient outages with fast OpenCode/OpenCode Go fallbacks. |
 
-### Fro Bot PR #343 Non-Blocking Concerns
+### Prior PR Non-Blocking Concerns
 
 - `isOpenCodeColor` accepts any alphabetic-starting string and may accept invalid-looking values.
 - `validatePositiveInteger` has an unnecessary cast.
@@ -148,7 +148,7 @@ These are source-configured defaults for the next PR. They should live in one au
 
 ### PR 1: Overlay hardening
 
-Addresses Fro Bot NBCs and trust-boundary tightening with minimal product surface change.
+Addresses prior non-blocking review concerns and trust-boundary tightening with minimal product surface change.
 
 ### PR 2: Source category model defaults with fallbacks
 
@@ -205,7 +205,7 @@ Implements restrictive `mcps` allowlists using concrete MCP tool keys and collis
 - Maintenance path: permission ordering test still proves stronger rules win.
 
 **Verification:**
-- Overlay unit tests cover Fro Bot's missing-test list.
+- Overlay unit tests cover the prior missing-test list.
 - Project config cannot steer model/provider routing.
 - Bundled agent `model:` content-integrity ban remains intact.
 
@@ -456,7 +456,6 @@ Implements restrictive `mcps` allowlists using concrete MCP tool keys and collis
 
 - Origin plan: `docs/plans/2026-05-09-001-feat-agent-model-configuration-plan.md`
 - Merged PR: https://github.com/marcusrbrown/systematic/pull/343
-- Fro Bot review: https://github.com/marcusrbrown/systematic/pull/343#pullrequestreview-4257599753
 - Related code: `src/lib/agent-overlays.ts`
 - Related code: `src/lib/config-handler.ts`
 - Related code: `src/lib/config.ts`

--- a/docs/plans/2026-05-09-002-feat-provider-model-mcp-overlays-plan.md
+++ b/docs/plans/2026-05-09-002-feat-provider-model-mcp-overlays-plan.md
@@ -1,55 +1,55 @@
 ---
-title: feat: Add Provider Model Defaults and MCP Overlays
+title: feat: Add Source Model Defaults and MCP Overlays
 type: feat
 status: active
 date: 2026-05-09
 origin: docs/plans/2026-05-09-001-feat-agent-model-configuration-plan.md
 ---
 
-# feat: Add Provider Model Defaults and MCP Overlays
+# feat: Add Source Model Defaults and MCP Overlays
 
 ## Overview
 
 Build the deferred second layer on top of merged agent configuration overlays through separate, safer follow-up PRs:
 
 1. harden the overlay foundation from PR #343 review findings,
-2. add explicit opt-in provider-aware model defaults,
+2. add source-configured category model defaults with `fallback_models`,
 3. spike MCP tool inventory access before implementing any MCP allowlist shortcut,
 4. implement MCP overlays only if the spike proves final OpenCode MCP tool keys are mechanically available.
 
-The first overlay PR intentionally shipped without provider-specific zero-config model defaults or `mcps` shortcuts because the safe OpenCode mapping was not proven at planning time. Follow-up research against OpenCode source clarifies some constraints: plugin `config(cfg)` runs after provider hooks/config assembly, permission rules are evaluated with last-match semantics, and MCP executable tool keys come from `mcp.tools()` as sanitized `<server>_<tool>` keys. It does **not** prove that Systematic's config hook can access final MCP tool inventory; that remains a blocking spike before any MCP permission emission.
+The first overlay PR intentionally shipped without provider-specific zero-config model defaults or `mcps` shortcuts because the safe OpenCode mapping was not proven at planning time. The required follow-up is now explicit: Systematic should ship source-configured default `model` plus ordered `fallback_models` per bundled agent category, applied when users have not provided exact/category model overrides. OpenCode core docs/schema do not document native `fallback_models`, while oh-my-opencode-slim and Magic Context demonstrate plugin-managed fallback chains; Systematic must therefore implement or verify a real fallback mechanism rather than emitting inert fields. Follow-up research against OpenCode source also clarifies MCP constraints: plugin `config(cfg)` runs after provider hooks/config assembly, permission rules are evaluated with last-match semantics, and MCP executable tool keys come from `mcp.tools()` as sanitized `<server>_<tool>` keys. It does **not** prove that Systematic's config hook can access final MCP tool inventory; that remains a blocking spike before any MCP permission emission.
 
 ## Problem Frame
 
 Systematic users can now tune bundled agents through top-level `agents` and `categories` overlays, but two high-value knobs remain deferred:
 
-- Provider-specific model defaults can specialize agents, but silently emitting model choices because a provider exists would surprise users and may change cost, privacy, latency, and data-routing behavior.
+- Source-configured provider/model defaults can specialize agents immediately after install, but must include explicit fallback chains and remain overrideable by user/custom config because they affect cost, privacy, latency, and data-routing behavior.
 - MCP allowlists can narrow agent capabilities, but they must map to real OpenCode permission keys rather than inert metadata or guessed server-prefix patterns.
 
-The follow-up should add these only where user intent is explicit and the runtime contract is mechanical and testable. It should also fold in the approved non-blocking concerns from PR #343 while the overlay code is still fresh.
+The follow-up should add source-owned category defaults intentionally, not by opportunistic provider detection, and only ship fallback behavior when the runtime contract is mechanical and testable. It should also fold in the approved non-blocking concerns from PR #343 while the overlay code is still fresh.
 
 ## Requirements Trace
 
 - R1. Preserve bundled agent markdown portability: no `model:` frontmatter in bundled agent files.
 - R2. Treat model selection as trust-sensitive because it affects cost, privacy, data routing, and provider choice.
-- R3. Project `.opencode/systematic.json` must not be able to set or erase higher-trust `model`, `permission`, `skills`, `mcps`, or provider-default policy fields.
-- R4. Provider-specific built-in model defaults must be explicit opt-in through a Systematic config surface; configured OpenCode providers alone are not consent.
-- R5. Provider defaults may emit model values only when the selected provider is configured in OpenCode config and has a known Systematic model-default table.
-- R6. Ambiguous provider situations must fail closed: when more than one candidate provider is configured and no explicit Systematic provider-default selection exists, omit built-in model defaults and inherit.
-- R7. Explicit user/custom `agents.<key>.model` and `categories.<id>.model` remain structurally validated but not availability-validated; OpenCode owns runtime behavior for explicit user choices.
+- R3. Project `.opencode/systematic.json` must not be able to set or erase higher-trust `model`, `permission`, `skills`, `mcps`, or model-default policy fields.
+- R4. Systematic must ship source-configured default `model` plus ordered `fallback_models` for each bundled agent category: `design`, `docs`, `document-review`, `research`, `review`, and `workflow`.
+- R5. Source-configured category defaults apply automatically when there is no stronger exact/category user/custom model override; bundled markdown remains model-free.
+- R6. `fallback_models` must be real runtime behavior through a verified OpenCode-compatible config field or a separately planned runtime interception architecture. The next implementation PR must not emit inert fallback metadata; if native support is not proven, stop after the spike and update the plan instead of building an unbounded fallback manager.
+- R7. Explicit user/custom `agents.<key>.model`, `categories.<id>.model`, and future explicit `fallback_models` overrides remain structurally validated but not availability-validated; user/custom config owns those choices. A stronger explicit `model` without same-layer `fallback_models` suppresses weaker source fallback chains so source defaults cannot route fallback traffic after a user-selected primary model.
 - R8. Add `mcps` as a Systematic-managed capability shortcut only if implementation can access or derive final OpenCode MCP tool keys mechanically before emitting config.
 - R9. If final MCP tool keys are unavailable during config handling, defer MCP overlays rather than emitting wildcard or guessed prefix rules.
 - R10. `mcps` semantics, if shipped, are restrictive allowlists: omitted means inherit weaker behavior, `mcps: []` means deny configured MCP tools, and `mcps: ["server"]` means only the listed servers' tools are allowed from that layer.
 - R11. MCP overlays, if shipped, must be security-sensitive like `permission` and `skills`; project config must not loosen or erase higher-trust MCP policy.
 - R12. Preserve permission rule ordering: weaker layers first, stronger layers later, because OpenCode permission evaluation uses last matching rule.
 - R13. Validate unknown MCP server names, disabled MCP servers, sanitized key collisions, malformed overlay values, and cross-layer permission conflicts before mutating OpenCode config.
-- R14. Keep docs explicit that provider defaults and MCP overlays are configuration-time conveniences, not bundled frontmatter, runtime fallback chains, or native `agent.mcps` fields.
+- R14. Keep docs explicit that source model defaults and MCP overlays are configuration-time conveniences, not bundled frontmatter or native `agent.mcps` fields. For `fallback_models`, docs must state whether Systematic implements fallback behavior itself or delegates to a verified OpenCode field.
 - R15. Address PR #343 non-blocking hardening where cheap: color validation/docs, temperature default tests, permission-ordering comments, and category `hidden` coverage.
 
 ## Scope Boundaries
 
-- No runtime fallback manager, retry chain, or provider failover orchestration.
-- No provider default emitted solely from provider detection; explicit Systematic opt-in is required.
+- No provider default emitted solely from provider detection; defaults come from a reviewed source table, not from opportunistic local provider discovery.
+- No inert `fallback_models` metadata. If OpenCode does not support the field, a Systematic-owned fallback mechanism is required before the feature ships.
 - No MCP server installation or bundling. Users still configure MCP servers in OpenCode.
 - No MCP overlay implementation unless final MCP tool keys are mechanically available during config handling or through a stable OpenCode API.
 - No wildcard/prefix MCP permission grants unless a proof test shows OpenCode permission semantics make them safe against key collisions and future-tool privilege expansion.
@@ -59,7 +59,6 @@ The follow-up should add these only where user intent is explicit and the runtim
 
 ### Deferred to Separate Tasks
 
-- Runtime model fallback chains: separate design if OpenCode exposes a first-class fallback config surface.
 - MCP tool-level allowlists: this plan only considers whole-server allowlists after final tool-key inventory is available.
 - MCP overlays themselves are deferred if the spike cannot prove safe inventory access.
 
@@ -80,13 +79,29 @@ The follow-up should add these only where user intent is explicit and the runtim
 - Prompt-only capability policy is insufficient. Permission-affecting behavior needs explicit OpenCode permission rules and tests.
 - MCP references must resolve to configured capabilities rather than markdown references or assumed servers.
 
-### OpenCode Source Findings
+### OpenCode / Plugin Model Findings
 
+- OpenCode core docs and `https://opencode.ai/config.json` document `agent.<name>.model` but do not document native `agent.<name>.fallback_models`; treat fallback chains as plugin-managed unless implementation proves current OpenCode honors a concrete field.
+- Magic Context supports per-agent `model` plus `fallback_models: string | string[]` for internal agents, demonstrating the desired user-facing shape. Current defaults include `github-copilot/claude-sonnet-4-6`, `anthropic/claude-sonnet-4-6`, `opencode-go/minimax-m2.7`, `openai/gpt-5.4`, `openai/gpt-5.4-mini`, `google/gemini-3.1-pro`, `google/gemini-3-flash`, and `opencode/gpt-5-nano`.
+- oh-my-opencode-slim uses preset/default model maps plus plugin-managed fallback chains, demonstrating category/agent role defaults and ordered fallback behavior. Current examples include `openai/gpt-5.5`, `openai/gpt-5.4-mini`, `opencode-go/glm-5.1`, `opencode-go/deepseek-v4-pro`, `opencode-go/minimax-m2.7`, `opencode-go/kimi-k2.6`, and `opencode-go/deepseek-v4-flash`.
 - Plugin config hooks run after provider hooks/config assembly, so `cfg.provider` can be inspected during `config(cfg)`. This is not consent to select a model provider.
 - OpenCode agent config supports `model` and `permission`; runtime agent models are provider/model pairs.
 - Permission config normalizes shorthand into rules; runtime evaluation uses wildcard matching and `findLast`, so later rules override earlier rules.
 - OpenCode MCP tool execution uses the final `mcp.tools()` key map. Exposed keys are sanitized as `<server>_<tool>` with non-alphanumeric, non-underscore, non-hyphen characters converted to `_`.
 - OpenCode source also has an internal MCP cache path using `server:tool`; permission mapping should target the final `mcp.tools()` key only if Systematic can access that final map or reproduce it with proven inputs.
+
+### Recommended Source Model Defaults
+
+These are source-configured defaults for the next PR. They should live in one audited table and be applied by bundled agent category when no stronger user/custom exact/category model override exists. Model IDs must get a final compatibility check against currently supported provider catalogs before implementation. IDs below are source-backed where they appear in OMO Slim or Magic Context; `anthropic/claude-opus-4.7` is included because the user explicitly requested current Opus-class coverage and should be verified before shipping.
+
+| Category | Default `model` | Ordered `fallback_models` | Rationale |
+|----------|-----------------|---------------------------|-----------|
+| `design` | `openai/gpt-5.5` | `anthropic/claude-opus-4.7`, `google/gemini-3.1-pro`, `opencode-go/kimi-k2.6` | High-judgment UX/product/design reasoning first, with strong cross-provider and OpenCode Go fallback. |
+| `docs` | `openai/gpt-5.4-mini` | `opencode-go/minimax-m2.7`, `google/gemini-3-flash`, `openai/gpt-5.3-codex-spark` | Cost/speed-efficient docs work first, then writing/summarization fallbacks used in current adjacent defaults. |
+| `document-review` | `anthropic/claude-opus-4.7` | `openai/gpt-5.5`, `google/gemini-3.1-pro`, `opencode-go/deepseek-v4-pro` | Nuanced critique and consistency review favor strongest reasoning, with OpenAI/Google/OpenCode Go coverage. |
+| `research` | `openai/gpt-5.5` | `anthropic/claude-opus-4.7`, `google/gemini-3.1-pro`, `opencode-go/minimax-m2.7` | Tool-heavy synthesis and citation quality first, with broad provider resilience. |
+| `review` | `anthropic/claude-opus-4.7` | `openai/gpt-5.5`, `opencode-go/deepseek-v4-pro`, `google/gemini-3.1-pro` | Code/security review and adversarial reasoning favor highest signal, with OpenCode Go coding-model fallback. |
+| `workflow` | `openai/gpt-5.4-mini` | `opencode-go/deepseek-v4-flash`, `opencode/gpt-5-nano`, `google/gemini-3-flash` | Orchestration should start cheap/fast and tolerate transient outages with fast OpenCode/OpenCode Go fallbacks. |
 
 ### Fro Bot PR #343 Non-Blocking Concerns
 
@@ -99,10 +114,11 @@ The follow-up should add these only where user intent is explicit and the runtim
 
 ## Key Technical Decisions
 
-- **Split delivery into separate PRs.** Hardening, provider defaults, MCP spike, and MCP implementation have different risk profiles and should not block each other.
-- **Model routing is trust-sensitive.** Add `model` and provider-default policy fields to the protected overlay field set so project config cannot steer provider/model choices without user/custom config consent.
-- **Provider defaults are explicit opt-in.** Add a small Systematic config surface such as `agent_defaults.model_provider: "openai"` to select a provider for built-in agent model defaults. Exact final naming can change during implementation, but the config must be top-level, source-aware, and protected from project config.
-- **No automatic provider choice from detection alone.** Provider detection only validates that an explicitly selected provider appears configured. Multiple configured providers are not resolved by preference order unless the user/custom config selects one.
+- **Split delivery into separate PRs.** Hardening, source model defaults, MCP spike, and MCP implementation have different risk profiles and should not block each other.
+- **Model routing is trust-sensitive.** Add `model` now and `fallback_models` when introduced to the protected overlay field set so project config cannot steer provider/model choices without user/custom config consent.
+- **Source defaults are intentional defaults, not provider detection.** Ship an audited source table keyed by bundled category with `model` plus ordered `fallback_models`; apply it when no stronger user/custom exact/category model override exists.
+- **Fallback behavior must be real.** OpenCode core does not document native `fallback_models`; PR 2 must first empirically verify a supported field in the installed OpenCode version. If no native field exists, stop and produce a separate runtime fallback architecture plan instead of attempting an unbounded fallback manager inside config-only overlay code.
+- **Project config cannot steer model routing.** Source defaults may route models, and user/custom config may override them, but project config remains blocked from setting or erasing `model`/`fallback_models`. Model/fallback precedence is field-aware: a stronger explicit `model` resets fallback routing unless the same stronger layer also sets `fallback_models`; a stronger `fallback_models` without `model` intentionally replaces only the fallback chain for the resolved model.
 - **Explicit model overlays remain pass-through.** User/custom model overlays are structurally validated and emitted unchanged; Systematic does not ping provider APIs or rewrite explicit values.
 - **MCP overlays require a spike gate.** Do not implement `mcps` until a spike proves access to final MCP tool keys or a stable equivalent during config handling.
 - **No wildcard MCP grants by default.** Prefix/wildcard rules can expand privileges via future tools or sanitized key collisions. Prefer enumerated concrete keys; if enumeration is impossible, defer.
@@ -113,17 +129,20 @@ The follow-up should add these only where user intent is explicit and the runtim
 
 ### Resolved During Planning
 
-- **Can provider configuration be inspected in the plugin config hook?** Yes, OpenCode source shows provider hooks/config are applied before plugin `config(cfg)`, so configured provider IDs can be inspected. This does not justify implicit model defaults.
+- **Should source-configured category model defaults ship?** Yes. The feature requires default provider/model combinations per category plus fallback chains. These defaults live outside bundled markdown and apply only when no stronger user/custom override exists.
+- **Does OpenCode natively support `fallback_models`?** Current public docs/schema do not document it. oh-my-opencode-slim and Magic Context demonstrate plugin-managed fallback chains, so Systematic must verify or implement real fallback semantics before shipping docs that promise fallback behavior.
+- **Can provider configuration be inspected in the plugin config hook?** Yes, OpenCode source shows provider hooks/config are applied before plugin `config(cfg)`, so configured provider IDs can be inspected. This may support availability checks, but the default table itself is source-configured rather than inferred from detection.
 - **Which MCP key shape should permissions target?** Target the final `mcp.tools()` output key, sanitized as `<server>_<tool>`, but only if final keys are actually available or derivable with collision checks.
 - **Do permission rules support override ordering?** Yes, runtime evaluation uses last matching rule.
-- **Should provider defaults and MCP overlays ship together?** No. They are independent and should be split to avoid coupling lower-risk model-default work to security-sensitive MCP work.
+- **Should source model defaults and MCP overlays ship together?** No. They are independent and should be split to avoid coupling lower-risk model-default work to security-sensitive MCP work.
 
 ### Deferred to Implementation
 
 - **Exact OpenCode `cfg.provider` object shape:** Confirm against installed types/source during implementation and keep model-default inference conservative.
-- **Exact protected config field shape:** Choose final field names for provider-default opt-in while preserving the policy in this plan.
+- **Exact `fallback_models` implementation hook:** Verify whether current OpenCode honors a native field. If not, defer fallback implementation to a separate runtime architecture plan; do not build a wrapper opportunistically in PR 2.
+- **Exact protected config field shape:** Choose final field names for explicit user/custom fallback overrides while preserving the policy in this plan.
 - **MCP inventory feasibility:** Prove whether final `mcp.tools()` keys are accessible or mechanically derivable during config handling. If not, stop before implementing `mcps`.
-- **Default model table:** Define a small provider/model table during provider-default implementation, with tests and docs. Keep the first table conservative.
+- **Default model table compatibility:** Before implementation, verify the recommended source table model IDs against the current provider catalogs or replace them with currently valid equivalents while preserving category intent.
 
 ## Phased Delivery
 
@@ -131,9 +150,9 @@ The follow-up should add these only where user intent is explicit and the runtim
 
 Addresses Fro Bot NBCs and trust-boundary tightening with minimal product surface change.
 
-### PR 2: Explicit provider model defaults
+### PR 2: Source category model defaults with fallbacks
 
-Adds opt-in provider-default policy and built-in model table without MCP changes.
+Adds audited category-level `model` defaults and verifies `fallback_models` support before shipping fallback behavior, without MCP changes. Docs for this behavior ship in the same PR if implementation proceeds.
 
 ### PR 3: MCP inventory spike
 
@@ -190,9 +209,9 @@ Implements restrictive `mcps` allowlists using concrete MCP tool keys and collis
 - Project config cannot steer model/provider routing.
 - Bundled agent `model:` content-integrity ban remains intact.
 
-- [ ] **Unit 2: Add explicit provider-default opt-in**
+- [ ] **Unit 2: Add source category model defaults with fallbacks**
 
-**Goal:** Add provider-aware built-in model defaults without silent zero-config provider selection.
+**Goal:** Add source-configured category `model` plus ordered `fallback_models` defaults, applied when no explicit user/custom exact/category model override exists.
 
 **Requirements:** R1, R2, R3, R4, R5, R6, R7, R14
 
@@ -207,12 +226,14 @@ Implements restrictive `mcps` allowlists using concrete MCP tool keys and collis
 - Test: `tests/unit/config.test.ts`
 
 **Approach:**
-- Add a source-aware Systematic provider-default config surface, tentatively `agent_defaults.model_provider`.
-- Protect the provider-default field from project config, same as `model`, `permission`, `skills`, and later `mcps`.
-- Add a provider-default resolver beside `inferBuiltInTemperature`, but keep it separate so temperature defaults remain provider-independent.
-- Emit built-in model defaults only when user/custom config explicitly selects a provider and OpenCode config contains that provider.
-- Preserve precedence: explicit exact overlay model > explicit category overlay model > safe opt-in provider default > markdown/inheritance.
-- Omit model defaults when the selected provider is absent, when provider config shape is unknown, or when no provider-default policy is set.
+- Add an audited source default table keyed by bundled category with `model` and ordered `fallback_models`, using the Recommended Source Model Defaults section as the starting point after final provider-catalog compatibility checks.
+- Keep bundled agent markdown model-free; apply source defaults in the default-resolution layer between built-in temperature defaults and inherited OpenCode defaults.
+- Protect user/custom `fallback_models` overrides like `model`, `permission`, and `skills`; project config cannot set or erase model routing policy.
+- Define precedence: exact user/custom `model`/`fallback_models` > category user/custom `model`/`fallback_models` > source category defaults > inheritance.
+- First add an empirical compatibility check for native fallback support in the installed OpenCode version. If no supported field exists, stop this unit after documenting the failed spike result; do not emit `fallback_models` and do not implement a runtime fallback manager in this PR.
+- If native fallback support is verified, emit the exact supported field shape and add regression coverage proving OpenCode consumes it as intended.
+- Apply model/fallback precedence field-aware: a stronger explicit `model` suppresses weaker source `fallback_models` unless the same stronger layer also provides `fallback_models`; a stronger `fallback_models` without `model` intentionally replaces only the fallback chain for the resolved model.
+- Do not infer a category default from locally configured providers. Source defaults are intentional; provider detection may only be used to skip unavailable fallback candidates or produce clear diagnostics if the chosen mechanism supports that safely.
 - Do not rewrite explicit user model values and do not probe remote provider APIs.
 
 **Patterns to follow:**
@@ -220,24 +241,25 @@ Implements restrictive `mcps` allowlists using concrete MCP tool keys and collis
 - Source-aware overlay merge logic in `src/lib/config.ts`.
 
 **Test scenarios:**
-- Happy path: user/custom config selects provider `openai`, OpenCode config contains `provider.openai`, and an agent with no explicit model receives a known built-in model default.
-- Happy path: exact agent `model` overrides category and provider defaults.
-- Happy path: category `model` overrides provider defaults.
-- Edge case: no provider-default policy leaves `model` omitted even when OpenCode has configured providers.
-- Edge case: selected provider missing from OpenCode config leaves `model` omitted or fails with a clear validation error; choose one behavior and document it before implementation.
-- Edge case: multiple providers configured without explicit provider-default policy leaves `model` omitted.
-- Security path: project config cannot set or erase provider-default policy.
-- Error path: malformed explicit model still fails structural validation.
-- Integration: emitted agent config never comes from bundled agent frontmatter.
+- Happy path: no user/custom model override applies the category source default `model` and ordered `fallback_models` for each bundled category.
+- Happy path: exact user/custom `model` and same-layer `fallback_models` override category and source defaults.
+- Happy path: category user/custom `model` and same-layer `fallback_models` override source defaults for every bundled agent in that category.
+- Edge case: exact/category user-custom `model` without same-layer `fallback_models` emits the explicit model and suppresses source fallback chains.
+- Edge case: exact/category user-custom `fallback_models` without `model` replaces only the fallback chain for the resolved model.
+- Edge case: bundled markdown still omits `model` and `fallback_models`; emitted values come only from the source/default-resolution layer or user/custom config.
+- Edge case: unavailable fallback candidates are handled according to the verified mechanism without changing explicit user choices.
+- Security path: project config cannot set or erase `model` or `fallback_models` policy.
+- Error path: malformed explicit `model` or `fallback_models` fails structural validation.
+- Integration: native fallback behavior is empirically verified or the unit stops before shipping inert metadata.
 
 **Verification:**
-- Zero-config environments still inherit models.
-- Provider defaults require explicit user/custom opt-in.
+- Zero-config environments receive source category defaults while bundled markdown remains model-free.
+- Fallback behavior is real and tested through native OpenCode support; otherwise fallback remains unshipped and the plan records the blocker.
 - Bundled agent `model:` content-integrity ban remains intact.
 
-- [ ] **Unit 3: Document provider model defaults**
+- [ ] **Unit 3: Document source model defaults and fallback chains**
 
-**Goal:** Update docs for explicit provider-default behavior before starting MCP work.
+**Goal:** Update docs for source-configured category defaults and fallback behavior before starting MCP work.
 
 **Requirements:** R1, R2, R3, R4, R5, R6, R7, R14
 
@@ -248,10 +270,10 @@ Implements restrictive `mcps` allowlists using concrete MCP tool keys and collis
 - Modify: `docs/src/content/docs/getting-started/configuration.mdx`
 
 **Approach:**
-- Document provider-aware model defaults as opt-in and conservative.
-- Document that configured OpenCode providers alone do not change model inheritance.
+- Document the shipped category default `model` plus `fallback_models` table and the precedence rules.
+- Document whether fallback behavior is native OpenCode config or Systematic-managed, based on Unit 2's verified implementation path.
 - Document that explicit user/custom model overlays are passed through structurally and may still fail at OpenCode runtime if the provider/model is unavailable.
-- Document project-config restrictions for `model`, provider defaults, `permission`, and `skills`.
+- Document project-config restrictions for `model`, `fallback_models`, `permission`, and `skills`.
 
 **Patterns to follow:**
 - Existing agent overlay docs added by PR #343.
@@ -260,7 +282,7 @@ Implements restrictive `mcps` allowlists using concrete MCP tool keys and collis
 - Test expectation: none -- documentation-only changes. Existing docs build verifies syntax and generated site integrity.
 
 **Verification:**
-- Docs clearly distinguish inherited models, opt-in provider defaults, and explicit user overrides.
+- Docs clearly distinguish source defaults, fallback chains, inherited models, and explicit user overrides.
 
 - [ ] **Unit 4: Spike MCP tool-key inventory and permission safety**
 
@@ -268,7 +290,7 @@ Implements restrictive `mcps` allowlists using concrete MCP tool keys and collis
 
 **Requirements:** R8, R9, R10, R11, R12, R13, R14
 
-**Dependencies:** Unit 1
+**Dependencies:** Unit 3
 
 **Files:**
 - Create: `tests/manual/mcp-permission-key-probe.ts` *(or equivalent manual probe artifact if automated tests are impractical)*
@@ -402,10 +424,10 @@ Implements restrictive `mcps` allowlists using concrete MCP tool keys and collis
 
 ## System-Wide Impact
 
-- **Interaction graph:** Systematic config loading feeds overlay validation, bundled agent emission, and OpenCode permission evaluation. Provider defaults depend on source-aware Systematic config plus incoming OpenCode provider config. MCP overlay behavior depends on final MCP tool inventory if available.
-- **Error propagation:** Invalid overlay config should fail fast during plugin config handling with source-path and key-path context. Explicit user model availability remains an OpenCode runtime concern.
+- **Interaction graph:** Systematic config loading feeds overlay validation, bundled agent emission, and OpenCode permission evaluation. Source model defaults depend on audited Systematic default tables plus the verified fallback mechanism. MCP overlay behavior depends on final MCP tool inventory if available.
+- **Error propagation:** Invalid overlay config should fail fast during plugin config handling with source-path and key-path context. Explicit user model availability remains an OpenCode runtime concern unless the verified fallback mechanism safely preflights candidates.
 - **State lifecycle risks:** Config mutation must remain atomic; invalid provider/MCP overlays must not partially mutate `config.agent`, `config.command`, `config.skills`, or `config.mcp`.
-- **API surface parity:** Exact agent overlays and category overlays need matching behavior for `model` and `mcps`, except exact-only fields such as `disable` remain exact-only.
+- **API surface parity:** Exact agent overlays and category overlays need matching behavior for `model`, `fallback_models`, and `mcps`, except exact-only fields such as `disable` remain exact-only.
 - **Integration coverage:** Unit tests should cover validation, but config-handler tests must prove emitted OpenCode config shape and permission ordering. MCP needs a spike/probe before unit tests can safely assert emitted permissions.
 - **Unchanged invariants:** Bundled agents remain model-free; project config remains lower trust for provider/model and permission-affecting fields; registry generation should not change unless docs/assets inputs change.
 
@@ -413,10 +435,10 @@ Implements restrictive `mcps` allowlists using concrete MCP tool keys and collis
 
 | Risk | Mitigation |
 |------|------------|
-| Provider defaults surprise users by changing model inheritance | Require explicit user/custom provider-default opt-in; configured providers alone do not select models. |
-| Project config routes prompts to a different provider | Treat `model` and provider-default policy as protected fields. |
-| Provider config shape differs across OpenCode versions | Keep resolver conservative and covered by tests; unknown shapes produce no default. |
-| Multiple configured providers create arbitrary selection | Omit model defaults unless user/custom config chooses a provider. |
+| Source defaults surprise users by changing model inheritance | Document the zero-config default model table prominently; keep bundled markdown model-free and allow user/custom overrides. |
+| Project config routes prompts to a different provider | Treat `model` and `fallback_models` as protected fields. |
+| `fallback_models` is not native OpenCode config | Verify a supported field; if absent, stop and plan runtime fallback architecture separately. Do not ship inert metadata. |
+| Provider model IDs churn | Centralize defaults in one table and validate/update before release. |
 | MCP key mapping is unavailable in config hook | Spike first; if final keys are unavailable, keep `mcps` deferred. |
 | Wildcard MCP grants expand privileges through future tools | Prefer enumerated concrete keys; do not ship guessed prefix grants. |
 | Sanitized MCP key collisions cross server boundaries | Detect collisions before emitting rules. |
@@ -426,9 +448,9 @@ Implements restrictive `mcps` allowlists using concrete MCP tool keys and collis
 ## Documentation / Operational Notes
 
 - This is a developer-facing config feature with no persistent production service.
-- Provider-default PR notes should emphasize explicit opt-in and project-config restrictions.
+- Source-model-default PR notes should emphasize the category default table, fallback behavior, project-config restrictions, and user/custom override path.
 - MCP PR notes should emphasize restrictive allowlist semantics and that MCP servers must already be configured in OpenCode.
-- PR descriptions should include post-merge validation notes to watch plugin load failures, overlay config issues, provider routing surprises, and MCP permission reports in GitHub issues/PR comments.
+- PR descriptions should include post-merge validation notes to watch plugin load failures, overlay config issues, provider routing/fallback surprises, and MCP permission reports in GitHub issues/PR comments.
 
 ## Sources & References
 
@@ -441,3 +463,12 @@ Implements restrictive `mcps` allowlists using concrete MCP tool keys and collis
 - Related tests: `tests/unit/agent-overlays.test.ts`
 - Related tests: `tests/unit/config-handler.test.ts`
 - Related tests: `tests/unit/config.test.ts`
+- OMO Slim README/presets: https://raw.githubusercontent.com/alvinunreal/oh-my-opencode-slim/master/README.md
+- OMO Slim author preset: https://raw.githubusercontent.com/alvinunreal/oh-my-opencode-slim/master/docs/authors-preset.md
+- Magic Context configuration docs: https://raw.githubusercontent.com/cortexkit/opencode-magic-context/master/CONFIGURATION.md
+- OpenCode agents docs: https://opencode.ai/docs/agents/
+- OpenCode config schema: https://opencode.ai/config.json
+- OpenCode agents docs: https://opencode.ai/docs/agents/
+- OpenCode config schema: https://opencode.ai/config.json
+- Magic Context configuration docs: https://github.com/cortexkit/opencode-magic-context/blob/master/CONFIGURATION.md
+- oh-my-opencode-slim configuration docs: https://github.com/alvinunreal/oh-my-opencode-slim/blob/master/docs/configuration.md

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -43,6 +43,7 @@ Use top-level `agents` and `categories` maps to tune bundled Systematic agents w
   "agents": {
     // Unqualified unique stem form.
     "security-sentinel": {
+      // User or custom config only; project config cannot choose model/provider routing.
       "model": "anthropic/claude-sonnet-4-5",
       "variant": "thinking",
       "steps": 20
@@ -61,11 +62,11 @@ Valid category IDs are `design`, `docs`, `document-review`, `research`, `review`
 
 Exact agent overlays accept the unique file stem (`security-sentinel`) or the qualified key (`review/security-sentinel`). Pick one canonical form across all config sources. Systematic merges config sources before resolving aliases, so cross-source alias collisions like user `agents.security-sentinel` plus project `agents.review/security-sentinel` fail duplicate-target validation instead of silently overriding.
 
-Supported overlay fields are `model`, `variant`, `temperature`, `top_p`, `permission`, `mode`, `color`, `steps`, `hidden`, exact-agent-only `disable`, and `skills`.
+Supported overlay fields are `model`, `variant`, `temperature`, `top_p`, `permission`, `mode`, `color`, `steps`, `hidden`, exact-agent-only `disable`, and `skills`. `color` accepts `#RGB`, `#RRGGBB`, or OpenCode named color tokens matching `[a-zA-Z][a-zA-Z0-9-]*`; whitespace/freeform numeric strings are rejected.
 
-`skills` is a Systematic-managed shortcut that writes OpenCode `permission.skill` rules using bundled skill frontmatter names such as `ce:review`. It is not a native OpenCode agent field. Because `permission` and `skills` control tool access, they are accepted only from user config or `$OPENCODE_CONFIG_DIR/systematic.json`; project config may tune agent behavior but cannot loosen a user's permission policy. Systematic does not expose an `mcps` shortcut in V1; MCP-specific permission mapping is out of scope for this config surface.
+`skills` is a Systematic-managed shortcut that writes OpenCode `permission.skill` rules using bundled skill frontmatter names such as `ce:review`. It is not a native OpenCode agent field. Because `model` controls provider routing/cost/privacy and `permission`/`skills` control tool access, those fields are accepted only from user config or `$OPENCODE_CONFIG_DIR/systematic.json`. Project config may tune non-sensitive presentation and runtime fields such as `variant`, `temperature`, `top_p`, `mode`, `color`, `steps`, `hidden`, or exact-agent `disable`, but it cannot choose model/provider routing or loosen permission/capability policy. Systematic does not expose an `mcps` shortcut in V1; MCP-specific permission mapping is out of scope for this config surface.
 
-Bundled agent markdown intentionally omits `model`. By default, emitted bundled agents also omit `model` so OpenCode inheritance keeps working. Systematic only emits a model when you configure `agents.<key>.model`; provider-specific zero-config model defaults are intentionally deferred.
+Bundled agent markdown intentionally omits `model`. By default, emitted bundled agents also omit `model` so OpenCode inheritance keeps working. Systematic only emits a model when you configure `agents.<key>.model` in user or custom config; provider-specific zero-config model defaults are intentionally deferred.
 
 Overlay application precedence for a Systematic-owned bundled agent is strongest first:
 
@@ -109,7 +110,7 @@ Systematic resolves configuration and content in the following order (highest pr
 5.  **User-level config:** `~/.config/opencode/systematic.json`
 6.  **Bundled assets:** Content shipped with the plugin package
 
-Config-source merge precedence is separate from overlay application precedence. Across Systematic config files, `disabled_*` arrays are union-merged, `bootstrap` is shallow-merged, and top-level `agents`/`categories` maps merge by key. A higher-priority source replaces the whole object for the same `agents.<key>` or `categories.<id>` entry; unrelated keys survive. Project overlays are the exception for security fields: they cannot define `permission` or `skills`, and same-key project overlays preserve user-level `permission`/`skills` fields instead of erasing them. After that effective config is built, Systematic applies category and exact overlays to bundled agents using the overlay precedence above.
+Config-source merge precedence is separate from overlay application precedence. Across Systematic config files, `disabled_*` arrays are union-merged, `bootstrap` is shallow-merged, and top-level `agents`/`categories` maps merge by key. A higher-priority source replaces the whole object for the same `agents.<key>` or `categories.<id>` entry; unrelated keys survive. Project overlays are the exception for trust-sensitive fields: they cannot define `model`, `permission`, or `skills`, and same-key project overlays preserve user-level `model`/`permission`/`skills` fields instead of erasing them. After that effective config is built, Systematic applies category and exact overlays to bundled agents using the overlay precedence above.
 
 ## Advanced Configuration
 
@@ -130,6 +131,7 @@ The Systematic configuration file is parsed as JSONC, meaning you can include co
   },
   "agents": {
     "repo-research-analyst": {
+      // User or custom config only; project config cannot choose model/provider routing.
       "model": "anthropic/claude-sonnet-4-5"
     }
   }

--- a/src/lib/agent-overlays.ts
+++ b/src/lib/agent-overlays.ts
@@ -414,7 +414,7 @@ function validatePositiveInteger(
   keyPath: string,
   value: unknown,
 ): void {
-  if (!Number.isInteger(value) || (value as number) < 1) {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
     throwConfigError(sourcePath, keyPath, 'must be a positive integer')
   }
 }

--- a/src/lib/config-handler.ts
+++ b/src/lib/config-handler.ts
@@ -317,6 +317,9 @@ function setPermissionRule(
   setting: PermissionSetting,
 ): void {
   const rules = accumulator.get(tool) ?? new Map<string, PermissionSetting>()
+  // OpenCode permission evaluation uses the last matching rule. Map insertion
+  // order is therefore intentional here: delete before set moves same-pattern
+  // overrides to the end so stronger exact overlays beat weaker category rules.
   if (rules.has(pattern)) rules.delete(pattern)
   rules.set(pattern, setting)
   accumulator.set(tool, rules)

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -64,7 +64,7 @@ interface ConfigSource {
   trust: 'user' | 'project' | 'custom'
 }
 
-const SECURITY_OVERLAY_FIELDS = new Set(['permission', 'skills'])
+const SECURITY_OVERLAY_FIELDS = new Set(['model', 'permission', 'skills'])
 
 function isErrorWithCode(error: unknown): error is Error & { code?: unknown } {
   return error instanceof Error && 'code' in error

--- a/tests/integration/opencode.test.ts
+++ b/tests/integration/opencode.test.ts
@@ -152,7 +152,7 @@ describe('SystematicPlugin config hook integration', () => {
   }
 
   test('exact overlay emits a tuned bundled agent', async () => {
-    writeSystematicConfig({
+    writeCustomSystematicConfig({
       agents: {
         'correctness-reviewer': {
           model: 'openrouter/anthropic/claude-sonnet-4',
@@ -279,7 +279,7 @@ describe('SystematicPlugin config hook integration', () => {
   })
 
   test('well-shaped nonexistent explicit model passes validation and emits unchanged', async () => {
-    writeSystematicConfig({
+    writeCustomSystematicConfig({
       agents: {
         'correctness-reviewer': {
           model: 'nonexistent-provider/nonexistent-model',

--- a/tests/unit/agent-overlays.test.ts
+++ b/tests/unit/agent-overlays.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import {
   type BundledAgentInventory,
   buildBundledAgentInventory,
+  inferBuiltInTemperature,
   validateAgentOverlays,
 } from '../../src/lib/agent-overlays.js'
 import type { SourcedOverlayConfig } from '../../src/lib/config.js'
@@ -183,6 +184,21 @@ describe('validateAgentOverlays', () => {
     ).toThrow(/categories\.unknown.*Valid categories: review, workflow/)
   })
 
+  test('category overlays accept hidden', () => {
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {},
+          categories: {
+            review: source('categories', 'review', { hidden: true }),
+          },
+        },
+        nativeAgents: {},
+      }),
+    ).not.toThrow()
+  })
+
   test('rejects unknown and unsupported fields with key path', () => {
     for (const field of [
       'unknown',
@@ -278,6 +294,23 @@ describe('validateAgentOverlays', () => {
         ),
       )
     }
+  })
+
+  test.each(['', ' cyan', '12345'])('rejects invalid color %p', (color) => {
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {
+            'correctness-reviewer': source('agents', 'correctness-reviewer', {
+              color,
+            }),
+          },
+          categories: {},
+        },
+        nativeAgents: {},
+      }),
+    ).toThrow(/agents\.correctness-reviewer\.color/)
   })
 
   test('native replacement conflicts with exact unqualified and qualified overlays', () => {
@@ -456,5 +489,21 @@ describe('validateAgentOverlays', () => {
         nativeAgents: {},
       }),
     ).not.toThrow()
+  })
+})
+
+describe('inferBuiltInTemperature', () => {
+  test.each([
+    ['correctness-reviewer', 'Reviews code', 0.1],
+    ['security-sentinel', 'Audits risk', 0.1],
+    ['architecture-strategist', 'Plans architecture', 0.2],
+    ['repo-research-analyst', 'Researches repositories', 0.2],
+    ['readme-writer', 'Writes docs', 0.3],
+    ['changelog-editor', 'Edits release notes', 0.3],
+    ['design-iterator', 'Creates visual concepts', 0.6],
+    ['creative-ideator', 'Brainstorms product ideas', 0.6],
+    ['general-helper', 'Handles miscellaneous work', 0.3],
+  ])('returns %p temperature for %s', (name, description, expected) => {
+    expect(inferBuiltInTemperature(name, description)).toBe(expected)
   })
 })

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -733,7 +733,7 @@ model: gpt-4
         name: 'other-reviewer',
         description: 'Other reviewer',
       })
-      writeSystematicConfig({
+      writeCustomSystematicConfig({
         agents: {
           'correctness-reviewer': {
             model: 'openrouter/anthropic/claude-sonnet-4',

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -474,7 +474,7 @@ describe('config', () => {
             path.join(projectConfigDir, 'systematic.json'),
             JSON.stringify({
               agents: {
-                'correctness-reviewer': { model: 'anthropic/claude-sonnet-4' },
+                'correctness-reviewer': { temperature: 0.4 },
               },
             }),
           )
@@ -485,7 +485,7 @@ describe('config', () => {
             review: { temperature: 0.2 },
           })
           expect(result.config.agents).toEqual({
-            'correctness-reviewer': { model: 'anthropic/claude-sonnet-4' },
+            'correctness-reviewer': { temperature: 0.4 },
           })
         } finally {
           if (userConfigBackup !== null) {
@@ -496,7 +496,7 @@ describe('config', () => {
         }
       })
 
-      test('project agent overlay replaces user same-key overlay wholesale', () => {
+      test('project same-key overlays cannot erase user model policy', () => {
         const userConfigDir = path.join(os.homedir(), '.config/opencode')
         const userConfigPath = path.join(userConfigDir, 'systematic.json')
         const userConfigBackup = tryReadFile(userConfigPath)
@@ -525,7 +525,7 @@ describe('config', () => {
             projectConfigPath,
             JSON.stringify({
               agents: {
-                'correctness-reviewer': { model: 'anthropic/claude-sonnet-4' },
+                'correctness-reviewer': { temperature: 0.4 },
               },
             }),
           )
@@ -533,7 +533,7 @@ describe('config', () => {
           const result = loadConfigWithSources(testDir)
 
           expect(result.config.agents).toEqual({
-            'correctness-reviewer': { model: 'anthropic/claude-sonnet-4' },
+            'correctness-reviewer': { temperature: 0.4, model: 'openai/gpt-5' },
           })
           expect(
             result.overlays.agents['correctness-reviewer']?.sourcePath,
@@ -547,12 +547,18 @@ describe('config', () => {
         }
       })
 
-      test('project overlays cannot configure permission or managed skills', () => {
+      test('project overlays cannot configure model, permission, or managed skills', () => {
         const projectConfigDir = path.join(testDir, '.opencode')
         fs.mkdirSync(projectConfigDir)
         const projectConfigPath = path.join(projectConfigDir, 'systematic.json')
 
         for (const config of [
+          {
+            agents: {
+              'correctness-reviewer': { model: 'openai/gpt-5' },
+            },
+          },
+          { categories: { review: { model: 'openai/gpt-5' } } },
           {
             agents: {
               'correctness-reviewer': { permission: { bash: 'allow' } },
@@ -590,6 +596,7 @@ describe('config', () => {
               },
               agents: {
                 'correctness-reviewer': {
+                  model: 'openai/gpt-5',
                   permission: { read: 'deny' },
                   temperature: 0.1,
                 },
@@ -603,7 +610,7 @@ describe('config', () => {
             path.join(projectConfigDir, 'systematic.json'),
             JSON.stringify({
               categories: { review: { temperature: 0.4 } },
-              agents: { 'correctness-reviewer': { model: 'openai/gpt-5' } },
+              agents: { 'correctness-reviewer': { hidden: true } },
             }),
           )
 
@@ -615,8 +622,9 @@ describe('config', () => {
             skills: ['ce:review'],
           })
           expect(result.config.agents?.['correctness-reviewer']).toEqual({
-            model: 'openai/gpt-5',
+            hidden: true,
             permission: { read: 'deny' },
+            model: 'openai/gpt-5',
           })
         } finally {
           if (userConfigBackup !== null) {
@@ -640,7 +648,7 @@ describe('config', () => {
             path.join(projectConfigDir, 'systematic.json'),
             JSON.stringify({
               categories: {
-                review: { model: 'openai/gpt-5', temperature: 0.1 },
+                review: { steps: 8, temperature: 0.1 },
               },
             }),
           )


### PR DESCRIPTION
## Summary

- hardens agent overlay validation for trust-sensitive routing fields
- prevents project config from setting or erasing `model` policy while preserving higher-trust user/custom config
- documents accepted `color` values and project-config restrictions
- adds the follow-up plan for source-configured category model defaults with `fallback_models` and MCP overlay gating

## Verification

- `bun run typecheck`
- `bun run lint` *(exit 0; pre-existing complexity warnings outside this change)*
- `bun test tests/unit/agent-overlays.test.ts tests/unit/config-handler.test.ts tests/unit/config.test.ts tests/integration/opencode.test.ts`
- `bun test`
- `bun scripts/content-integrity.ts`
- `bun run registry:drift`
- `bun run registry:validate`
- `bun run docs:build`
