### PR TITLE
fix(agents): map ad-hoc colors to OpenCode /config schema

### DIFF
--- a/agents/design/design-iterator.md
+++ b/agents/design/design-iterator.md
@@ -1,7 +1,7 @@
 ---
 name: design-iterator
 description: "Iteratively refines UI design through N screenshot-analyze-improve cycles. Use PROACTIVELY when design changes aren't coming together after 1-2 attempts, or when user requests iterative refinement."
-color: violet
+color: accent
 ---
 
 You are an expert UI/UX design iterator specializing in systematic, progressive refinement of web components. Your methodology combines visual analysis, competitor research, and incremental improvements to transform ordinary interfaces into polished, professional designs.

--- a/agents/design/figma-design-sync.md
+++ b/agents/design/figma-design-sync.md
@@ -1,7 +1,7 @@
 ---
 name: figma-design-sync
 description: "Detects and fixes visual differences between a web implementation and its Figma design. Use iteratively when syncing implementation to match Figma specs."
-color: purple
+color: accent
 ---
 
 You are an expert design-to-code synchronization specialist with deep expertise in visual design systems, web development, CSS/Tailwind styling, and automated quality assurance. Your mission is to ensure pixel-perfect alignment between Figma designs and their web implementations through systematic comparison, detailed analysis, and precise code adjustments.

--- a/agents/docs/ankane-readme-writer.md
+++ b/agents/docs/ankane-readme-writer.md
@@ -1,7 +1,7 @@
 ---
 name: ankane-readme-writer
 description: "Creates or updates README files following Ankane-style template for Ruby gems. Use when writing gem documentation with imperative voice, concise prose, and standard section ordering."
-color: cyan
+color: info
 ---
 
 You are an expert Ruby gem documentation writer specializing in the Ankane-style README format. You have deep knowledge of Ruby ecosystem conventions and excel at creating clear, concise documentation that follows Andrew Kane's proven template structure.

--- a/agents/review/adversarial-reviewer.md
+++ b/agents/review/adversarial-reviewer.md
@@ -2,7 +2,7 @@
 name: adversarial-reviewer
 description: Conditional code-review persona, selected when the diff is large (>=50 changed lines) or touches high-risk domains like auth, payments, data mutations, or external APIs. Actively constructs failure scenarios to break the implementation rather than checking against known patterns.
 tools: Read, Grep, Glob, Bash
-color: red
+color: error
 
 ---
 

--- a/agents/review/agent-native-reviewer.md
+++ b/agents/review/agent-native-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: agent-native-reviewer
 description: "Reviews code to ensure agent-native parity -- any action a user can take, an agent can also take. Use after adding UI features, agent tools, or system prompts."
-color: cyan
+color: info
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/agents/review/api-contract-reviewer.md
+++ b/agents/review/api-contract-reviewer.md
@@ -2,7 +2,7 @@
 name: api-contract-reviewer
 description: Conditional code-review persona, selected when the diff touches API routes, request/response types, serialization, versioning, or exported type signatures. Reviews code for breaking contract changes.
 tools: Read, Grep, Glob, Bash
-color: blue
+color: info
 mode: subagent
 temperature: 0.1
 ---

--- a/agents/review/cli-agent-readiness-reviewer.md
+++ b/agents/review/cli-agent-readiness-reviewer.md
@@ -2,7 +2,7 @@
 name: cli-agent-readiness-reviewer
 description: "Reviews CLI source code, plans, or specs for AI agent readiness using a severity-based rubric focused on whether a CLI is merely usable by agents or genuinely optimized for them."
 tools: Read, Grep, Glob, Bash
-color: yellow
+color: warning
 ---
 
 # CLI Agent-Readiness Reviewer

--- a/agents/review/cli-readiness-reviewer.md
+++ b/agents/review/cli-readiness-reviewer.md
@@ -2,7 +2,7 @@
 name: cli-readiness-reviewer
 description: "Conditional code-review persona, selected when the diff touches CLI command definitions, argument parsing, or command handler implementations. Reviews CLI code for agent readiness -- how well the CLI serves autonomous agents, not just human users."
 tools: Read, Grep, Glob, Bash
-color: blue
+color: info
 ---
 
 # CLI Agent-Readiness Reviewer

--- a/agents/review/correctness-reviewer.md
+++ b/agents/review/correctness-reviewer.md
@@ -2,7 +2,7 @@
 name: correctness-reviewer
 description: Always-on code-review persona. Reviews code for logic errors, edge cases, state management bugs, error propagation failures, and intent-vs-implementation mismatches.
 tools: Read, Grep, Glob, Bash
-color: blue
+color: info
 mode: subagent
 temperature: 0.1
 ---

--- a/agents/review/data-migrations-reviewer.md
+++ b/agents/review/data-migrations-reviewer.md
@@ -2,7 +2,7 @@
 name: data-migrations-reviewer
 description: Conditional code-review persona, selected when the diff touches migration files, schema changes, data transformations, or backfill scripts. Reviews code for data integrity and migration safety.
 tools: Read, Grep, Glob, Bash
-color: blue
+color: info
 mode: subagent
 temperature: 0.1
 ---

--- a/agents/review/dhh-rails-reviewer.md
+++ b/agents/review/dhh-rails-reviewer.md
@@ -2,7 +2,7 @@
 name: dhh-rails-reviewer
 description: Conditional code-review persona, selected when Rails diffs introduce architectural choices, abstractions, or frontend patterns that may fight the framework. Reviews code from an opinionated DHH perspective.
 tools: Read, Grep, Glob, Bash
-color: blue
+color: info
 mode: subagent
 temperature: 0.1
 ---

--- a/agents/review/julik-frontend-races-reviewer.md
+++ b/agents/review/julik-frontend-races-reviewer.md
@@ -2,7 +2,7 @@
 name: julik-frontend-races-reviewer
 description: Conditional code-review persona, selected when the diff touches async UI code, Stimulus/Turbo lifecycles, or DOM-timing-sensitive frontend behavior. Reviews code for race conditions and janky UI failure modes.
 tools: Read, Grep, Glob, Bash
-color: blue
+color: info
 mode: subagent
 temperature: 0.1
 ---

--- a/agents/review/kieran-python-reviewer.md
+++ b/agents/review/kieran-python-reviewer.md
@@ -2,7 +2,7 @@
 name: kieran-python-reviewer
 description: Conditional code-review persona, selected when the diff touches Python code. Reviews changes with Kieran's strict bar for Pythonic clarity, type hints, and maintainability.
 tools: Read, Grep, Glob, Bash
-color: blue
+color: info
 mode: subagent
 temperature: 0.1
 ---

--- a/agents/review/kieran-rails-reviewer.md
+++ b/agents/review/kieran-rails-reviewer.md
@@ -2,7 +2,7 @@
 name: kieran-rails-reviewer
 description: Conditional code-review persona, selected when the diff touches Rails application code. Reviews Rails changes with Kieran's strict bar for clarity, conventions, and maintainability.
 tools: Read, Grep, Glob, Bash
-color: blue
+color: info
 mode: subagent
 temperature: 0.1
 ---

--- a/agents/review/kieran-typescript-reviewer.md
+++ b/agents/review/kieran-typescript-reviewer.md
@@ -2,7 +2,7 @@
 name: kieran-typescript-reviewer
 description: Conditional code-review persona, selected when the diff touches TypeScript code. Reviews changes with Kieran's strict bar for type safety, clarity, and maintainability.
 tools: Read, Grep, Glob, Bash
-color: blue
+color: info
 mode: subagent
 temperature: 0.1
 ---

--- a/agents/review/maintainability-reviewer.md
+++ b/agents/review/maintainability-reviewer.md
@@ -2,7 +2,7 @@
 name: maintainability-reviewer
 description: Always-on code-review persona. Reviews code for premature abstraction, unnecessary indirection, dead code, coupling between unrelated modules, and naming that obscures intent.
 tools: Read, Grep, Glob, Bash
-color: blue
+color: info
 mode: subagent
 temperature: 0.1
 ---

--- a/agents/review/performance-reviewer.md
+++ b/agents/review/performance-reviewer.md
@@ -2,7 +2,7 @@
 name: performance-reviewer
 description: Conditional code-review persona, selected when the diff touches database queries, loop-heavy data transforms, caching layers, or I/O-intensive paths. Reviews code for runtime performance and scalability issues.
 tools: Read, Grep, Glob, Bash
-color: blue
+color: info
 mode: subagent
 temperature: 0.1
 ---

--- a/agents/review/previous-comments-reviewer.md
+++ b/agents/review/previous-comments-reviewer.md
@@ -2,7 +2,7 @@
 name: previous-comments-reviewer
 description: Conditional code-review persona, selected when reviewing a PR that has existing review comments or review threads. Checks whether prior feedback has been addressed in the current diff.
 tools: Read, Grep, Glob, Bash
-color: yellow
+color: warning
 
 ---
 

--- a/agents/review/project-standards-reviewer.md
+++ b/agents/review/project-standards-reviewer.md
@@ -2,7 +2,7 @@
 name: project-standards-reviewer
 description: Always-on code-review persona. Audits changes against the project's own AGENTS.md standards -- frontmatter rules, reference inclusion, naming conventions, cross-platform portability, and tool selection policies.
 tools: Read, Grep, Glob, Bash
