### PR TITLE
chore(plans): reconcile stale plan statuses to shipped reality

### DIFF
--- a/docs/plans/2026-05-05-001-feat-ce-work-beta-graduation-plan.md
+++ b/docs/plans/2026-05-05-001-feat-ce-work-beta-graduation-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Graduate ce-work-beta into ce-work via native task() dispatch"
 type: feat
-status: active
+status: completed
 date: 2026-05-05
 origin: docs/brainstorms/2026-05-05-ce-work-beta-graduation-requirements.md
 ---

--- a/docs/plans/2026-05-09-003-feat-source-configured-agent-models-plan.md
+++ b/docs/plans/2026-05-09-003-feat-source-configured-agent-models-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Add Source-Configured Agent Models"
 type: feat
-status: active
+status: superseded
 date: 2026-05-09
 origin: docs/plans/2026-05-09-002-feat-provider-model-mcp-overlays-plan.md
 ---


### PR DESCRIPTION
Frontmatter-only housekeeping. Two plan docs in `docs/plans/` were left at `status: active` after the work shipped:

| Plan | Was | Now | Reason |
| --- | --- | --- | --- |
| `2026-05-05-001-feat-ce-work-beta-graduation-plan.md` | active | **completed** | Work shipped via PR #341 (v2.8.0). The plan's units 1-2 implemented the graduation; the pre-merge verification checklist was satisfied at merge. |
| `2026-05-09-003-feat-source-configured-agent-models-plan.md` | active | **superseded** | The single-string source-default work shipped via PR #345 (v2.10.0). The array-shape evolution shipped via PR #348 (v2.11.0) under plan `2026-05-09-004`. Plan #003's scope is fully delivered through both follow-ups. |

After this lands, every plan in `docs/plans/` is either `completed` or `superseded` — no stale `active` entries remain.

Discovered during a strategic queue review at the end of a multi-PR session that left main in an unusually clean state. Three stale memory entries (referencing infrastructure that no longer exists) were also archived in the same review pass.

No behavior change, no source touched, 4 lines total.
