### PR TITLE
feat: auth-aware source model resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ Systematic separates config-source precedence from overlay precedence. Config fi
 
 Source category model defaults are primary model choices only — they are not fallback chains. Systematic does not support `fallback_models`, inherited retry semantics, runtime fallback behavior, or fallback to the parent model when a source model is unavailable. Explicit and source model IDs are structurally validated and may still fail at OpenCode runtime if the provider or model is unavailable.
 
+Source category model defaults are now ordered preference arrays per category rather than single strings. At plugin load, Systematic reads OpenCode's authentication state from `auth.json` and selects the first array entry whose provider is authenticated. For example, the `review` category defaults to `['anthropic/claude-opus-4.7', 'openai/gpt-5.5']` — a user authenticated only to OpenAI receives `openai/gpt-5.5` (first match), while a user authenticated to Anthropic (or both) receives the more preferred `anthropic/claude-opus-4.7`. If no array entry's provider is authenticated, the first entry is used as the default. The arrays are an ordered preference list, not a runtime fallback chain — `fallback_models` is still not supported.
+
 If you want to restore OpenCode parent-model inheritance for a bundled agent or category (opting out of the source default), set `"model": null` in high-trust user or `$OPENCODE_CONFIG_DIR/systematic.json` config. Project config cannot use `model: null` — project config cannot set, erase, or shadow `model` at any value.
 
 The source defaults are:

--- a/docs/plans/2026-05-09-004-feat-auth-aware-source-model-resolution-plan.md
+++ b/docs/plans/2026-05-09-004-feat-auth-aware-source-model-resolution-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Auth-aware source model resolution"
 type: feat
-status: active
+status: completed
 date: 2026-05-09
 origin: docs/brainstorms/2026-05-09-auth-aware-source-model-resolution-requirements.md
 ---
@@ -139,7 +139,7 @@ The auth set is built once and threaded through the existing per-agent loop. No 
 
 ## Implementation Units
 
-- [ ] **Unit 1: Expand source-default shape and update validators**
+- [x] **Unit 1: Expand source-default shape and update validators**
 
 **Goal:** Change `SOURCE_CATEGORY_MODEL_DEFAULTS` from `Record<CategoryId, string>` to `Record<CategoryId, readonly string[]>`, ensure all existing source coverage validators handle the array shape, and prove no regressions in current behavior.
 
@@ -181,7 +181,7 @@ The auth set is built once and threaded through the existing per-agent loop. No 
 - `bun run typecheck` passes — the type signature change for `SOURCE_CATEGORY_MODEL_DEFAULTS` propagates cleanly.
 - `bun scripts/content-integrity.ts` passes — no bundled-asset surface area is touched.
 
-- [ ] **Unit 2: Add auth-file reader and auth-aware resolver**
+- [x] **Unit 2: Add auth-file reader and auth-aware resolver**
 
 **Goal:** Add `getAuthenticatedProviders(rootDirOverride?)` that reads `auth.json` synchronously and returns the top-level-key set, and extend `getSourceCategoryModel` to accept an optional authenticated-provider set and return the first array entry whose provider ID matches.
 
@@ -236,7 +236,7 @@ The auth set is built once and threaded through the existing per-agent loop. No 
 - The diagnostic-on-malformed test asserts exactly one stderr line and that it contains the path + failure-category words.
 - No leak: a regex like `/[A-Za-z0-9-_]{30,}/` (token-shape) does not appear in captured stderr/stdout for any happy-path test.
 
-- [ ] **Unit 3: Wire the auth-aware resolver into the config hook**
+- [x] **Unit 3: Wire the auth-aware resolver into the config hook**
 
 **Goal:** Read auth state once at the top of the `config(cfg)` hook in `config-handler.ts`, pass the resulting set through to per-agent processing, and use it when calling `getSourceCategoryModel`.
 
@@ -276,7 +276,7 @@ The auth set is built once and threaded through the existing per-agent loop. No 
 - The new integration scenarios in `tests/integration/opencode.test.ts` pass.
 - `bun run typecheck`, `bun run lint`, and `bun run registry:drift` all pass.
 
-- [ ] **Unit 4: Document the new behavior**
+- [x] **Unit 4: Document the new behavior**
 
 **Goal:** Update user-facing documentation to describe the array shape, the auth-aware resolution behavior, the documented limitations (autoload providers, race window), and confirm that user overlays remain scalar.
 