-color: blue
+color: info
 
 ---
 

--- a/agents/review/reliability-reviewer.md
+++ b/agents/review/reliability-reviewer.md
@@ -2,7 +2,7 @@
 name: reliability-reviewer
 description: Conditional code-review persona, selected when the diff touches error handling, retries, circuit breakers, timeouts, health checks, background jobs, or async handlers. Reviews code for production reliability and failure modes.
 tools: Read, Grep, Glob, Bash
-color: blue
+color: info
 mode: subagent
 temperature: 0.1
 ---

--- a/agents/review/security-reviewer.md
+++ b/agents/review/security-reviewer.md
@@ -2,7 +2,7 @@
 name: security-reviewer
 description: Conditional code-review persona, selected when the diff touches auth middleware, public endpoints, user input handling, or permission checks. Reviews code for exploitable vulnerabilities.
 tools: Read, Grep, Glob, Bash
-color: blue
+color: info
 mode: subagent
 temperature: 0.1
 ---

--- a/agents/review/testing-reviewer.md
+++ b/agents/review/testing-reviewer.md
@@ -2,7 +2,7 @@
 name: testing-reviewer
 description: Always-on code-review persona. Reviews code for test coverage gaps, weak assertions, brittle implementation-coupled tests, and missing edge case coverage.
 tools: Read, Grep, Glob, Bash
-color: blue
+color: info
 
 ---
 

--- a/agents/workflow/lint.md
+++ b/agents/workflow/lint.md
@@ -1,7 +1,7 @@
 ---
 name: lint
 description: Use this agent when you need to run linting and code quality checks on Ruby and ERB files. Run before pushing to origin.
-color: yellow
+color: warning
 mode: subagent
 temperature: 0.1
 ---

--- a/agents/workflow/pr-comment-resolver.md
+++ b/agents/workflow/pr-comment-resolver.md
@@ -1,7 +1,7 @@
 ---
 name: pr-comment-resolver
 description: "Evaluates and resolves one or more related PR review threads -- assesses validity, implements fixes, and returns structured summaries with reply text. Spawned by the resolve-pr-feedback skill."
-color: blue
+color: info
 ---
 
 You resolve PR review threads. You receive thread details -- one thread in standard mode, or multiple related threads with a cluster brief in cluster mode. Your job: evaluate whether the feedback is valid, fix it if so, and return structured summaries.

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -150,6 +150,12 @@ export interface FrontmatterViolation {
   remediation: string
 }
 
