### PR TITLE
docs(solutions): compound 3 learnings from May 9 release sprint

### DIFF
--- a/docs/solutions/best-practices/layered-trust-boundaries-overlay-config-2026-05-09.md
+++ b/docs/solutions/best-practices/layered-trust-boundaries-overlay-config-2026-05-09.md
@@ -1,7 +1,7 @@
 ---
-title: Layered trust boundaries for plugin overlay configuration fields
+title: Trust-sensitive overlay fields in plugin configuration
 date: 2026-05-09
-category: docs/solutions/best-practices/
+category: best-practices
 module: config-system
 problem_type: best_practice
 component: tooling
@@ -14,10 +14,10 @@ applies_when:
 related_components:
   - tooling
   - authentication
-tags: [config, security, trust-boundaries, overlay, merge, policy]
+tags: [config, security, overlay, merge, allowlist, trust]
 ---
 
-# Layered trust boundaries for plugin overlay configuration fields
+# Trust-sensitive overlay fields in plugin configuration
 
 ## Context
 
@@ -27,12 +27,12 @@ replacement rule: `$OPENCODE_CONFIG_DIR > project .opencode/systematic.json >
 user ~/.config/opencode/systematic.json > defaults`. Whichever source had the
 highest priority for a given key won — for *every* field on that key.
 
-PR #344 review found this conflated two distinct trust profiles. Some overlay
-fields are **presentational** (`color`, `hidden`, `description-suffix`) — the
-person editing project config typically owns the visual experience and should
-be able to set them. Other fields are **policy** (`model`, `permission`,
-`skills`, eventually `mcps`, `fallback_models`) — they affect cost, privacy,
-data routing, and capability surface area. Letting a committed-to-repo project
+PR #344 review found this conflated two distinct trust profiles. Most overlay
+fields are project-tunable — `temperature`, `top_p`, `mode`, `color`, `steps`,
+`hidden`, exact-agent `disable` — the person editing project config typically
+owns the runtime knob and tuning them is convenience, not policy. A small set
+of fields are trust-sensitive: they affect provider routing, cost, privacy,
+capability surface area, or data routing. Letting a committed-to-repo project
 config silently route prompts to a different provider, or grant capability
 access the user-level config explicitly denied, is a security regression
 disguised as a convenience.
@@ -44,32 +44,35 @@ config's intentional model choice has been silently overridden by code review.
 
 ## Guidance
 
-Don't merge overlay fields uniformly. Split fields by trust profile and
-enforce that at config-load time, not later:
+Don't merge overlay fields uniformly. Identify the trust-sensitive subset and
+enforce that at config-load time, not at config-application time:
 
-1. **Define an explicit `PROTECTED_OVERLAY_FIELDS` allow-list** of fields that
+1. **Define an explicit `SECURITY_OVERLAY_FIELDS` allowlist** of fields that
    only the user-level and `OPENCODE_CONFIG_DIR` sources may set or erase. In
-   Systematic this currently includes `model`, `fallback_models`, `permission`,
-   `skills`, and `mcps`.
+   Systematic at HEAD this is exactly four fields:
+   - `model` — provider routing, cost, data routing
+   - `variant` — provider routing variant (per `README.md`, controls
+     "provider routing/cost/privacy")
+   - `permission` — tool/skill permission rules
+   - `skills` — managed skill allowlist (translates to `permission.skill`)
 2. **Reject project-source attempts to set protected fields** with an error
    that names the source path and config key. The error message should be
    actionable: "Field `agents.correctness-reviewer.model` is only valid in
-   user config or OPENCODE_CONFIG_DIR config; project config cannot set or
-   erase model routing policy."
+   user config or OPENCODE_CONFIG_DIR config".
 3. **Allow project sources to set non-protected fields** (`temperature`,
-   `top_p`, `mode`, `color`, `steps`, `hidden`, `variant`, `disable`) since
+   `top_p`, `mode`, `color`, `steps`, `hidden`, exact-agent `disable`) since
    those don't carry the same trust weight.
 4. **Replace-not-erase semantics**: a project same-key overlay must not be
    able to wipe a higher-trust field by writing the same agent key with that
    field absent. Field-aware merge: protected fields from higher-trust sources
    survive even when a lower-trust source replaces the same key wholesale.
-5. **Field-aware fallback chains**: a stronger explicit `model` from a
-   higher-trust source suppresses a weaker source's `fallback_models` unless
-   the same stronger source also provides `fallback_models` — otherwise source
-   defaults could route fallback traffic after a user-selected primary.
-6. **Test the security boundary explicitly**, not as a side effect. A project
+5. **Test the security boundary explicitly**, not as a side effect. A project
    config file containing `agents.x.model: ...` must have a regression test
    that asserts it throws.
+6. **When a new field gets proposed, classify it through this boundary first.**
+   Future overlay fields like fallback chains or MCP-capability allowlists
+   should be classified through this same trust-sensitive boundary before
+   shipping. Don't let the field set drift implicitly.
 
 ## Why This Matters
 