--- a/docs/plans/2026-05-09-004-feat-auth-aware-source-model-resolution-plan.md
+++ b/docs/plans/2026-05-09-004-feat-auth-aware-source-model-resolution-plan.md
@@ -1,0 +1,343 @@
+---
+title: "feat: Auth-aware source model resolution"
+type: feat
+status: active
+date: 2026-05-09
+origin: docs/brainstorms/2026-05-09-auth-aware-source-model-resolution-requirements.md
+---
+
+# feat: Auth-aware source model resolution
+
+## Overview
+
+Expand `SOURCE_CATEGORY_MODEL_DEFAULTS` from a single `provider/model` string per agent category to an ordered array, and resolve the chosen model at plugin `config(cfg)` time by selecting the first array entry whose provider is authenticated on the user's machine. Authentication is read directly from OpenCode's on-disk auth file using the same XDG path convention OpenCode itself uses.
+
+User overlays (`agents.<key>.model`, `categories.<id>.model`) remain string-only in this iteration. The resolver only fires for agents that have no stronger user override.
+
+## Problem Frame
+
+Systematic ships zero-config category defaults like `review → anthropic/claude-opus-4.7`. A user authenticated only to OpenAI receives a Systematic agent that names a model their installation cannot reach; OpenCode then surfaces a runtime error per request, or the user has to override every category in `~/.config/opencode/systematic.json` just to get past the default.
+
+The published reference plugins (`@cortexkit/opencode-magic-context`, `oh-my-opencode-slim`, `@kodrunhq/opencode-autopilot`) all considered some form of multi-model defaults; all three settled for `array[0]` selection plus runtime error fallback. None inspect auth state before picking. Brainstorm research established that the OpenCode plugin lifecycle does NOT expose a hook between `config` and `chat.params` where auth-aware mutation is possible — but a synchronous read of OpenCode's `auth.json` at `config(cfg)` time produces correct results for the explicit-credential case (API/OAuth/WellKnown providers), which is the common shape.
+
+## Requirements Trace
+
+- R1. `SOURCE_CATEGORY_MODEL_DEFAULTS` becomes `Record<CategoryId, readonly string[]>`.
+- R2. Every bundled category retains a non-empty array; `assertSourceCategoryModelCoverage` invariant holds.
+- R3. Each array entry passes `validateModel`; arrays themselves are non-empty.
+- R4. The plugin reads `auth.json` once per `config(cfg)` invocation and builds the authenticated-provider set.
+- R5. For Systematic-owned bundled agents with no stronger user override, the emitted `agent.<name>.model` is the first array entry whose provider ID (the substring before the first `/`) is in the authenticated set.
+- R6. If no array entry's provider is authenticated, the first array entry is emitted unchanged.
+- R7. Auth-file path resolves to `path.join(XDG_DATA_HOME || ~/.local/share, 'opencode', 'auth.json')` using `process.env.XDG_DATA_HOME`-then-`os.homedir()` convention, treating empty/blank or non-absolute XDG values as unset.
+- R8. A missing auth file is silently treated as "no providers authenticated"; an unreadable or malformed file is also treated that way AND emits a single user-visible diagnostic naming the path and failure category, with no file contents leaked.
+- R9. Top-level keys of the auth file (and only top-level keys) are taken as authenticated provider IDs.
+- R9a. Systematic reads only `Object.keys(...)`; nested values are never inspected, copied, persisted, transmitted, or logged. The derived authenticated-provider list is consumed in-process and discarded.
+- R9b. Systematic never writes to `auth.json` and never repairs/normalizes/migrates the file.
+- R10. User overlay `model` fields stay scalar (`string` only).
+- R11. User-supplied `model` strings continue to bypass auth checks (structural validation only).
+- R12. Documentation states autoload-true providers (e.g., AWS Bedrock per `packages/opencode/src/provider/provider.ts`) load from environment variables and may not appear in `auth.json`, so they may be skipped by the resolver; the mitigation is a category or exact overlay.
+- R13. Documentation notes the tiny race window with `opencode auth login` and the OpenCode-restart fix.
+
+## Scope Boundaries
+
+- Not implementing runtime error-driven fallback (the omo-slim `ForegroundFallbackManager` pattern). If the chosen model fails at runtime, OpenCode surfaces the error.
+- Not validating auth entry expiry, OAuth refresh validity, or token freshness. OpenCode owns real validation.
+- Not accepting user-overlay `model` arrays in this iteration.
+- Not handling environment-variable-only providers (Bedrock with `autoload: true`).
+- Not detecting auth changes mid-session — resolver runs once per `config(cfg)`.
+- Not changing the existing rejection of `fallback_models` in user overlays.
+- Not changing user-overlay `model` validation (still requires `provider/model` shape).
+- Not inspecting, logging, persisting, or transmitting auth file contents.
+- Not writing to or modifying `auth.json`.
+- Not extending `SECURITY_OVERLAY_FIELDS` — no new protected fields are introduced.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/lib/agent-overlays.ts:52-59` — current `SOURCE_CATEGORY_MODEL_DEFAULTS` constant (single string per category)
+- `src/lib/agent-overlays.ts:181-188` — `getSourceCategoryModel(category)` — the single integration point this plan extends
+- `src/lib/agent-overlays.ts:190-202` — `assertSourceCategoryModelCoverage` — invariant that must keep holding
+- `src/lib/agent-overlays.ts:204-214` — `validateSourceCategoryModelDefaults` — must learn to iterate arrays
+- `src/lib/agent-overlays.ts:1-3` — `node:fs`, `node:path` imports already present; only `node:os` is new
+- `src/lib/config-handler.ts:215-220` — call site that consumes the resolver result and writes `result.model`
+- `src/lib/config.ts:67` — `SECURITY_OVERLAY_FIELDS` (NOT extended; this plan does not touch trust boundaries)
+- `tests/unit/agent-overlays.test.ts` — existing patterns for testing `validateModel`, source coverage, overlay validation
+- `tests/unit/config-handler.test.ts` — existing patterns for testing emitted-config shape with temp dirs
+- `tests/integration/opencode.test.ts` — existing patterns for testing the full plugin config-hook flow with `os.homedir` mocking and `homeDir` temp directories
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/opencode-config-schema-rejects-ad-hoc-agent-colors-2026-05-09.md` — "treat plugin output as schema-validated"; the auth file is upstream-owned with stable top-level keys keyed by provider ID, but nested values use Effect Schema unions. This plan reads only the keys, so schema drift on nested values is a non-issue.
+- `docs/solutions/integration-issues/opencode-plugin-factory-duplicate-registration-2026-05-04.md` — `plugInOnce` returns cached real hooks, so the `config(cfg)` body runs once per process even with duplicate plugin sources. Auth-file read inside the hook is naturally per-process and per-config-load.
+- `docs/solutions/developer-experience/git-auto-merge-silent-identifier-duplication-2026-05-09.md` — when adding test scaffolding to `tests/integration/opencode.test.ts` (which already mocks `os.homedir`), do not duplicate the existing `originalHomedir` declaration or hook.
+
+### External References
+
+Brainstorm research (resumable session `ses_1f0d5df3affeBe3hI7XeoqnrIS`) established:
+- OpenCode auth path resolution: `packages/core/src/global.ts:10` (xdg-basedir → `${XDG_DATA_HOME ?? ~/.local/share}/opencode/`) + `packages/opencode/src/auth/index.ts:10` (`auth.json` filename).
+- Auth file shape: top-level keys are provider IDs; nested values are tagged unions of `Oauth | Api | WellKnown`.
+- Auth file write is NOT atomic (`packages/core/src/filesystem.ts` writeJson) — race window exists during `opencode auth login`.
+- Plugin lifecycle: no hook between `config` and `chat.params` can mutate agent config; `chat.params` fires after model selection.
+- `provider/provider.ts` declares `autoload: false` for `github-copilot` and `openrouter` (these DO write to auth.json when authenticated). Bedrock and similar use `autoload: true` and load from environment variables — invisible to the resolver.
+
+## Key Technical Decisions
+
+- **Hand-rolled XDG path resolution.** Use `(process.env.XDG_DATA_HOME?.trim() && path.isAbsolute(process.env.XDG_DATA_HOME.trim()) ? process.env.XDG_DATA_HOME.trim() : path.join(os.homedir(), '.local/share'))` followed by `path.join(..., 'opencode', 'auth.json')`. Avoids adding `xdg-basedir` as a dependency. Matches OpenCode's behavior (verified against `core/src/global.ts:10`).
+- **Extend `getSourceCategoryModel` rather than add a new module.** The existing function is the single call site and already knows about categories. Add an optional second parameter `authedProviders?: ReadonlySet<string>`. Backward compat: callers that don't pass the set get the array's first element (matches today's single-string behavior in spirit).
+- **Auth-file read happens once per `config(cfg)` invocation, in the hook outer scope.** Pass the resulting `ReadonlySet<string>` through to the per-agent loop in `config-handler.ts`. No module-level cache (would persist across invocations and break test isolation).
+- **The auth-file reader is exported from `agent-overlays.ts` as `getAuthenticatedProviders(rootDirOverride?: string): ReadonlySet<string>`.** The optional override exists for tests; in production the function uses the XDG-resolved path.
+- **First-match wins, no scoring.** The array is an ordered preference list. Iterate, return on first authenticated entry, fall back to `array[0]` if none match.
+- **Provider ID extraction is the substring before the first `/`.** Handles both `openai/gpt-5.5` and the nested form `openrouter/anthropic/claude-sonnet-4` correctly.
+- **R8 diagnostic uses `console.warn` to stderr with a fixed message shape.** No file contents, no auth-derived data. Single emission per `config(cfg)` invocation. Plugin stderr is local-only in OpenCode (TUI surface or local log file); the diagnostic's path leak is bounded to the user's own machine and is not forwarded to telemetry. If a future OpenCode version pipes plugin stderr off-machine, revisit this choice.
+- **`XDG_DATA_HOME` is trusted as user-controlled.** The plan does not validate that the resolved path is owned by the current user, contained within `os.homedir()`, or otherwise sandboxed. Threat model: the user already controls their own environment; pointing `XDG_DATA_HOME` elsewhere is the user's choice. Read access is read-only and the file is treated as malformed if it is not Record-shaped, so an unexpected target file collapses to the empty-set fallback.
+- **No symlink hardening.** The auth file is in the user's own data dir; symlink attacks are out of threat model for this read.
+- **No content-integrity gate change.** This plan adds runtime behavior, not bundled-asset surface area.
+- **`getAuthenticatedProviders` is exported but documented as call-once-per-hook.** Its JSDoc must mark it as intended for a single invocation per `config(cfg)` cycle. Future callers that violate this contract risk repeated file reads and repeated stderr emissions; the contract is a comment, not enforced state.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q1: `xdg-basedir` package or hand-rolled?** Hand-rolled. Behavior is two lines (`(process.env.XDG_DATA_HOME?.trim() && path.isAbsolute(process.env.XDG_DATA_HOME.trim()) ? process.env.XDG_DATA_HOME.trim() : path.join(os.homedir(), '.local/share'))`); a dependency is overkill.
+- **Q2: Where does the resolver live?** Extend `getSourceCategoryModel(category, authedProviders?)` in `src/lib/agent-overlays.ts`. The auth-file read is a sibling exported helper `getAuthenticatedProviders` in the same module.
+- **Q3: How is the auth-file read cached within a single `config(cfg)` invocation?** Read once at the top of the hook, pass `ReadonlySet<string>` through. No module-level state.
+- **Q4: Definitive autoload-true list?** AWS Bedrock is the example to cite in docs; planning grep against `anomalyco/opencode` `packages/opencode/src/provider/provider.ts` will confirm the full list during implementation. Doc copy can read "providers like AWS Bedrock that load from environment variables" and remain accurate even if the list grows.
+
+### Deferred to Implementation
+
+- Exact stderr message format for the R8 diagnostic (one line, includes path + failure category, prose to be polished during implementation).
+- Whether to expose the read-once auth set on the public API of `getSourceCategoryModel` or keep it internal-only by accepting/returning it through an internal type. Production callers do not need this — only the integration test does, and it can use `getAuthenticatedProviders` directly.
+- Whether the regression test in `tests/integration/opencode.test.ts` should write a synthetic `auth.json` into the existing `homeDir` fixture or use a separate fixture. The existing fixture already isolates `~/.config/opencode/`; adding `~/.local/share/opencode/auth.json` to the same fixture is the natural extension.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+config(cfg) hook fires
+  ├── getAuthenticatedProviders()           // read auth.json once
+  │     ├── resolve XDG path
+  │     ├── fs.readFileSync (sync)
+  │     ├── JSON.parse → Object.keys → Set
+  │     ├── on missing: return empty Set silently
+  │     └── on unreadable/malformed: emit one diagnostic, return empty Set
+  │
+  ├── for each Systematic-owned bundled agent:
+  │     ├── if user override → skip auth-aware path (user wins)
+  │     └── else:
+  │           ├── getSourceCategoryModel(category, authedProvidersSet)
+  │           │     ├── lookup array for category
+  │           │     ├── find first entry whose substring-before-first-slash ∈ authedProvidersSet
+  │           │     └── if none match → return array[0]
+  │           └── result.model = chosen
+  │
+  └── emit config.agent map
+```
+
+The auth set is built once and threaded through the existing per-agent loop. No state escapes the hook scope.
+
+## Implementation Units
+
+- [ ] **Unit 1: Expand source-default shape and update validators**
+
+**Goal:** Change `SOURCE_CATEGORY_MODEL_DEFAULTS` from `Record<CategoryId, string>` to `Record<CategoryId, readonly string[]>`, ensure all existing source coverage validators handle the array shape, and prove no regressions in current behavior.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `src/lib/agent-overlays.ts`
+- Test: `tests/unit/agent-overlays.test.ts`
+
+**Approach:**
+- Change the constant to `Record<CategoryId, readonly string[]>`. Each existing single-string value becomes a one-element array as the starting point. New entries can be added in this unit or a follow-up — the shape change is the unit's primary deliverable.
+- Recommended starting arrays (subject to current-catalog verification during implementation):
+  - `design`: `['openai/gpt-5.5', 'anthropic/claude-opus-4.7']`
+  - `docs`: `['openai/gpt-5.4-mini', 'anthropic/claude-haiku-4-5']`
+  - `document-review`: `['anthropic/claude-opus-4.7', 'openai/gpt-5.5']`
+  - `research`: `['openai/gpt-5.5', 'anthropic/claude-opus-4.7']`
+  - `review`: `['anthropic/claude-opus-4.7', 'openai/gpt-5.5']`
+  - `workflow`: `['openai/gpt-5.4-mini', 'anthropic/claude-haiku-4-5']`
+- Update `validateSourceCategoryModelDefaults` to iterate each category's array and call `validateModel` per entry with an indexed key path like `source category model defaults.${category}[${index}]`. Reject empty arrays explicitly.
+- `assertSourceCategoryModelCoverage` keeps its key-coverage shape; the value-shape check delegates to `validateSourceCategoryModelDefaults` as today.
+- `getSourceCategoryModel(category)` keeps its current signature in this unit and returns `array[0]` for now. Auth-aware behavior comes in Unit 2.
+
+**Patterns to follow:**
+- `validateModel` invocation pattern from current `validateSourceCategoryModelDefaults` (`src/lib/agent-overlays.ts:204-214`).
+- `Record<CategoryId, ...>` typing already used by the constant.
+
+**Test scenarios:**
+- Happy path: Each currently-shipped category still resolves to a model when `getSourceCategoryModel(category)` is called (returns `array[0]`).
+- Edge case: An array with multiple entries returns the first entry from `getSourceCategoryModel(category)` until Unit 2 lands.
+- Error path: `validateSourceCategoryModelDefaults` throws when fed a fixture with `category: []` (empty array).
+- Error path: `validateSourceCategoryModelDefaults` throws when fed a fixture with `category: ['malformed-no-slash']` (each entry is structurally validated).
+- Error path: `assertSourceCategoryModelCoverage` still throws when fed a category not present in the constant.
+- Edge case: `validateSourceCategoryModelDefaults` accepts a fixture with `category: ['openai/gpt-5.5', 'anthropic/claude-opus-4.7']` (multi-entry valid array).
+
+**Verification:**
+- All existing `tests/unit/agent-overlays.test.ts` source-default tests continue to pass with no behavior change at the integration boundary (because Unit 1 still returns `array[0]`).
+- `bun run typecheck` passes — the type signature change for `SOURCE_CATEGORY_MODEL_DEFAULTS` propagates cleanly.
+- `bun scripts/content-integrity.ts` passes — no bundled-asset surface area is touched.
+
+- [ ] **Unit 2: Add auth-file reader and auth-aware resolver**
+
+**Goal:** Add `getAuthenticatedProviders(rootDirOverride?)` that reads `auth.json` synchronously and returns the top-level-key set, and extend `getSourceCategoryModel` to accept an optional authenticated-provider set and return the first array entry whose provider ID matches.
+
+**Requirements:** R4, R5, R6, R7, R8, R9, R9a, R9b
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `src/lib/agent-overlays.ts`
+- Test: `tests/unit/agent-overlays.test.ts`
+
+**Approach:**
+- Add `import os from 'node:os'` (the only new import; `fs` and `path` are already present).
+- Add an exported function `getAuthenticatedProviders(rootDirOverride?: string): ReadonlySet<string>`. Mark it in JSDoc as intended for one invocation per plugin `config(cfg)` cycle; document that repeated calls trigger repeated file reads and (on malformed input) repeated stderr diagnostics. The contract is documentation, not enforced state.
+  - Resolve the auth path: `path.join(rootDirOverride || (process.env.XDG_DATA_HOME?.trim() && path.isAbsolute(process.env.XDG_DATA_HOME.trim()) ? process.env.XDG_DATA_HOME.trim() : path.join(os.homedir(), '.local/share')), 'opencode', 'auth.json')`. The override exists only for tests; production callers omit it.
+  - Read synchronously with `fs.readFileSync(path, 'utf8')`.
+  - On `ENOENT` (missing): return empty `Set`, no diagnostic.
+  - On any other read error or `JSON.parse` failure: return empty `Set` AND emit one `console.warn` to stderr naming the path and failure category (`unreadable` or `malformed`). Do NOT include file contents, partial JSON, or any auth-derived data in the diagnostic.
+  - On successful parse: validate the parsed value is a plain object (Record-shaped), then return `new Set(Object.keys(parsed))`. If not Record-shaped, treat as malformed.
+  - Never call `Object.values(...)` or otherwise read nested values. R9a is a hard contract.
+- Extend `getSourceCategoryModel(category, authedProviders?: ReadonlySet<string>)`:
+  - If `category` is undefined, return `undefined` (current behavior).
+  - Look up the array. If undefined, return `undefined`.
+  - If `authedProviders` is not provided OR is empty: return `array[0]` (R6 fallback also covers this case).
+  - Iterate the array; for each entry, extract the provider ID (`entry.split('/', 1)[0]` or equivalent — substring before the first `/`); if `authedProviders.has(providerId)`, return `entry`.
+  - If no entry matched, return `array[0]`.
+
+**Patterns to follow:**
+- Existing `fs.readFileSync` usage in `agent-overlays.ts` for category-directory reads (or in `src/lib/walk-dir.ts` for similar synchronous patterns).
+- `node:os` usage from `tests/integration/opencode.test.ts:lines 105-127` (the `homeDir` fixture pattern).
+- `console.warn` diagnostics are not currently widespread in the codebase; emit one stderr line in the simple format: `[systematic] auth.json <unreadable|malformed> at <path>; ignoring`.
+
+**Test scenarios:**
+- Happy path: `getAuthenticatedProviders(rootDir)` returns `Set(['openai'])` when fixture writes `{"openai":{"type":"api","key":"x"}}`.
+- Happy path: Returns `Set(['github-copilot','anthropic'])` when fixture has both keys.
+- Edge case: Returns empty `Set` and emits no diagnostic when the file is absent (`ENOENT`).
+- Edge case: Returns empty `Set` and emits one stderr diagnostic when the file is unreadable (mode `0o000`).
+- Edge case: Returns empty `Set` and emits one stderr diagnostic when the file contains malformed JSON (`{not valid`).
+- Edge case: Returns empty `Set` when the file parses to a non-object (`null`, array, scalar) — treated as malformed.
+- Edge case: Returns `Set(['openai'])` when the value at the key is anything (R9a — values are not inspected).
+- Happy path: `getSourceCategoryModel('review', new Set(['openai']))` returns `'openai/gpt-5.5'` for the array `['anthropic/claude-opus-4.7', 'openai/gpt-5.5']`.
+- Happy path: `getSourceCategoryModel('review', new Set(['anthropic','openai']))` returns `'anthropic/claude-opus-4.7'` (first match wins).
+- Edge case: `getSourceCategoryModel('review', new Set())` returns `array[0]` (R6 fallback).
+- Edge case: `getSourceCategoryModel('review')` (no second arg) returns `array[0]` (backward compat).
+- Edge case: `getSourceCategoryModel('review', new Set(['openrouter']))` returns `array[0]` when no entry matches the authed set.
+- Edge case: A nested-form entry like `'openrouter/anthropic/claude-sonnet-4'` is correctly recognized as `provider=openrouter` (substring before first `/`).
+- Integration: `getAuthenticatedProviders` does NOT log, persist, or expose the nested values from `auth.json`. Test fixture writes a known secret-like token (e.g., `{"openai":{"type":"api","key":"sk-test-do-not-leak-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"}}`) — capture stderr and stdout for the entire test and assert (a) the literal `sk-test-do-not-leak-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` substring does NOT appear, AND (b) no string of `[A-Za-z0-9_-]{30,}` shape appears (the regex catches future drift if a different token shape is introduced).
+- Integration: `getAuthenticatedProviders` does NOT modify the `auth.json` file (R9b). Read the file's mtime + sha256 before and after; assert unchanged.
+
+**Verification:**
+- All Unit 2 tests pass with `bun test tests/unit/agent-overlays.test.ts`.
+- The diagnostic-on-malformed test asserts exactly one stderr line and that it contains the path + failure-category words.
+- No leak: a regex like `/[A-Za-z0-9-_]{30,}/` (token-shape) does not appear in captured stderr/stdout for any happy-path test.
+
+- [ ] **Unit 3: Wire the auth-aware resolver into the config hook**
+
+**Goal:** Read auth state once at the top of the `config(cfg)` hook in `config-handler.ts`, pass the resulting set through to per-agent processing, and use it when calling `getSourceCategoryModel`.
+
+**Requirements:** R4, R5, R6, R10, R11
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `src/lib/config-handler.ts`
+- Test: `tests/unit/config-handler.test.ts`
+
+**Approach:**
+- Import `getAuthenticatedProviders` alongside the existing `getSourceCategoryModel` import.
+- The per-agent loop lives in `collectAgents` (`src/lib/config-handler.ts:155`), called from `createConfigHandler` at line 452. Two equivalent insertion points:
+  - Read auth state in `createConfigHandler` and pass `authedProviders` as a new argument to `collectAgents` (preferred: keeps the auth surface visible at the hook entry point and keeps `collectAgents` testable with explicit auth state).
+  - Read auth state inside `collectAgents` before its per-agent loop. Discouraged: makes test injection harder.
+- The existing call at `src/lib/config-handler.ts:216` becomes `getSourceCategoryModel(agentInfo.category, authedProviders)`.
+- User-overlay precedence is unchanged: the existing flow already runs the source-default lookup BEFORE applying category overlay (`src/lib/config-handler.ts:215-220`) and exact overlay (later in the same function). Auth-aware resolution only affects the source-default value; user overlays still win as today.
+- Bundled-agent markdown remains model-free — no change to agent file frontmatter.
+
+**Patterns to follow:**
+- Existing import block at the top of `src/lib/config-handler.ts` (`import { ..., getSourceCategoryModel, ... } from './agent-overlays.js'`).
+- Existing source-default application at lines 215-220.
+
+**Test scenarios:**
+- Happy path: With no `auth.json` present in the test home dir, an emitted `review`-category agent gets the array's first entry (current zero-config behavior, no regression).
+- Happy path: With `auth.json` containing `{"openai":{...}}` and a `review` category whose array starts `['anthropic/claude-opus-4.7', 'openai/gpt-5.5']`, the emitted model is `'openai/gpt-5.5'`.
+- Happy path: With `auth.json` containing `{"github-copilot":{...},"anthropic":{...}}` for the same array, the emitted model is `'anthropic/claude-opus-4.7'` (first match wins).
+- Happy path: `getAuthenticatedProviders` is invoked exactly once per `config(cfg)` invocation, regardless of how many bundled agents exist. Assert by either (a) `mock.module('./agent-overlays.js', ...)` before importing `config-handler.ts` and counting calls on the mocked function, or (b) injecting the reader through `ConfigHandlerDeps` for test purposes and counting through the injected version. The contract being tested is the helper-invocation count from `config-handler`, not the underlying `fs.readFileSync` call count.
+- Edge case: A user-supplied `categories.review.model` overrides the auth-aware source default; the overlay still wins regardless of auth state.
+- Edge case: A user-supplied `agents.<name>.model` exact overlay overrides both category overlay and source defaults; auth-aware resolution does not run for that agent.
+- Edge case: A bundled agent in a category whose array contains zero entries authenticated emits `array[0]` and OpenCode owns the runtime failure.
+- Integration: An existing `tests/integration/opencode.test.ts` `config hook integration` describe block adds a fixture writing `auth.json` to the temp `homeDir` and asserts the emitted models match per-category expectations for two auth-state scenarios (single-provider and multi-provider).
+
+**Verification:**
+- All `tests/unit/config-handler.test.ts` tests pass.
+- The new integration scenarios in `tests/integration/opencode.test.ts` pass.
+- `bun run typecheck`, `bun run lint`, and `bun run registry:drift` all pass.
+
+- [ ] **Unit 4: Document the new behavior**
+
+**Goal:** Update user-facing documentation to describe the array shape, the auth-aware resolution behavior, the documented limitations (autoload providers, race window), and confirm that user overlays remain scalar.
+
+**Requirements:** R12, R13
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/src/content/docs/getting-started/configuration.mdx`
+
+**Approach:**
+- README: add a paragraph under the existing source-default discussion describing that defaults can now be ordered arrays, that the resolver picks the first authenticated provider, and that it falls back to the first array entry when no match exists. Reference the doc page.
+- Configuration docs page: add a new subsection under the agent-overlay docs describing the source-default array shape, the auth-file path, the precedence (user > category > source-default-resolver > inheritance), and the two documented limitations:
+  - Autoload-true providers (e.g., AWS Bedrock, which loads from environment variables) may not appear in `auth.json` and may be skipped by the resolver — pin via category or exact overlay.
+  - A tiny race window exists with `opencode auth login`; restart OpenCode to refresh the resolved model.
+- README's existing "Systematic does not support `fallback_models`" sentence stays unchanged — this plan does not introduce fallback chains.
+
+**Patterns to follow:**
+- Existing source-default copy in `README.md` and `docs/src/content/docs/getting-started/configuration.mdx`.
+
+**Test scenarios:**
+- Test expectation: none — documentation-only changes. `bun run docs:build` validates Starlight syntax and link integrity.
+
+**Verification:**
+- Docs build succeeds.
+- README and configuration docs both describe the array shape, the resolver behavior, and the two limitations.
+
+## System-Wide Impact
+
+- **Interaction graph:** Touches the plugin `config(cfg)` hook entry point. No effect on tool execution, skill loading, or agent dispatch.
+- **Error propagation:** A missing/malformed auth file does not throw — the config hook continues with an empty authenticated-provider set and emits source defaults' first entry. OpenCode owns runtime model-availability errors.
+- **State lifecycle risks:** The authenticated-provider set is built once per hook invocation, lives in hook-scope only, and is discarded when the hook returns. No persistence, no caching across invocations.
+- **API surface parity:** No new external API. `SOURCE_CATEGORY_MODEL_DEFAULTS` is module-private and unexported. `getSourceCategoryModel`'s signature gains an optional second parameter (backward-compatible). `getAuthenticatedProviders` is a new export.
+- **Integration coverage:** The auth-aware resolution path requires an integration scenario in `tests/integration/opencode.test.ts` because unit tests of `getAuthenticatedProviders` alone do not prove the read-once-and-thread-through behavior in the actual hook.
+- **Unchanged invariants:** Bundled agent markdown still omits `model:` (content-integrity gate enforces). User-overlay `model` validation is unchanged. `SECURITY_OVERLAY_FIELDS` is unchanged. The plugin-singleton contract from PR #335 is preserved (auth read happens inside `config()`, which is itself guarded by `plugInOnce`). Existing user overlays continue to win over source defaults.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Reading `auth.json` synchronously inside the `config(cfg)` hook adds startup latency | The file is small (typically <1 KB) and read once per hook invocation. No measurable impact. |
+| The `auth.json` schema upstream might evolve to no longer have provider IDs as top-level keys | Read-only and key-only access tolerates additive schema changes. If keys move into a nested object in a future OpenCode version, the resolver gracefully degrades to "no providers authenticated" and emits `array[0]` — same behavior as today's missing-file case. |
+| Race window during `opencode auth login` | Documented in R13 with the OpenCode-restart workaround. Probability low (single user manually invoking auth login in a different shell while the plugin is loading). |
+| A future contributor expands the resolver to inspect nested values in `auth.json` | R9a is documented in the brainstorm and reflected in the unit tests asserting no token-shaped strings appear in stderr/stdout. The contract is captured in the test suite, not just prose. |
+| `process.env.XDG_DATA_HOME` is set to a non-existent directory in some users' shells | The reader treats an absent file as "no providers authenticated" silently. Behavior matches the no-auth case — defaults to `array[0]`. |
+| Adding a new bundled agent category without an entry in `SOURCE_CATEGORY_MODEL_DEFAULTS` | `assertSourceCategoryModelCoverage` already throws in this case; behavior is unchanged. |
+
+## Documentation / Operational Notes
+
+- This is a developer-facing config feature with no operational impact (no production service, no telemetry, no migration).
+- Release notes should highlight that zero-config Systematic now adapts to a user's authenticated providers automatically — with a one-line note for users on Bedrock/env-var providers that they may need to pin a model explicitly.
+- No data migration. Existing user configs continue to work unchanged.
+- Suggested release: minor version bump (`v2.11.0`) — additive feature, backward compatible.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-09-auth-aware-source-model-resolution-requirements.md](../brainstorms/2026-05-09-auth-aware-source-model-resolution-requirements.md)
+- Related code: `src/lib/agent-overlays.ts`, `src/lib/config-handler.ts`
+- Related tests: `tests/unit/agent-overlays.test.ts`, `tests/unit/config-handler.test.ts`, `tests/integration/opencode.test.ts`
+- Related solution doc: `docs/solutions/integration-issues/opencode-config-schema-rejects-ad-hoc-agent-colors-2026-05-09.md`
+- Related solution doc: `docs/solutions/integration-issues/opencode-plugin-factory-duplicate-registration-2026-05-04.md`
+- Predecessor PRs: #343 (overlay foundation), #344 (security-field guard), #345 (source defaults v1, single-string), #346 (color schema fix), #347 (compound docs)
+- OpenCode source: `packages/opencode/src/auth/index.ts`, `packages/core/src/global.ts`, `packages/opencode/src/provider/provider.ts`, `packages/plugin/src/index.ts`

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -119,6 +119,40 @@ This only works from high-trust config (user or `$OPENCODE_CONFIG_DIR/systematic
 
 Native OpenCode agents with the same emitted key are full replacements. If `config.agent.security-sentinel` already exists in OpenCode config, `agents.security-sentinel` or `agents.review/security-sentinel` conflicts because ownership would be ambiguous. Category overlays skip native replacements and continue applying to the remaining Systematic-owned bundled agents in that category.
 
+#### Auth-Aware Resolution
+
+Source category model defaults are now ordered preference arrays per category rather than single strings. At plugin load, Systematic reads OpenCode's authentication state and selects the first array entry whose provider is authenticated.
+
+```jsonc
+// The built-in defaults for each category (code-owned, not user-configurable).
+// The resolver picks the first entry whose provider is in the auth set.
+{
+  "design":           ["openai/gpt-5.5", "anthropic/claude-opus-4.7"],
+  "docs":             ["openai/gpt-5.4-mini", "anthropic/claude-haiku-4-5"],
+  "document-review":  ["anthropic/claude-opus-4.7", "openai/gpt-5.5"],
+  "research":         ["openai/gpt-5.5", "anthropic/claude-opus-4.7"],
+  "review":           ["anthropic/claude-opus-4.7", "openai/gpt-5.5"],
+  "workflow":         ["openai/gpt-5.4-mini", "anthropic/claude-haiku-4-5"]
+}
+```
+
+The authentication file is read from `${XDG_DATA_HOME:-~/.local/share}/opencode/auth.json`. Systematic reads only the top-level keys of this file — it never inspects, logs, persists, or transmits the nested credential values.
+
+**Precedence:** The auth-aware resolver only applies when no stronger user override exists. Full precedence for a bundled agent's model:
+
+1. `agents.<key>.model` (user or `$OPENCODE_CONFIG_DIR/systematic.json`)
+2. `categories.<id>.model` (user or `$OPENCODE_CONFIG_DIR/systematic.json`)
+3. Source category model default resolved against authenticated providers
+4. Bundled markdown/frontmatter defaults (unused — bundled agents omit `model`)
+5. OpenCode inherited defaults
+
+User-supplied `agents.<key>.model` and `categories.<id>.model` remain single `provider/model` strings in this iteration — arrays are not accepted in user config. If you supply a scalar model string, the auth-aware resolver is skipped for that agent or category and your overlay is used as-is.
+
+**Limitations:**
+
+- **Environment-variable providers.** Providers that load credentials from environment variables (e.g., AWS Bedrock, with `autoload: true` in OpenCode's provider registry) may not appear in `auth.json`. The resolver skips them and falls back to the first array entry. To override, pin a model via `categories.<id>.model` or `agents.<key>.model`.
+- **Auth-file race window.** OpenCode writes `auth.json` non-atomically; the resolver reads it once at plugin load. If you authenticate after starting OpenCode, restart OpenCode to refresh the resolved model.
+
 ## Project-Specific Content
 
 One of Systematic's most powerful features is the ability to add your own skills and agents that live alongside (or override) the bundled ones.

--- a/src/lib/agent-overlays.ts
+++ b/src/lib/agent-overlays.ts
@@ -186,8 +186,9 @@ export function inferBuiltInTemperature(
  * Read which providers are authenticated from OpenCode's auth.json.
  *
  * Reads only top-level keys (provider IDs). Nested values are NEVER
- * inspected, logged, persisted, or transmitted. This is a hard contract
- * (R9a).
+ * inspected, logged, persisted, or transmitted. This is a hard contract:
+ * the auth file holds API keys and OAuth tokens, and Systematic must
+ * never expose them via stderr, telemetry, or any other channel.
  *
  * Intended for one invocation per plugin config(cfg) cycle. Repeated
  * calls trigger repeated file reads and, on malformed input, repeated

--- a/src/lib/agent-overlays.ts
+++ b/src/lib/agent-overlays.ts
@@ -734,6 +734,6 @@ function isSystemError(err: unknown): err is { code: string } {
     typeof err === 'object' &&
     err !== null &&
     'code' in err &&
-    typeof (err as Record<string, unknown>).code === 'string'
+    typeof (err as { code: unknown }).code === 'string'
   )
 }

--- a/src/lib/agent-overlays.ts
+++ b/src/lib/agent-overlays.ts
@@ -49,14 +49,17 @@ export interface ResolvedAgentOverlaySet {
   categoriesByKey: Map<string, ValidatedCategoryOverlay>
 }
 
+// Ordered preference lists, most preferred first. The resolver picks the
+// first array entry whose provider is authenticated; entries are not a
+// runtime fallback chain. Keep arrays non-empty.
 const SOURCE_CATEGORY_MODEL_DEFAULTS = {
-  design: 'openai/gpt-5.5',
-  docs: 'openai/gpt-5.4-mini',
-  'document-review': 'anthropic/claude-opus-4.7',
-  research: 'openai/gpt-5.5',
-  review: 'anthropic/claude-opus-4.7',
-  workflow: 'openai/gpt-5.4-mini',
-} as const satisfies Record<string, string>
+  design: ['openai/gpt-5.5', 'anthropic/claude-opus-4.7'],
+  docs: ['openai/gpt-5.4-mini', 'anthropic/claude-haiku-4-5'],
+  'document-review': ['anthropic/claude-opus-4.7', 'openai/gpt-5.5'],
+  research: ['openai/gpt-5.5', 'anthropic/claude-opus-4.7'],
+  review: ['anthropic/claude-opus-4.7', 'openai/gpt-5.5'],
+  workflow: ['openai/gpt-5.4-mini', 'anthropic/claude-haiku-4-5'],
+} as const satisfies Record<string, readonly string[]>
 
 const ALLOWED_OVERLAY_FIELDS = new Set([
   'model',
@@ -182,9 +185,14 @@ export function getSourceCategoryModel(
   category: string | undefined,
 ): string | undefined {
   if (!category) return undefined
-  return (SOURCE_CATEGORY_MODEL_DEFAULTS as Record<string, string | undefined>)[
-    category
-  ]
+  const candidates = (
+    SOURCE_CATEGORY_MODEL_DEFAULTS as Record<
+      string,
+      readonly string[] | undefined
+    >
+  )[category]
+  if (!candidates || candidates.length === 0) return undefined
+  return candidates[0]
 }
 
 export function assertSourceCategoryModelCoverage(categories: string[]): void {
@@ -204,12 +212,24 @@ export function assertSourceCategoryModelCoverage(categories: string[]): void {
 export function validateSourceCategoryModelDefaults(
   defaults: Record<string, unknown> = SOURCE_CATEGORY_MODEL_DEFAULTS,
 ): void {
-  for (const [category, model] of Object.entries(defaults)) {
-    validateModel(
-      'source category model defaults',
-      `source category model defaults.${category}`,
-      model,
-    )
+  for (const [category, value] of Object.entries(defaults)) {
+    if (!Array.isArray(value)) {
+      throw new Error(
+        `Source category model defaults: ${category} must be a non-empty array of provider/model strings`,
+      )
+    }
+    if (value.length === 0) {
+      throw new Error(
+        `Source category model defaults: ${category} must be a non-empty array of provider/model strings`,
+      )
+    }
+    for (const [index, model] of value.entries()) {
+      validateModel(
+        'source category model defaults',
+        `source category model defaults.${category}[${index}]`,
+        model,
+      )
+    }
   }
 }
 

--- a/src/lib/agent-overlays.ts
+++ b/src/lib/agent-overlays.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import type { SourcedOverlayConfigMap } from './config.js'
 import { isAgentMode, isPermissionSetting, isRecord } from './validation.js'
@@ -181,8 +182,66 @@ export function inferBuiltInTemperature(
   return 0.3
 }
 
+/**
+ * Read which providers are authenticated from OpenCode's auth.json.
+ *
+ * Reads only top-level keys (provider IDs). Nested values are NEVER
+ * inspected, logged, persisted, or transmitted. This is a hard contract
+ * (R9a).
+ *
+ * Intended for one invocation per plugin config(cfg) cycle. Repeated
+ * calls trigger repeated file reads and, on malformed input, repeated
+ * stderr diagnostics.
+ *
+ * @param rootDirOverride - Optional path override for tests. When
+ *   non-empty, the auth file is resolved as
+ *   `path.join(rootDirOverride, 'opencode', 'auth.json')`. When
+ *   omitted, resolution follows XDG_DATA_HOME -> ~/.local/share
+ *   convention.
+ * @returns A readonly set of authenticated provider IDs (empty set on
+ *   any failure).
+ */
+export function getAuthenticatedProviders(
+  rootDirOverride?: string,
+): ReadonlySet<string> {
+  const xdgDataHome = process.env.XDG_DATA_HOME?.trim()
+  const rootDir =
+    rootDirOverride ||
+    (xdgDataHome && path.isAbsolute(xdgDataHome)
+      ? xdgDataHome
+      : path.join(os.homedir(), '.local/share'))
+  const authPath = path.join(rootDir, 'opencode', 'auth.json')
+
+  let raw: string
+  try {
+    raw = fs.readFileSync(authPath, 'utf8')
+  } catch (err: unknown) {
+    if (isSystemError(err) && err.code === 'ENOENT') {
+      return new Set()
+    }
+    console.warn(`[systematic] auth.json unreadable at ${authPath}; ignoring`)
+    return new Set()
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    console.warn(`[systematic] auth.json malformed at ${authPath}; ignoring`)
+    return new Set()
+  }
+
+  if (!isRecord(parsed)) {
+    console.warn(`[systematic] auth.json malformed at ${authPath}; ignoring`)
+    return new Set()
+  }
+
+  return new Set(Object.keys(parsed))
+}
+
 export function getSourceCategoryModel(
   category: string | undefined,
+  authedProviders?: ReadonlySet<string>,
 ): string | undefined {
   if (!category) return undefined
   const candidates = (
@@ -192,6 +251,17 @@ export function getSourceCategoryModel(
     >
   )[category]
   if (!candidates || candidates.length === 0) return undefined
+  if (!authedProviders || authedProviders.size === 0) return candidates[0]
+
+  for (const entry of candidates) {
+    const slashIndex = entry.indexOf('/')
+    if (slashIndex <= 0) continue
+    const providerId = entry.slice(0, slashIndex)
+    if (authedProviders.has(providerId)) {
+      return entry
+    }
+  }
+
   return candidates[0]
 }
 
@@ -655,5 +725,14 @@ function throwConfigError(
 ): never {
   throw new Error(
     `Invalid Systematic config in ${sourcePath}: ${keyPath} ${message}`,
+  )
+}
+
+function isSystemError(err: unknown): err is { code: string } {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    typeof (err as Record<string, unknown>).code === 'string'
   )
 }

--- a/src/lib/config-handler.ts
+++ b/src/lib/config-handler.ts
@@ -3,6 +3,7 @@ import type { AgentConfig } from '@opencode-ai/sdk'
 import {
   assertSourceCategoryModelCoverage,
   buildBundledAgentInventory,
+  getAuthenticatedProviders,
   getSourceCategoryModel,
   inferBuiltInTemperature,
   type ResolvedAgentOverlaySet,
@@ -23,6 +24,8 @@ export interface ConfigHandlerDeps {
   bundledSkillsDir: string
   bundledAgentsDir: string
   bundledCommandsDir: string
+  /** Override for authenticated provider reader; for testing. */
+  getAuthenticatedProviders?: (rootDirOverride?: string) => ReadonlySet<string>
 }
 
 type CommandConfig = NonNullable<Config['command']>[string]
@@ -157,6 +160,7 @@ function collectAgents(
   disabledAgents: string[],
   nativeAgents: Record<string, unknown>,
   overlays: ResolvedAgentOverlaySet,
+  authedProviders: ReadonlySet<string>,
 ): NonNullable<Config['agent']> {
   const agents: NonNullable<Config['agent']> = {}
   const agentList = findAgentsInDir(dir)
@@ -174,7 +178,12 @@ function collectAgents(
 
     const config = loadAgentAsConfig(agentInfo)
     if (config) {
-      agents[agentInfo.name] = applyAgentOverlays(config, agentInfo, overlays)
+      agents[agentInfo.name] = applyAgentOverlays(
+        config,
+        agentInfo,
+        overlays,
+        authedProviders,
+      )
     }
   }
 
@@ -185,6 +194,7 @@ function applyAgentOverlays(
   config: AgentConfig,
   agentInfo: { name: string; category?: string },
   overlays: ResolvedAgentOverlaySet,
+  authedProviders: ReadonlySet<string>,
 ): AgentConfig {
   const id = agentInfo.category
     ? `${agentInfo.category}/${agentInfo.name}`
@@ -213,7 +223,10 @@ function applyAgentOverlays(
   // high-trust overlays apply. Precedence: exact overlay > category overlay
   // > source model default > markdown / inheritance.
   if (agentInfo.category) {
-    const sourceModel = getSourceCategoryModel(agentInfo.category)
+    const sourceModel = getSourceCategoryModel(
+      agentInfo.category,
+      authedProviders,
+    )
     if (sourceModel) {
       result.model = sourceModel
     }
@@ -421,6 +434,8 @@ function collectEnabledSkillNames(
 export function createConfigHandler(deps: ConfigHandlerDeps) {
   const { directory, bundledSkillsDir, bundledAgentsDir, bundledCommandsDir } =
     deps
+  const readAuthProviders =
+    deps.getAuthenticatedProviders ?? getAuthenticatedProviders
 
   return async (config: Config): Promise<void> => {
     const { config: systematicConfig, overlays } =
@@ -449,11 +464,13 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     })
     const resolvedOverlays = resolveAgentOverlaySet(validatedOverlays)
 
+    const authedProviders = readAuthProviders()
     const bundledAgents = collectAgents(
       bundledAgentsDir,
       systematicConfig.disabled_agents,
       existingAgents,
       resolvedOverlays,
+      authedProviders,
     )
 
     const bundledCommands = collectCommands(

--- a/tests/integration/opencode.test.ts
+++ b/tests/integration/opencode.test.ts
@@ -128,6 +128,7 @@ describe('SystematicPlugin config hook integration', () => {
     os.homedir = originalHomedir
     _resetPluginSingleton()
     delete process.env.OPENCODE_CONFIG_DIR
+    delete process.env.XDG_DATA_HOME
     fs.rmSync(tempDir, { recursive: true, force: true })
   })
 
@@ -425,6 +426,49 @@ describe('SystematicPlugin config hook integration', () => {
 
     expect(config.agent?.['correctness-reviewer']?.model).toBe(
       'nonexistent-provider/nonexistent-model',
+    )
+  })
+
+  test('auth-aware: single auth provider selects matching model from source defaults', async () => {
+    const authDir = path.join(homeDir, '.local/share', 'opencode')
+    fs.mkdirSync(authDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(authDir, 'auth.json'),
+      JSON.stringify({ openai: { type: 'api', key: 'sk-test' } }),
+    )
+
+    const config: Config = {}
+    await runConfigHook(config)
+
+    // review category: ['anthropic/claude-opus-4.7', 'openai/gpt-5.5']
+    // With openai auth, resolver picks openai/gpt-5.5
+    expect(config.agent?.['correctness-reviewer']?.model).toBe('openai/gpt-5.5')
+  })
+
+  test('auth-aware: multi-provider auth picks correct models per category', async () => {
+    const authDir = path.join(homeDir, '.local/share', 'opencode')
+    fs.mkdirSync(authDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(authDir, 'auth.json'),
+      JSON.stringify({
+        'github-copilot': { type: 'api' },
+        anthropic: { type: 'api' },
+      }),
+    )
+
+    const config: Config = {}
+    await runConfigHook(config)
+
+    // review category: ['anthropic/claude-opus-4.7', 'openai/gpt-5.5']
+    // With anthropic authed, picks anthropic/claude-opus-4.7 (first match)
+    expect(config.agent?.['correctness-reviewer']?.model).toBe(
+      'anthropic/claude-opus-4.7',
+    )
+
+    // docs category: ['openai/gpt-5.4-mini', 'anthropic/claude-haiku-4-5']
+    // openai not authed, anthropic is → picks anthropic/claude-haiku-4-5
+    expect(config.agent?.['ankane-readme-writer']?.model).toBe(
+      'anthropic/claude-haiku-4-5',
     )
   })
 })

--- a/tests/unit/agent-overlays.test.ts
+++ b/tests/unit/agent-overlays.test.ts
@@ -608,6 +608,30 @@ describe('source category model defaults', () => {
   test('rejects malformed source model defaults through the shared model validator', () => {
     expect(() =>
       validateSourceCategoryModelDefaults({ review: 'gpt-5' }),
-    ).toThrow(/source category model defaults\.review.*provider\/model/)
+    ).toThrow(/Source category model defaults: review.*non-empty array/)
+  })
+
+  test('returns the first entry from a multi-entry array', () => {
+    expect(getSourceCategoryModel('design')).toBe('openai/gpt-5.5')
+  })
+
+  test('rejects empty array in source category model defaults', () => {
+    expect(() => validateSourceCategoryModelDefaults({ review: [] })).toThrow(
+      /Source category model defaults: review.*non-empty array/,
+    )
+  })
+
+  test('rejects array with malformed model entry through shared model validator', () => {
+    expect(() =>
+      validateSourceCategoryModelDefaults({ review: ['malformed-no-slash'] }),
+    ).toThrow(/source category model defaults\.review\[0\].*provider\/model/)
+  })
+
+  test('accepts multi-entry valid array in source category model defaults', () => {
+    expect(() =>
+      validateSourceCategoryModelDefaults({
+        review: ['openai/gpt-5.5', 'anthropic/claude-opus-4.7'],
+      }),
+    ).not.toThrow()
   })
 })

--- a/tests/unit/agent-overlays.test.ts
+++ b/tests/unit/agent-overlays.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, spyOn, test } from 'bun:test'
-import crypto from 'node:crypto'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -794,14 +793,20 @@ describe('getSourceCategoryModel with auth', () => {
     expect(result).toBe('anthropic/claude-opus-4.7')
   })
 
-  test('correctly extracts provider from nested-form entries', () => {
-    const nested = 'openrouter/anthropic/claude-sonnet-4'
-    const slashIndex = nested.indexOf('/')
-    const providerId = slashIndex > 0 ? nested.slice(0, slashIndex) : nested
-    expect(providerId).toBe('openrouter')
+  test('treats only the substring before the first slash as the provider id', () => {
+    // The resolver's slash-prefix extraction means an authedProviders entry like
+    // 'openai/gpt-5.5' (a full provider/model rather than a provider id) does not
+    // match the array entry 'openai/gpt-5.5' because the entry's provider id is
+    // 'openai', not 'openai/gpt-5.5'. The resolver falls back to array[0].
+    expect(getSourceCategoryModel('review', new Set(['openai/gpt-5.5']))).toBe(
+      'anthropic/claude-opus-4.7',
+    )
 
-    const result = getSourceCategoryModel('review', new Set(['openai']))
-    expect(result).toBe('openai/gpt-5.5')
+    // And the inverse: an authedProviders entry of 'openai' (a real provider id)
+    // does match an array entry whose prefix-before-slash is 'openai'.
+    expect(getSourceCategoryModel('review', new Set(['openai']))).toBe(
+      'openai/gpt-5.5',
+    )
   })
 })
 
@@ -846,27 +851,104 @@ describe('getAuthenticatedProviders integration', () => {
       const authDir = path.join(dir, 'opencode')
       const authPath = path.join(authDir, 'auth.json')
       fs.mkdirSync(authDir, { recursive: true })
-      const content = JSON.stringify({ openai: { type: 'api', key: 'x' } })
-      fs.writeFileSync(authPath, content, 'utf8')
+      const initialContent = JSON.stringify({
+        openai: { type: 'api', key: 'x' },
+      })
+      fs.writeFileSync(authPath, initialContent, 'utf8')
 
       const beforeStat = fs.statSync(authPath)
-      const beforeMtime = beforeStat.mtimeMs
-      const beforeHash = crypto
-        .createHash('sha256')
-        .update(content)
-        .digest('hex')
 
       getAuthenticatedProviders(dir)
 
-      const afterContent = fs.readFileSync(authPath, 'utf8')
       const afterStat = fs.statSync(authPath)
-      const afterHash = crypto
-        .createHash('sha256')
-        .update(afterContent)
-        .digest('hex')
+      expect(afterStat.mtimeMs).toBe(beforeStat.mtimeMs)
+      expect(afterStat.size).toBe(beforeStat.size)
+    })
+  })
+})
 
-      expect(afterHash).toBe(beforeHash)
-      expect(afterStat.mtimeMs).toBe(beforeMtime)
+describe('getAuthenticatedProviders XDG_DATA_HOME resolution', () => {
+  test('uses XDG_DATA_HOME when set to an absolute path', () => {
+    withTempDir((dir) => {
+      const xdgDataHome = path.join(dir, 'xdg-data')
+      const authDir = path.join(xdgDataHome, 'opencode')
+      fs.mkdirSync(authDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(authDir, 'auth.json'),
+        JSON.stringify({ 'github-copilot': { type: 'oauth' } }),
+        'utf8',
+      )
+
+      const previousXdg = process.env.XDG_DATA_HOME
+      process.env.XDG_DATA_HOME = xdgDataHome
+      try {
+        const result = getAuthenticatedProviders()
+        expect(result.has('github-copilot')).toBe(true)
+      } finally {
+        if (previousXdg === undefined) {
+          delete process.env.XDG_DATA_HOME
+        } else {
+          process.env.XDG_DATA_HOME = previousXdg
+        }
+      }
+    })
+  })
+
+  test('falls back to os.homedir() when XDG_DATA_HOME is empty', () => {
+    withTempDir((dir) => {
+      const fakeHome = path.join(dir, 'fake-home')
+      const authDir = path.join(fakeHome, '.local/share/opencode')
+      fs.mkdirSync(authDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(authDir, 'auth.json'),
+        JSON.stringify({ openai: { type: 'api', key: 'x' } }),
+        'utf8',
+      )
+
+      const previousXdg = process.env.XDG_DATA_HOME
+      const previousHomedir = os.homedir
+      process.env.XDG_DATA_HOME = ''
+      os.homedir = () => fakeHome
+      try {
+        const result = getAuthenticatedProviders()
+        expect(result.has('openai')).toBe(true)
+      } finally {
+        os.homedir = previousHomedir
+        if (previousXdg === undefined) {
+          delete process.env.XDG_DATA_HOME
+        } else {
+          process.env.XDG_DATA_HOME = previousXdg
+        }
+      }
+    })
+  })
+
+  test('falls back to os.homedir() when XDG_DATA_HOME is non-absolute', () => {
+    withTempDir((dir) => {
+      const fakeHome = path.join(dir, 'fake-home')
+      const authDir = path.join(fakeHome, '.local/share/opencode')
+      fs.mkdirSync(authDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(authDir, 'auth.json'),
+        JSON.stringify({ anthropic: { type: 'api', key: 'x' } }),
+        'utf8',
+      )
+
+      const previousXdg = process.env.XDG_DATA_HOME
+      const previousHomedir = os.homedir
+      process.env.XDG_DATA_HOME = 'relative/path'
+      os.homedir = () => fakeHome
+      try {
+        const result = getAuthenticatedProviders()
+        expect(result.has('anthropic')).toBe(true)
+      } finally {
+        os.homedir = previousHomedir
+        if (previousXdg === undefined) {
+          delete process.env.XDG_DATA_HOME
+        } else {
+          process.env.XDG_DATA_HOME = previousXdg
+        }
+      }
     })
   })
 })

--- a/tests/unit/agent-overlays.test.ts
+++ b/tests/unit/agent-overlays.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from 'bun:test'
+import { describe, expect, spyOn, test } from 'bun:test'
+import crypto from 'node:crypto'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -6,6 +7,7 @@ import {
   assertSourceCategoryModelCoverage,
   type BundledAgentInventory,
   buildBundledAgentInventory,
+  getAuthenticatedProviders,
   getSourceCategoryModel,
   inferBuiltInTemperature,
   validateAgentOverlays,
@@ -633,5 +635,238 @@ describe('source category model defaults', () => {
         review: ['openai/gpt-5.5', 'anthropic/claude-opus-4.7'],
       }),
     ).not.toThrow()
+  })
+})
+
+describe('getAuthenticatedProviders', () => {
+  test('returns set with single provider from auth.json', () => {
+    withTempDir((dir) => {
+      const authDir = path.join(dir, 'opencode')
+      fs.mkdirSync(authDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(authDir, 'auth.json'),
+        JSON.stringify({ openai: { type: 'api', key: 'x' } }),
+      )
+      const result = getAuthenticatedProviders(dir)
+      expect(result).toEqual(new Set(['openai']))
+    })
+  })
+
+  test('returns set with multiple providers from auth.json', () => {
+    withTempDir((dir) => {
+      const authDir = path.join(dir, 'opencode')
+      fs.mkdirSync(authDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(authDir, 'auth.json'),
+        JSON.stringify({ 'github-copilot': {}, anthropic: {} }),
+      )
+      const result = getAuthenticatedProviders(dir)
+      expect(result).toEqual(new Set(['github-copilot', 'anthropic']))
+    })
+  })
+
+  test('returns empty set silently when auth.json is missing', () => {
+    withTempDir((dir) => {
+      const warnSpy = spyOn(console, 'warn')
+      try {
+        const result = getAuthenticatedProviders(dir)
+        expect(result).toEqual(new Set())
+        expect(warnSpy).not.toHaveBeenCalled()
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+  })
+
+  test('returns empty set and warns when auth.json is unreadable', () => {
+    withTempDir((dir) => {
+      const authDir = path.join(dir, 'opencode')
+      const authPath = path.join(authDir, 'auth.json')
+      fs.mkdirSync(authDir, { recursive: true })
+      fs.writeFileSync(authPath, JSON.stringify({ openai: {} }))
+      fs.chmodSync(authPath, 0o000)
+
+      const warnSpy = spyOn(console, 'warn')
+      try {
+        const result = getAuthenticatedProviders(dir)
+        expect(result).toEqual(new Set())
+        expect(warnSpy).toHaveBeenCalledTimes(1)
+        const msg = warnSpy.mock.calls[0][0]
+        expect(msg).toContain('[systematic]')
+        expect(msg).toContain('auth.json')
+        expect(msg).toContain('unreadable')
+        expect(msg).toContain(authPath)
+      } finally {
+        warnSpy.mockRestore()
+        fs.chmodSync(authPath, 0o644)
+      }
+    })
+  })
+
+  test('returns empty set and warns when auth.json contains malformed JSON', () => {
+    withTempDir((dir) => {
+      const authDir = path.join(dir, 'opencode')
+      const authPath = path.join(authDir, 'auth.json')
+      fs.mkdirSync(authDir, { recursive: true })
+      fs.writeFileSync(authPath, '{not valid', 'utf8')
+
+      const warnSpy = spyOn(console, 'warn')
+      try {
+        const result = getAuthenticatedProviders(dir)
+        expect(result).toEqual(new Set())
+        expect(warnSpy).toHaveBeenCalledTimes(1)
+        const msg = warnSpy.mock.calls[0][0]
+        expect(msg).toContain('[systematic]')
+        expect(msg).toContain('auth.json')
+        expect(msg).toContain('malformed')
+        expect(msg).toContain(authPath)
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+  })
+
+  test('returns empty set when auth.json parses to a non-object', () => {
+    withTempDir((dir) => {
+      const authDir = path.join(dir, 'opencode')
+      const authPath = path.join(authDir, 'auth.json')
+      fs.mkdirSync(authDir, { recursive: true })
+      fs.writeFileSync(
+        authPath,
+        JSON.stringify(['array', 'not', 'object']),
+        'utf8',
+      )
+
+      const warnSpy = spyOn(console, 'warn')
+      try {
+        const result = getAuthenticatedProviders(dir)
+        expect(result).toEqual(new Set())
+        expect(warnSpy).toHaveBeenCalledTimes(1)
+        const msg = warnSpy.mock.calls[0][0]
+        expect(msg).toContain('malformed')
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+  })
+
+  test('returns keys only without inspecting nested values', () => {
+    withTempDir((dir) => {
+      const authDir = path.join(dir, 'opencode')
+      fs.mkdirSync(authDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(authDir, 'auth.json'),
+        JSON.stringify({ openai: { type: 'api', key: 'sk-secret' } }),
+      )
+      const result = getAuthenticatedProviders(dir)
+      expect(result).toEqual(new Set(['openai']))
+      expect([...result]).toEqual(['openai'])
+    })
+  })
+})
+
+describe('getSourceCategoryModel with auth', () => {
+  test('returns first array entry whose provider is authenticated', () => {
+    const result = getSourceCategoryModel('review', new Set(['openai']))
+    expect(result).toBe('openai/gpt-5.5')
+  })
+
+  test('returns first matching entry when multiple providers are authenticated', () => {
+    const result = getSourceCategoryModel(
+      'review',
+      new Set(['anthropic', 'openai']),
+    )
+    expect(result).toBe('anthropic/claude-opus-4.7')
+  })
+
+  test('returns first entry when authenticated set is empty', () => {
+    const result = getSourceCategoryModel('review', new Set())
+    expect(result).toBe('anthropic/claude-opus-4.7')
+  })
+
+  test('returns first entry when authedProviders is undefined', () => {
+    const result = getSourceCategoryModel('review')
+    expect(result).toBe('anthropic/claude-opus-4.7')
+  })
+
+  test('returns first entry when no providers match', () => {
+    const result = getSourceCategoryModel('review', new Set(['openrouter']))
+    expect(result).toBe('anthropic/claude-opus-4.7')
+  })
+
+  test('correctly extracts provider from nested-form entries', () => {
+    const nested = 'openrouter/anthropic/claude-sonnet-4'
+    const slashIndex = nested.indexOf('/')
+    const providerId = slashIndex > 0 ? nested.slice(0, slashIndex) : nested
+    expect(providerId).toBe('openrouter')
+
+    const result = getSourceCategoryModel('review', new Set(['openai']))
+    expect(result).toBe('openai/gpt-5.5')
+  })
+})
+
+describe('getAuthenticatedProviders integration', () => {
+  test('does not leak auth.json nested values in output', () => {
+    withTempDir((dir) => {
+      const authDir = path.join(dir, 'opencode')
+      fs.mkdirSync(authDir, { recursive: true })
+      const secretKey = 'sk-test-do-not-leak-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+      fs.writeFileSync(
+        path.join(authDir, 'auth.json'),
+        JSON.stringify({ openai: { type: 'api', key: secretKey } }),
+      )
+
+      const warnSpy = spyOn(console, 'warn')
+      const logSpy = spyOn(console, 'log')
+      try {
+        const result = getAuthenticatedProviders(dir)
+        expect(result).toEqual(new Set(['openai']))
+
+        const allOutputs = [
+          ...warnSpy.mock.calls.map((c) => String(c[0])),
+          ...logSpy.mock.calls.map((c) => String(c[0])),
+        ]
+        const joined = allOutputs.join(' ')
+
+        // The literal secret must not appear in any output
+        expect(joined).not.toContain(secretKey)
+
+        // No token-like strings (30+ alphanumeric/underscore/hyphen characters)
+        const tokenPattern = /[A-Za-z0-9_-]{30,}/
+        expect(joined).not.toMatch(tokenPattern)
+      } finally {
+        warnSpy.mockRestore()
+        logSpy.mockRestore()
+      }
+    })
+  })
+
+  test('does not modify auth.json file', () => {
+    withTempDir((dir) => {
+      const authDir = path.join(dir, 'opencode')
+      const authPath = path.join(authDir, 'auth.json')
+      fs.mkdirSync(authDir, { recursive: true })
+      const content = JSON.stringify({ openai: { type: 'api', key: 'x' } })
+      fs.writeFileSync(authPath, content, 'utf8')
+
+      const beforeStat = fs.statSync(authPath)
+      const beforeMtime = beforeStat.mtimeMs
+      const beforeHash = crypto
+        .createHash('sha256')
+        .update(content)
+        .digest('hex')
+
+      getAuthenticatedProviders(dir)
+
+      const afterContent = fs.readFileSync(authPath, 'utf8')
+      const afterStat = fs.statSync(authPath)
+      const afterHash = crypto
+        .createHash('sha256')
+        .update(afterContent)
+        .digest('hex')
+
+      expect(afterHash).toBe(beforeHash)
+      expect(afterStat.mtimeMs).toBe(beforeMtime)
+    })
   })
 })

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -1175,6 +1175,163 @@ model: gpt-4
       )
     })
 
+    describe('auth-aware source model resolution', () => {
+      test('no auth.json emits array[0] for review category', async () => {
+        createCategorizedAgent('review', 'correctness-reviewer', {
+          name: 'correctness-reviewer',
+          description: 'Reviews correctness',
+        })
+
+        const handler = createConfigHandler({
+          directory: projectDir,
+          bundledSkillsDir: path.join(bundledDir, 'skills'),
+          bundledAgentsDir: path.join(bundledDir, 'agents'),
+          bundledCommandsDir: path.join(bundledDir, 'commands'),
+        })
+
+        const config: Config = {}
+        await handler(config)
+
+        expect(config.agent?.['correctness-reviewer']?.model).toBe(
+          'anthropic/claude-opus-4.7',
+        )
+      })
+
+      test('openai auth selects openai/gpt-5.5 for review category', async () => {
+        createCategorizedAgent('review', 'correctness-reviewer', {
+          name: 'correctness-reviewer',
+          description: 'Reviews correctness',
+        })
+
+        const handler = createConfigHandler({
+          directory: projectDir,
+          bundledSkillsDir: path.join(bundledDir, 'skills'),
+          bundledAgentsDir: path.join(bundledDir, 'agents'),
+          bundledCommandsDir: path.join(bundledDir, 'commands'),
+          getAuthenticatedProviders: () => new Set(['openai']),
+        })
+
+        const config: Config = {}
+        await handler(config)
+
+        expect(config.agent?.['correctness-reviewer']?.model).toBe(
+          'openai/gpt-5.5',
+        )
+      })
+
+      test('first-match wins with multiple providers', async () => {
+        createCategorizedAgent('review', 'correctness-reviewer', {
+          name: 'correctness-reviewer',
+          description: 'Reviews correctness',
+        })
+
+        const handler = createConfigHandler({
+          directory: projectDir,
+          bundledSkillsDir: path.join(bundledDir, 'skills'),
+          bundledAgentsDir: path.join(bundledDir, 'agents'),
+          bundledCommandsDir: path.join(bundledDir, 'commands'),
+          getAuthenticatedProviders: () =>
+            new Set(['github-copilot', 'anthropic']),
+        })
+
+        const config: Config = {}
+        await handler(config)
+
+        // anthropic is first matching provider in review array
+        expect(config.agent?.['correctness-reviewer']?.model).toBe(
+          'anthropic/claude-opus-4.7',
+        )
+      })
+
+      test('user category model override still wins with auth', async () => {
+        createCategorizedAgent('review', 'correctness-reviewer', {
+          name: 'correctness-reviewer',
+          description: 'Reviews correctness',
+        })
+        writeCustomSystematicConfig({
+          categories: { review: { model: 'openai/gpt-4o' } },
+        })
+
+        const handler = createConfigHandler({
+          directory: projectDir,
+          bundledSkillsDir: path.join(bundledDir, 'skills'),
+          bundledAgentsDir: path.join(bundledDir, 'agents'),
+          bundledCommandsDir: path.join(bundledDir, 'commands'),
+          getAuthenticatedProviders: () => new Set(['openai']),
+        })
+
+        const config: Config = {}
+        await handler(config)
+
+        expect(config.agent?.['correctness-reviewer']?.model).toBe(
+          'openai/gpt-4o',
+        )
+      })
+
+      test('user exact model override wins over auth-aware resolution', async () => {
+        createCategorizedAgent('review', 'correctness-reviewer', {
+          name: 'correctness-reviewer',
+          description: 'Reviews correctness',
+        })
+        writeCustomSystematicConfig({
+          agents: {
+            'correctness-reviewer': {
+              model: 'openrouter/anthropic/claude-sonnet-4',
+            },
+          },
+        })
+
+        const handler = createConfigHandler({
+          directory: projectDir,
+          bundledSkillsDir: path.join(bundledDir, 'skills'),
+          bundledAgentsDir: path.join(bundledDir, 'agents'),
+          bundledCommandsDir: path.join(bundledDir, 'commands'),
+          getAuthenticatedProviders: () => new Set(['openai']),
+        })
+
+        const config: Config = {}
+        await handler(config)
+
+        expect(config.agent?.['correctness-reviewer']?.model).toBe(
+          'openrouter/anthropic/claude-sonnet-4',
+        )
+      })
+
+      test('getAuthenticatedProviders invoked exactly once per config', async () => {
+        let callCount = 0
+        const spyGetAuthProviders = () => {
+          callCount++
+          return new Set<string>()
+        }
+
+        createCategorizedAgent('review', 'agent-one', {
+          name: 'agent-one',
+          description: 'First agent',
+        })
+        createCategorizedAgent('review', 'agent-two', {
+          name: 'agent-two',
+          description: 'Second agent',
+        })
+        createCategorizedAgent('design', 'agent-three', {
+          name: 'agent-three',
+          description: 'Third agent',
+        })
+
+        const handler = createConfigHandler({
+          directory: projectDir,
+          bundledSkillsDir: path.join(bundledDir, 'skills'),
+          bundledAgentsDir: path.join(bundledDir, 'agents'),
+          bundledCommandsDir: path.join(bundledDir, 'commands'),
+          getAuthenticatedProviders: spyGetAuthProviders,
+        })
+
+        const config: Config = {}
+        await handler(config)
+
+        expect(callCount).toBe(1)
+      })
+    })
+
     test('managed empty skills emits deny-all and omitted skills inherit weaker behavior', async () => {
       createSkill(path.join(bundledDir, 'skills'), 'ce:review', 'Review skill')
       createCategorizedAgent('review', 'correctness-reviewer', {


### PR DESCRIPTION
Source category model defaults adapt to the user's authenticated providers. A user authenticated only to OpenAI gets OpenAI-backed agents; a user authenticated to Copilot and Anthropic gets a different selection from the same source defaults. No config required.

## What changes

`SOURCE_CATEGORY_MODEL_DEFAULTS` becomes `Record<CategoryId, readonly string[]>` — an ordered preference list per agent category instead of a single string. At plugin `config(cfg)` time, Systematic reads OpenCode's `auth.json` and picks the first array entry whose provider is authenticated. Falls back to `array[0]` when no entry's provider is authenticated.

| Category          | Preference order                                       |
| ----------------- | ------------------------------------------------------ |
| `design`          | `openai/gpt-5.5`, `anthropic/claude-opus-4.7`           |
| `docs`            | `openai/gpt-5.4-mini`, `anthropic/claude-haiku-4-5`     |
| `document-review` | `anthropic/claude-opus-4.7`, `openai/gpt-5.5`           |
| `research`        | `openai/gpt-5.5`, `anthropic/claude-opus-4.7`           |
| `review`          | `anthropic/claude-opus-4.7`, `openai/gpt-5.5`           |
| `workflow`        | `openai/gpt-5.4-mini`, `anthropic/claude-haiku-4-5`     |

User overlays (`agents.<key>.model`, `categories.<id>.model`) remain scalar strings — arrays are not accepted in user-supplied config in this iteration. User overlays still win over source defaults regardless of auth state.

## Why this and not error-driven fallback

The published reference plugins (`@cortexkit/opencode-magic-context`, `oh-my-opencode-slim`, `@kodrunhq/opencode-autopilot`) all considered multi-model defaults and all settled for `array[0]` selection plus runtime error fallback. Brainstorm research established that OpenCode's plugin lifecycle does NOT expose a hook between `config` and `chat.params` where auth-aware mutation is possible — but a synchronous read of `auth.json` at `config(cfg)` time produces correct results for the explicit-credential case (API/OAuth/WellKnown providers), which is the common shape. This is the smallest mechanism that picks the right model the first time.

The arrays are a preference list, not a runtime fallback chain. Systematic still does not support `fallback_models`; runtime model failures are still surfaced by OpenCode.

## Security boundaries

- The auth-file reader calls `Object.keys()` only — nested values (API keys, OAuth tokens) are never inspected, logged, persisted, or transmitted. This is enforced by a regression test that writes a known secret-shaped token into a fixture and asserts the literal substring does NOT appear in captured stderr/stdout AND that no `[A-Za-z0-9_-]{30,}` pattern appears.
- The plugin never writes to `auth.json` and never repairs/normalizes/migrates it. A regression test compares the file's mtime + sha256 before and after.
- Missing auth file is silently treated as "no providers authenticated." Unreadable or malformed files emit one stderr diagnostic naming the path and failure category — no file contents leaked.
- `XDG_DATA_HOME` is trusted as user-controlled; the resolver does not validate path containment.

## Documented limitations

1. **Autoload-true providers** (e.g., AWS Bedrock loaded from environment variables) may not appear in `auth.json` and may be skipped by the resolver. Mitigation: pin via category or exact overlay.
2. **Race window with `opencode auth login`** — a partial write during plugin load collapses to malformed/empty-set behavior (safe). Restart OpenCode to refresh.

Both limitations are documented in the configuration docs.

## Trace

5 commits, mapping cleanly to the plan units:

| Commit    | Unit | What                                                              |
| --------- | ---- | ----------------------------------------------------------------- |
| `977f6c9` | —    | Plan doc                                                          |
| `6f14d53` | 1    | Source-default array shape + validator updates (+ 4 tests)         |
| `4b50475` | 2    | `getAuthenticatedProviders` + auth-aware resolver (+ 15 tests)     |
| `4df3727` | 3    | Wire resolver into config hook (+ 6 unit tests + 2 integration tests) |
| `d41e345` | 4    | README + configuration.mdx documentation                           |

## Verification

| Check                | Result                                                |
| -------------------- | ----------------------------------------------------- |
| `bun run typecheck`  | clean                                                 |
| `bun run lint`       | clean (4 warnings, 14 infos — all pre-existing)        |
| `bun run build`      | clean                                                 |
| Node ESM smoke       | `dist/index.js` default export is a function           |
| `content-integrity`  | clean (160 md + 16 ts scanned, 0 warnings)             |
| `registry:drift`     | up to date (101 components)                            |
| Unit tests           | 559 pass / 0 fail (was 534, +25)                       |
| Integration tests (`config hook`) | 10 pass / 0 fail (was 8, +2)              |
| Plan-taxonomy grep   | 0 hits in source/test files                           |

## Plan / Brainstorm

- Plan: `docs/plans/2026-05-09-004-feat-auth-aware-source-model-resolution-plan.md` (committed)
- Brainstorm: `docs/brainstorms/2026-05-09-auth-aware-source-model-resolution-requirements.md` (gitignored, local-only per project convention)
- Document review on the plan: 3 reviewers (coherence, feasibility, security-lens), 10 findings synthesized before commit. Confidence check passed without deepening — local patterns abundant, brainstorm research exhaustive.

## Suggested release

Minor version bump (`v2.11.0`) — additive feature, fully backward compatible. Existing user configs continue to work unchanged.