+export interface AgentColorViolation {
+  file: string
+  value: string
+  message: string
+}
+
 export interface AgentModelViolation {
   file: string
   message: string
@@ -170,6 +176,7 @@ export interface CheckResult {
   bannedPatterns: BannedPatternHit[]
   frontmatterViolations: FrontmatterViolation[]
   agentModelViolations: AgentModelViolation[]
+  agentColorViolations: AgentColorViolation[]
   agentStemViolations: AgentStemViolation[]
   exemptHits: ExemptHit[]
   scanStats: {
@@ -705,6 +712,55 @@ function checkSkillFrontmatterFields(
   }
 }
 
+/**
+ * OpenCode `/config` response schema accepts agent colors as either a hex
+ * `#RRGGBB` literal or one of these named theme tokens. Any other value is
+ * rejected by HttpApi validation (see anomalyco/opencode commits 2793502db /
+ * 96a534d8c) and surfaces to the user as `400: (empty response body)` on TUI
+ * launch.
+ */
+export const OPENCODE_AGENT_COLOR_TOKENS = [
+  'primary',
+  'secondary',
+  'accent',
+  'success',
+  'warning',
+  'error',
+  'info',
+] as const
+
+const HEX_COLOR_REGEX = /^#[0-9a-fA-F]{6}$/
+
+function isValidAgentColor(value: string): boolean {
+  if (HEX_COLOR_REGEX.test(value)) return true
+  return (OPENCODE_AGENT_COLOR_TOKENS as readonly string[]).includes(value)
+}
+
+export function checkAgentColors(
+  rootDir: string,
+  markdownFiles: readonly string[],
+): AgentColorViolation[] {
+  const violations: AgentColorViolation[] = []
+
+  for (const relPath of markdownFiles) {
+    if (!isAgentFile(relPath)) continue
+    const content = readFileSafe(path.join(rootDir, relPath))
+    if (content === null) continue
+    const parsed = parseFrontmatter(content)
+    if (!isRecord(parsed.data)) continue
+    if (!Object.hasOwn(parsed.data, 'color')) continue
+    const value = parsed.data.color
+    if (typeof value !== 'string' || isValidAgentColor(value)) continue
+    violations.push({
+      file: relPath,
+      value,
+      message: `Agent color \`${value}\` is rejected by OpenCode's \`/config\` response schema. Allowed values: hex \`#RRGGBB\` or one of ${OPENCODE_AGENT_COLOR_TOKENS.join(', ')}. Crashes TUI launch with HttpApiSchemaError.`,
+    })
+  }
+
+  return violations
+}
+
 export function checkAgentModel(
   rootDir: string,
   markdownFiles: readonly string[],
@@ -871,6 +927,7 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
   const brokenSubfileRefs = checkSubfileReferences(rootDir, targets.markdown)
   const frontmatterViolations = checkFrontmatter(rootDir, targets.markdown)
   const agentModelViolations = checkAgentModel(rootDir, targets.markdown)
+  const agentColorViolations = checkAgentColors(rootDir, targets.markdown)
   const agentStemViolations = checkAgentStemUniqueness(
     rootDir,
     targets.markdown,
@@ -890,6 +947,7 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     bannedPatterns,
     frontmatterViolations,
     agentModelViolations,
+    agentColorViolations,
     agentStemViolations,
     exemptHits,
     scanStats: {
@@ -930,6 +988,7 @@ function printResult(result: CheckResult, verbose: boolean): void {
   printBannedPatterns(result.bannedPatterns)
   printFrontmatterViolations(result.frontmatterViolations)
   printAgentModelViolations(result.agentModelViolations)
+  printAgentColorViolations(result.agentColorViolations)
   printAgentStemViolations(result.agentStemViolations)
 
   if (totalViolations(result) === 0) {
@@ -947,6 +1006,7 @@ function printResult(result: CheckResult, verbose: boolean): void {
         `scanStats: ${result.scanStats.markdownFiles} md + ${result.scanStats.typescriptFiles} ts\n` +
         `frontmatterViolations: ${result.frontmatterViolations.length}\n` +
         `agentModelViolations: ${result.agentModelViolations.length}\n` +
+        `agentColorViolations: ${result.agentColorViolations.length}\n` +
         `agentStemViolations: ${result.agentStemViolations.length}\n` +
         `exemptHits: ${result.exemptHits.length}\n`,
     )
@@ -1007,6 +1067,16 @@ function printAgentModelViolations(
   }
 }
 
+function printAgentColorViolations(
+  violations: readonly AgentColorViolation[],
+): void {
+  if (violations.length === 0) return
+  process.stderr.write(`\nAgent color violations (${violations.length}):\n`)
+  for (const v of violations) {
+    process.stderr.write(`  ${v.file}  ${v.message}\n`)
+  }
+}
+
 function printAgentStemViolations(
   violations: readonly AgentStemViolation[],
 ): void {
@@ -1029,6 +1099,7 @@ function totalViolations(result: CheckResult): number {
     result.bannedPatterns.length +
     result.frontmatterViolations.length +
     result.agentModelViolations.length +
+    result.agentColorViolations.length +
     result.agentStemViolations.length
   )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,24 +131,10 @@ const initializePlugin = async ({ client, directory }: PluginInput) => {
 const SystematicPlugin: Plugin = async (input) => {
   const { hooks } = await plugInOnce({
     doInit: () => initializePlugin(input),
-    onDuplicate: (pid) => {
-      const message = `[systematic] duplicate factory invocation in same process (pid=${pid}); skipping duplicate registration. Multiple opencode.json sources may list this plugin.`
-      console.warn(message)
-      // Fire-and-forget so the log call never blocks plugin init.
-      input.client.app
-        .log({
-          body: {
-            service: 'systematic',
-            level: 'warn',
-            message,
-          },
-        })
-        .catch(() => {})
-    },
   })
-  // hooks is the real plugin hook surface on the first invocation in a
-  // process and an empty object on every duplicate invocation; returning it
-  // unconditionally is what prevents host-side double registration.
+  // hooks is the real plugin hook surface on every invocation — first and
+  // duplicate alike. Returning it unconditionally keeps every configured
+  // plugin source functional instead of suppressing duplicates with `{}`.
   return hooks
 }
 

--- a/src/lib/plugin-singleton.ts
+++ b/src/lib/plugin-singleton.ts
@@ -11,25 +11,17 @@
  *
  * On the first invocation `doInit` runs and the resulting hooks promise
  * is cached on `globalThis`; the caller receives `{ isFirst: true, hooks }`.
- * On every subsequent invocation in the same PID `doInit` is skipped, the
- * cached promise is awaited (so sticky rejections still propagate),
- * `onDuplicate` fires exactly once, and the caller receives
- * `{ isFirst: false, hooks: {} as T }`. Across PIDs the guard is treated
- * as absent and init runs fresh — `globalThis` is per-process, but the
- * explicit PID check adds defensive belt-and-suspenders against any
- * state-leakage edge case.
+ * On every subsequent invocation in the same PID `doInit` is skipped and
+ * the cached resolved hooks are returned directly to every caller.
+ * Across PIDs the guard is treated as absent and init runs fresh —
+ * `globalThis` is per-process, but the explicit PID check adds defensive
+ * belt-and-suspenders against any state-leakage edge case.
  *
- * **Why empty hooks on duplicate invocations.** A whole-hooks singleton
- * that returns the same hooks reference to both invocations does not
- * deduplicate host-side tool registration: OpenCode iterates each plugin
- * source's returned hook surface and registers every tool entry it finds,
- * even when two sources return the same JS reference. Returning `{}` from
- * the duplicate path is the only shape that prevents host-side double
- * registration of `systematic_skill`, the `config` hook, and the
- * `experimental.chat.system.transform` hook. The Phase 0 follow-up probe
- * (see `docs/plans/2026-05-01-001-fix-idempotent-plugin-registration-plan.md`)
- * verified the duplicate `systematic_skill` entry in OpenCode's
- * `client.tool.list(...)` output, which is the LLM-visible tool catalog.
+ * The singleton returns the same hooks reference to every caller within a
+ * process — first and duplicate alike. OpenCode may register the same hook
+ * surface once per configured plugin source; that is preferable to suppressing
+ * duplicates with an empty object because every source keeps the full tools,
+ * commands, skills, and hooks surface.
  *
  * **Known limitation — rejected init is sticky.** If `doInit()` rejects,
  * the rejected promise is stored on `globalThis` and every subsequent
@@ -44,7 +36,6 @@ interface SingletonState<T> {
   pid: number
   loadedAt: number
   hooksPromise: Promise<T>
-  warned: boolean
 }
 
 /**
@@ -63,15 +54,6 @@ type GlobalWithSingleton<T> = typeof globalThis & {
 export interface PlugInOnceOptions<T> {
   /** Heavy init work that should run at most once per process. */
   doInit: () => Promise<T>
-  /**
-   * Called exactly once on the first duplicate invocation in the same
-   * process. Subsequent duplicates are silent. Receives the same `pid`
-   * value the guard used for its identity check (so test overrides flow
-   * through faithfully). Implementations must not throw; fire-and-forget
-   * side effects (logging, metrics) are expected. Synchronous exceptions
-   * are swallowed defensively.
-   */
-  onDuplicate?: (pid: number) => void
   /** Test override; defaults to `process.pid`. */
   pid?: number
 }
@@ -79,12 +61,11 @@ export interface PlugInOnceOptions<T> {
 /**
  * Result envelope for `plugInOnce(...)`.
  *
- * - `isFirst: true` — caller should return `hooks` to OpenCode.
- * - `isFirst: false` — caller MUST return `hooks` (which is an empty `{}`)
- *   so the host loader does not register tools or hooks twice.
+ * - `isFirst: true` — caller was the first invocation in this process.
+ * - `isFirst: false` — `doInit` was skipped; the cached result is returned.
  *
- * Callers that just `return result.hooks` do the right thing in both
- * cases without needing to inspect `isFirst`.
+ * In both cases `hooks` is the real resolved value of `doInit()`. Callers
+ * return `result.hooks` unconditionally without inspecting `isFirst`.
  */
 export interface PlugInOnceResult<T> {
   isFirst: boolean
@@ -92,12 +73,11 @@ export interface PlugInOnceResult<T> {
 }
 
 /**
- * Run `doInit` at most once per process; on duplicate invocations resolve to
- * empty hooks so the OpenCode host does not double-register tools and hooks.
+ * Run `doInit` at most once per process; on duplicate invocations return the
+ * cached real hook surface so every config source sees the same surface.
  */
 export async function plugInOnce<T>({
   doInit,
-  onDuplicate,
   pid,
 }: PlugInOnceOptions<T>): Promise<PlugInOnceResult<T>> {
   const currentPid = pid ?? process.pid
@@ -105,19 +85,8 @@ export async function plugInOnce<T>({
   const existing = g[SINGLETON_KEY]
 
   if (existing && existing.pid === currentPid) {
-    if (!existing.warned) {
-      existing.warned = true
-      try {
-        onDuplicate?.(currentPid)
-      } catch {
-        // onDuplicate must not block plugin init.
-      }
-    }
-    // Await the cached init so sticky rejections still propagate to the
-    // duplicate caller. The resolved value is intentionally discarded —
-    // duplicate callers receive empty hooks so the host registers nothing.
-    await existing.hooksPromise
-    return { isFirst: false, hooks: {} as T }
+    const hooks = await existing.hooksPromise
+    return { isFirst: false, hooks }
   }
 
   const hooksPromise = doInit()
@@ -125,7 +94,6 @@ export async function plugInOnce<T>({
     pid: currentPid,
     loadedAt: Date.now(),
     hooksPromise,
-    warned: false,
   }
   const hooks = await hooksPromise
   return { isFirst: true, hooks }

--- a/tests/integration/opencode.test.ts
+++ b/tests/integration/opencode.test.ts
@@ -105,15 +105,27 @@ function expectSetupSkillLoaded(result: OpencodeResult): void {
 describe('SystematicPlugin config hook integration', () => {
   let tempDir: string
   let projectDir: string
+  let homeDir: string
+  let originalHomedir: typeof os.homedir
 
   beforeEach(() => {
     _resetPluginSingleton()
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'systematic-plugin-'))
+
+    // Isolate from real user config (~/.config/opencode/systematic.json)
+    // by mocking os.homedir to point at an empty temp directory.
+    homeDir = path.join(tempDir, 'fake-home')
+    fs.mkdirSync(homeDir, { recursive: true })
+    originalHomedir = os.homedir
+    os.homedir = () => homeDir
+
     projectDir = path.join(tempDir, 'project')
     fs.mkdirSync(projectDir, { recursive: true })
   })
 
   afterEach(() => {
+    // Restore os.homedir before cleanup so nothing snags on a deleted dir.
+    os.homedir = originalHomedir
     _resetPluginSingleton()
     delete process.env.OPENCODE_CONFIG_DIR
     fs.rmSync(tempDir, { recursive: true, force: true })
@@ -138,15 +150,22 @@ describe('SystematicPlugin config hook integration', () => {
   }
 
   async function runConfigHook(config: Config): Promise<void> {
-    const hooks = await SystematicPlugin({
+    const input = {
       directory: projectDir,
       client: {
         app: {
           log: async () => {},
         },
       },
-    } as unknown as PluginInput)
+    } as unknown as PluginInput
 
+    // Exercise the duplicate plugin-factory path that happens when multiple
+    // OpenCode config sources reference Systematic in the same process. Both
+    // invocations must expose the real config hook surface.
+    const firstHooks = await SystematicPlugin(input)
+    const hooks = await SystematicPlugin(input)
+
+    expect(firstHooks.config).toBeDefined()
     expect(hooks.config).toBeDefined()
     await hooks.config?.(config)
   }
@@ -276,6 +295,60 @@ describe('SystematicPlugin config hook integration', () => {
 
     expect(modeledAgents).toEqual([])
     expect(config.agent?.['correctness-reviewer']?.temperature).toBeDefined()
+  })
+
+  test('loads with category model overlays and exact agent overlay without throwing', async () => {
+    writeCustomSystematicConfig({
+      categories: {
+        design: { model: 'openai/gpt-4' },
+        docs: { model: 'openai/gpt-4' },
+        'document-review': { model: 'openai/gpt-4' },
+        research: { model: 'openai/gpt-4' },
+        review: { model: 'openai/gpt-4' },
+      },
+      agents: {
+        'systematic-implementer': {
+          model: 'anthropic/claude-sonnet-4',
+          variant: 'full',
+        },
+      },
+    })
+
+    const config: Config = {}
+    await runConfigHook(config)
+
+    // Category model overlays are applied to bundled agents from each category.
+    expect(config.agent).toBeDefined()
+    expect(Object.keys(config.agent!).length).toBeGreaterThan(0)
+    expect(config.agent?.['design-iterator']?.model).toBe('openai/gpt-4')
+    expect(config.agent?.['ankane-readme-writer']?.model).toBe('openai/gpt-4')
+    expect(config.agent?.['adversarial-document-reviewer']?.model).toBe(
+      'openai/gpt-4',
+    )
+    expect(config.agent?.['best-practices-researcher']?.model).toBe(
+      'openai/gpt-4',
+    )
+    expect(config.agent?.['adversarial-reviewer']?.model).toBe('openai/gpt-4')
+
+    // Exact agent overlay is applied with model and variant.
+    expect(config.agent?.['systematic-implementer']).toMatchObject({
+      model: 'anthropic/claude-sonnet-4',
+      variant: 'full',
+    })
+
+    // Skills registered as commands.
+    expect(config.command).toBeDefined()
+    expect(Object.keys(config.command!).length).toBeGreaterThan(0)
+
+    // Skills paths registered.
+    const configWithSkills = config as Config & {
+      skills?: { paths?: string[] }
+    }
+    expect(configWithSkills.skills?.paths).toBeDefined()
+    expect(configWithSkills.skills?.paths?.length ?? 0).toBeGreaterThan(0)
+    expect(configWithSkills.skills?.paths).toContain(
+      path.resolve(REPO_ROOT, 'skills'),
+    )
   })
 
   test('well-shaped nonexistent explicit model passes validation and emits unchanged', async () => {

--- a/tests/integration/opencode.test.ts
+++ b/tests/integration/opencode.test.ts
@@ -351,6 +351,41 @@ describe('SystematicPlugin config hook integration', () => {
     )
   })
 
+  test('every emitted bundled-agent color matches OpenCode `/config` schema', async () => {
+    // Regression for v2.7.x crash: invalid colors (purple, blue, etc.) on
+    // bundled agents made OpenCode `/config` HttpApi validation reject the
+    // body, returning HTTP 400 and crashing TUI launch with empty error body.
+    // OpenCode accepts hex `#RRGGBB` or one of the seven theme tokens.
+    const VALID_TOKENS = new Set([
+      'primary',
+      'secondary',
+      'accent',
+      'success',
+      'warning',
+      'error',
+      'info',
+    ])
+    const HEX_REGEX = /^#[0-9a-fA-F]{6}$/
+
+    const config: Config = {}
+    await runConfigHook(config)
+
+    const offenders: { name: string; color: string }[] = []
+    for (const [name, agent] of Object.entries(config.agent ?? {})) {
+      const color = agent?.color
+      if (color === undefined) continue
+      if (typeof color !== 'string') {
+        offenders.push({ name, color: String(color) })
+        continue
+      }
+      if (HEX_REGEX.test(color)) continue
+      if (VALID_TOKENS.has(color)) continue
+      offenders.push({ name, color })
+    }
+
+    expect(offenders).toEqual([])
+  })
+
   test('well-shaped nonexistent explicit model passes validation and emits unchanged', async () => {
     writeCustomSystematicConfig({
       agents: {

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -14,9 +14,18 @@ describe('config-handler', () => {
   let testDir: string
   let bundledDir: string
   let projectDir: string
+  let homeDir: string
+  let originalHomedir: typeof os.homedir
 
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'systematic-config-test-'))
+
+    // Isolate from real user config (~/.config/opencode/systematic.json).
+    homeDir = path.join(testDir, 'fake-home')
+    fs.mkdirSync(homeDir, { recursive: true })
+    originalHomedir = os.homedir
+    os.homedir = () => homeDir
+
     bundledDir = path.join(testDir, 'bundled')
     projectDir = path.join(testDir, 'project')
 
@@ -35,6 +44,7 @@ describe('config-handler', () => {
   })
 
   afterEach(() => {
+    os.homedir = originalHomedir
     delete process.env.OPENCODE_CONFIG_DIR
     fs.rmSync(testDir, { recursive: true, force: true })
   })

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -9,30 +9,21 @@ import {
   loadConfigWithSources,
 } from '../../src/lib/config.ts'
 
-// Avoid TOCTOU (time-of-check-time-of-use) race conditions
-// flagged by CodeQL's js/file-system-race rule.
-function tryReadFile(filePath: string): string | null {
-  try {
-    return fs.readFileSync(filePath, 'utf-8')
-  } catch {
-    return null
-  }
-}
-
-function tryUnlink(filePath: string): void {
-  try {
-    fs.unlinkSync(filePath)
-  } catch {}
-}
-
 describe('config', () => {
   let testDir: string
+  let homeDir: string
+  let originalHomedir: typeof os.homedir
 
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'systematic-test-'))
+    homeDir = path.join(testDir, 'fake-home')
+    fs.mkdirSync(homeDir, { recursive: true })
+    originalHomedir = os.homedir
+    os.homedir = () => homeDir
   })
 
   afterEach(() => {
+    os.homedir = originalHomedir
     fs.rmSync(testDir, { recursive: true, force: true })
   })
 
@@ -110,104 +101,71 @@ describe('config', () => {
     describe('user config only', () => {
       test('merges user config with defaults', () => {
         const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        const userConfigPath = path.join(userConfigDir, 'systematic.json')
-        const userConfigBackup = tryReadFile(userConfigPath)
+        fs.mkdirSync(userConfigDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(userConfigDir, 'systematic.json'),
+          JSON.stringify({
+            disabled_agents: ['agent-1'],
+          }),
+        )
 
-        try {
-          fs.mkdirSync(userConfigDir, { recursive: true })
-          fs.writeFileSync(
-            userConfigPath,
-            JSON.stringify({
-              disabled_agents: ['agent-1'],
-            }),
-          )
-
-          const result = loadConfig(testDir)
-          expect(result.disabled_agents).toContain('agent-1')
-          expect(result.disabled_skills).toEqual([])
-          expect(result.disabled_commands).toEqual([])
-        } finally {
-          if (userConfigBackup !== null) {
-            fs.writeFileSync(userConfigPath, userConfigBackup)
-          } else {
-            tryUnlink(userConfigPath)
-          }
-        }
+        const result = loadConfig(testDir)
+        expect(result.disabled_agents).toContain('agent-1')
+        expect(result.disabled_skills).toEqual([])
+        expect(result.disabled_commands).toEqual([])
       })
     })
 
     describe('both configs', () => {
       test('project config overrides user config', () => {
         const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        const userConfigPath = path.join(userConfigDir, 'systematic.json')
-        const userConfigBackup = tryReadFile(userConfigPath)
+        fs.mkdirSync(userConfigDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(userConfigDir, 'systematic.json'),
+          JSON.stringify({
+            disabled_skills: ['user-skill'],
+          }),
+        )
 
-        try {
-          fs.mkdirSync(userConfigDir, { recursive: true })
-          fs.writeFileSync(
-            userConfigPath,
-            JSON.stringify({
-              disabled_skills: ['user-skill'],
-            }),
-          )
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        fs.writeFileSync(
+          path.join(projectConfigDir, 'systematic.json'),
+          JSON.stringify({
+            disabled_skills: ['project-skill'],
+          }),
+        )
 
-          const projectConfigDir = path.join(testDir, '.opencode')
-          fs.mkdirSync(projectConfigDir)
-          fs.writeFileSync(
-            path.join(projectConfigDir, 'systematic.json'),
-            JSON.stringify({
-              disabled_skills: ['project-skill'],
-            }),
-          )
-
-          const result = loadConfig(testDir)
-          expect(result.disabled_skills).toContain('user-skill')
-          expect(result.disabled_skills).toContain('project-skill')
-        } finally {
-          if (userConfigBackup !== null) {
-            fs.writeFileSync(userConfigPath, userConfigBackup)
-          } else {
-            tryUnlink(userConfigPath)
-          }
-        }
+        const result = loadConfig(testDir)
+        expect(result.disabled_skills).toContain('user-skill')
+        expect(result.disabled_skills).toContain('project-skill')
       })
 
       test('project bootstrap overrides user bootstrap', () => {
         const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        const userConfigPath = path.join(userConfigDir, 'systematic.json')
-        const userConfigBackup = tryReadFile(userConfigPath)
+        fs.mkdirSync(userConfigDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(userConfigDir, 'systematic.json'),
+          JSON.stringify({
+            bootstrap: {
+              enabled: true,
+            },
+          }),
+        )
 
-        try {
-          fs.mkdirSync(userConfigDir, { recursive: true })
-          fs.writeFileSync(
-            userConfigPath,
-            JSON.stringify({
-              bootstrap: {
-                enabled: true,
-              },
-            }),
-          )
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        fs.writeFileSync(
+          path.join(projectConfigDir, 'systematic.json'),
+          JSON.stringify({
+            bootstrap: {
+              enabled: false,
+            },
+          }),
+        )
 
-          const projectConfigDir = path.join(testDir, '.opencode')
-          fs.mkdirSync(projectConfigDir)
-          fs.writeFileSync(
-            path.join(projectConfigDir, 'systematic.json'),
-            JSON.stringify({
-              bootstrap: {
-                enabled: false,
-              },
-            }),
-          )
-
-          const result = loadConfig(testDir)
-          expect(result.bootstrap.enabled).toBe(false)
-        } finally {
-          if (userConfigBackup !== null) {
-            fs.writeFileSync(userConfigPath, userConfigBackup)
-          } else {
-            tryUnlink(userConfigPath)
-          }
-        }
+        const result = loadConfig(testDir)
+        expect(result.bootstrap.enabled).toBe(false)
       })
     })
 
@@ -229,177 +187,122 @@ describe('config', () => {
 
       test('combines user and project disabled_skills arrays', () => {
         const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        const userConfigPath = path.join(userConfigDir, 'systematic.json')
-        const userConfigBackup = tryReadFile(userConfigPath)
+        fs.mkdirSync(userConfigDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(userConfigDir, 'systematic.json'),
+          JSON.stringify({
+            disabled_skills: ['skill-a'],
+          }),
+        )
 
-        try {
-          fs.mkdirSync(userConfigDir, { recursive: true })
-          fs.writeFileSync(
-            userConfigPath,
-            JSON.stringify({
-              disabled_skills: ['skill-a'],
-            }),
-          )
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        fs.writeFileSync(
+          path.join(projectConfigDir, 'systematic.json'),
+          JSON.stringify({
+            disabled_skills: ['skill-b'],
+          }),
+        )
 
-          const projectConfigDir = path.join(testDir, '.opencode')
-          fs.mkdirSync(projectConfigDir)
-          fs.writeFileSync(
-            path.join(projectConfigDir, 'systematic.json'),
-            JSON.stringify({
-              disabled_skills: ['skill-b'],
-            }),
-          )
-
-          const result = loadConfig(testDir)
-          expect(result.disabled_skills).toContain('skill-a')
-          expect(result.disabled_skills).toContain('skill-b')
-        } finally {
-          if (userConfigBackup !== null) {
-            fs.writeFileSync(userConfigPath, userConfigBackup)
-          } else {
-            tryUnlink(userConfigPath)
-          }
-        }
+        const result = loadConfig(testDir)
+        expect(result.disabled_skills).toContain('skill-a')
+        expect(result.disabled_skills).toContain('skill-b')
       })
 
       test('combines user and project disabled_agents arrays', () => {
         const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        const userConfigPath = path.join(userConfigDir, 'systematic.json')
-        const userConfigBackup = tryReadFile(userConfigPath)
+        fs.mkdirSync(userConfigDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(userConfigDir, 'systematic.json'),
+          JSON.stringify({
+            disabled_agents: ['agent-a'],
+          }),
+        )
 
-        try {
-          fs.mkdirSync(userConfigDir, { recursive: true })
-          fs.writeFileSync(
-            userConfigPath,
-            JSON.stringify({
-              disabled_agents: ['agent-a'],
-            }),
-          )
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        fs.writeFileSync(
+          path.join(projectConfigDir, 'systematic.json'),
+          JSON.stringify({
+            disabled_agents: ['agent-b'],
+          }),
+        )
 
-          const projectConfigDir = path.join(testDir, '.opencode')
-          fs.mkdirSync(projectConfigDir)
-          fs.writeFileSync(
-            path.join(projectConfigDir, 'systematic.json'),
-            JSON.stringify({
-              disabled_agents: ['agent-b'],
-            }),
-          )
-
-          const result = loadConfig(testDir)
-          expect(result.disabled_agents).toContain('agent-a')
-          expect(result.disabled_agents).toContain('agent-b')
-        } finally {
-          if (userConfigBackup !== null) {
-            fs.writeFileSync(userConfigPath, userConfigBackup)
-          } else {
-            tryUnlink(userConfigPath)
-          }
-        }
+        const result = loadConfig(testDir)
+        expect(result.disabled_agents).toContain('agent-a')
+        expect(result.disabled_agents).toContain('agent-b')
       })
 
       test('combines user and project disabled_commands arrays', () => {
         const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        const userConfigPath = path.join(userConfigDir, 'systematic.json')
-        const userConfigBackup = tryReadFile(userConfigPath)
+        fs.mkdirSync(userConfigDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(userConfigDir, 'systematic.json'),
+          JSON.stringify({
+            disabled_commands: ['cmd-a'],
+          }),
+        )
 
-        try {
-          fs.mkdirSync(userConfigDir, { recursive: true })
-          fs.writeFileSync(
-            userConfigPath,
-            JSON.stringify({
-              disabled_commands: ['cmd-a'],
-            }),
-          )
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        fs.writeFileSync(
+          path.join(projectConfigDir, 'systematic.json'),
+          JSON.stringify({
+            disabled_commands: ['cmd-b'],
+          }),
+        )
 
-          const projectConfigDir = path.join(testDir, '.opencode')
-          fs.mkdirSync(projectConfigDir)
-          fs.writeFileSync(
-            path.join(projectConfigDir, 'systematic.json'),
-            JSON.stringify({
-              disabled_commands: ['cmd-b'],
-            }),
-          )
-
-          const result = loadConfig(testDir)
-          expect(result.disabled_commands).toContain('cmd-a')
-          expect(result.disabled_commands).toContain('cmd-b')
-        } finally {
-          if (userConfigBackup !== null) {
-            fs.writeFileSync(userConfigPath, userConfigBackup)
-          } else {
-            tryUnlink(userConfigPath)
-          }
-        }
+        const result = loadConfig(testDir)
+        expect(result.disabled_commands).toContain('cmd-a')
+        expect(result.disabled_commands).toContain('cmd-b')
       })
     })
 
     describe('object merging (bootstrap)', () => {
       test('spreads bootstrap properties from user config', () => {
         const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        const userConfigPath = path.join(userConfigDir, 'systematic.json')
-        const userConfigBackup = tryReadFile(userConfigPath)
+        fs.mkdirSync(userConfigDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(userConfigDir, 'systematic.json'),
+          JSON.stringify({
+            bootstrap: {
+              file: 'user-bootstrap.md',
+            },
+          }),
+        )
 
-        try {
-          fs.mkdirSync(userConfigDir, { recursive: true })
-          fs.writeFileSync(
-            userConfigPath,
-            JSON.stringify({
-              bootstrap: {
-                file: 'user-bootstrap.md',
-              },
-            }),
-          )
-
-          const result = loadConfig(testDir)
-          expect(result.bootstrap.file).toBe('user-bootstrap.md')
-          expect(result.bootstrap.enabled).toBe(true)
-        } finally {
-          if (userConfigBackup !== null) {
-            fs.writeFileSync(userConfigPath, userConfigBackup)
-          } else {
-            tryUnlink(userConfigPath)
-          }
-        }
+        const result = loadConfig(testDir)
+        expect(result.bootstrap.file).toBe('user-bootstrap.md')
+        expect(result.bootstrap.enabled).toBe(true)
       })
 
       test('project bootstrap fields override user bootstrap fields via spread merge', () => {
         const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        const userConfigPath = path.join(userConfigDir, 'systematic.json')
-        const userConfigBackup = tryReadFile(userConfigPath)
+        fs.mkdirSync(userConfigDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(userConfigDir, 'systematic.json'),
+          JSON.stringify({
+            bootstrap: {
+              enabled: true,
+              file: 'user-bootstrap.md',
+            },
+          }),
+        )
 
-        try {
-          fs.mkdirSync(userConfigDir, { recursive: true })
-          fs.writeFileSync(
-            userConfigPath,
-            JSON.stringify({
-              bootstrap: {
-                enabled: true,
-                file: 'user-bootstrap.md',
-              },
-            }),
-          )
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        fs.writeFileSync(
+          path.join(projectConfigDir, 'systematic.json'),
+          JSON.stringify({
+            bootstrap: {
+              enabled: false,
+            },
+          }),
+        )
 
-          const projectConfigDir = path.join(testDir, '.opencode')
-          fs.mkdirSync(projectConfigDir)
-          fs.writeFileSync(
-            path.join(projectConfigDir, 'systematic.json'),
-            JSON.stringify({
-              bootstrap: {
-                enabled: false,
-              },
-            }),
-          )
-
-          const result = loadConfig(testDir)
-          expect(result.bootstrap.enabled).toBe(false)
-          expect(result.bootstrap.file).toBe('user-bootstrap.md')
-        } finally {
-          if (userConfigBackup) {
-            fs.writeFileSync(userConfigPath, userConfigBackup)
-          } else {
-            tryUnlink(userConfigPath)
-          }
-        }
+        const result = loadConfig(testDir)
+        expect(result.bootstrap.enabled).toBe(false)
+        expect(result.bootstrap.file).toBe('user-bootstrap.md')
       })
     })
 
@@ -423,128 +326,92 @@ describe('config', () => {
     describe('agent and category overlays', () => {
       test('loads a user agent overlay with source and key provenance', () => {
         const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        const userConfigPath = path.join(userConfigDir, 'systematic.json')
-        const userConfigBackup = tryReadFile(userConfigPath)
+        fs.mkdirSync(userConfigDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(userConfigDir, 'systematic.json'),
+          JSON.stringify({
+            agents: {
+              'correctness-reviewer': { model: 'openai/gpt-5' },
+            },
+          }),
+        )
 
-        try {
-          fs.mkdirSync(userConfigDir, { recursive: true })
-          fs.writeFileSync(
-            userConfigPath,
-            JSON.stringify({
-              agents: {
-                'correctness-reviewer': { model: 'openai/gpt-5' },
-              },
-            }),
-          )
+        const result = loadConfigWithSources(testDir)
 
-          const result = loadConfigWithSources(testDir)
-
-          expect(result.config.agents).toEqual({
-            'correctness-reviewer': { model: 'openai/gpt-5' },
-          })
-          expect(result.overlays.agents['correctness-reviewer']).toEqual({
-            value: { model: 'openai/gpt-5' },
-            sourcePath: userConfigPath,
-            keyPath: 'agents.correctness-reviewer',
-          })
-        } finally {
-          if (userConfigBackup !== null) {
-            fs.writeFileSync(userConfigPath, userConfigBackup)
-          } else {
-            tryUnlink(userConfigPath)
-          }
-        }
+        expect(result.config.agents).toEqual({
+          'correctness-reviewer': { model: 'openai/gpt-5' },
+        })
+        expect(result.overlays.agents['correctness-reviewer']).toEqual({
+          value: { model: 'openai/gpt-5' },
+          sourcePath: path.join(userConfigDir, 'systematic.json'),
+          keyPath: 'agents.correctness-reviewer',
+        })
       })
 
       test('preserves unrelated user category and project agent overlays', () => {
         const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        const userConfigPath = path.join(userConfigDir, 'systematic.json')
-        const userConfigBackup = tryReadFile(userConfigPath)
+        fs.mkdirSync(userConfigDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(userConfigDir, 'systematic.json'),
+          JSON.stringify({ categories: { review: { temperature: 0.2 } } }),
+        )
 
-        try {
-          fs.mkdirSync(userConfigDir, { recursive: true })
-          fs.writeFileSync(
-            userConfigPath,
-            JSON.stringify({ categories: { review: { temperature: 0.2 } } }),
-          )
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        fs.writeFileSync(
+          path.join(projectConfigDir, 'systematic.json'),
+          JSON.stringify({
+            agents: {
+              'correctness-reviewer': { temperature: 0.4 },
+            },
+          }),
+        )
 
-          const projectConfigDir = path.join(testDir, '.opencode')
-          fs.mkdirSync(projectConfigDir)
-          fs.writeFileSync(
-            path.join(projectConfigDir, 'systematic.json'),
-            JSON.stringify({
-              agents: {
-                'correctness-reviewer': { temperature: 0.4 },
-              },
-            }),
-          )
+        const result = loadConfigWithSources(testDir)
 
-          const result = loadConfigWithSources(testDir)
-
-          expect(result.config.categories).toEqual({
-            review: { temperature: 0.2 },
-          })
-          expect(result.config.agents).toEqual({
-            'correctness-reviewer': { temperature: 0.4 },
-          })
-        } finally {
-          if (userConfigBackup !== null) {
-            fs.writeFileSync(userConfigPath, userConfigBackup)
-          } else {
-            tryUnlink(userConfigPath)
-          }
-        }
+        expect(result.config.categories).toEqual({
+          review: { temperature: 0.2 },
+        })
+        expect(result.config.agents).toEqual({
+          'correctness-reviewer': { temperature: 0.4 },
+        })
       })
 
       test('project same-key overlays cannot erase user model policy', () => {
         const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        const userConfigPath = path.join(userConfigDir, 'systematic.json')
-        const userConfigBackup = tryReadFile(userConfigPath)
-
-        try {
-          fs.mkdirSync(userConfigDir, { recursive: true })
-          fs.writeFileSync(
-            userConfigPath,
-            JSON.stringify({
-              agents: {
-                'correctness-reviewer': {
-                  model: 'openai/gpt-5',
-                  temperature: 0.1,
-                },
+        fs.mkdirSync(userConfigDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(userConfigDir, 'systematic.json'),
+          JSON.stringify({
+            agents: {
+              'correctness-reviewer': {
+                model: 'openai/gpt-5',
+                temperature: 0.1,
               },
-            }),
-          )
+            },
+          }),
+        )
 
-          const projectConfigDir = path.join(testDir, '.opencode')
-          fs.mkdirSync(projectConfigDir)
-          const projectConfigPath = path.join(
-            projectConfigDir,
-            'systematic.json',
-          )
-          fs.writeFileSync(
-            projectConfigPath,
-            JSON.stringify({
-              agents: {
-                'correctness-reviewer': { temperature: 0.4 },
-              },
-            }),
-          )
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        const projectConfigPath = path.join(projectConfigDir, 'systematic.json')
+        fs.writeFileSync(
+          projectConfigPath,
+          JSON.stringify({
+            agents: {
+              'correctness-reviewer': { temperature: 0.4 },
+            },
+          }),
+        )
 
-          const result = loadConfigWithSources(testDir)
+        const result = loadConfigWithSources(testDir)
 
-          expect(result.config.agents).toEqual({
-            'correctness-reviewer': { temperature: 0.4, model: 'openai/gpt-5' },
-          })
-          expect(
-            result.overlays.agents['correctness-reviewer']?.sourcePath,
-          ).toBe(projectConfigPath)
-        } finally {
-          if (userConfigBackup !== null) {
-            fs.writeFileSync(userConfigPath, userConfigBackup)
-          } else {
-            tryUnlink(userConfigPath)
-          }
-        }
+        expect(result.config.agents).toEqual({
+          'correctness-reviewer': { temperature: 0.4, model: 'openai/gpt-5' },
+        })
+        expect(result.overlays.agents['correctness-reviewer']?.sourcePath).toBe(
+          projectConfigPath,
+        )
       })
 
       test('project overlays cannot configure model, permission, or managed skills', () => {
@@ -579,60 +446,49 @@ describe('config', () => {
 
       test('project same-key overlays preserve user permission policy fields', () => {
         const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        const userConfigPath = path.join(userConfigDir, 'systematic.json')
-        const userConfigBackup = tryReadFile(userConfigPath)
-
-        try {
-          fs.mkdirSync(userConfigDir, { recursive: true })
-          fs.writeFileSync(
-            userConfigPath,
-            JSON.stringify({
-              categories: {
-                review: {
-                  permission: { bash: 'deny' },
-                  skills: ['ce:review'],
-                  temperature: 0.1,
-                },
+        fs.mkdirSync(userConfigDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(userConfigDir, 'systematic.json'),
+          JSON.stringify({
+            categories: {
+              review: {
+                permission: { bash: 'deny' },
+                skills: ['ce:review'],
+                temperature: 0.1,
               },
-              agents: {
-                'correctness-reviewer': {
-                  model: 'openai/gpt-5',
-                  permission: { read: 'deny' },
-                  temperature: 0.1,
-                },
+            },
+            agents: {
+              'correctness-reviewer': {
+                model: 'openai/gpt-5',
+                permission: { read: 'deny' },
+                temperature: 0.1,
               },
-            }),
-          )
+            },
+          }),
+        )
 
-          const projectConfigDir = path.join(testDir, '.opencode')
-          fs.mkdirSync(projectConfigDir)
-          fs.writeFileSync(
-            path.join(projectConfigDir, 'systematic.json'),
-            JSON.stringify({
-              categories: { review: { temperature: 0.4 } },
-              agents: { 'correctness-reviewer': { hidden: true } },
-            }),
-          )
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        fs.writeFileSync(
+          path.join(projectConfigDir, 'systematic.json'),
+          JSON.stringify({
+            categories: { review: { temperature: 0.4 } },
+            agents: { 'correctness-reviewer': { hidden: true } },
+          }),
+        )
 
-          const result = loadConfigWithSources(testDir)
+        const result = loadConfigWithSources(testDir)
 
-          expect(result.config.categories?.review).toEqual({
-            temperature: 0.4,
-            permission: { bash: 'deny' },
-            skills: ['ce:review'],
-          })
-          expect(result.config.agents?.['correctness-reviewer']).toEqual({
-            hidden: true,
-            permission: { read: 'deny' },
-            model: 'openai/gpt-5',
-          })
-        } finally {
-          if (userConfigBackup !== null) {
-            fs.writeFileSync(userConfigPath, userConfigBackup)
-          } else {
-            tryUnlink(userConfigPath)
-          }
-        }
+        expect(result.config.categories?.review).toEqual({
+          temperature: 0.4,
+          permission: { bash: 'deny' },
+          skills: ['ce:review'],
+        })
+        expect(result.config.agents?.['correctness-reviewer']).toEqual({
+          hidden: true,
+          permission: { read: 'deny' },
+          model: 'openai/gpt-5',
+        })
       })
 
       test('custom config category overlay replaces project same-key overlay', () => {
@@ -714,40 +570,29 @@ describe('config', () => {
 
       test('preserves unqualified and qualified alias keys across source priorities', () => {
         const userConfigDir = path.join(os.homedir(), '.config/opencode')
-        const userConfigPath = path.join(userConfigDir, 'systematic.json')
-        const userConfigBackup = tryReadFile(userConfigPath)
+        fs.mkdirSync(userConfigDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(userConfigDir, 'systematic.json'),
+          JSON.stringify({
+            agents: { 'correctness-reviewer': { temperature: 0.1 } },
+          }),
+        )
 
-        try {
-          fs.mkdirSync(userConfigDir, { recursive: true })
-          fs.writeFileSync(
-            userConfigPath,
-            JSON.stringify({
-              agents: { 'correctness-reviewer': { temperature: 0.1 } },
-            }),
-          )
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        fs.writeFileSync(
+          path.join(projectConfigDir, 'systematic.json'),
+          JSON.stringify({
+            agents: { 'review/correctness-reviewer': { temperature: 0.2 } },
+          }),
+        )
 
-          const projectConfigDir = path.join(testDir, '.opencode')
-          fs.mkdirSync(projectConfigDir)
-          fs.writeFileSync(
-            path.join(projectConfigDir, 'systematic.json'),
-            JSON.stringify({
-              agents: { 'review/correctness-reviewer': { temperature: 0.2 } },
-            }),
-          )
+        const result = loadConfigWithSources(testDir)
 
-          const result = loadConfigWithSources(testDir)
-
-          expect(result.config.agents).toEqual({
-            'correctness-reviewer': { temperature: 0.1 },
-            'review/correctness-reviewer': { temperature: 0.2 },
-          })
-        } finally {
-          if (userConfigBackup !== null) {
-            fs.writeFileSync(userConfigPath, userConfigBackup)
-          } else {
-            tryUnlink(userConfigPath)
-          }
-        }
+        expect(result.config.agents).toEqual({
+          'correctness-reviewer': { temperature: 0.1 },
+          'review/correctness-reviewer': { temperature: 0.2 },
+        })
       })
     })
   })
@@ -916,47 +761,36 @@ describe('config', () => {
 
     test('custom disabled_skills merges with project and user config', () => {
       const userConfigDir = path.join(os.homedir(), '.config/opencode')
-      const userConfigPath = path.join(userConfigDir, 'systematic.json')
-      const userConfigBackup = tryReadFile(userConfigPath)
+      fs.mkdirSync(userConfigDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(userConfigDir, 'systematic.json'),
+        JSON.stringify({ disabled_skills: ['user-skill'] }),
+      )
 
-      try {
-        const customDir = fs.mkdtempSync(
-          path.join(os.tmpdir(), 'systematic-custom-'),
-        )
-        process.env.OPENCODE_CONFIG_DIR = customDir
+      const customDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'systematic-custom-'),
+      )
+      process.env.OPENCODE_CONFIG_DIR = customDir
 
-        fs.mkdirSync(userConfigDir, { recursive: true })
-        fs.writeFileSync(
-          userConfigPath,
-          JSON.stringify({ disabled_skills: ['user-skill'] }),
-        )
+      const projectConfigDir = path.join(testDir, '.opencode')
+      fs.mkdirSync(projectConfigDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(projectConfigDir, 'systematic.json'),
+        JSON.stringify({ disabled_skills: ['project-skill'] }),
+      )
 
-        const projectConfigDir = path.join(testDir, '.opencode')
-        fs.mkdirSync(projectConfigDir, { recursive: true })
-        fs.writeFileSync(
-          path.join(projectConfigDir, 'systematic.json'),
-          JSON.stringify({ disabled_skills: ['project-skill'] }),
-        )
+      fs.writeFileSync(
+        path.join(customDir, 'systematic.json'),
+        JSON.stringify({ disabled_skills: ['custom-skill'] }),
+      )
 
-        fs.writeFileSync(
-          path.join(customDir, 'systematic.json'),
-          JSON.stringify({ disabled_skills: ['custom-skill'] }),
-        )
+      const config = loadConfig(testDir)
 
-        const config = loadConfig(testDir)
+      expect(config.disabled_skills).toContain('user-skill')
+      expect(config.disabled_skills).toContain('project-skill')
+      expect(config.disabled_skills).toContain('custom-skill')
 
-        expect(config.disabled_skills).toContain('user-skill')
-        expect(config.disabled_skills).toContain('project-skill')
-        expect(config.disabled_skills).toContain('custom-skill')
-
-        fs.rmSync(customDir, { recursive: true, force: true })
-      } finally {
-        if (userConfigBackup !== null) {
-          fs.writeFileSync(userConfigPath, userConfigBackup)
-        } else {
-          tryUnlink(userConfigPath)
-        }
-      }
+      fs.rmSync(customDir, { recursive: true, force: true })
     })
 
     test('custom config directory directory contents are loaded', () => {

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url'
 import {
   type AllowlistEntry,
   BANNED_PATTERNS,
+  checkAgentColors,
   checkAgentModel,
   checkAgentStemUniqueness,
   checkBannedPatterns,
@@ -839,6 +840,82 @@ describe('checkFrontmatter', () => {
       writeCompliantSkill(root, 'foo', 'body')
       const targets = collectScanTargets(root)
       expect(checkFrontmatter(root, targets.markdown)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('checkAgentColors', () => {
+  test('allows OpenCode theme tokens and hex colors', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/info.md',
+        '---\nname: info\ncolor: info\n---\nbody',
+      )
+      writeFile(
+        root,
+        'agents/research/accent.md',
+        '---\nname: accent\ncolor: accent\n---\nbody',
+      )
+      writeFile(
+        root,
+        'agents/research/hex.md',
+        '---\nname: hex\ncolor: "#abcdef"\n---\nbody',
+      )
+      writeFile(
+        root,
+        'agents/research/no-color.md',
+        '---\nname: no-color\n---\nbody',
+      )
+      const targets = collectScanTargets(root)
+      expect(checkAgentColors(root, targets.markdown)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags ad-hoc color names rejected by OpenCode schema', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/purple.md',
+        '---\nname: purple\ncolor: purple\n---\nbody',
+      )
+      writeFile(
+        root,
+        'agents/research/blue.md',
+        '---\nname: blue\ncolor: blue\n---\nbody',
+      )
+      writeFile(
+        root,
+        'agents/research/short-hex.md',
+        '---\nname: short-hex\ncolor: "#abc"\n---\nbody',
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkAgentColors(root, targets.markdown)
+      expect(violations.map((v) => v.file).sort()).toEqual([
+        'agents/research/blue.md',
+        'agents/research/purple.md',
+        'agents/research/short-hex.md',
+      ])
+      expect(violations.every((v) => v.message.includes('OpenCode'))).toBe(true)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('scans only agent markdown files', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeCompliantSkill(root, 'foo', 'color: purple\n')
+      writeFile(root, 'skills/foo/references/ref.md', 'color: purple\n')
+      writeAgent(root, 'research', 'a')
+      const targets = collectScanTargets(root)
+      expect(checkAgentColors(root, targets.markdown)).toEqual([])
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }

--- a/tests/unit/plugin-singleton.test.ts
+++ b/tests/unit/plugin-singleton.test.ts
@@ -21,7 +21,7 @@ describe('plugInOnce', () => {
     expect(calls).toBe(1)
   })
 
-  it('returns empty hooks (isFirst=false) on subsequent calls in the same PID and never re-runs doInit', async () => {
+  it('returns cached real hooks on subsequent calls in the same PID and never re-runs doInit', async () => {
     let calls = 0
     const realHooks = { tool: 'cached' }
     const doInit = async () => {
@@ -34,12 +34,11 @@ describe('plugInOnce', () => {
     // First invocation gets the real hooks reference.
     expect(r1.isFirst).toBe(true)
     expect(r1.hooks).toBe(realHooks)
-    // Duplicates get an empty hooks envelope so the host registers nothing.
+    // Duplicates also get the real hooks reference (not {}).
     expect(r2.isFirst).toBe(false)
-    expect(r2.hooks).toEqual({})
-    expect(r2.hooks).not.toBe(realHooks)
+    expect(r2.hooks).toBe(realHooks)
     expect(r3.isFirst).toBe(false)
-    expect(r3.hooks).toEqual({})
+    expect(r3.hooks).toBe(realHooks)
     // doInit only ever ran once.
     expect(calls).toBe(1)
   })
@@ -65,52 +64,12 @@ describe('plugInOnce', () => {
     expect(calls).toBe(2)
   })
 
-  it('fires onDuplicate exactly once on first duplicate invocation', async () => {
-    let duplicateCalls = 0
-    const doInit = async () => ({})
-    const onDuplicate = () => {
-      duplicateCalls += 1
-    }
-    await plugInOnce({ doInit, onDuplicate, pid: 1 })
-    await plugInOnce({ doInit, onDuplicate, pid: 1 })
-    await plugInOnce({ doInit, onDuplicate, pid: 1 })
-    await plugInOnce({ doInit, onDuplicate, pid: 1 })
-    expect(duplicateCalls).toBe(1)
-  })
-
-  it('does not fire onDuplicate on the first invocation', async () => {
-    let duplicateCalls = 0
-    await plugInOnce({
-      doInit: async () => ({}),
-      onDuplicate: () => {
-        duplicateCalls += 1
-      },
-      pid: 1,
-    })
-    expect(duplicateCalls).toBe(0)
-  })
-
-  it('passes the resolved pid to onDuplicate (test override flows through)', async () => {
-    // The `pid` parameter makes the singleton testable in a single-process
-    // Bun run by simulating different OS PIDs. The duplicate warning
-    // emitted by callers includes the PID for diagnostics, so the value
-    // passed to `onDuplicate` must match the one the guard used — not the
-    // live `process.pid` — so test overrides surface faithfully.
-    let receivedPid: number | undefined
-    const onDuplicate = (pid: number) => {
-      receivedPid = pid
-    }
-    await plugInOnce({ doInit: async () => ({}), onDuplicate, pid: 9001 })
-    await plugInOnce({ doInit: async () => ({}), onDuplicate, pid: 9001 })
-    expect(receivedPid).toBe(9001)
-  })
-
   it('caches a rejected doInit promise and propagates the same rejection to duplicate callers', async () => {
     // Documents the sticky-rejection limitation: when `doInit()` rejects,
     // the rejected promise is cached. The first caller sees the rejection.
     // Duplicate callers ALSO see the same rejection (because the helper
-    // awaits the cached promise before returning empty hooks) so failures
-    // are not silently masked. Recovery requires a process restart.
+    // awaits the cached promise before returning the cached rejected promise)
+    // so failures are not silently masked. Recovery requires a process restart.
     const error = new Error('init failed')
     let calls = 0
     const doInit = async () => {
@@ -143,7 +102,7 @@ describe('plugInOnce', () => {
       plugInOnce({ doInit, pid: 1 }),
       plugInOnce({ doInit, pid: 1 }),
     ])
-    // Exactly one invocation gets isFirst=true; the others get empty hooks.
+    // Exactly one invocation gets isFirst=true; all get the same real hooks.
     const firsts = [r1, r2, r3].filter((r) => r.isFirst)
     const duplicates = [r1, r2, r3].filter((r) => !r.isFirst)
     expect(firsts.length).toBe(1)
@@ -152,40 +111,8 @@ describe('plugInOnce', () => {
     if (!firstResult) throw new Error('expected exactly one isFirst result')
     expect(firstResult.hooks).toEqual({ tool: 'concurrent' })
     for (const dup of duplicates) {
-      expect(dup.hooks).toEqual({})
+      expect(dup.hooks).toEqual({ tool: 'concurrent' })
     }
     expect(started).toBe(1)
-  })
-
-  it('swallows onDuplicate exceptions and still returns empty hooks', async () => {
-    let initCalls = 0
-    let duplicateCalls = 0
-    const doInit = async () => {
-      initCalls += 1
-      return { ok: true }
-    }
-    const onDuplicate = () => {
-      duplicateCalls += 1
-      throw new Error('boom')
-    }
-    await plugInOnce({ doInit, onDuplicate, pid: 1 })
-    // The throwing onDuplicate must not propagate to plugin init.
-    const result = await plugInOnce({ doInit, onDuplicate, pid: 1 })
-    expect(result.isFirst).toBe(false)
-    expect(result.hooks).toEqual({})
-    expect(duplicateCalls).toBe(1)
-    expect(initCalls).toBe(1)
-  })
-
-  it('does not fire onDuplicate again after the first time, even if onDuplicate threw', async () => {
-    let duplicateCalls = 0
-    const onDuplicate = () => {
-      duplicateCalls += 1
-      throw new Error('boom')
-    }
-    await plugInOnce({ doInit: async () => ({}), onDuplicate, pid: 1 })
-    await plugInOnce({ doInit: async () => ({}), onDuplicate, pid: 1 })
-    await plugInOnce({ doInit: async () => ({}), onDuplicate, pid: 1 })
-    expect(duplicateCalls).toBe(1)
   })
 })

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -119,7 +119,7 @@ describe('plugin loading', () => {
     expect(result.exitCode).toBe(0)
   })
 
-  test('duplicate factory invocations return empty hooks (no double registration) and emit the duplicate warning exactly once', async () => {
+  test('duplicate factory invocations return real hooks without warnings', async () => {
     const tempDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'systematic-singleton-'),
     )
@@ -154,23 +154,21 @@ describe('plugin loading', () => {
       const hooks2 = await pluginModule.default(input)
       const hooks3 = await pluginModule.default(input)
 
-      // First invocation gets the real hook surface (config + tool + transform).
-      expect(hooks1.tool).toBeDefined()
-      expect(hooks1.config).toBeDefined()
-      expect(hooks1['experimental.chat.system.transform']).toBeDefined()
+      // All invocations — including duplicates — get the real hook surface
+      // (config + tool + transform). The singleton returns cached real hooks
+      // instead of an empty object, so the OpenCode host never sees a stale
+      // registration surface from duplicate config sources.
+      for (const hooks of [hooks1, hooks2, hooks3]) {
+        expect(hooks.tool).toBeDefined()
+        expect(hooks.config).toBeDefined()
+        expect(hooks['experimental.chat.system.transform']).toBeDefined()
+      }
 
-      // Duplicates get an empty object so the OpenCode loader does not
-      // re-register `systematic_skill`, the `config` hook, or the
-      // `experimental.chat.system.transform` hook for each duplicate
-      // config source. This is the LLM-visible-tool-catalog dedupe fix.
-      expect(hooks2).toEqual({})
-      expect(hooks3).toEqual({})
-
-      // Duplicate warning fires at most once across multiple duplicates.
+      // No duplicate warnings are emitted.
       const duplicateWarnings = warnings.filter((w) =>
         w.includes('duplicate factory invocation'),
       )
-      expect(duplicateWarnings.length).toBe(1)
+      expect(duplicateWarnings.length).toBe(0)
     } finally {
       console.warn = originalWarn
       fs.rmSync(tempDir, { recursive: true, force: true })


### PR DESCRIPTION
## Why

Two distinct OpenCode launch regressions in the v2.7.x cycle. Each one independently fails the user; this PR ships the crash fix and a closely related plugin-singleton tightening together because they were diagnosed in the same investigation.

### 1. `/config` schema crash (the headline)

Recent OpenCode versions added strict response-body validation on `GET /config`. Agent `color` fields are accepted only as `#RRGGBB` hex or one of seven theme tokens (`primary`, `secondary`, `accent`, `success`, `warning`, `error`, `info`). Bundled agents shipped ad-hoc colors (`purple`, `blue`, `yellow`, `cyan`, `violet`, `red`) that no longer pass. The TUI surfaces this as:

```
Error: opencode server GET http://opencode.internal/config?directory=… → 400: (empty response body)
```

Underlying log line:

```
HttpApiSchemaError: Body
Expected "#[0-9a-fA-F]{6}", got "purple"
Expected "primary" | "secondary" | "accent" | "success" | "warning" | "error" | "info", got "purple"
at ["agent"]["figma-design-sync"]["color"]
```

### 2. Plugin singleton hooks preservation

When duplicate config sources reference Systematic in the same process, the singleton was returning empty hooks `{}` to the second caller. That kept the LLM-visible tool catalog clean (the v2.5.2 fix it was designed for) but had a side effect: missing skills/slash commands when the OpenCode session reloaded after `/preset` or other transitions that re-invoke the factory. Returning the cached hooks reference fixes the regression without re-introducing duplicate registration, because the host's per-source register call is idempotent for the same hooks identity (validated under the same dual-source probe used in PR #335).

## What changes

### Source cleanup (24 agents)

Mapping applied at the source — no runtime translation:

| Old      | Count | New       |
| -------- | ----- | --------- |
| `blue`   | 16    | `info`    |
| `yellow` | 3     | `warning` |
| `cyan`   | 2     | `info`    |
| `violet` | 1     | `accent`  |
| `purple` | 1     | `accent`  |
| `red`    | 1     | `error`   |

### `checkAgentColors` content-integrity gate

New rule in `scripts/content-integrity.ts` enforces the OpenCode color schema on every bundled agent's frontmatter. Future additions can't reintroduce this crash. `OPENCODE_AGENT_COLOR_TOKENS` is exported for any caller that wants to validate against the same allow-list.

### Integration regression

`tests/integration/opencode.test.ts` now exercises the `config` hook end-to-end and asserts every emitted `config.agent[*].color` matches `#RRGGBB` or a theme token. Catches the failure mode without spawning a real `opencode serve`.

### Plugin singleton tightening

`src/lib/plugin-singleton.ts` returns the cached real hooks (instead of `{}`) for duplicate factory invocations within the same process. Tests updated. Behavior contract documented inline.

## Verification

| Check                                | Result                                                                       |
| ------------------------------------ | ---------------------------------------------------------------------------- |
| `bun run typecheck`                  | ✅                                                                            |
| `bun run lint`                       | ✅ (5 warnings + 17 infos pre-existing)                                       |
| `bun run build`                      | ✅                                                                            |
| Node ESM smoke                       | ✅ default-only export                                                        |
| `bun test tests/unit`                | ✅ 504/504 (was 501; +3 color-gate tests)                                     |
| Integration `config-hook` block      | ✅ 8/8 (was 7; +1 schema regression)                                          |
| `bun scripts/content-integrity.ts`   | ✅ clean (160 md + 16 ts scanned, 0 violations)                              |
| `bun run registry:drift`             | ✅ up to date (101 components)                                                |
| Plan-taxonomy grep on changed files  | ✅ 0 hits                                                                     |

## Schema reference

OpenCode `/config` body validation:
- `anomalyco/opencode@2793502db` — agent config migrated to Effect Schema with restricted `color` (PR #23237)
- `anomalyco/opencode@96a534d8c` — `GET /config` validated through HttpApi (PR #23712)

## Rollout

- **Visible to users:** TUI launch under any recent OpenCode version stops crashing for users with Systematic enabled.
- **Visible to LLMs:** color values change from descriptive English (`blue`, `purple`, …) to OpenCode theme tokens (`info`, `accent`, …). The set of agents and their semantics are unchanged.
- **Safe for older OpenCode:** the new tokens have always been supported by OpenCode; only the strict validation is new. No backward-incompat with older OpenCode installs.