@@ -77,7 +80,7 @@ enforce that at config-load time, not later:
   These are different trust contexts. A merge model that doesn't reflect that
   is broken by design, not by oversight.
 - **The "convenience" framing hides cost.** Letting project config tune the
-  visual treatment of agents is convenience. Letting it choose providers is
+  runtime knobs of agents is convenience. Letting it choose providers is
   silent policy override. Splitting the fields keeps the convenience without
   the override.
 - **Detection must be fail-fast, not best-effort.** If you check trust at
@@ -96,8 +99,6 @@ enforce that at config-load time, not later:
   sources at different trust levels
 - Reviewing existing overlay merge logic before shipping security-sensitive
   features (model routing, capability allowlists, permission rules)
-- Designing a fallback chain or model-selection feature where users will
-  naturally want to express "my user config picks A, never anything else"
 - Auditing whether a "convenience" config feature crosses into "policy"
 
 ## Examples
@@ -119,55 +120,100 @@ function mergeOverlayMaps(sources) {
 // Project config can set model, permission, skills, etc. with no resistance.
 ```
 
-### After (PR #344 — protected-field guard)
+### After (PR #344 — security-field guard)
+
+The actual implementation in `src/lib/config.ts` rejects security fields at
+load time when the source trust level is `'project'`, then preserves any
+higher-trust security fields when project config replaces the same key:
 
 ```ts
-const PROTECTED_OVERLAY_FIELDS = [
+const SECURITY_OVERLAY_FIELDS = new Set([
   'model',
-  'fallback_models',
+  'variant',
   'permission',
   'skills',
-  'mcps',
-] as const
+])
 
-function loadProjectConfig(path) {
-  const raw = readJSON(path)
-  // Reject protected fields at load time, before any merge.
-  for (const [key, value] of Object.entries(raw.agents ?? {})) {
-    for (const field of PROTECTED_OVERLAY_FIELDS) {
-      if (field in value) {
-        throw new Error(
-          `Field 'agents.${key}.${field}' in ${path} is only valid in ` +
-          `user config or OPENCODE_CONFIG_DIR config; ` +
-          `project config cannot set or erase model routing policy.`
-        )
-      }
-    }
-  }
-  return raw
+interface SourcedOverlayConfig {
+  value: Record<string, unknown>
+  sourcePath: string
+  keyPath: string
 }
 
-// Field-aware merge preserves higher-trust protected fields even when
-// a lower-trust source replaces the same key wholesale.
-function mergeOverlayMaps(sources) {
-  const result = {}
-  for (const source of sources) { // ordered weakest-to-strongest
-    for (const [key, incoming] of Object.entries(source.agents ?? {})) {
-      const existing = result[key]
-      if (!existing) { result[key] = incoming; continue }
-      // Lower-trust replacement: keep higher-trust protected fields.
-      const merged = { ...incoming }
-      if (source.trust < existing.trust) {
-        for (const field of PROTECTED_OVERLAY_FIELDS) {
-          if (field in existing) merged[field] = existing[field]
-        }
-      }
-      result[key] = merged
+interface SourceInput {
+  config: { agents?: Record<string, Record<string, unknown>> }
+  path: string
+  trust: 'default' | 'user' | 'project' | 'custom'
+}
+
+function rejectProjectSecurityOverlay(
+  sourcePath: string,
+  keyPath: string,
+  value: Record<string, unknown>,
+): void {
+  for (const field of SECURITY_OVERLAY_FIELDS) {
+    if (Object.hasOwn(value, field)) {
+      throw new Error(
+        `Invalid Systematic config in ${sourcePath}: ` +
+          `${keyPath}.${field} is only valid in user config or ` +
+          `OPENCODE_CONFIG_DIR config`,
+      )
+    }
+  }
+}
+
+function preserveSecurityFields(
+  previous: Record<string, unknown>,
+  next: Record<string, unknown>,
+): Record<string, unknown> {
+  const result = { ...next }
+  for (const field of SECURITY_OVERLAY_FIELDS) {
+    if (Object.hasOwn(previous, field)) {
+      result[field] = previous[field]
     }
   }
   return result
 }
+
+function mergeOverlayMap(
+  target: Record<string, SourcedOverlayConfig>,
+  source: SourceInput,
+): void {
+  const overlayMap = source.config.agents
+  if (!overlayMap) return
+
+  for (const [key, value] of Object.entries(overlayMap)) {
+    const keyPath = `agents.${key}`
+
+    if (source.trust === 'project') {
+      rejectProjectSecurityOverlay(source.path, keyPath, value)
+    }
+
+    const previous = target[key]
+    const nextValue =
+      source.trust === 'project' && previous
+        ? preserveSecurityFields(previous.value, value)
+        : value
+
+    target[key] = {
+      value: nextValue,
+      sourcePath: source.path,
+      keyPath,
+    }
+  }
+}
 ```
+
+The two invariants this teaches:
+
+1. Project config may not set security fields. The throw at load time names
+   both the source file and the config key path.
+2. Project same-key replacement may not erase higher-trust security fields.
+   When the project source replaces an existing entry, security fields from
+   the previous (higher-trust) source are preserved into the new value.
+
+User and `OPENCODE_CONFIG_DIR` (custom) config can still own those fields
+freely.
 
 ### Test scenario that names the boundary
 
@@ -186,14 +232,17 @@ test('project overlays reject model: null as security field violation', () => {
 ```
 
 The test names the threat (`security field violation`) and the policy
-(`project ... cannot set or erase model routing policy`). Future readers
+(`only valid in user config or OPENCODE_CONFIG_DIR config`). Future readers
 understand it's not a syntax check — it's a trust boundary.
 
 ## Related
 
 - PR #343 (squash d5a3678) — initial overlay implementation, uniform merge
-- PR #344 (squash 0fb3fbc) — trust-boundary hardening
-- PR #345 (squash 1eecfb0) — extended `PROTECTED_OVERLAY_FIELDS` to include
-  `fallback_models` for the source-default model chain feature
-- `src/lib/config.ts` — current implementation of the protected-field guard
+- PR #344 (squash 0fb3fbc) — security-field guard added; current
+  `SECURITY_OVERLAY_FIELDS` set established
+- PR #345 (squash 1eecfb0) — source-default model table; explicitly does
+  NOT extend the security-field set (Systematic does not currently support
+  `fallback_models` per `README.md` line 339)
+- `src/lib/config.ts` — current implementation of the security-field guard
+  (`SECURITY_OVERLAY_FIELDS` at line 67, used at lines 257 and 271)
 - `tests/unit/config.test.ts` — regression coverage for the boundary

--- a/docs/solutions/best-practices/layered-trust-boundaries-overlay-config-2026-05-09.md
+++ b/docs/solutions/best-practices/layered-trust-boundaries-overlay-config-2026-05-09.md
@@ -1,0 +1,199 @@
+---
+title: Layered trust boundaries for plugin overlay configuration fields
+date: 2026-05-09
+category: docs/solutions/best-practices/
+module: config-system
+problem_type: best_practice
+component: tooling
+severity: high
+applies_when:
+  - Designing config overlays where multiple sources can contribute (defaults, user, project, env)
+  - Adding a new field that affects model selection, permissions, capabilities, or data routing
+  - Reviewing a config-merge implementation that treats all overlay fields uniformly
+  - Allowing project-local config files (which collaborators commit to a repo) to set policy
+related_components:
+  - tooling
+  - authentication
+tags: [config, security, trust-boundaries, overlay, merge, policy]
+---
+
+# Layered trust boundaries for plugin overlay configuration fields
+
+## Context
+
+Systematic's first agent-overlay implementation (PR #343) merged top-level
+`agents` and `categories` config maps from four sources with a uniform same-key
+replacement rule: `$OPENCODE_CONFIG_DIR > project .opencode/systematic.json >
+user ~/.config/opencode/systematic.json > defaults`. Whichever source had the
+highest priority for a given key won — for *every* field on that key.
+
+PR #344 review found this conflated two distinct trust profiles. Some overlay
+fields are **presentational** (`color`, `hidden`, `description-suffix`) — the
+person editing project config typically owns the visual experience and should
+be able to set them. Other fields are **policy** (`model`, `permission`,
+`skills`, eventually `mcps`, `fallback_models`) — they affect cost, privacy,
+data routing, and capability surface area. Letting a committed-to-repo project
+config silently route prompts to a different provider, or grant capability
+access the user-level config explicitly denied, is a security regression
+disguised as a convenience.
+
+The committed-config-as-repo-artifact part is the lever. A teammate's
+`.opencode/systematic.json` lands on your machine through `git pull`. If that
+file can set `agents.<x>.model: provider/sketchy-model`, the user-level
+config's intentional model choice has been silently overridden by code review.
+
+## Guidance
+
+Don't merge overlay fields uniformly. Split fields by trust profile and
+enforce that at config-load time, not later:
+
+1. **Define an explicit `PROTECTED_OVERLAY_FIELDS` allow-list** of fields that
+   only the user-level and `OPENCODE_CONFIG_DIR` sources may set or erase. In
+   Systematic this currently includes `model`, `fallback_models`, `permission`,
+   `skills`, and `mcps`.
+2. **Reject project-source attempts to set protected fields** with an error
+   that names the source path and config key. The error message should be
+   actionable: "Field `agents.correctness-reviewer.model` is only valid in
+   user config or OPENCODE_CONFIG_DIR config; project config cannot set or
+   erase model routing policy."
+3. **Allow project sources to set non-protected fields** (`temperature`,
+   `top_p`, `mode`, `color`, `steps`, `hidden`, `variant`, `disable`) since
+   those don't carry the same trust weight.
+4. **Replace-not-erase semantics**: a project same-key overlay must not be
+   able to wipe a higher-trust field by writing the same agent key with that
+   field absent. Field-aware merge: protected fields from higher-trust sources
+   survive even when a lower-trust source replaces the same key wholesale.
+5. **Field-aware fallback chains**: a stronger explicit `model` from a
+   higher-trust source suppresses a weaker source's `fallback_models` unless
+   the same stronger source also provides `fallback_models` — otherwise source
+   defaults could route fallback traffic after a user-selected primary.
+6. **Test the security boundary explicitly**, not as a side effect. A project
+   config file containing `agents.x.model: ...` must have a regression test
+   that asserts it throws.
+
+## Why This Matters
+
+- **Project config is collaborator-controlled, user config is user-controlled.**
+  These are different trust contexts. A merge model that doesn't reflect that
+  is broken by design, not by oversight.
+- **The "convenience" framing hides cost.** Letting project config tune the
+  visual treatment of agents is convenience. Letting it choose providers is
+  silent policy override. Splitting the fields keeps the convenience without
+  the override.
+- **Detection must be fail-fast, not best-effort.** If you check trust at
+  config-application time (during the plugin `config(cfg)` hook), invalid
+  policy may have already partially mutated `config.agent`, `config.command`,
+  `config.skills.paths`, or `config.mcp`. Validate before any mutation; build
+  staged copies and assign once.
+- **Field-aware merge protects the user from their own collaborators.** Even
+  with good intent, a teammate adding `agents.<x>.model: their-favorite-model`
+  to project config shouldn't override a user-level deny — and shouldn't
+  succeed silently.
+
+## When to Apply
+
+- Adding a new overlay field to any plugin that loads config from multiple
+  sources at different trust levels
+- Reviewing existing overlay merge logic before shipping security-sensitive
+  features (model routing, capability allowlists, permission rules)
+- Designing a fallback chain or model-selection feature where users will
+  naturally want to express "my user config picks A, never anything else"
+- Auditing whether a "convenience" config feature crosses into "policy"
+
+## Examples
+
+### Before (PR #343 — uniform same-key replacement)
+
+```ts
+// Same-key replacement at every source priority.
+function mergeOverlayMaps(sources) {
+  const result = {}
+  for (const source of sources) { // ordered weakest-to-strongest
+    for (const [key, value] of Object.entries(source.agents ?? {})) {
+      result[key] = value // wholesale replacement, all fields
+    }
+  }
+  return result
+}
+
+// Project config can set model, permission, skills, etc. with no resistance.
+```
+
+### After (PR #344 — protected-field guard)
+
+```ts
+const PROTECTED_OVERLAY_FIELDS = [
+  'model',
+  'fallback_models',
+  'permission',
+  'skills',
+  'mcps',
+] as const
+
+function loadProjectConfig(path) {
+  const raw = readJSON(path)
+  // Reject protected fields at load time, before any merge.
+  for (const [key, value] of Object.entries(raw.agents ?? {})) {
+    for (const field of PROTECTED_OVERLAY_FIELDS) {
+      if (field in value) {
+        throw new Error(
+          `Field 'agents.${key}.${field}' in ${path} is only valid in ` +
+          `user config or OPENCODE_CONFIG_DIR config; ` +
+          `project config cannot set or erase model routing policy.`
+        )
+      }
+    }
+  }
+  return raw
+}
+
+// Field-aware merge preserves higher-trust protected fields even when
+// a lower-trust source replaces the same key wholesale.
+function mergeOverlayMaps(sources) {
+  const result = {}
+  for (const source of sources) { // ordered weakest-to-strongest
+    for (const [key, incoming] of Object.entries(source.agents ?? {})) {
+      const existing = result[key]
+      if (!existing) { result[key] = incoming; continue }
+      // Lower-trust replacement: keep higher-trust protected fields.
+      const merged = { ...incoming }
+      if (source.trust < existing.trust) {
+        for (const field of PROTECTED_OVERLAY_FIELDS) {
+          if (field in existing) merged[field] = existing[field]
+        }
+      }
+      result[key] = merged
+    }
+  }
+  return result
+}
+```
+
+### Test scenario that names the boundary
+
+```ts
+test('project overlays reject model: null as security field violation', () => {
+  const projectConfigPath = path.join(testDir, '.opencode/systematic.json')
+  fs.writeFileSync(
+    projectConfigPath,
+    JSON.stringify({ agents: { 'correctness-reviewer': { model: null } } }),
+  )
+  expect(() => loadConfigWithSources(testDir)).toThrow(projectConfigPath)
+  expect(() => loadConfigWithSources(testDir)).toThrow(
+    /only valid in user config or OPENCODE_CONFIG_DIR config/,
+  )
+})
+```
+
+The test names the threat (`security field violation`) and the policy
+(`project ... cannot set or erase model routing policy`). Future readers
+understand it's not a syntax check — it's a trust boundary.
+
+## Related
+
+- PR #343 (squash d5a3678) — initial overlay implementation, uniform merge
+- PR #344 (squash 0fb3fbc) — trust-boundary hardening
+- PR #345 (squash 1eecfb0) — extended `PROTECTED_OVERLAY_FIELDS` to include
+  `fallback_models` for the source-default model chain feature
+- `src/lib/config.ts` — current implementation of the protected-field guard
+- `tests/unit/config.test.ts` — regression coverage for the boundary

--- a/docs/solutions/developer-experience/git-auto-merge-silent-identifier-duplication-2026-05-09.md
+++ b/docs/solutions/developer-experience/git-auto-merge-silent-identifier-duplication-2026-05-09.md
@@ -1,0 +1,198 @@
+---
+title: Git auto-merge silently duplicates test setup/teardown identifiers
+date: 2026-05-09
+category: docs/solutions/developer-experience/
+module: testing-infrastructure
+problem_type: developer_experience
+component: testing_framework
+severity: high
+applies_when:
+  - Rebasing a feature branch onto main when both branches added or modified test setup/teardown
+  - Resolving merge conflicts that auto-merge cleanly with no visible markers
+  - Verifying a rebase before push when the only check is `grep -E '<<<<<<< |======='`
+related_components:
+  - development_workflow
+  - tooling
+tags: [git, rebase, auto-merge, testing, conflict-resolution, false-positive]
+---
+
+# Git auto-merge silently duplicates test setup/teardown identifiers
+
+## Context
+
+During the PR #345 rebase onto current `main`, git's 3-way merge auto-merged
+`tests/integration/opencode.test.ts` with **zero conflict markers reported** —
+the conflict-marker grep returned clean and the file was staged automatically.
+The merge nevertheless produced four redundancies inside the same describe
+block:
+
+- duplicate `let originalHomedir: typeof os.homedir` declarations (lines 107
+  and 110)
+- duplicate `originalHomedir = os.homedir` assignments inside `beforeEach`
+- conflicting `os.homedir = () => ...` reassignments — one pointing at a real
+  `homeDir` directory created by `fs.mkdirSync`, the other pointing at a
+  sibling path (`path.join(tempDir, 'home')`) that was **never created**
+- duplicate `os.homedir = originalHomedir` restore in `afterEach`
+
+This survived the conflict-marker check and was only caught when TypeScript's
+duplicate-declaration error emitted at test load time.
+
+The mechanism: PR #346 (already in `main`) and PR #345 (the branch being
+rebased) **independently added the same hoisted `let originalHomedir`
+declaration plus its associated assignment/restore pattern** at slightly
+different positions inside the same `describe` block. Each side's hunk anchored
+on different surrounding lines, so git's diff3 fell back to "additive merge" —
+both blocks were inserted and considered resolved.
+
+## Guidance
+
+When rebasing or merging branches that both touched test scaffolding (`describe`
+bodies, `beforeEach`/`afterEach` hooks, fixture builders, mock setup), do not
+trust a clean conflict-marker grep alone. Run a second verification pass that
+checks for **duplicate identifier declarations** in the auto-merged hunks.
+
+```sh
+# After rebase/merge, before push, for any test file the merge touched:
+git diff main -- tests/ | grep -E '^\+ *let ' | sort | uniq -d
+# Any output here means the same identifier is being declared in multiple
+# places inside the same scope (or scopes that share TS lexical declaration
+# rules). Inspect those locations manually.
+```
+
+For Bun/Vitest-style tests, also add a scope check for duplicate `os.homedir =`
+or other module-mock reassignments that should appear exactly once per
+beforeEach:
+
+```sh
+git show HEAD:tests/integration/opencode.test.ts | \
+  awk '/beforeEach\(/,/}\)/' | grep -c 'os.homedir = '
+# Expect exactly 1 (or your project's known count). >1 means duplicated.
+```
+
+Treat the canonical `bun run typecheck` and `bun test` commands as the actual
+merge gate — never skip them after a non-trivial rebase, even when the rebase
+"completed cleanly."
+
+## Why This Matters
+
+- **Conflict markers are necessary but not sufficient evidence of correctness.**
+  Git marks conflicts when its merge algorithm cannot decide, but it can decide
+  *incorrectly* and produce code that compiles in some languages and crashes
+  at load time in others.
+- **Test scaffolding is a high-incidence area for this failure mode.** Setup
+  hooks accumulate hoisted state (`let foo: T`) and reassignment patterns
+  (`originalFoo = foo; foo = mock`) that are very likely to be added by
+  multiple PRs in parallel during active development. Two PRs landing the same
+  isolation pattern within hours of each other is the worst case.
+- **The TypeScript error caught it; a JS-only project might not have.** The
+  redundant assignments are syntactically valid JS — they would silently shadow
+  earlier values and break the assumption that `originalFoo` holds the real
+  module's pre-mock value, leaking mocks across tests.
+- **Lint rules like `noRedeclare` would flag this too** if enabled with
+  `--max-diagnostics` high enough. Biome flagged it but only after exhausting
+  the default warning cap.
+
+## When to Apply
+
+- Any rebase of a feature branch onto a `main` that has merged a PR which
+  modified the same test file
+- Any merge that auto-resolves test setup/teardown hunks
+- Fast-iteration windows where multiple PRs ship in the same day touching
+  shared infrastructure
+
+## Examples
+
+### Before (broken auto-merge — both blocks survived)
+
+```ts
+describe('SystematicPlugin config hook integration', () => {
+  let tempDir: string
+  let originalHomedir: typeof os.homedir   // ← from PR #346 (main)
+  let projectDir: string
+  let homeDir: string
+  let originalHomedir: typeof os.homedir   // ← from PR #345 (rebased branch)
+                                            //   TS: redeclared identifier
+
+  beforeEach(() => {
+    _resetPluginSingleton()
+    originalHomedir = os.homedir            // ← from PR #346
+    tempDir = fs.mkdtempSync(...)
+    homeDir = path.join(tempDir, 'fake-home')
+    fs.mkdirSync(homeDir, { recursive: true })
+    originalHomedir = os.homedir            // ← from PR #345 (duplicate)
+    os.homedir = () => homeDir              // ← from PR #346 — points at real dir
+    projectDir = path.join(tempDir, 'project')
+    fs.mkdirSync(projectDir, { recursive: true })
+    os.homedir = () => path.join(tempDir, 'home')  // ← from PR #345 —
+                                                    //   points at uncreated sibling
+  })
+
+  afterEach(() => {
+    os.homedir = originalHomedir            // ← from PR #346
+    _resetPluginSingleton()
+    delete process.env.OPENCODE_CONFIG_DIR
+    os.homedir = originalHomedir            // ← from PR #345 (duplicate)
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+})
+```
+
+### After (resolved by keeping the fully-realized side)
+
+```ts
+describe('SystematicPlugin config hook integration', () => {
+  let tempDir: string
+  let projectDir: string
+  let homeDir: string
+  let originalHomedir: typeof os.homedir
+
+  beforeEach(() => {
+    _resetPluginSingleton()
+    originalHomedir = os.homedir
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'systematic-plugin-'))
+
+    homeDir = path.join(tempDir, 'fake-home')
+    fs.mkdirSync(homeDir, { recursive: true })
+    os.homedir = () => homeDir
+
+    projectDir = path.join(tempDir, 'project')
+    fs.mkdirSync(projectDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    os.homedir = originalHomedir
+    _resetPluginSingleton()
+    delete process.env.OPENCODE_CONFIG_DIR
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+})
+```
+
+The resolution rule: when both sides add structurally similar hooks, prefer the
+side whose effects are **fully realized** — here, the `homeDir` variant whose
+`fs.mkdirSync` actually creates the directory `os.homedir` returns.
+
+### Verification command from the rebase that caught this
+
+```sh
+# This is what flagged the issue, after `git rebase --continue` reported
+# "Successfully rebased":
+bun test tests/integration/opencode.test.ts -t 'config hook' 2>&1 | head -20
+# error: "originalHomedir" has already been declared
+#     at tests/integration/opencode.test.ts:110:7
+# note: "originalHomedir" was originally declared here
+#    at tests/integration/opencode.test.ts:107:7
+```
+
+The duplicate-declaration error is the canary. If your test files emit one
+after a rebase, this is almost always the cause.
+
+## Related
+
+- `docs/solutions/integration-issues/zsh-for-loop-word-splitting-silent-failure-2026-04-17.md`
+  — sibling pattern: a separate verification pass that uses the *same broken
+  iteration* as the conversion will fail in lockstep. Always verify with a
+  *different* mechanism than the one you used to apply the change.
+- PR #345 (squash 1eecfb0) — the rebase where this was first observed and fixed
+- PR #346 (squash 7e4cb92) — the main-side commit that introduced the
+  competing test isolation block

--- a/docs/solutions/developer-experience/git-auto-merge-silent-identifier-duplication-2026-05-09.md
+++ b/docs/solutions/developer-experience/git-auto-merge-silent-identifier-duplication-2026-05-09.md
@@ -1,7 +1,7 @@
 ---
 title: Git auto-merge silently duplicates test setup/teardown identifiers
 date: 2026-05-09
-category: docs/solutions/developer-experience/
+category: developer-experience
 module: testing-infrastructure
 problem_type: developer_experience
 component: testing_framework

--- a/docs/solutions/integration-issues/opencode-config-schema-rejects-ad-hoc-agent-colors-2026-05-09.md
+++ b/docs/solutions/integration-issues/opencode-config-schema-rejects-ad-hoc-agent-colors-2026-05-09.md
@@ -1,0 +1,145 @@
+---
+title: OpenCode /config HttpApi rejects ad-hoc bundled agent color names, crashing TUI launch
+date: 2026-05-09
+category: docs/solutions/integration-issues/
+module: agent-bundle
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - "TUI launch fails with: opencode server GET .../config?directory=... -> 400: (empty response body)"
+  - "OpenCode log shows HttpApiSchemaError: Body Expected '#[0-9a-fA-F]{6}', got 'purple'"
+  - "Error path is ['agent']['<bundled-agent-name>']['color']"
+  - "Plugin config hook runs successfully but the resulting /config response fails server-side schema validation"
+  - "Empty response body — TUI sees only HTTP 400 with no diagnostic detail"
+root_cause: missing_validation
+resolution_type: code_fix
+severity: critical
+related_components:
+  - tooling
+  - documentation
+tags: [opencode, plugin, agent-config, schema-validation, color, http-400, regression]
+---
+
+# OpenCode /config HttpApi rejects ad-hoc bundled agent color names, crashing TUI launch
+
+## Problem
+
+OpenCode added strict Effect Schema validation on `GET /config` response
+bodies. Any bundled agent emitted with a `color` value outside the new schema
+causes the entire `/config` endpoint to return HTTP 400 with an empty body,
+which crashes TUI launch. Systematic was emitting `color: purple`, `color:
+blue`, `color: yellow`, `color: cyan`, `color: violet`, and `color: red` across
+24 of 50 bundled agents — every one would crash a launch on a recent OpenCode
+version.
+
+## Symptoms
+
+User-visible:
+
+```
+Error: opencode server GET http://opencode.internal/config?directory=...
+       → 400: (empty response body)
+```
+
+OpenCode log (`~/.local/share/opencode/log/<timestamp>.log`):
+
+```
+HttpApiSchemaError: Body
+Expected "#[0-9a-fA-F]{6}", got "purple"
+Expected "primary" | "secondary" | "accent" | "success" | "warning" | "error" | "info", got "purple"
+at ["agent"]["figma-design-sync"]["color"]
+```
+
+The empty response body is the worst part — the TUI surfaces only the HTTP
+400, with no path or schema-error detail. Diagnosis requires reading the
+OpenCode log directly.
+
+## What Didn't Work
+
+- **Suspecting the plugin singleton** (PR #335 work). The duplicate-call
+  `return {}` regression was real and worth fixing, but it caused missing
+  skills/slash commands after `/preset`, not the `/config` HTTP 400. Diagnosis
+  initially conflated the two.
+- **Suspecting `~/.config/opencode/systematic.json`.** The Systematic
+  user-level config was syntactically valid and not required to trigger the
+  crash. The problem reproduced with an empty user config.
+- **Suspecting the local file plugin path itself.** `plugin: ["./src/index.ts"]`
+  is not inherently the cause — once OpenCode logs were inspected, the schema
+  error path made the real culprit obvious.
+- **Inferring from the empty response body alone.** The body carries no
+  diagnostic. Without the OpenCode log, this looks like a generic plugin
+  load failure.
+
+## Solution
+
+Two-layer fix:
+
+1. **Source cleanup**: rename ad-hoc colors in 24 bundled agent frontmatter
+   files to OpenCode-valid theme tokens. Mapping applied:
+
+   | From            | To       | Rationale                         |
+   | --------------- | -------- | --------------------------------- |
+   | `blue` (16x)    | `info`   | informational/cool                |
+   | `cyan` (2x)     | `info`   | merges with blue                  |
+   | `yellow` (3x)   | `warning`| semantic match                    |
+   | `violet` (1x)   | `accent` | accent fits                       |
+   | `purple` (1x)   | `accent` | reported crash agent              |
+   | `red` (1x)      | `error`  | adversarial-reviewer, semantic    |
+
+2. **Content-integrity gate** at `scripts/content-integrity.ts`: new
+   `checkAgentColors` rule scans every `agents/**/*.md` file's `color:`
+   frontmatter and asserts the value matches OpenCode's schema (`#RRGGBB` hex,
+   or one of `primary | secondary | accent | success | warning | error |
+   info`). Runs in CI on every PR. Mirrors the existing `checkAgentModel` rule
+   that bans `model:` fields on bundled agents.
+
+3. **Integration regression** in `tests/integration/opencode.test.ts`: runs
+   the plugin config hook against an empty config and asserts every emitted
+   `agent[*].color` matches the schema. Catches future drift before CI.
+
+## Why This Works
+
+OpenCode's `AgentConfig.color` field uses an Effect Schema union of
+`#[0-9a-fA-F]{6}` regex and a literal-token enum. Anything else the plugin
+emits gets rejected when the API serves `/config`. The HttpApi response
+validator was added in OpenCode `96a534d8c` (PR #23712), and the strict
+color schema was added in `2793502db` (PR #23237). Before those commits the
+client ignored the field and the bug was latent.
+
+By cleaning the source and enforcing both at gate time and runtime, drift
+cannot recur silently — adding a new agent with `color: green` would fail the
+content-integrity gate before merge, and a runtime emission with the wrong
+shape would fail the integration test.
+
+## Prevention
+
+- **Content-integrity gate.** `scripts/content-integrity.ts:checkAgentColors`
+  is now CI-blocking. Any new bundled agent with a non-schema `color` value
+  fails the build.
+- **Integration regression test.** `tests/integration/opencode.test.ts`
+  contains an `every emitted bundled-agent color matches OpenCode /config
+  schema` test that exercises the real plugin config hook, not just helper
+  functions.
+- **Treat plugin output as schema-validated.** OpenCode is moving toward
+  Effect Schema validation across all surfaces. When adding any new bundled
+  config field — `mode`, `temperature`, `top_p`, etc. — verify the upstream
+  schema before emitting and add an integration assertion.
+- **Read OpenCode logs first when the TUI returns HTTP 400 with empty body.**
+  The 400 carries no body; the log carries the path and schema error. Default
+  log location: `~/.local/share/opencode/log/<timestamp>.log`.
+- **Pin the upstream remote.** Systematic research targets `anomalyco/opencode`,
+  not `sst/opencode`. Verifying schemas against the wrong fork wastes time.
+
+## Related Issues
+
+- PR #346 (squash 7e4cb92) — the fix
+- PR #335 (idempotent plugin registration) — separate regression conflated
+  with this during initial diagnosis
+- OpenCode commit `2793502db` / PR #23237 — introduced restricted
+  `AgentConfig.color` Effect Schema
+- OpenCode commit `96a534d8c` / PR #23712 — bridged `GET /config` through
+  HttpApi response validation; this is what made the bug visible
+- Memory `#2615` — captures the schema reference for future bundled-agent
+  additions
+- `docs/solutions/integration-issues/opencode-plugin-factory-duplicate-registration-2026-05-04.md`
+  — sibling regression discovered in the same diagnostic session

--- a/docs/solutions/integration-issues/opencode-config-schema-rejects-ad-hoc-agent-colors-2026-05-09.md
+++ b/docs/solutions/integration-issues/opencode-config-schema-rejects-ad-hoc-agent-colors-2026-05-09.md
@@ -1,7 +1,7 @@
 ---
 title: OpenCode /config HttpApi rejects ad-hoc bundled agent color names, crashing TUI launch
 date: 2026-05-09
-category: docs/solutions/integration-issues/
+category: integration-issues
 module: agent-bundle
 problem_type: integration_issue
 component: tooling


### PR DESCRIPTION
Captures three new learnings from today's v2.8.0 → v2.10.0 release sprint while context is fresh, per `ce:compound`. All three are net-new — overlap analysis against the existing 12-doc corpus showed no high-confidence duplicates.

## What's documented

| Doc | Track | Severity | Source |
|---|---|---|---|
| `developer-experience/git-auto-merge-silent-identifier-duplication-2026-05-09.md` | knowledge | high | PR #345 rebase produced clean conflict-free merges containing duplicate `let` declarations and conflicting reassignments inside test setup hooks |
| `integration-issues/opencode-config-schema-rejects-ad-hoc-agent-colors-2026-05-09.md` | bug | critical | PR #346 — TUI launch crash from invalid bundled agent colors against new HttpApi schema |
| `best-practices/layered-trust-boundaries-overlay-config-2026-05-09.md` | knowledge | high | PR #344 review surfaced that uniform same-key replacement merged policy fields with the same trust as presentational fields |

## Why these and not others

- **Auto-merge silent duplication** is a different mechanism than the existing zsh word-splitting doc (different tool layer entirely) and worth its own entry. The two cross-reference each other as sibling "verification with a different mechanism" cases.
- **Color schema rejection** had a one-line ENVIRONMENT memory (#2615) but no durable doc. The integration regression and the diagnostic recipe (read OpenCode logs when the TUI returns empty 400) are too valuable to leave only in cross-session memory.
- **Layered trust boundaries** generalizes a pattern that will keep showing up — any future overlay field has to land on one side of the protected/non-protected line. Naming the pattern explicitly makes future PRs faster.

## What's NOT included

- Plan #002's MCP spike result — work hasn't happened yet.
- Source-default model table itself — that's feature documentation in `docs/src/content/docs/getting-started/configuration.mdx`, not a problem-resolution learning.
- Test count drift in AGENTS.md says 15 unit / 2 integration; reality is 18 / 1. Separate sweep, would be scope creep here.

## Discoverability check

AGENTS.md line 55 already references `docs/solutions/` under the `docs/` directory tree with the structure description (`organized by category with YAML frontmatter (module, tags, problem_type)`). An agent reading AGENTS.md learns the knowledge store exists, its structure, and its purpose. No edit needed.

## Validation

- All 3 frontmatter blocks validate against `references/schema.yaml` (track-correct fields, valid enum values for `problem_type`/`component`/`severity`/`root_cause`/`resolution_type`, hyphen-separated tags).
- `bun scripts/content-integrity.ts` clean (no banned patterns introduced).
- Phase 2.5 selective refresh: none of the new docs contradict existing learnings; no `ce:compound-refresh` follow-up needed.
