### PR TITLE
feat(config): seed source agent model defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,8 @@ systematic/
 - **Testing:** `bun:test` with `describe`/`it`. Real temp dirs for FS isolation, no mocking libraries. Integration tests skip if deps unavailable
 - **Bundled agents:** MUST omit the `model` field in frontmatter. OpenCode subagents inherit the invoking primary agent's model when `model` is unset (see https://opencode.ai/docs/agents/). The literal value `model: inherit` is NOT supported — it crashed subagent dispatch on OpenCode versions prior to [sst/opencode#17888](https://github.com/sst/opencode/pull/17888) (March 2026), and is undocumented in OpenCode. The content-integrity gate enforces this.
 
+  This rule applies to **bundled agent markdown/frontmatter only**. The runtime config emitted for categorized bundled agents may include source-owned `model` defaults from TypeScript code (see Configuration section). These are two separate layers: portable markdown stays model-free, while TypeScript code owns opinionated defaults that are emitted during config handling.
+
 ## Anti-Patterns
 
 - `require()` — use ESM imports

--- a/README.md
+++ b/README.md
@@ -326,11 +326,34 @@ Configuration is loaded from multiple locations and merged (later sources overri
 | `bootstrap.enabled` | `boolean` | `true` | Inject the `using-systematic` guide into system prompts |
 | `bootstrap.file` | `string` | — | Custom bootstrap file path (overrides default) |
 
-Agent overlays support `model`, `variant`, `temperature`, `top_p`, `permission`, `mode`, `color`, `steps`, `hidden`, exact-agent-only `disable`, and managed `skills`. `color` accepts `#RGB`, `#RRGGBB`, or OpenCode named color tokens matching `[a-zA-Z][a-zA-Z0-9-]*`; whitespace/freeform numeric strings are rejected. `skills` uses bundled skill frontmatter names like `ce:review`; it is a shortcut that writes OpenCode `permission.skill` rules, not a native OpenCode agent field. Because `model` controls provider routing/cost/privacy and `permission`/`skills` control tool access, those fields are only accepted from user config or `$OPENCODE_CONFIG_DIR/systematic.json`. Project config may tune non-sensitive presentation and runtime fields such as `variant`, `temperature`, `top_p`, `mode`, `color`, `steps`, `hidden`, or exact-agent `disable`, but it cannot choose model/provider routing or loosen permission/capability policy.
+Agent overlays support `model`, `variant`, `temperature`, `top_p`, `permission`, `mode`, `color`, `steps`, `hidden`, exact-agent-only `disable`, and managed `skills`. `color` accepts `#RGB`, `#RRGGBB`, or OpenCode named color tokens matching `[a-zA-Z][a-zA-Z0-9-]*`; whitespace/freeform numeric strings are rejected. `skills` uses bundled skill frontmatter names like `ce:review`; it is a shortcut that writes OpenCode `permission.skill` rules, not a native OpenCode agent field. Because `model` and `variant` control provider routing/cost/privacy and `permission`/`skills` control tool access, those fields are only accepted from user config or `$OPENCODE_CONFIG_DIR/systematic.json`. Project config may tune non-sensitive presentation and runtime fields such as `temperature`, `top_p`, `mode`, `color`, `steps`, `hidden`, or exact-agent `disable`, but it cannot choose model/provider routing, tune `variant`, or loosen permission/capability policy.
 
-Systematic separates config-source precedence from overlay precedence. Config files merge in this order: user config, project config, then `$OPENCODE_CONFIG_DIR/systematic.json` if set. Higher-priority `agents.<key>` and `categories.<id>` entries replace lower-priority entries wholesale, while unrelated keys survive. Project overlays are the exception for trust-sensitive fields: same-key project overlays preserve user-level `model`, `permission`, and `skills` fields instead of erasing them. After the effective config is built, exact `agents` overlays beat category overlays, which beat built-in policy defaults, bundled markdown defaults, and OpenCode inherited defaults.
+Systematic separates config-source precedence from overlay precedence. Config files merge in this order: user config, project config, then `$OPENCODE_CONFIG_DIR/systematic.json` if set. Higher-priority `agents.<key>` and `categories.<id>` entries replace lower-priority entries wholesale, while unrelated keys survive. Project overlays are the exception for trust-sensitive fields: same-key project overlays preserve user-level `model`, `variant`, `permission`, and `skills` fields instead of erasing them. After the effective config is built, Systematic applies agent overlay precedence for bundled agents:
 
-Bundled agents omit `model` by default so OpenCode model inheritance keeps working. Systematic emits a `model` only when you configure one explicitly in user or custom config; provider-specific zero-config model defaults are intentionally deferred.
+1. Exact `agents.<key>` overlay (high-trust `model` wins)
+2. `categories.<category-id>` overlay (high-trust `model` wins)
+3. Source category model default (built-in, code-owned)
+4. Bundled markdown/frontmatter defaults
+5. OpenCode inherited defaults
+
+Source category model defaults are primary model choices only — they are not fallback chains. Systematic does not support `fallback_models`, inherited retry semantics, runtime fallback behavior, or fallback to the parent model when a source model is unavailable. Explicit and source model IDs are structurally validated and may still fail at OpenCode runtime if the provider or model is unavailable.
+
+The source defaults are:
+
+| Category | Default `model` | Rationale |
+|----------|-----------------|-----------|
+| `design` | `openai/gpt-5.5` | High-judgment UX/product/design work benefits from a strong general reasoning model. |
+| `docs` | `openai/gpt-5.4-mini` | Documentation and summarization should start cheaper/faster. |
+| `document-review` | `anthropic/claude-opus-4.7` | Requirements and plan critique benefit from strongest nuanced reasoning. |
+| `research` | `openai/gpt-5.5` | Tool-heavy synthesis and source evaluation benefit from a strong general reasoning model. |
+| `review` | `anthropic/claude-opus-4.7` | Code/security/adversarial review benefits from strongest reasoning. |
+| `workflow` | `openai/gpt-5.4-mini` | Orchestration and bounded implementation should default cheaper/faster. |
+
+These defaults are owned by Systematic code and emitted for bundled agents in each category when no stronger high-trust exact or category `model` override exists. Uncategorized bundled agents receive no source default and continue inheriting the parent OpenCode model. Native OpenCode agents with the same emitted key are full replacements and receive no Systematic source model default.
+
+Bundled agent markdown still intentionally omits `model` — the field belongs in source code defaults, not portable markdown files. Authors must not add `model:` frontmatter to bundled agent files.
+
+Systematic emits a source model as the default; you can override it per-agent or per-category in user or `$OPENCODE_CONFIG_DIR/systematic.json` config. Project config cannot set, erase, or shadow `model` policy.
 
 Native OpenCode agents with the same emitted key are full replacements. An exact Systematic overlay for that key conflicts, while category overlays skip native replacements and continue applying to other bundled agents. Use one canonical agent key form across config sources (`security-sentinel` or `review/security-sentinel`) because alias collisions fail duplicate-target validation.
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ Systematic separates config-source precedence from overlay precedence. Config fi
 
 Source category model defaults are primary model choices only — they are not fallback chains. Systematic does not support `fallback_models`, inherited retry semantics, runtime fallback behavior, or fallback to the parent model when a source model is unavailable. Explicit and source model IDs are structurally validated and may still fail at OpenCode runtime if the provider or model is unavailable.
 
+If you want to restore OpenCode parent-model inheritance for a bundled agent or category (opting out of the source default), set `"model": null` in high-trust user or `$OPENCODE_CONFIG_DIR/systematic.json` config. Project config cannot use `model: null` — project config cannot set, erase, or shadow `model` at any value.
+
 The source defaults are:
 
 | Category | Default `model` | Rationale |
@@ -354,6 +356,22 @@ These defaults are owned by Systematic code and emitted for bundled agents in ea
 Bundled agent markdown still intentionally omits `model` — the field belongs in source code defaults, not portable markdown files. Authors must not add `model:` frontmatter to bundled agent files.
 
 Systematic emits a source model as the default; you can override it per-agent or per-category in user or `$OPENCODE_CONFIG_DIR/systematic.json` config. Project config cannot set, erase, or shadow `model` policy.
+
+> **Migration: Restoring parent-model inheritance.** If you previously relied on bundled agents inheriting the parent OpenCode model (no source defaults), set `"model": null` in your high-trust config to opt out of the source default per agent or per category. For example:
+>
+> ```jsonc
+> // ~/.config/opencode/systematic.json or $OPENCODE_CONFIG_DIR/systematic.json
+> {
+>   "categories": {
+>     "review": { "model": null }     // All review agents inherit parent model
+>   },
+>   "agents": {
+>     "security-sentinel": { "model": null }  // Single agent inherits parent model
+>   }
+> }
+> ```
+>
+> This only works from high-trust config (user or `$OPENCODE_CONFIG_DIR/systematic.json`). Project `.opencode/systematic.json` cannot set `model: null` or any `model` value.
 
 Native OpenCode agents with the same emitted key are full replacements. An exact Systematic overlay for that key conflicts, while category overlays skip native replacements and continue applying to other bundled agents. Use one canonical agent key form across config sources (`security-sentinel` or `review/security-sentinel`) because alias collisions fail duplicate-target validation.
 

--- a/docs/plans/2026-05-09-002-feat-provider-model-mcp-overlays-plan.md
+++ b/docs/plans/2026-05-09-002-feat-provider-model-mcp-overlays-plan.md
@@ -1,10 +1,15 @@
 ---
 title: feat: Add Source Model Defaults and MCP Overlays
 type: feat
-status: active
+status: superseded
 date: 2026-05-09
 origin: docs/plans/2026-05-09-001-feat-agent-model-configuration-plan.md
+superseded_at: 2026-05-09
+superseded_by: docs/plans/2026-05-09-003-feat-source-configured-agent-models-plan.md
+superseded_reason: "Source-configured primary model defaults are replanned separately from fallback_models and MCP overlays. The successor plan keeps fallback behavior out of scope so primary model defaults can ship independently."
 ---
+
+> **Status: superseded.** The overlay hardening portion shipped in PR #344. The source-configured primary model work is superseded by `docs/plans/2026-05-09-003-feat-source-configured-agent-models-plan.md`, which explicitly excludes `fallback_models` and MCP overlays so primary model defaults can ship independently.
 
 # feat: Add Source Model Defaults and MCP Overlays
 

--- a/docs/plans/2026-05-09-003-feat-source-configured-agent-models-plan.md
+++ b/docs/plans/2026-05-09-003-feat-source-configured-agent-models-plan.md
@@ -36,6 +36,8 @@ PR #343 added top-level `agents` and `categories` overlays but intentionally lef
 - R8. Validate every source default model string through the same structural `provider/model` rules as explicit overlays before emission.
 - R9. Do not emit, document as supported, or silently accept `fallback_models` in this feature.
 - R10. Update public docs to explain the source model table, override precedence, project-config restriction, and no-fallback scope.
+- R11. Support `model: null` in high-trust user/config-dir config as an inheritance opt-out that restores OpenCode parent-model routing for a bundled agent or category.
+- R12. Add migration guidance: users who relied on inherited parent-model routing for categorized bundled agents can set high-trust `categories.<id>.model: null` or exact `agents.<key>.model: null`; project config cannot do this.
 
 ## Scope Boundaries
 
@@ -242,9 +244,9 @@ Implementation shape:
 
 - [ ] **Unit 4: Update docs for source model defaults**
 
-**Goal:** Document the source model table, precedence, override paths, and no-fallback scope.
+**Goal:** Document the source model table, precedence, override paths, `model: null` inheritance opt-out, migration guidance, and no-fallback scope.
 
-**Requirements:** R1, R2, R3, R4, R5, R9, R10
+**Requirements:** R1, R2, R3, R4, R5, R9, R10, R11, R12
 
 **Dependencies:** Unit 2
 

--- a/docs/plans/2026-05-09-003-feat-source-configured-agent-models-plan.md
+++ b/docs/plans/2026-05-09-003-feat-source-configured-agent-models-plan.md
@@ -1,0 +1,310 @@
+---
+title: "feat: Add Source-Configured Agent Models"
+type: feat
+status: active
+date: 2026-05-09
+origin: docs/plans/2026-05-09-002-feat-provider-model-mcp-overlays-plan.md
+---
+
+# feat: Add Source-Configured Agent Models
+
+## Overview
+
+Add source-configured default `model` values for Systematic bundled agents by category. The defaults live in TypeScript/default-resolution code, not bundled agent markdown, and are emitted into OpenCode agent config only for Systematic-owned bundled agents. High-trust exact and category model overlays still override source defaults; project config still cannot steer model routing.
+
+This plan deliberately excludes `fallback_models`, MCP overlays, provider probing, and runtime retry behavior. OpenCode supports `agent.<name>.model`; that is enough to ship source-configured primary models. Fallback support is separate future work and must not block this implementation.
+
+## Problem Frame
+
+PR #343 added top-level `agents` and `categories` overlays but intentionally left model choice inherited unless users configured explicit models. The next feature is to give Systematic's bundled agents opinionated, source-owned model defaults per role category while preserving the existing trust boundaries:
+
+- bundled `agents/**/*.md` remain portable and model-free;
+- source defaults are controlled by Systematic code, not project config;
+- higher-trust user/config-dir config can override exact agents or whole categories;
+- native same-name OpenCode agents remain user-owned replacements;
+- no unsupported fallback metadata is emitted.
+
+## Requirements Trace
+
+- R1. Ship source-configured primary `model` defaults for all bundled agent categories: `design`, `docs`, `document-review`, `research`, `review`, and `workflow`.
+- R2. Keep bundled agent markdown portable: no `model:` frontmatter in bundled `agents/**/*.md`, and no `model: inherit`.
+- R3. Apply source model defaults automatically when no stronger high-trust exact/category `model` override exists.
+- R4. Preserve existing trust boundary: project `.opencode/systematic.json` cannot set, erase, null, empty-string, or shadow `model` policy.
+- R5. Keep explicit high-trust model overlays structurally validated but not availability-validated; OpenCode owns runtime provider/model availability failures.
+- R6. Apply defaults only to Systematic-owned bundled agents. Native same-name OpenCode agents remain full replacements and receive no Systematic source model default.
+- R7. Uncategorized bundled agents receive no category model default and continue inheriting the parent OpenCode model.
+- R8. Validate every source default model string through the same structural `provider/model` rules as explicit overlays before emission.
+- R9. Do not emit, document as supported, or silently accept `fallback_models` in this feature.
+- R10. Update public docs to explain the source model table, override precedence, project-config restriction, and no-fallback scope.
+
+## Scope Boundaries
+
+- No `fallback_models` implementation, config field, docs example, or emitted metadata.
+- No runtime fallback manager, event-hook retry supervisor, or second-provider replay behavior.
+- No MCP overlay work.
+- No provider detection, provider availability probing, remote catalog calls, or network checks during config handling or tests.
+- No bundled agent frontmatter model fields.
+- No prompt/description/options overlay expansion.
+- No changes to OpenCode native agent replacement semantics.
+
+### Deferred to Separate Tasks
+
+- Runtime fallback behavior: separate plan/upstream OpenCode contract if/when we choose to pursue it.
+- MCP inventory spike and MCP overlays: separate PR sequence.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/lib/config-handler.ts` is the config emission choke point. `applyAgentOverlays()` currently starts from bundled markdown config, applies built-in temperature defaults, then category overlays, then exact overlays.
+- `src/lib/agent-overlays.ts` owns overlay inventory, validation, category/exact resolution, and `inferBuiltInTemperature()`.
+- `src/lib/config.ts` loads sourced Systematic config and protects security-sensitive fields. `model` is already protected from project config.
+- `src/lib/agents.ts` parses optional agent frontmatter fields, but bundled agent files must omit `model`.
+- `scripts/content-integrity.ts` enforces the bundled-agent `model` frontmatter ban.
+- `tests/unit/config-handler.test.ts`, `tests/unit/agent-overlays.test.ts`, `tests/unit/config.test.ts`, and `tests/integration/opencode.test.ts` cover the overlay/config emission surface.
+
+### Institutional Learnings
+
+- Bundled agents must stay model-free; omitted `model` is the portable OpenCode inheritance path for markdown assets.
+- Source-owned defaults belong in config/default-resolution, not in bundled markdown.
+- Config mutation must validate first and assign after success to avoid partial OpenCode config mutation on errors.
+- Config source precedence and agent overlay precedence are separate concerns: source merge is user → project → config-dir; emitted agent precedence is high-trust exact overlay → high-trust category overlay → built-in/source defaults → markdown → OpenCode inheritance.
+- Native OpenCode same-name agents are replacements, not Systematic overlay targets.
+
+### External References
+
+- OpenCode agents docs: https://opencode.ai/docs/agents/
+- OpenCode config schema: https://opencode.ai/config.json
+- Prior model/default research from OMO Slim and Magic Context for current model IDs and role-based model choices.
+
+## Source Model Table
+
+These source defaults are primary model choices only. They are intentionally **not** fallback chains.
+
+| Category | Default `model` | Rationale |
+|----------|-----------------|-----------|
+| `design` | `openai/gpt-5.5` | High-judgment UX/product/design work benefits from a strong general reasoning model. |
+| `docs` | `openai/gpt-5.4-mini` | Documentation and summarization should start cheaper/faster. |
+| `document-review` | `anthropic/claude-opus-4.7` | Requirements and plan critique benefit from strongest nuanced reasoning. |
+| `research` | `openai/gpt-5.5` | Tool-heavy synthesis and source evaluation benefit from a strong general reasoning model. |
+| `review` | `anthropic/claude-opus-4.7` | Code/security/adversarial review benefits from strongest reasoning. |
+| `workflow` | `openai/gpt-5.4-mini` | Orchestration and bounded implementation should default cheaper/faster. |
+
+## Key Technical Decisions
+
+- **Source defaults are automatic package policy.** Source-configured models apply by bundled category when no stronger high-trust exact/category model override exists. This is the feature; do not add an opt-in gate unless implementation reveals a concrete breakage.
+- **Defaults live in code, not markdown.** Keep bundled agents model-free and add a single audited TypeScript table keyed by category.
+- **Built-in default layer owns model defaults.** Apply source models alongside existing built-in temperature defaults before category/exact overlays, so higher-trust overlays remain stronger.
+- **Project config remains lower trust.** Project config still cannot set or erase `model`. If project config overlays a same key for non-sensitive fields, higher-trust model policy is preserved by existing protection.
+- **No provider availability checks.** Source and explicit models are structurally validated as `provider/model`; OpenCode runtime reports unavailable provider/model errors.
+- **No fallback leakage.** `fallback_models` remains unsupported in this feature and must not appear in emitted config or supported docs.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Is this blocked on `fallback_models` support?** No. This plan ships primary `model` defaults only. Fallback behavior is explicitly out of scope.
+- **Should source defaults apply automatically?** Yes. That is the requested source-configured model behavior. User/config-dir exact and category model overrides remain stronger.
+- **Where should defaults live?** In source TypeScript default-resolution code, not bundled agent markdown.
+- **Should provider availability be checked?** No. Validation remains structural only.
+
+### Deferred to Implementation
+
+- **Exact helper names and module boundaries:** choose the smallest shape that keeps validation reusable and readable.
+- **Manual source-table sanity check:** implementation may use already-researched/current docs to catch obvious stale IDs, but must not add automated provider/catalog probing, network calls, or availability tests. If a listed ID is obviously stale, update the table to the current equivalent and document the substitution in the PR.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+The emitted model for a Systematic bundled agent should resolve in this order:
+
+| Precedence | Source | Example |
+|------------|--------|---------|
+| 1 | High-trust exact overlay | `agents.correctness-reviewer.model` |
+| 2 | High-trust category overlay | `categories.review.model` |
+| 3 | Source category default | `review -> anthropic/claude-opus-4.7` |
+| 4 | Bundled markdown | omitted for bundled assets |
+| 5 | OpenCode inherited parent model | no `model` emitted |
+
+Implementation shape:
+
+1. Define source model defaults in `src/lib/agent-overlays.ts` or a tiny adjacent helper.
+2. Validate the table using the same structural model-string validation as user overlays.
+3. During `applyAgentOverlays()`, set `config.model` from the source table for categorized bundled agents at the built-in/source default layer. Source defaults intentionally take precedence over any bundled markdown `model` field; content integrity should prevent such markdown from shipping, but source policy still wins defensively before high-trust overlays apply.
+4. Apply category and exact overlays after the source default so higher-trust explicit models override it.
+5. Skip source defaults for native same-name replacements and uncategorized bundled agents.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add source model default helpers**
+
+**Goal:** Define and validate the source category model table without changing emitted config yet.
+
+**Requirements:** R1, R2, R5, R8, R9
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `src/lib/agent-overlays.ts`
+- Test: `tests/unit/agent-overlays.test.ts`
+
+**Approach:**
+- Add one source-owned table keyed by bundled category IDs, plus an invariant that every discovered bundled category is either in the table or explicitly listed as intentionally inheriting.
+- Reuse or extract the existing model-string validator so source defaults and explicit overlays share the same structural rule.
+- Expose a small helper for looking up a category default; return `undefined` for unknown/uncategorized agents.
+- Do not add `fallback_models` to allowed overlay fields or table values.
+
+**Patterns to follow:**
+- `inferBuiltInTemperature()` and its branch tests.
+- Existing overlay model validation in `agent-overlays.ts`.
+
+**Test scenarios:**
+- Happy path: every bundled category returns the expected source model.
+- Edge case: unknown category returns no source model.
+- Edge case: every discovered bundled category is explicitly covered by the source table or an intentional-inherit allowlist.
+- Error path: a malformed source model string fails validation in a test-only invariant path.
+
+**Verification:**
+- Source defaults are centralized, validated, model-only, and category coverage is intentional.
+
+- [ ] **Unit 2: Emit source models through built-in defaults**
+
+**Goal:** Apply source model defaults to bundled Systematic agents while preserving exact/category override precedence and native replacement behavior.
+
+**Requirements:** R1, R3, R4, R5, R6, R7, R8, R9
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `src/lib/config-handler.ts`
+- Test: `tests/unit/config-handler.test.ts`
+- Test: `tests/integration/opencode.test.ts`
+
+**Approach:**
+- In `applyAgentOverlays()`, apply the source category model default at the built-in default layer, near temperature defaults. Do not merge source defaults through `DEFAULT_CONFIG`, `loadConfigWithSources()`, or ordinary user/project/custom overlay state.
+- Apply source defaults only for bundled agents with known categories.
+- Preserve current category and exact overlay application order so explicit high-trust `model` values override source defaults. A high-trust `variant` applies only alongside the resolved model; project `variant` should be protected with other model-routing fields.
+- Preserve native same-name replacement behavior; Systematic should not overlay source defaults onto user-owned native agents.
+- Update integration expectations that previously asserted no emitted model under zero config.
+
+**Patterns to follow:**
+- Current temperature default application in `applyAgentOverlays()`.
+- Native same-name replacement tests and overlay conflict tests in `config-handler.test.ts`.
+
+**Test scenarios:**
+- Happy path: zero Systematic config emits source model defaults for bundled agents in all six categories.
+- Happy path: `loadConfig()` / `loadConfigWithSources()` with no high-trust model overlay returns no source-default model overlays; source defaults appear only during bundled agent emission.
+- Happy path: high-trust exact `model` overrides a source default for one bundled agent.
+- Happy path: high-trust category `model` overrides source defaults for every bundled agent in that category.
+- Happy path: high-trust category overlay with non-model fields, such as `temperature`, does not erase the source model.
+- Edge case: uncategorized bundled agent receives no source model default and inherits OpenCode model.
+- Edge case: native same-name OpenCode replacement receives no Systematic source model default, even when a category default exists.
+- Edge case: source defaults defensively replace any bundled markdown model before high-trust overlays apply, while content-integrity still forbids bundled markdown models.
+- Error path: invalid source model table prevents config mutation before assigning `config.agent`.
+- Integration: zero-config OpenCode agent output includes expected source model defaults and no `fallback_models` key.
+
+**Verification:**
+- Emitted config follows precedence: exact overlay > category overlay > source model default > markdown/inheritance.
+
+- [ ] **Unit 3: Keep trust-boundary and unsupported-field tests explicit**
+
+**Goal:** Lock the lower-trust project-config behavior, model-adjacent `variant` protection, and no-fallback scope around the new source defaults.
+
+**Requirements:** R4, R5, R9
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `tests/unit/config.test.ts`
+- Modify: `tests/unit/agent-overlays.test.ts`
+
+**Approach:**
+- Keep existing project-config `model` rejection tests intact.
+- Add `variant` to the protected model-routing field set unless implementation proves OpenCode `variant` cannot steer model behavior; project config must not set or erase it.
+- Add one delta test proving project config cannot erase or override a source default or higher-trust model while changing allowed non-sensitive fields.
+- Add explicit unsupported-field tests for `fallback_models` in `agents` and `categories` overlays so future fallback work cannot sneak in through loose object merging.
+- Add an emitted-config scan proving Systematic-owned bundled agents never include `fallback_models` under zero config or with overlays.
+
+**Patterns to follow:**
+- Existing `SECURITY_OVERLAY_FIELDS` project rejection coverage in `config.test.ts`.
+- Unknown overlay field validation in `agent-overlays.test.ts`.
+
+**Test scenarios:**
+- Security path: project config cannot set `agents.<key>.model`, `categories.<id>.model`, `agents.<key>.variant`, or `categories.<id>.variant`.
+- Security path: project same-key overlay cannot erase a source default or higher-trust exact `model` while changing allowed non-sensitive fields.
+- Error path: `agents.<key>.fallback_models` is rejected as unsupported.
+- Error path: `categories.<id>.fallback_models` is rejected as unsupported.
+- Integration/unit path: emitted Systematic bundled agents contain no `fallback_models` key.
+
+**Verification:**
+- Source defaults do not weaken the existing project-config trust boundary.
+
+- [ ] **Unit 4: Update docs for source model defaults**
+
+**Goal:** Document the source model table, precedence, override paths, and no-fallback scope.
+
+**Requirements:** R1, R2, R3, R4, R5, R9, R10
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/src/content/docs/getting-started/configuration.mdx`
+- Modify: `skills/writing-systematic-skills/references/foundation-conventions.md` *(only if needed to clarify that runtime source defaults do not permit bundled markdown `model` fields)*
+
+**Approach:**
+- Update examples that currently say emitted bundled agents omit `model` by default.
+- Show the source model table and the override precedence.
+- Keep the bundled markdown rule explicit: authors still omit `model` in agent files.
+- State that Systematic does not support `fallback_models`, inherited retry semantics, runtime fallback behavior, or fallback to the parent model when a source model is unavailable.
+- State that explicit and source model IDs are structurally validated and may still fail at OpenCode runtime if unavailable.
+
+**Patterns to follow:**
+- Existing agent overlay documentation sections in README and configuration guide.
+
+**Test scenarios:**
+- Test expectation: none -- documentation-only changes. Existing docs build verifies site integrity.
+
+**Verification:**
+- Public docs match emitted behavior and do not imply fallback support.
+
+## System-Wide Impact
+
+- **Interaction graph:** Config loading, overlay validation, bundled agent config emission, docs generation expectations, and integration output all see the new source model defaults.
+- **Error propagation:** Malformed source defaults should fail before mutating OpenCode config. Unavailable providers/models remain OpenCode runtime errors.
+- **State lifecycle risks:** No persistent state or data migration. Main risk is accidental provider/model routing surprise; docs, release notes, and override paths make the source policy explicit.
+- **API surface parity:** Exact and category model overlays continue to work. Native OpenCode same-name agents remain replacements. Bundled markdown remains model-free.
+- **Integration coverage:** Unit tests cover helper validation and precedence; integration verifies zero-config emitted agents include source models and no fallback metadata.
+- **Unchanged invariants:** Project config cannot control `model`, `variant`, `permission`, or `skills`; content-integrity continues banning bundled agent `model` frontmatter.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Source defaults route agents to provider IDs a user has not configured | Document provider/model defaults, trust-boundary implications, and override path; runtime availability remains OpenCode-owned. |
+| Model IDs churn | Use current researched IDs; do structural validation in tests and record any obvious manual source-table correction in the PR. No automated provider probing. |
+| Source defaults accidentally weaken project-config trust boundary | Keep and extend project-source rejection/preservation tests, including `variant`. |
+| Defaults accidentally apply to native user-owned agents | Add native same-name replacement coverage. |
+| Future fallback work leaks into this PR | Keep `fallback_models` unsupported and add negative tests. |
+
+## Documentation / Operational Notes
+
+- PR description should call out the behavior change as trust-sensitive: zero-config bundled agents now emit source-owned category model defaults and may send agent context to the listed providers instead of inheriting the parent model.
+- Release notes should list the category model table, say no Systematic fallback/retry occurs, and show how to override via user/config-dir config if users want different routing.
+- Do not describe fallback chains as supported.
+
+## Sources & References
+
+- Origin plan: `docs/plans/2026-05-09-002-feat-provider-model-mcp-overlays-plan.md`
+- Prior foundation plan: `docs/plans/2026-05-09-001-feat-agent-model-configuration-plan.md`
+- Related code: `src/lib/config-handler.ts`
+- Related code: `src/lib/agent-overlays.ts`
+- Related code: `src/lib/config.ts`
+- Related code: `src/lib/agents.ts`
+- Related tests: `tests/unit/config-handler.test.ts`
+- Related tests: `tests/unit/agent-overlays.test.ts`
+- Related tests: `tests/unit/config.test.ts`
+- Related tests: `tests/integration/opencode.test.ts`
+- OpenCode agents docs: https://opencode.ai/docs/agents/
+- OpenCode config schema: https://opencode.ai/config.json

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -78,6 +78,8 @@ Overlay application precedence for a Systematic-owned bundled agent is strongest
 
 Source category model defaults are primary model choices only — they are not fallback chains. Systematic does not support `fallback_models`, inherited retry semantics, runtime fallback behavior, or fallback to the parent model when a source model is unavailable. Explicit and source model IDs are structurally validated and may still fail at OpenCode runtime if the provider or model is unavailable.
 
+If you want to restore OpenCode parent-model inheritance for a bundled agent or category (opting out of the source default), set `"model": null` in high-trust user or `$OPENCODE_CONFIG_DIR/systematic.json` config. Project config cannot use `model: null` — project config cannot set, erase, or shadow `model` at any value.
+
 ### Source Category Model Defaults
 
 The following source defaults apply to bundled Systematic agents by category when no stronger high-trust exact or category `model` override exists:
@@ -96,6 +98,24 @@ These defaults are owned by Systematic code and emitted only for Systematic-owne
 Bundled agent markdown files must still omit `model` — the field belongs in source code defaults, not portable markdown. This is enforced by Systematic's content-integrity gate.
 
 Source defaults preserve the existing trust boundary: user config or `$OPENCODE_CONFIG_DIR/systematic.json` can override `model` per-agent or per-category, but project `.opencode/systematic.json` cannot set, erase, or shadow `model` policy.
+
+:::note[Migration: Restoring parent-model inheritance]
+If you previously relied on bundled agents inheriting the parent OpenCode model (no source defaults), set `"model": null` in your high-trust config to opt out of the source default per agent or per category:
+
+```jsonc
+// ~/.config/opencode/systematic.json or $OPENCODE_CONFIG_DIR/systematic.json
+{
+  "categories": {
+    "review": { "model": null }     // All review agents inherit parent model
+  },
+  "agents": {
+    "security-sentinel": { "model": null }  // Single agent inherits parent model
+  }
+}
+```
+
+This only works from high-trust config (user or `$OPENCODE_CONFIG_DIR/systematic.json`). Project `.opencode/systematic.json` cannot set `model: null` or any `model` value.
+:::
 
 Native OpenCode agents with the same emitted key are full replacements. If `config.agent.security-sentinel` already exists in OpenCode config, `agents.security-sentinel` or `agents.review/security-sentinel` conflicts because ownership would be ambiguous. Category overlays skip native replacements and continue applying to the remaining Systematic-owned bundled agents in that category.
 

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -64,17 +64,38 @@ Exact agent overlays accept the unique file stem (`security-sentinel`) or the qu
 
 Supported overlay fields are `model`, `variant`, `temperature`, `top_p`, `permission`, `mode`, `color`, `steps`, `hidden`, exact-agent-only `disable`, and `skills`. `color` accepts `#RGB`, `#RRGGBB`, or OpenCode named color tokens matching `[a-zA-Z][a-zA-Z0-9-]*`; whitespace/freeform numeric strings are rejected.
 
-`skills` is a Systematic-managed shortcut that writes OpenCode `permission.skill` rules using bundled skill frontmatter names such as `ce:review`. It is not a native OpenCode agent field. Because `model` controls provider routing/cost/privacy and `permission`/`skills` control tool access, those fields are accepted only from user config or `$OPENCODE_CONFIG_DIR/systematic.json`. Project config may tune non-sensitive presentation and runtime fields such as `variant`, `temperature`, `top_p`, `mode`, `color`, `steps`, `hidden`, or exact-agent `disable`, but it cannot choose model/provider routing or loosen permission/capability policy. Systematic does not expose an `mcps` shortcut in V1; MCP-specific permission mapping is out of scope for this config surface.
+`skills` is a Systematic-managed shortcut that writes OpenCode `permission.skill` rules using bundled skill frontmatter names such as `ce:review`. It is not a native OpenCode agent field. Because `model` and `variant` control provider routing/cost/privacy and `permission`/`skills` control tool access, those fields are accepted only from user config or `$OPENCODE_CONFIG_DIR/systematic.json`. Project config may tune non-sensitive presentation and runtime fields such as `temperature`, `top_p`, `mode`, `color`, `steps`, `hidden`, or exact-agent `disable`, but it cannot choose model/provider routing, tune `variant`, or loosen permission/capability policy. Systematic does not expose an `mcps` shortcut in V1; MCP-specific permission mapping is out of scope for this config surface.
 
-Bundled agent markdown intentionally omits `model`. By default, emitted bundled agents also omit `model` so OpenCode inheritance keeps working. Systematic only emits a model when you configure `agents.<key>.model` in user or custom config; provider-specific zero-config model defaults are intentionally deferred.
+Bundled agent markdown intentionally omits `model`. Instead, Systematic ships source-owned category model defaults that are emitted for bundled agents in each known category. These defaults are primary model choices only, not fallback chains. Systematic does not support `fallback_models`, inherited retry semantics, runtime fallback behavior, or fallback to the parent model when a source model is unavailable. Explicit and source model IDs are structurally validated and may still fail at OpenCode runtime if the provider or model is unavailable.
 
 Overlay application precedence for a Systematic-owned bundled agent is strongest first:
 
-1. Exact `agents.<key>` overlay
-2. `categories.<category-id>` overlay
-3. Built-in Systematic policy defaults, such as temperature defaults
+1. Exact `agents.<key>` overlay (high-trust `model` wins)
+2. `categories.<category-id>` overlay (high-trust `model` wins)
+3. Source category model default (built-in, code-owned)
 4. Bundled markdown/frontmatter defaults
 5. OpenCode inherited defaults
+
+Source category model defaults are primary model choices only — they are not fallback chains. Systematic does not support `fallback_models`, inherited retry semantics, runtime fallback behavior, or fallback to the parent model when a source model is unavailable. Explicit and source model IDs are structurally validated and may still fail at OpenCode runtime if the provider or model is unavailable.
+
+### Source Category Model Defaults
+
+The following source defaults apply to bundled Systematic agents by category when no stronger high-trust exact or category `model` override exists:
+
+| Category | Default `model` | Rationale |
+|----------|-----------------|-----------|
+| `design` | `openai/gpt-5.5` | High-judgment UX/product/design work benefits from a strong general reasoning model. |
+| `docs` | `openai/gpt-5.4-mini` | Documentation and summarization should start cheaper/faster. |
+| `document-review` | `anthropic/claude-opus-4.7` | Requirements and plan critique benefit from strongest nuanced reasoning. |
+| `research` | `openai/gpt-5.5` | Tool-heavy synthesis and source evaluation benefit from a strong general reasoning model. |
+| `review` | `anthropic/claude-opus-4.7` | Code/security/adversarial review benefits from strongest reasoning. |
+| `workflow` | `openai/gpt-5.4-mini` | Orchestration and bounded implementation should default cheaper/faster. |
+
+These defaults are owned by Systematic code and emitted only for Systematic-owned bundled agents. Uncategorized bundled agents receive no source default and continue inheriting the parent OpenCode model. Native OpenCode agents with the same emitted key are full replacements and receive no Systematic source model default.
+
+Bundled agent markdown files must still omit `model` — the field belongs in source code defaults, not portable markdown. This is enforced by Systematic's content-integrity gate.
+
+Source defaults preserve the existing trust boundary: user config or `$OPENCODE_CONFIG_DIR/systematic.json` can override `model` per-agent or per-category, but project `.opencode/systematic.json` cannot set, erase, or shadow `model` policy.
 
 Native OpenCode agents with the same emitted key are full replacements. If `config.agent.security-sentinel` already exists in OpenCode config, `agents.security-sentinel` or `agents.review/security-sentinel` conflicts because ownership would be ambiguous. Category overlays skip native replacements and continue applying to the remaining Systematic-owned bundled agents in that category.
 
@@ -110,7 +131,7 @@ Systematic resolves configuration and content in the following order (highest pr
 5.  **User-level config:** `~/.config/opencode/systematic.json`
 6.  **Bundled assets:** Content shipped with the plugin package
 
-Config-source merge precedence is separate from overlay application precedence. Across Systematic config files, `disabled_*` arrays are union-merged, `bootstrap` is shallow-merged, and top-level `agents`/`categories` maps merge by key. A higher-priority source replaces the whole object for the same `agents.<key>` or `categories.<id>` entry; unrelated keys survive. Project overlays are the exception for trust-sensitive fields: they cannot define `model`, `permission`, or `skills`, and same-key project overlays preserve user-level `model`/`permission`/`skills` fields instead of erasing them. After that effective config is built, Systematic applies category and exact overlays to bundled agents using the overlay precedence above.
+Config-source merge precedence is separate from overlay application precedence. Across Systematic config files, `disabled_*` arrays are union-merged, `bootstrap` is shallow-merged, and top-level `agents`/`categories` maps merge by key. A higher-priority source replaces the whole object for the same `agents.<key>` or `categories.<id>` entry; unrelated keys survive. Project overlays are the exception for trust-sensitive fields: they cannot define `model`, `variant`, `permission`, or `skills`, and same-key project overlays preserve user-level `model`/`variant`/`permission`/`skills` fields instead of erasing them. After that effective config is built, Systematic applies category and exact overlays to bundled agents using the overlay precedence above.
 
 ## Advanced Configuration
 

--- a/skills/onboarding/scripts/inventory.mjs
+++ b/skills/onboarding/scripts/inventory.mjs
@@ -339,7 +339,7 @@ async function detectLanguagesAndFrameworks() {
       if (allDeps[dep]) {
         // Check exclusion rules before adding
         const exclusions = NODE_FRAMEWORK_EXCLUSIONS[fw]
-        if (exclusions && exclusions.some((ex) => allDeps[ex])) continue
+        if (exclusions?.some((ex) => allDeps[ex])) continue
 
         const ver = allDeps[dep].replace(/[\^~>=<]/g, '').split(' ')[0]
         frameworks.push(ver ? `${fw} ${ver}` : fw)
@@ -821,7 +821,7 @@ async function findTestInfra() {
     'src/__tests__',
   ]
   for (const dir of testDirs) {
-    if (await exists(join(root, dir))) dirs.push(dir + '/')
+    if (await exists(join(root, dir))) dirs.push(`${dir}/`)
   }
 
   // Test config files
@@ -1042,13 +1042,13 @@ async function main() {
     infrastructure,
   }
 
-  process.stdout.write(JSON.stringify(inventory) + '\n')
+  process.stdout.write(`${JSON.stringify(inventory)}\n`)
 }
 
 main().catch((err) => {
   // Always exit 0 with valid JSON, even on error
   process.stdout.write(
-    JSON.stringify({
+    `${JSON.stringify({
       error: err.message,
       name: basename(root),
       languages: [],
@@ -1062,6 +1062,6 @@ main().catch((err) => {
       docs: [],
       testInfra: { dirs: [], config: [] },
       infrastructure: { envFiles: [], configFiles: [], services: [] },
-    }) + '\n',
+    })}\n`,
   )
 })

--- a/skills/writing-systematic-skills/SKILL.md
+++ b/skills/writing-systematic-skills/SKILL.md
@@ -86,7 +86,7 @@ description: ...
 ---
 ```
 
-Per [OpenCode's agent docs](https://opencode.ai/docs/agents/), subagents with no `model` inherit the model of the primary agent that invoked them — which is the desired portable behavior. Do **not** declare `model: inherit`: that literal value is undocumented and produces `ProviderModelNotFoundError` on OpenCode older than ~v1.13.x (pre [sst/opencode#17888](https://github.com/sst/opencode/pull/17888)). Hardcoded provider model IDs (`anthropic/...`, `openai/...`, etc.) are also banned because they break users on other providers.
+Per [OpenCode's agent docs](https://opencode.ai/docs/agents/), subagents with no `model` inherit the model of the primary agent that invoked them — which is the desired portable behavior. Do **not** declare `model: inherit`: that literal value is undocumented and produces `ProviderModelNotFoundError` on OpenCode older than ~v1.13.x (pre [sst/opencode#17888](https://github.com/sst/opencode/pull/17888)). Hardcoded provider model IDs (`anthropic/...`, `openai/...`, etc.) are also banned from **bundled agent markdown/frontmatter** because they break users on other providers. Source-owned category model defaults in TypeScript code are a separate mechanism — they are audited, centrally maintained, and do not violate this markdown rule.
 
 For agent or API attribution, `ai:systematic` is the machine ID used by Systematic-owned operations, such as Proof's `by` field and `X-Agent-Id` header. It is not a skill cross-reference convention.
 

--- a/skills/writing-systematic-skills/references/foundation-conventions.md
+++ b/skills/writing-systematic-skills/references/foundation-conventions.md
@@ -120,9 +120,9 @@ Per [OpenCode's agent docs](https://opencode.ai/docs/agents/): **"If you don't s
 
 Do **not** declare `model: inherit`. That literal value is undocumented and was treated as a real provider/model string by `Provider.parseModel()` until [sst/opencode#17888](https://github.com/sst/opencode/pull/17888) landed in mid-March 2026 — producing `ProviderModelNotFoundError` on every subagent invocation for anyone on an older OpenCode. Omitting the field works on every OpenCode version and is what the docs canonically describe.
 
-Hardcoded provider IDs (`anthropic/claude-...`, `openai/gpt-...`, etc.) are also banned because they make an agent unusable for users on other providers. If a future agent truly depends on a specific provider, document the constraint in the plan and get explicit review before adding the hardcoded model.
+Hardcoded provider IDs (`anthropic/claude-...`, `openai/gpt-...`, etc.) are also banned from **bundled agent markdown/frontmatter** because they make an agent unusable for users on other providers. This ban does not apply to source-owned category model defaults in TypeScript code, which are centrally maintained, structurally validated, and emitted at the built-in/default layer during config handling. If a future agent truly depends on a specific provider in its markdown, document the constraint in the plan and get explicit review before adding the hardcoded model.
 
-Systematic now provides source-owned category model defaults in TypeScript code for all six bundled agent categories (`design`, `docs`, `document-review`, `research`, `review`, `workflow`). These code-level defaults are emitted during config handling and do not change the markdown contract: bundled agent files must still omit `model` frontmatter. The content-integrity gate continues to enforce this ban regardless of what source defaults provide.
+Systematic provides source-owned category model defaults in TypeScript code for all six bundled agent categories (`design`, `docs`, `document-review`, `research`, `review`, `workflow`). These code-level defaults are emitted during config handling and do not change the markdown contract: bundled agent files must still omit `model` frontmatter. The content-integrity gate continues to enforce the markdown-level ban independently of what source code defaults provide.
 
 ### Machine ID
 

--- a/skills/writing-systematic-skills/references/foundation-conventions.md
+++ b/skills/writing-systematic-skills/references/foundation-conventions.md
@@ -122,6 +122,8 @@ Do **not** declare `model: inherit`. That literal value is undocumented and was 
 
 Hardcoded provider IDs (`anthropic/claude-...`, `openai/gpt-...`, etc.) are also banned because they make an agent unusable for users on other providers. If a future agent truly depends on a specific provider, document the constraint in the plan and get explicit review before adding the hardcoded model.
 
+Systematic now provides source-owned category model defaults in TypeScript code for all six bundled agent categories (`design`, `docs`, `document-review`, `research`, `review`, `workflow`). These code-level defaults are emitted during config handling and do not change the markdown contract: bundled agent files must still omit `model` frontmatter. The content-integrity gate continues to enforce this ban regardless of what source defaults provide.
+
 ### Machine ID
 
 `ai:systematic` is a machine identity string for Systematic-owned operations. Proof uses it as the `by` field on operations and the `X-Agent-Id` header. Keep it lowercase and stable.

--- a/src/lib/agent-overlays.ts
+++ b/src/lib/agent-overlays.ts
@@ -58,8 +58,6 @@ const SOURCE_CATEGORY_MODEL_DEFAULTS = {
   workflow: 'openai/gpt-5.4-mini',
 } as const satisfies Record<string, string>
 
-const SOURCE_MODEL_INTENTIONAL_INHERIT_CATEGORIES = new Set<string>()
-
 const ALLOWED_OVERLAY_FIELDS = new Set([
   'model',
   'variant',
@@ -184,19 +182,16 @@ export function getSourceCategoryModel(
   category: string | undefined,
 ): string | undefined {
   if (!category) return undefined
-
-  validateSourceCategoryModelDefaults()
-  const defaults: Record<string, string> = SOURCE_CATEGORY_MODEL_DEFAULTS
-  return defaults[category]
+  return (SOURCE_CATEGORY_MODEL_DEFAULTS as Record<string, string | undefined>)[
+    category
+  ]
 }
 
 export function assertSourceCategoryModelCoverage(categories: string[]): void {
   validateSourceCategoryModelDefaults()
 
   const missingCategories = categories.filter(
-    (category) =>
-      !Object.hasOwn(SOURCE_CATEGORY_MODEL_DEFAULTS, category) &&
-      !SOURCE_MODEL_INTENTIONAL_INHERIT_CATEGORIES.has(category),
+    (category) => !Object.hasOwn(SOURCE_CATEGORY_MODEL_DEFAULTS, category),
   )
 
   if (missingCategories.length > 0) {
@@ -367,6 +362,7 @@ function validateOverlayFieldValue(
 ): void {
   switch (field) {
     case 'model':
+      if (value === null) return // null opt-out: inherit parent model
       validateModel(sourcePath, keyPath, value)
       return
     case 'variant':

--- a/src/lib/agent-overlays.ts
+++ b/src/lib/agent-overlays.ts
@@ -49,6 +49,17 @@ export interface ResolvedAgentOverlaySet {
   categoriesByKey: Map<string, ValidatedCategoryOverlay>
 }
 
+const SOURCE_CATEGORY_MODEL_DEFAULTS = {
+  design: 'openai/gpt-5.5',
+  docs: 'openai/gpt-5.4-mini',
+  'document-review': 'anthropic/claude-opus-4.7',
+  research: 'openai/gpt-5.5',
+  review: 'anthropic/claude-opus-4.7',
+  workflow: 'openai/gpt-5.4-mini',
+} as const satisfies Record<string, string>
+
+const SOURCE_MODEL_INTENTIONAL_INHERIT_CATEGORIES = new Set<string>()
+
 const ALLOWED_OVERLAY_FIELDS = new Set([
   'model',
   'variant',
@@ -167,6 +178,44 @@ export function inferBuiltInTemperature(
     return 0.6
   }
   return 0.3
+}
+
+export function getSourceCategoryModel(
+  category: string | undefined,
+): string | undefined {
+  if (!category) return undefined
+
+  validateSourceCategoryModelDefaults()
+  const defaults: Record<string, string> = SOURCE_CATEGORY_MODEL_DEFAULTS
+  return defaults[category]
+}
+
+export function assertSourceCategoryModelCoverage(categories: string[]): void {
+  validateSourceCategoryModelDefaults()
+
+  const missingCategories = categories.filter(
+    (category) =>
+      !Object.hasOwn(SOURCE_CATEGORY_MODEL_DEFAULTS, category) &&
+      !SOURCE_MODEL_INTENTIONAL_INHERIT_CATEGORIES.has(category),
+  )
+
+  if (missingCategories.length > 0) {
+    throw new Error(
+      `Source category model defaults missing intentional coverage for: ${missingCategories.join(', ')}`,
+    )
+  }
+}
+
+export function validateSourceCategoryModelDefaults(
+  defaults: Record<string, unknown> = SOURCE_CATEGORY_MODEL_DEFAULTS,
+): void {
+  for (const [category, model] of Object.entries(defaults)) {
+    validateModel(
+      'source category model defaults',
+      `source category model defaults.${category}`,
+      model,
+    )
+  }
 }
 
 function validateExactAgentOverlays(

--- a/src/lib/config-handler.ts
+++ b/src/lib/config-handler.ts
@@ -1,6 +1,7 @@
 import type { Config } from '@opencode-ai/plugin'
 import type { AgentConfig } from '@opencode-ai/sdk'
 import {
+  assertSourceCategoryModelCoverage,
   buildBundledAgentInventory,
   getSourceCategoryModel,
   inferBuiltInTemperature,
@@ -264,7 +265,12 @@ function applyOverlayObject(
 ): void {
   for (const field of OVERLAY_ASSIGN_FIELDS) {
     if (Object.hasOwn(overlay, field)) {
-      ;(target as Record<string, unknown>)[field] = overlay[field]
+      // model: null means "restore inheritance" — delete any source default
+      if (field === 'model' && overlay[field] === null) {
+        delete target[field]
+      } else {
+        ;(target as Record<string, unknown>)[field] = overlay[field]
+      }
     }
   }
 
@@ -434,6 +440,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
       bundledAgentsDir,
       systematicConfig.disabled_agents,
     )
+    assertSourceCategoryModelCoverage(inventory.categories)
     const validatedOverlays = validateAgentOverlays({
       inventory,
       overlays,

--- a/src/lib/config-handler.ts
+++ b/src/lib/config-handler.ts
@@ -2,6 +2,7 @@ import type { Config } from '@opencode-ai/plugin'
 import type { AgentConfig } from '@opencode-ai/sdk'
 import {
   buildBundledAgentInventory,
+  getSourceCategoryModel,
   inferBuiltInTemperature,
   type ResolvedAgentOverlaySet,
   resolveAgentOverlaySet,
@@ -205,6 +206,17 @@ function applyAgentOverlays(
     agentInfo.name,
     result.description,
   )
+
+  // Apply source category model default for categorized bundled agents.
+  // Source defaults defensively replace any bundled markdown model before
+  // high-trust overlays apply. Precedence: exact overlay > category overlay
+  // > source model default > markdown / inheritance.
+  if (agentInfo.category) {
+    const sourceModel = getSourceCategoryModel(agentInfo.category)
+    if (sourceModel) {
+      result.model = sourceModel
+    }
+  }
 
   if (categoryOverlay) {
     applyOverlayObject(result, categoryOverlay.value, permissionRules)

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -64,7 +64,12 @@ interface ConfigSource {
   trust: 'user' | 'project' | 'custom'
 }
 
-const SECURITY_OVERLAY_FIELDS = new Set(['model', 'permission', 'skills'])
+const SECURITY_OVERLAY_FIELDS = new Set([
+  'model',
+  'variant',
+  'permission',
+  'skills',
+])
 
 function isErrorWithCode(error: unknown): error is Error & { code?: unknown } {
   return error instanceof Error && 'code' in error

--- a/tests/integration/opencode.test.ts
+++ b/tests/integration/opencode.test.ts
@@ -285,16 +285,41 @@ describe('SystematicPlugin config hook integration', () => {
     expect(config).toEqual(before)
   })
 
-  test('no user model config leaves emitted bundled agents without default models', async () => {
+  test('zero config emits source model defaults for categorized agents and no fallback_models', async () => {
     const config: Config = {}
     await runConfigHook(config)
 
-    const modeledAgents = Object.entries(config.agent ?? {}).filter(
-      ([, agent]) => agent?.model !== undefined,
+    // Assert correct source model per category for at least one real bundled agent
+    expect(config.agent?.['correctness-reviewer']?.model).toBe(
+      'anthropic/claude-opus-4.7',
+    )
+    expect(config.agent?.['correctness-reviewer']?.temperature).toBeDefined()
+
+    // design category
+    expect(config.agent?.['design-implementation-reviewer']?.model).toBe(
+      'openai/gpt-5.5',
+    )
+    // docs category
+    expect(config.agent?.['ankane-readme-writer']?.model).toBe(
+      'openai/gpt-5.4-mini',
+    )
+    // document-review category
+    expect(config.agent?.['adversarial-document-reviewer']?.model).toBe(
+      'anthropic/claude-opus-4.7',
+    )
+    // research category
+    expect(config.agent?.['best-practices-researcher']?.model).toBe(
+      'openai/gpt-5.5',
+    )
+    // workflow category
+    expect(config.agent?.['bug-reproduction-validator']?.model).toBe(
+      'openai/gpt-5.4-mini',
     )
 
-    expect(modeledAgents).toEqual([])
-    expect(config.agent?.['correctness-reviewer']?.temperature).toBeDefined()
+    // Verify no fallback_models leak into any emitted agent
+    for (const [, agent] of Object.entries(config.agent ?? {})) {
+      expect(agent).not.toHaveProperty('fallback_models')
+    }
   })
 
   test('loads with category model overlays and exact agent overlay without throwing', async () => {

--- a/tests/integration/opencode.test.ts
+++ b/tests/integration/opencode.test.ts
@@ -110,13 +110,13 @@ describe('SystematicPlugin config hook integration', () => {
 
   beforeEach(() => {
     _resetPluginSingleton()
+    originalHomedir = os.homedir
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'systematic-plugin-'))
 
     // Isolate from real user config (~/.config/opencode/systematic.json)
     // by mocking os.homedir to point at an empty temp directory.
     homeDir = path.join(tempDir, 'fake-home')
     fs.mkdirSync(homeDir, { recursive: true })
-    originalHomedir = os.homedir
     os.homedir = () => homeDir
 
     projectDir = path.join(tempDir, 'project')

--- a/tests/unit/agent-overlays.test.ts
+++ b/tests/unit/agent-overlays.test.ts
@@ -3,10 +3,13 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import {
+  assertSourceCategoryModelCoverage,
   type BundledAgentInventory,
   buildBundledAgentInventory,
+  getSourceCategoryModel,
   inferBuiltInTemperature,
   validateAgentOverlays,
+  validateSourceCategoryModelDefaults,
 } from '../../src/lib/agent-overlays.js'
 import type { SourcedOverlayConfig } from '../../src/lib/config.js'
 
@@ -223,6 +226,40 @@ describe('validateAgentOverlays', () => {
         }),
       ).toThrow(new RegExp(`agents\\.correctness-reviewer\\.${field}`))
     }
+  })
+
+  test('rejects fallback_models in exact agent overlays', () => {
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {
+            'correctness-reviewer': source('agents', 'correctness-reviewer', {
+              fallback_models: ['openai/gpt-4'],
+            }),
+          },
+          categories: {},
+        },
+        nativeAgents: {},
+      }),
+    ).toThrow(/agents\.correctness-reviewer\.fallback_models.*unsupported/)
+  })
+
+  test('rejects fallback_models in category overlays', () => {
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {},
+          categories: {
+            review: source('categories', 'review', {
+              fallback_models: ['openai/gpt-4'],
+            }),
+          },
+        },
+        nativeAgents: {},
+      }),
+    ).toThrow(/categories\.review\.fallback_models.*unsupported/)
   })
 
   test('rejects category disable but accepts exact disable', () => {
@@ -505,5 +542,40 @@ describe('inferBuiltInTemperature', () => {
     ['general-helper', 'Handles miscellaneous work', 0.3],
   ])('returns %p temperature for %s', (name, description, expected) => {
     expect(inferBuiltInTemperature(name, description)).toBe(expected)
+  })
+})
+
+describe('source category model defaults', () => {
+  test.each([
+    ['design', 'openai/gpt-5.5'],
+    ['docs', 'openai/gpt-5.4-mini'],
+    ['document-review', 'anthropic/claude-opus-4.7'],
+    ['research', 'openai/gpt-5.5'],
+    ['review', 'anthropic/claude-opus-4.7'],
+    ['workflow', 'openai/gpt-5.4-mini'],
+  ])('returns source model %p for category %s', (category, expected) => {
+    expect(getSourceCategoryModel(category)).toBe(expected)
+  })
+
+  test('returns no source model for unknown and uncategorized agents', () => {
+    expect(getSourceCategoryModel('unknown')).toBeUndefined()
+    expect(getSourceCategoryModel(undefined)).toBeUndefined()
+  })
+
+  test('covers every discovered bundled category intentionally', () => {
+    const inventory = buildBundledAgentInventory(
+      path.join(process.cwd(), 'agents'),
+      [],
+    )
+
+    expect(() =>
+      assertSourceCategoryModelCoverage(inventory.categories),
+    ).not.toThrow()
+  })
+
+  test('rejects malformed source model defaults through the shared model validator', () => {
+    expect(() =>
+      validateSourceCategoryModelDefaults({ review: 'gpt-5' }),
+    ).toThrow(/source category model defaults\.review.*provider\/model/)
   })
 })

--- a/tests/unit/agent-overlays.test.ts
+++ b/tests/unit/agent-overlays.test.ts
@@ -479,6 +479,38 @@ describe('validateAgentOverlays', () => {
     ).toThrow(/agents\.correctness-reviewer\.skills/)
   })
 
+  test('accepts null model as high-trust inheritance opt-out', () => {
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {
+            'correctness-reviewer': source('agents', 'correctness-reviewer', {
+              model: null,
+            }),
+          },
+          categories: {},
+        },
+        nativeAgents: {},
+      }),
+    ).not.toThrow()
+  })
+
+  test('accepts null model in category overlays', () => {
+    expect(() =>
+      validateAgentOverlays({
+        inventory: createInventory(),
+        overlays: {
+          agents: {},
+          categories: {
+            review: source('categories', 'review', { model: null }),
+          },
+        },
+        nativeAgents: {},
+      }),
+    ).not.toThrow()
+  })
+
   test('model requires provider/model and does not normalize shorthand', () => {
     for (const model of ['gpt-4', 'inherit']) {
       expect(() =>

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -684,7 +684,7 @@ model: gpt-4
       expect(config.command?.['systematic:routed-skill']?.model).toBe('gpt-4')
     })
 
-    test('applies built-in temperature defaults without emitting default model', async () => {
+    test('applies built-in temperature and source model defaults for categorized agents', async () => {
       createCategorizedAgent('review', 'correctness-reviewer', {
         name: 'correctness-reviewer',
         description: 'Reviews correctness',
@@ -701,7 +701,197 @@ model: gpt-4
       await handler(config)
 
       expect(config.agent?.['correctness-reviewer']?.temperature).toBe(0.1)
-      expect(config.agent?.['correctness-reviewer']?.model).toBeUndefined()
+      expect(config.agent?.['correctness-reviewer']?.model).toBe(
+        'anthropic/claude-opus-4.7',
+      )
+    })
+
+    test('uncategorized bundled agent receives no source model default', async () => {
+      createAgent(path.join(bundledDir, 'agents'), 'uncategorized', {
+        name: 'uncategorized',
+        description: 'No category agent',
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.uncategorized?.temperature).toBeDefined()
+      expect(config.agent?.uncategorized?.model).toBeUndefined()
+    })
+
+    test('zero config emits source model defaults for all categorized agents', async () => {
+      createCategorizedAgent('design', 'design-agent', {
+        name: 'design-agent',
+        description: 'Design agent',
+      })
+      createCategorizedAgent('docs', 'docs-agent', {
+        name: 'docs-agent',
+        description: 'Docs agent',
+      })
+      createCategorizedAgent('document-review', 'doc-review-agent', {
+        name: 'doc-review-agent',
+        description: 'Document review agent',
+      })
+      createCategorizedAgent('research', 'research-agent', {
+        name: 'research-agent',
+        description: 'Research agent',
+      })
+      createCategorizedAgent('review', 'review-agent', {
+        name: 'review-agent',
+        description: 'Review agent',
+      })
+      createCategorizedAgent('workflow', 'workflow-agent', {
+        name: 'workflow-agent',
+        description: 'Workflow agent',
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.['design-agent']?.model).toBe('openai/gpt-5.5')
+      expect(config.agent?.['docs-agent']?.model).toBe('openai/gpt-5.4-mini')
+      expect(config.agent?.['doc-review-agent']?.model).toBe(
+        'anthropic/claude-opus-4.7',
+      )
+      expect(config.agent?.['research-agent']?.model).toBe('openai/gpt-5.5')
+      expect(config.agent?.['review-agent']?.model).toBe(
+        'anthropic/claude-opus-4.7',
+      )
+      expect(config.agent?.['workflow-agent']?.model).toBe(
+        'openai/gpt-5.4-mini',
+      )
+
+      // No fallback_models key leaks into any emitted agent
+      for (const [, agent] of Object.entries(config.agent ?? {})) {
+        expect(agent).not.toHaveProperty('fallback_models')
+      }
+    })
+
+    test('high-trust exact model overrides source default', async () => {
+      createCategorizedAgent('review', 'correctness-reviewer', {
+        name: 'correctness-reviewer',
+        description: 'Reviews correctness',
+      })
+      writeCustomSystematicConfig({
+        agents: {
+          'correctness-reviewer': {
+            model: 'openrouter/anthropic/claude-sonnet-4',
+          },
+        },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.['correctness-reviewer']?.model).toBe(
+        'openrouter/anthropic/claude-sonnet-4',
+      )
+    })
+
+    test('high-trust category model overrides source defaults for every agent in that category', async () => {
+      createCategorizedAgent('review', 'first-reviewer', {
+        name: 'first-reviewer',
+        description: 'First reviewer',
+      })
+      createCategorizedAgent('review', 'second-reviewer', {
+        name: 'second-reviewer',
+        description: 'Second reviewer',
+      })
+      writeCustomSystematicConfig({
+        categories: {
+          review: { model: 'openai/gpt-4o' },
+        },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.['first-reviewer']?.model).toBe('openai/gpt-4o')
+      expect(config.agent?.['second-reviewer']?.model).toBe('openai/gpt-4o')
+    })
+
+    test('category overlay with non-model fields preserves source model', async () => {
+      createCategorizedAgent('review', 'correctness-reviewer', {
+        name: 'correctness-reviewer',
+        description: 'Reviews correctness',
+      })
+      writeCustomSystematicConfig({
+        categories: {
+          review: { temperature: 0.55 },
+        },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.['correctness-reviewer']?.model).toBe(
+        'anthropic/claude-opus-4.7',
+      )
+      expect(config.agent?.['correctness-reviewer']?.temperature).toBe(0.55)
+    })
+
+    test('native same-name replacement receives no Systematic source model default', async () => {
+      createCategorizedAgent('review', 'native-replaced', {
+        name: 'native-replaced',
+        description: 'Bundled description',
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {
+        agent: {
+          'native-replaced': {
+            description: 'Native owns this key',
+            prompt: 'Native prompt',
+          },
+        },
+      }
+      await handler(config)
+
+      expect(config.agent?.['native-replaced']?.model).toBeUndefined()
+      expect(config.agent?.['native-replaced']?.description).toBe(
+        'Native owns this key',
+      )
     })
 
     test('built-in temperature overrides bundled markdown unless category or exact overlay is stronger', async () => {
@@ -775,7 +965,10 @@ model: gpt-4
       expect(agent?.color).toBe('#123abc')
       expect(agent?.steps).toBe(12)
       expect(agent?.hidden).toBe(true)
-      expect(config.agent?.['other-reviewer']?.model).toBeUndefined()
+      // other-reviewer (review category) gets source model default
+      expect(config.agent?.['other-reviewer']?.model).toBe(
+        'anthropic/claude-opus-4.7',
+      )
     })
 
     test('accepts and emits variant without model', async () => {
@@ -783,7 +976,7 @@ model: gpt-4
         name: 'correctness-reviewer',
         description: 'Reviews correctness',
       })
-      writeSystematicConfig({
+      writeCustomSystematicConfig({
         agents: { 'correctness-reviewer': { variant: 'small' } },
       })
 
@@ -798,7 +991,10 @@ model: gpt-4
       await handler(config)
 
       expect(config.agent?.['correctness-reviewer']?.variant).toBe('small')
-      expect(config.agent?.['correctness-reviewer']?.model).toBeUndefined()
+      // review-category agent still gets source model default even when variant is set via high-trust config
+      expect(config.agent?.['correctness-reviewer']?.model).toBe(
+        'anthropic/claude-opus-4.7',
+      )
     })
 
     test('managed skills shortcut emits ordered deny-all then allow-selected rules', async () => {

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -14,20 +14,14 @@ describe('config-handler', () => {
   let testDir: string
   let bundledDir: string
   let projectDir: string
-  let homeDir: string
-  let originalHomedir: typeof os.homedir
+  let originalOsHomedir: (() => string) | undefined
 
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'systematic-config-test-'))
-
-    // Isolate from real user config (~/.config/opencode/systematic.json).
-    homeDir = path.join(testDir, 'fake-home')
-    fs.mkdirSync(homeDir, { recursive: true })
-    originalHomedir = os.homedir
-    os.homedir = () => homeDir
-
     bundledDir = path.join(testDir, 'bundled')
     projectDir = path.join(testDir, 'project')
+    originalOsHomedir = os.homedir
+    os.homedir = () => path.join(testDir, 'home')
 
     fs.mkdirSync(path.join(bundledDir, 'skills'), { recursive: true })
     fs.mkdirSync(path.join(bundledDir, 'agents'), { recursive: true })
@@ -44,7 +38,7 @@ describe('config-handler', () => {
   })
 
   afterEach(() => {
-    os.homedir = originalHomedir
+    if (originalOsHomedir) os.homedir = originalOsHomedir
     delete process.env.OPENCODE_CONFIG_DIR
     fs.rmSync(testDir, { recursive: true, force: true })
   })
@@ -781,6 +775,162 @@ model: gpt-4
       }
     })
 
+    test('source defaults replace bundled markdown model for categorized agents', async () => {
+      createCategorizedAgent('review', 'correctness-reviewer', {
+        name: 'correctness-reviewer',
+        description: 'Reviews correctness',
+        model: 'openai/gpt-3.5-turbo',
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      // Source default wins over bundled markdown model
+      expect(config.agent?.['correctness-reviewer']?.model).toBe(
+        'anthropic/claude-opus-4.7',
+      )
+    })
+
+    test('source defaults do not emit for uncategorized agents even with markdown model', async () => {
+      createAgent(path.join(bundledDir, 'agents'), 'standalone', {
+        name: 'standalone',
+        description: 'No category agent',
+        model: 'openai/gpt-4',
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      // Uncategorized agents keep their markdown model since no source default applies
+      expect(config.agent?.standalone?.model).toBe('openai/gpt-4')
+    })
+
+    test('project config overlay with non-sensitive fields preserves source model', async () => {
+      createCategorizedAgent('review', 'correctness-reviewer', {
+        name: 'correctness-reviewer',
+        description: 'Reviews correctness',
+      })
+      writeSystematicConfig({
+        categories: { review: { temperature: 0.55 } },
+        agents: { 'correctness-reviewer': { hidden: true } },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      // Source model preserved even when project config sets non-sensitive fields
+      expect(config.agent?.['correctness-reviewer']?.model).toBe(
+        'anthropic/claude-opus-4.7',
+      )
+      expect(config.agent?.['correctness-reviewer']?.temperature).toBe(0.55)
+      expect(config.agent?.['correctness-reviewer']?.hidden).toBe(true)
+    })
+
+    test('high-trust exact model: null opt-out removes source default', async () => {
+      createCategorizedAgent('review', 'correctness-reviewer', {
+        name: 'correctness-reviewer',
+        description: 'Reviews correctness',
+      })
+      writeCustomSystematicConfig({
+        agents: {
+          'correctness-reviewer': { model: null },
+        },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      // model: null removes source default — agent inherits parent model
+      expect(config.agent?.['correctness-reviewer']?.model).toBeUndefined()
+    })
+
+    test('high-trust category model: null opt-out removes source default for category members', async () => {
+      createCategorizedAgent('review', 'first-reviewer', {
+        name: 'first-reviewer',
+        description: 'First reviewer',
+      })
+      createCategorizedAgent('review', 'second-reviewer', {
+        name: 'second-reviewer',
+        description: 'Second reviewer',
+      })
+      writeCustomSystematicConfig({
+        categories: {
+          review: { model: null },
+        },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.['first-reviewer']?.model).toBeUndefined()
+      expect(config.agent?.['second-reviewer']?.model).toBeUndefined()
+    })
+
+    test('exact model string overrides category model: null opt-out', async () => {
+      createCategorizedAgent('review', 'correctness-reviewer', {
+        name: 'correctness-reviewer',
+        description: 'Reviews correctness',
+      })
+      writeCustomSystematicConfig({
+        categories: { review: { model: null } },
+        agents: {
+          'correctness-reviewer': {
+            model: 'openrouter/anthropic/claude-sonnet-4',
+          },
+        },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      // Exact overlay string model beats category null opt-out
+      expect(config.agent?.['correctness-reviewer']?.model).toBe(
+        'openrouter/anthropic/claude-sonnet-4',
+      )
+    })
+
     test('high-trust exact model overrides source default', async () => {
       createCategorizedAgent('review', 'correctness-reviewer', {
         name: 'correctness-reviewer',
@@ -1223,6 +1373,24 @@ model: gpt-4
       await handler(config)
 
       expect(config.agent?.helper).toBeUndefined()
+    })
+
+    test('assertSourceCategoryModelCoverage fires on missing category', async () => {
+      // Create a categorized agent in a category not covered by source defaults
+      // The existing bundled agents dir has 6 covered categories (design, docs,
+      // document-review, research, review, workflow). An uncovered category would
+      // cause a throw inside createConfigHandler, but we can't create an actual
+      // uncovered directory in bundled agents. Instead, test that when the
+      // assertion is called with an uncovered category, it fails.
+      const { assertSourceCategoryModelCoverage: assertCoverage } =
+        await import('../../src/lib/agent-overlays.js')
+
+      expect(() => assertCoverage(['review', 'unknown-category'])).toThrow(
+        /Source category model defaults missing intentional coverage for/,
+      )
+      expect(() => assertCoverage(['review', 'unknown-category'])).toThrow(
+        /unknown-category/,
+      )
     })
 
     test('invalid overlay leaves config surfaces unmodified', async () => {

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -491,6 +491,86 @@ describe('config', () => {
         })
       })
 
+      test('project overlays cannot configure variant in agents or categories', () => {
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        const projectConfigPath = path.join(projectConfigDir, 'systematic.json')
+
+        for (const config of [
+          {
+            agents: {
+              'correctness-reviewer': { variant: 'large-context' },
+            },
+          },
+          { categories: { review: { variant: 'small' } } },
+        ]) {
+          fs.writeFileSync(projectConfigPath, JSON.stringify(config))
+
+          expect(() => loadConfigWithSources(testDir)).toThrow(
+            projectConfigPath,
+          )
+          expect(() => loadConfigWithSources(testDir)).toThrow(
+            /only valid in user config or OPENCODE_CONFIG_DIR config/,
+          )
+        }
+      })
+
+      test('project same-key overlay preserves variant from higher-trust config', () => {
+        const userConfigDir = path.join(os.homedir(), '.config/opencode')
+        const userConfigPath = path.join(userConfigDir, 'systematic.json')
+        const userConfigBackup = tryReadFile(userConfigPath)
+
+        try {
+          fs.mkdirSync(userConfigDir, { recursive: true })
+          fs.writeFileSync(
+            userConfigPath,
+            JSON.stringify({
+              agents: {
+                'correctness-reviewer': {
+                  variant: 'large-context',
+                  model: 'openai/gpt-5',
+                  temperature: 0.1,
+                },
+              },
+              categories: {
+                review: {
+                  variant: 'small',
+                  temperature: 0.2,
+                },
+              },
+            }),
+          )
+
+          const projectConfigDir = path.join(testDir, '.opencode')
+          fs.mkdirSync(projectConfigDir)
+          fs.writeFileSync(
+            path.join(projectConfigDir, 'systematic.json'),
+            JSON.stringify({
+              agents: { 'correctness-reviewer': { hidden: true } },
+              categories: { review: { temperature: 0.5 } },
+            }),
+          )
+
+          const result = loadConfigWithSources(testDir)
+
+          expect(result.config.agents?.['correctness-reviewer']).toEqual({
+            hidden: true,
+            variant: 'large-context',
+            model: 'openai/gpt-5',
+          })
+          expect(result.config.categories?.review).toEqual({
+            temperature: 0.5,
+            variant: 'small',
+          })
+        } finally {
+          if (userConfigBackup !== null) {
+            fs.writeFileSync(userConfigPath, userConfigBackup)
+          } else {
+            tryUnlink(userConfigPath)
+          }
+        }
+      })
+
       test('custom config category overlay replaces project same-key overlay', () => {
         const customDir = fs.mkdtempSync(
           path.join(os.tmpdir(), 'systematic-custom-'),

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -11,21 +11,29 @@ import {
 
 describe('config', () => {
   let testDir: string
-  let homeDir: string
-  let originalHomedir: typeof os.homedir
+  let originalOsHomedir: (() => string) | undefined
 
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'systematic-test-'))
-    homeDir = path.join(testDir, 'fake-home')
-    fs.mkdirSync(homeDir, { recursive: true })
-    originalHomedir = os.homedir
-    os.homedir = () => homeDir
+    originalOsHomedir = os.homedir
+    os.homedir = () => path.join(testDir, 'home')
   })
 
   afterEach(() => {
-    os.homedir = originalHomedir
+    if (originalOsHomedir) os.homedir = originalOsHomedir
     fs.rmSync(testDir, { recursive: true, force: true })
   })
+
+  function userConfigPath(): string {
+    return path.join(os.homedir(), '.config', 'opencode', 'systematic.json')
+  }
+
+  function writeUserConfig(config: Record<string, unknown>): string {
+    const filePath = userConfigPath()
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, JSON.stringify(config))
+    return filePath
+  }
 
   describe('loadConfig', () => {
     describe('no config files', () => {
@@ -100,14 +108,7 @@ describe('config', () => {
 
     describe('user config only', () => {
       test('merges user config with defaults', () => {
-        const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        fs.mkdirSync(userConfigDir, { recursive: true })
-        fs.writeFileSync(
-          path.join(userConfigDir, 'systematic.json'),
-          JSON.stringify({
-            disabled_agents: ['agent-1'],
-          }),
-        )
+        writeUserConfig({ disabled_agents: ['agent-1'] })
 
         const result = loadConfig(testDir)
         expect(result.disabled_agents).toContain('agent-1')
@@ -118,14 +119,7 @@ describe('config', () => {
 
     describe('both configs', () => {
       test('project config overrides user config', () => {
-        const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        fs.mkdirSync(userConfigDir, { recursive: true })
-        fs.writeFileSync(
-          path.join(userConfigDir, 'systematic.json'),
-          JSON.stringify({
-            disabled_skills: ['user-skill'],
-          }),
-        )
+        writeUserConfig({ disabled_skills: ['user-skill'] })
 
         const projectConfigDir = path.join(testDir, '.opencode')
         fs.mkdirSync(projectConfigDir)
@@ -142,16 +136,7 @@ describe('config', () => {
       })
 
       test('project bootstrap overrides user bootstrap', () => {
-        const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        fs.mkdirSync(userConfigDir, { recursive: true })
-        fs.writeFileSync(
-          path.join(userConfigDir, 'systematic.json'),
-          JSON.stringify({
-            bootstrap: {
-              enabled: true,
-            },
-          }),
-        )
+        writeUserConfig({ bootstrap: { enabled: true } })
 
         const projectConfigDir = path.join(testDir, '.opencode')
         fs.mkdirSync(projectConfigDir)
@@ -186,14 +171,7 @@ describe('config', () => {
       })
 
       test('combines user and project disabled_skills arrays', () => {
-        const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        fs.mkdirSync(userConfigDir, { recursive: true })
-        fs.writeFileSync(
-          path.join(userConfigDir, 'systematic.json'),
-          JSON.stringify({
-            disabled_skills: ['skill-a'],
-          }),
-        )
+        writeUserConfig({ disabled_skills: ['skill-a'] })
 
         const projectConfigDir = path.join(testDir, '.opencode')
         fs.mkdirSync(projectConfigDir)
@@ -210,14 +188,7 @@ describe('config', () => {
       })
 
       test('combines user and project disabled_agents arrays', () => {
-        const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        fs.mkdirSync(userConfigDir, { recursive: true })
-        fs.writeFileSync(
-          path.join(userConfigDir, 'systematic.json'),
-          JSON.stringify({
-            disabled_agents: ['agent-a'],
-          }),
-        )
+        writeUserConfig({ disabled_agents: ['agent-a'] })
 
         const projectConfigDir = path.join(testDir, '.opencode')
         fs.mkdirSync(projectConfigDir)
@@ -234,14 +205,7 @@ describe('config', () => {
       })
 
       test('combines user and project disabled_commands arrays', () => {
-        const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        fs.mkdirSync(userConfigDir, { recursive: true })
-        fs.writeFileSync(
-          path.join(userConfigDir, 'systematic.json'),
-          JSON.stringify({
-            disabled_commands: ['cmd-a'],
-          }),
-        )
+        writeUserConfig({ disabled_commands: ['cmd-a'] })
 
         const projectConfigDir = path.join(testDir, '.opencode')
         fs.mkdirSync(projectConfigDir)
@@ -260,16 +224,7 @@ describe('config', () => {
 
     describe('object merging (bootstrap)', () => {
       test('spreads bootstrap properties from user config', () => {
-        const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        fs.mkdirSync(userConfigDir, { recursive: true })
-        fs.writeFileSync(
-          path.join(userConfigDir, 'systematic.json'),
-          JSON.stringify({
-            bootstrap: {
-              file: 'user-bootstrap.md',
-            },
-          }),
-        )
+        writeUserConfig({ bootstrap: { file: 'user-bootstrap.md' } })
 
         const result = loadConfig(testDir)
         expect(result.bootstrap.file).toBe('user-bootstrap.md')
@@ -277,26 +232,16 @@ describe('config', () => {
       })
 
       test('project bootstrap fields override user bootstrap fields via spread merge', () => {
-        const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        fs.mkdirSync(userConfigDir, { recursive: true })
-        fs.writeFileSync(
-          path.join(userConfigDir, 'systematic.json'),
-          JSON.stringify({
-            bootstrap: {
-              enabled: true,
-              file: 'user-bootstrap.md',
-            },
-          }),
-        )
+        writeUserConfig({
+          bootstrap: { enabled: true, file: 'user-bootstrap.md' },
+        })
 
         const projectConfigDir = path.join(testDir, '.opencode')
         fs.mkdirSync(projectConfigDir)
         fs.writeFileSync(
           path.join(projectConfigDir, 'systematic.json'),
           JSON.stringify({
-            bootstrap: {
-              enabled: false,
-            },
+            bootstrap: { enabled: false },
           }),
         )
 
@@ -325,16 +270,9 @@ describe('config', () => {
 
     describe('agent and category overlays', () => {
       test('loads a user agent overlay with source and key provenance', () => {
-        const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        fs.mkdirSync(userConfigDir, { recursive: true })
-        fs.writeFileSync(
-          path.join(userConfigDir, 'systematic.json'),
-          JSON.stringify({
-            agents: {
-              'correctness-reviewer': { model: 'openai/gpt-5' },
-            },
-          }),
-        )
+        const userConfigPath = writeUserConfig({
+          agents: { 'correctness-reviewer': { model: 'openai/gpt-5' } },
+        })
 
         const result = loadConfigWithSources(testDir)
 
@@ -343,27 +281,22 @@ describe('config', () => {
         })
         expect(result.overlays.agents['correctness-reviewer']).toEqual({
           value: { model: 'openai/gpt-5' },
-          sourcePath: path.join(userConfigDir, 'systematic.json'),
+          sourcePath: userConfigPath,
           keyPath: 'agents.correctness-reviewer',
         })
       })
 
       test('preserves unrelated user category and project agent overlays', () => {
-        const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        fs.mkdirSync(userConfigDir, { recursive: true })
-        fs.writeFileSync(
-          path.join(userConfigDir, 'systematic.json'),
-          JSON.stringify({ categories: { review: { temperature: 0.2 } } }),
-        )
+        writeUserConfig({
+          categories: { review: { temperature: 0.2 } },
+        })
 
         const projectConfigDir = path.join(testDir, '.opencode')
         fs.mkdirSync(projectConfigDir)
         fs.writeFileSync(
           path.join(projectConfigDir, 'systematic.json'),
           JSON.stringify({
-            agents: {
-              'correctness-reviewer': { temperature: 0.4 },
-            },
+            agents: { 'correctness-reviewer': { temperature: 0.4 } },
           }),
         )
 
@@ -378,19 +311,14 @@ describe('config', () => {
       })
 
       test('project same-key overlays cannot erase user model policy', () => {
-        const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        fs.mkdirSync(userConfigDir, { recursive: true })
-        fs.writeFileSync(
-          path.join(userConfigDir, 'systematic.json'),
-          JSON.stringify({
-            agents: {
-              'correctness-reviewer': {
-                model: 'openai/gpt-5',
-                temperature: 0.1,
-              },
+        writeUserConfig({
+          agents: {
+            'correctness-reviewer': {
+              model: 'openai/gpt-5',
+              temperature: 0.1,
             },
-          }),
-        )
+          },
+        })
 
         const projectConfigDir = path.join(testDir, '.opencode')
         fs.mkdirSync(projectConfigDir)
@@ -444,28 +372,55 @@ describe('config', () => {
         }
       })
 
+      test('project overlays reject model: null as security field violation', () => {
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        const projectConfigPath = path.join(projectConfigDir, 'systematic.json')
+
+        for (const config of [
+          {
+            agents: { 'correctness-reviewer': { model: null } },
+          },
+          { categories: { review: { model: null } } },
+        ]) {
+          fs.writeFileSync(projectConfigPath, JSON.stringify(config))
+
+          expect(() => loadConfigWithSources(testDir)).toThrow(
+            projectConfigPath,
+          )
+          expect(() => loadConfigWithSources(testDir)).toThrow(
+            /only valid in user config or OPENCODE_CONFIG_DIR config/,
+          )
+        }
+      })
+
+      test('user config model: null passes config loading', () => {
+        writeUserConfig({
+          agents: { 'correctness-reviewer': { model: null } },
+        })
+
+        const result = loadConfigWithSources(testDir)
+
+        expect(result.config.agents?.['correctness-reviewer']?.model).toBeNull()
+      })
+
       test('project same-key overlays preserve user permission policy fields', () => {
-        const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        fs.mkdirSync(userConfigDir, { recursive: true })
-        fs.writeFileSync(
-          path.join(userConfigDir, 'systematic.json'),
-          JSON.stringify({
-            categories: {
-              review: {
-                permission: { bash: 'deny' },
-                skills: ['ce:review'],
-                temperature: 0.1,
-              },
+        writeUserConfig({
+          categories: {
+            review: {
+              permission: { bash: 'deny' },
+              skills: ['ce:review'],
+              temperature: 0.1,
             },
-            agents: {
-              'correctness-reviewer': {
-                model: 'openai/gpt-5',
-                permission: { read: 'deny' },
-                temperature: 0.1,
-              },
+          },
+          agents: {
+            'correctness-reviewer': {
+              model: 'openai/gpt-5',
+              permission: { read: 'deny' },
+              temperature: 0.1,
             },
-          }),
-        )
+          },
+        })
 
         const projectConfigDir = path.join(testDir, '.opencode')
         fs.mkdirSync(projectConfigDir)
@@ -516,59 +471,43 @@ describe('config', () => {
       })
 
       test('project same-key overlay preserves variant from higher-trust config', () => {
-        const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        const userConfigPath = path.join(userConfigDir, 'systematic.json')
-        const userConfigBackup = tryReadFile(userConfigPath)
+        writeUserConfig({
+          agents: {
+            'correctness-reviewer': {
+              variant: 'large-context',
+              model: 'openai/gpt-5',
+              temperature: 0.1,
+            },
+          },
+          categories: {
+            review: {
+              variant: 'small',
+              temperature: 0.2,
+            },
+          },
+        })
 
-        try {
-          fs.mkdirSync(userConfigDir, { recursive: true })
-          fs.writeFileSync(
-            userConfigPath,
-            JSON.stringify({
-              agents: {
-                'correctness-reviewer': {
-                  variant: 'large-context',
-                  model: 'openai/gpt-5',
-                  temperature: 0.1,
-                },
-              },
-              categories: {
-                review: {
-                  variant: 'small',
-                  temperature: 0.2,
-                },
-              },
-            }),
-          )
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        fs.writeFileSync(
+          path.join(projectConfigDir, 'systematic.json'),
+          JSON.stringify({
+            agents: { 'correctness-reviewer': { hidden: true } },
+            categories: { review: { temperature: 0.5 } },
+          }),
+        )
 
-          const projectConfigDir = path.join(testDir, '.opencode')
-          fs.mkdirSync(projectConfigDir)
-          fs.writeFileSync(
-            path.join(projectConfigDir, 'systematic.json'),
-            JSON.stringify({
-              agents: { 'correctness-reviewer': { hidden: true } },
-              categories: { review: { temperature: 0.5 } },
-            }),
-          )
+        const result = loadConfigWithSources(testDir)
 
-          const result = loadConfigWithSources(testDir)
-
-          expect(result.config.agents?.['correctness-reviewer']).toEqual({
-            hidden: true,
-            variant: 'large-context',
-            model: 'openai/gpt-5',
-          })
-          expect(result.config.categories?.review).toEqual({
-            temperature: 0.5,
-            variant: 'small',
-          })
-        } finally {
-          if (userConfigBackup !== null) {
-            fs.writeFileSync(userConfigPath, userConfigBackup)
-          } else {
-            tryUnlink(userConfigPath)
-          }
-        }
+        expect(result.config.agents?.['correctness-reviewer']).toEqual({
+          hidden: true,
+          variant: 'large-context',
+          model: 'openai/gpt-5',
+        })
+        expect(result.config.categories?.review).toEqual({
+          temperature: 0.5,
+          variant: 'small',
+        })
       })
 
       test('custom config category overlay replaces project same-key overlay', () => {
@@ -649,14 +588,9 @@ describe('config', () => {
       })
 
       test('preserves unqualified and qualified alias keys across source priorities', () => {
-        const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        fs.mkdirSync(userConfigDir, { recursive: true })
-        fs.writeFileSync(
-          path.join(userConfigDir, 'systematic.json'),
-          JSON.stringify({
-            agents: { 'correctness-reviewer': { temperature: 0.1 } },
-          }),
-        )
+        writeUserConfig({
+          agents: { 'correctness-reviewer': { temperature: 0.1 } },
+        })
 
         const projectConfigDir = path.join(testDir, '.opencode')
         fs.mkdirSync(projectConfigDir)
@@ -840,12 +774,7 @@ describe('config', () => {
     })
 
     test('custom disabled_skills merges with project and user config', () => {
-      const userConfigDir = path.join(os.homedir(), '.config/opencode')
-      fs.mkdirSync(userConfigDir, { recursive: true })
-      fs.writeFileSync(
-        path.join(userConfigDir, 'systematic.json'),
-        JSON.stringify({ disabled_skills: ['user-skill'] }),
-      )
+      writeUserConfig({ disabled_skills: ['user-skill'] })
 
       const customDir = fs.mkdtempSync(
         path.join(os.tmpdir(), 'systematic-custom-'),


### PR DESCRIPTION
## Summary

Adds source-owned model defaults for bundled Systematic agents by category while keeping bundled agent markdown model-free. Categorized bundled agents now emit audited default models unless higher-trust config overrides them.

## Details

- Defines and validates source model defaults for bundled agent categories
- Applies source defaults during config emission without changing native same-name agent replacement semantics
- Keeps project config from steering model routing via `model` or `variant`
- Supports high-trust `model: null` to restore inherited parent-model routing
- Rejects unsupported `fallback_models` overlays and verifies none are emitted
- Updates docs and authoring guidance for the new source/default/inheritance contract

## Migration note

Users who relied on inherited parent-model routing for categorized bundled agents can set `model: null` from user config or `$OPENCODE_CONFIG_DIR/systematic.json` at either the category or exact-agent level. Project `.opencode/systematic.json` cannot set or clear model routing.

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun test tests/unit/agent-overlays.test.ts tests/unit/config-handler.test.ts tests/unit/config.test.ts tests/integration/opencode.test.ts`
- `bun run build`
- `bun test`
- `bun scripts/content-integrity.ts`
- `bun run registry:drift && bun run registry:validate`
- `bun run docs:build`
