### PR TITLE
fix(plugin): move applyBootstrapContent out of entry point to restore plugin load

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,7 +49,15 @@ jobs:
         run: |
           node --input-type=module -e "
             const m = await import('./dist/index.js');
+            const exportKeys = Object.keys(m).sort();
+            const expected = ['default'];
+            if (JSON.stringify(exportKeys) !== JSON.stringify(expected)) {
+              throw new Error('Plugin entry must export only \`default\`. Got: ' + JSON.stringify(exportKeys) + '. Extra named exports break OpenCode plugin loading (the loader treats them as additional plugin factories and crashes when invoking them with no input). Move helpers to src/lib/.');
+            }
             const pluginFactory = m.default;
+            if (typeof pluginFactory !== 'function') {
+              throw new Error('Default export must be a function. Got: ' + typeof pluginFactory);
+            }
             const plugin = await pluginFactory({
               client: { app: { log: async () => {} } },
               directory: process.cwd()

--- a/docs/solutions/integration-issues/opencode-plugin-named-exports-break-loader-2026-05-11.md
+++ b/docs/solutions/integration-issues/opencode-plugin-named-exports-break-loader-2026-05-11.md
@@ -1,0 +1,141 @@
+---
+title: OpenCode plugin loader treats named exports as additional plugin factories — load failure
+date: 2026-05-11
+category: integration-issues
+module: systematic-plugin
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - "plugin load failure: 'undefined is not an object (evaluating output.system.length)'"
+  - Zero Systematic skills or slash commands available in OpenCode after launch
+  - OpenCode log shows `service=plugin path=@fro.bot/systematic@2.12.1 ... failed to load plugin`
+  - Skill count drops from 54 (working) to 10 (only OpenCode built-ins)
+  - CI smoke test passes; user install fails
+root_cause: scope_issue
+resolution_type: code_fix
+severity: critical
+tags:
+  - opencode
+  - plugin-loader
+  - esm-exports
+  - named-exports
+  - plugin-entry-point
+  - regression-pattern
+---
+
+# OpenCode plugin loader treats named exports as additional plugin factories — load failure
+
+## Problem
+
+After PR #352 added `export const applyBootstrapContent` to `src/index.ts` (so unit tests could import it directly), the built `dist/index.js` exposed two top-level exports: `{ default, applyBootstrapContent }`. When OpenCode loaded the published v2.12.1 package, every named export was treated as an additional plugin factory. The loader invoked `applyBootstrapContent` with no arguments, hit `output.system.length` where `output` was `undefined`, threw, and the entire plugin — including the intended `default` export — failed to load. No skills, no slash commands, no `systematic_skill` tool.
+
+## Symptoms
+
+OpenCode log (`~/.local/share/opencode/log/`) on v2.12.1 install:
+
+```
+INFO  service=plugin path=@fro.bot/systematic@2.12.1
+ERROR error=undefined is not an object (evaluating 'output.system.length') failed to load plugin
+INFO  service=skill count=10 init
+```
+
+After reverting to v2.12.0:
+
+```
+INFO  service=skill count=54 init
+```
+
+CI was green on the broken release. The Node ESM smoke test ran `m.default(...)` directly and only checked that bundled agents and commands loaded under the default export. It did not assert anything about the *shape* of the export set, so a stowaway named export went unnoticed.
+
+This was the **second occurrence** of the same pattern. v2.5.0 / PR #309 had previously broken plugin loading by exporting `INTERNAL_AGENT_SIGNATURES` from the entry. That fix moved the constant to `src/lib/bootstrap.ts` and added a comment "must NOT be re-exported from the plugin entry point." PR #352 added a different helper and didn't internalize the rule. The CI smoke test still didn't check export shape, so the second regression slipped through identically.
+
+## What Didn't Work
+
+- **Trusting the Node ESM smoke test.** It exercises `m.default(...)` and confirms the plugin works under that call shape — but doesn't model OpenCode's loader, which iterates *all* exports. A factory-shape test cannot catch a stowaway-export bug.
+- **The earlier code comment "must NOT be re-exported from the plugin entry point."** A comment in `src/lib/bootstrap.ts` is invisible during entry-file edits. PR #352 added a new helper and exported it from `src/index.ts` without ever reading the comment that warned against this exact move.
+- **Conventional unit tests on the helper.** PR #352's test imports were the *reason* the helper got exported. Tests pulling from `src/index.ts` is what introduced the regression.
+
+## Solution
+
+Three coordinated changes:
+
+1. **Move `applyBootstrapContent` (and `findBootstrapMarkerBlock` + marker constants) out of `src/index.ts` and into `src/lib/bootstrap.ts`.** The entry point now imports the helper. After rebuild, `Object.keys(dist/index.js)` is exactly `["default"]`.
+
+   ```diff
+   - // src/index.ts
+   - export const applyBootstrapContent = (
+   -   output: { system: string[] },
+   -   content: string,
+   - ): void => { ... }
+
+   + // src/lib/bootstrap.ts
+   + export const applyBootstrapContent = (
+   +   output: { system: string[] },
+   +   content: string,
+   + ): void => { ... }
+
+   + // src/index.ts
+   + import {
+   +   applyBootstrapContent,
+   +   getBootstrapContent,
+   +   INTERNAL_AGENT_SIGNATURES,
+   + } from './lib/bootstrap.js'
+   ```
+
+2. **Update the test file's import path** so it follows the symbol:
+
+   ```diff
+   - import { applyBootstrapContent } from '../../src/index.js'
+   + import { applyBootstrapContent } from '../../src/lib/bootstrap.js'
+   ```
+
+3. **Harden the CI Node smoke test** to assert default-only exports. This is the structural gate that would have caught both this regression and the v2.5.0 one:
+
+   ```js
+   const m = await import('./dist/index.js')
+   const exportKeys = Object.keys(m).sort()
+   const expected = ['default']
+   if (JSON.stringify(exportKeys) !== JSON.stringify(expected)) {
+     throw new Error(
+       'Plugin entry must export only `default`. Got: ' +
+       JSON.stringify(exportKeys) +
+       '. Extra named exports break OpenCode plugin loading (the loader ' +
+       'treats them as additional plugin factories and crashes when ' +
+       'invoking them with no input). Move helpers to src/lib/.'
+     )
+   }
+   if (typeof m.default !== 'function') {
+     throw new Error('Default export must be a function. Got: ' + typeof m.default)
+   }
+   ```
+
+The error message is intentionally verbose because it has to teach a future contributor (or AI agent) what the loader actually does — the rule isn't obvious from reading OpenCode's plugin documentation.
+
+## Why This Works
+
+OpenCode's plugin loader enumerates exports from a plugin module and treats each one as a plugin factory candidate. When the entry exposes only `default`, there's exactly one factory to invoke, with the correct input shape. When the entry exposes named symbols too, the loader invokes each one — and a utility helper has a totally different signature from a plugin factory. The first failure aborts the whole plugin load, including the legitimate `default` export.
+
+Moving helpers to `src/lib/` is the right structural answer because:
+- The bundler externalizes nothing extra (helpers are inlined into `dist/index.js` either way)
+- Unit tests import directly from `src/lib/*.ts`, which never goes through the plugin loader
+- The entry stays an "anti-shaped" interface — exactly one default export, nothing else
+
+The CI gate works because it asserts a *property of the build artifact* rather than a *property of the entry source*. Even if a future contributor exports a helper from `src/index.ts`, the build output is the canary, and the gate fails fast with an explanation of why.
+
+## Prevention
+
+1. **Plugin entrypoint files (`src/index.ts`) must contain a default export only.** Helpers, constants, types, and test-visible internals belong in `src/lib/`. This rule is structural, not aesthetic — OpenCode's loader makes it a correctness requirement.
+
+2. **CI smoke tests for plugins must assert export shape, not just call signature.** Asserting that `m.default()` works is necessary but not sufficient. The full assertion is `Object.keys(m) === ['default']`.
+
+3. **When a comment warns "must NOT be re-exported," promote the warning to an executable check.** The bootstrap.ts comment about `INTERNAL_AGENT_SIGNATURES` was honest documentation; it did not prevent the regression. The CI gate added in this fix is the executable form of the same warning.
+
+4. **For published-package regressions, check `npm view <pkg> version` and `dist/index.js` exports before the user's bug report.** When a release ships and behavior changes, `node -e "import('./dist/index.js').then(m => console.log(Object.keys(m)))"` against the installed copy answers "did our export surface change" in seconds.
+
+## Cross-references
+
+- Memory `#2065` (replaced as `#2687` post-PR #352) — the v2.5.0 lesson about `INTERNAL_AGENT_SIGNATURES`. The comment that came out of that incident is in `src/lib/bootstrap.ts:7-11`.
+- `docs/solutions/integration-issues/opencode-plugin-factory-duplicate-registration-2026-05-04.md` — the PR #335 origin of `plugInOnce`, which PR #352 inverted into per-load registration. That inversion is what brought `applyBootstrapContent` into existence as a testable symbol that needed an export.
+- `docs/solutions/integration-issues/opencode-config-schema-rejects-ad-hoc-agent-colors-2026-05-09.md` — the v2.9.2 launch-time regression. Same shape: CI green, npm publish, user install breaks. Both regressions share a root cause class: tests asserted source-level properties, not behavior of the published artifact against the real OpenCode launch lifecycle.
+- PR #352 (`refactor(plugin):` → no semantic-release, so the named-export change shipped only when PR #354's `fix:` triggered v2.12.1).
+- PR #354 (the `fix:` commit that triggered v2.12.1 — its diff is irrelevant to this regression, but its release trigger was the proximate cause of users seeing the bug).

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { Plugin, PluginInput } from '@opencode-ai/plugin'
 import {
+  applyBootstrapContent,
   getBootstrapContent,
   INTERNAL_AGENT_SIGNATURES,
 } from './lib/bootstrap.js'
@@ -17,42 +18,6 @@ const bundledSkillsDir = path.join(packageRoot, 'skills')
 const bundledAgentsDir = path.join(packageRoot, 'agents')
 const bundledCommandsDir = path.join(packageRoot, 'commands')
 const packageJsonPath = path.join(packageRoot, 'package.json')
-
-const BOOTSTRAP_MARKER_OPEN = '<SYSTEMATIC_WORKFLOWS>'
-const BOOTSTRAP_MARKER_CLOSE = '</SYSTEMATIC_WORKFLOWS>'
-
-const findBootstrapMarkerBlock = (
-  entry: string,
-): { start: number; end: number } | null => {
-  const start = entry.indexOf(BOOTSTRAP_MARKER_OPEN)
-  if (start === -1) return null
-  const closeStart = entry.indexOf(
-    BOOTSTRAP_MARKER_CLOSE,
-    start + BOOTSTRAP_MARKER_OPEN.length,
-  )
-  if (closeStart === -1) return null
-  return { start, end: closeStart + BOOTSTRAP_MARKER_CLOSE.length }
-}
-
-export const applyBootstrapContent = (
-  output: { system: string[] },
-  content: string,
-): void => {
-  for (let i = 0; i < output.system.length; i++) {
-    const entry = output.system[i]
-    const block = findBootstrapMarkerBlock(entry)
-    if (block !== null) {
-      output.system[i] =
-        entry.slice(0, block.start) + content + entry.slice(block.end)
-      return
-    }
-  }
-  if (output.system.length > 0) {
-    output.system[output.system.length - 1] += `\n\n${content}`
-  } else {
-    output.system.push(content)
-  }
-}
 
 const getPackageVersion = (): string => {
   try {

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -15,6 +15,52 @@ export const INTERNAL_AGENT_SIGNATURES = [
   'Summarize what was done in this conversation',
 ]
 
+const BOOTSTRAP_MARKER_OPEN = '<SYSTEMATIC_WORKFLOWS>'
+const BOOTSTRAP_MARKER_CLOSE = '</SYSTEMATIC_WORKFLOWS>'
+
+const findBootstrapMarkerBlock = (
+  entry: string,
+): { start: number; end: number } | null => {
+  const start = entry.indexOf(BOOTSTRAP_MARKER_OPEN)
+  if (start === -1) return null
+  const closeStart = entry.indexOf(
+    BOOTSTRAP_MARKER_CLOSE,
+    start + BOOTSTRAP_MARKER_OPEN.length,
+  )
+  if (closeStart === -1) return null
+  return { start, end: closeStart + BOOTSTRAP_MARKER_CLOSE.length }
+}
+
+/**
+ * Inject bootstrap content into the system prompt array, replacing any
+ * existing `<SYSTEMATIC_WORKFLOWS>` block. Multi-load idempotency is via
+ * the marker — most-recently-registered plugin wins under FIFO hook order.
+ *
+ * Exported for test access — must NOT be re-exported from the plugin entry
+ * point (src/index.ts) because OpenCode's plugin loader expects a single
+ * function export; additional named exports break loading. See
+ * `docs/solutions/integration-issues/` for the v2.5.0 and v2.12.1 incidents.
+ */
+export const applyBootstrapContent = (
+  output: { system: string[] },
+  content: string,
+): void => {
+  for (let i = 0; i < output.system.length; i++) {
+    const entry = output.system[i]
+    const block = findBootstrapMarkerBlock(entry)
+    if (block !== null) {
+      output.system[i] =
+        entry.slice(0, block.start) + content + entry.slice(block.end)
+      return
+    }
+  }
+  if (output.system.length > 0) {
+    output.system[output.system.length - 1] += `\n\n${content}`
+  } else {
+    output.system.push(content)
+  }
+}
+
 export interface BootstrapDeps {
   bundledSkillsDir: string
 }

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { applyBootstrapContent } from '../../src/index.js'
+import { applyBootstrapContent } from '../../src/lib/bootstrap.js'
 
 const SRC_DIR = path.resolve(import.meta.dirname, '../../src')
 const ROOT_DIR = path.resolve(import.meta.dirname, '../..')


### PR DESCRIPTION
## Why

`@fro.bot/systematic@2.12.1` is broken on install. Launching OpenCode with v2.12.1 in the user config shows zero Systematic skills or slash commands; reverting to v2.12.0 restores all 54. The OpenCode log spells out the failure:

```
service=plugin path=@fro.bot/systematic@2.12.1
error=undefined is not an object (evaluating 'output.system.length')
failed to load plugin
```

**Root cause.** PR #352's per-load registration refactor added `export const applyBootstrapContent` to `src/index.ts` so unit tests could import the helper directly. The built `dist/index.js` therefore exposes two top-level exports: `{ default, applyBootstrapContent }`. OpenCode's plugin loader treats every named export from a plugin entry as an additional plugin factory and invokes each one. `applyBootstrapContent` crashes immediately on `output.system.length` (called with no input) and the loader aborts the whole plugin — including the legitimate `default` export.

This is the **second occurrence** of the same pattern. v2.5.0 / PR #309 broke plugin loading by exporting `INTERNAL_AGENT_SIGNATURES` from the entry. That fix moved the constant to `src/lib/bootstrap.ts` and added a comment "must NOT be re-exported from the plugin entry point." The comment did not survive PR #352's edits to `src/index.ts`, and the CI smoke test never asserted export shape, so the second regression slipped through identically.

## What

Three coordinated changes:

1. **Move `applyBootstrapContent`, `findBootstrapMarkerBlock`, and the marker constants into `src/lib/bootstrap.ts`.** The entry point now imports the helper. After rebuild, `Object.keys(dist/index.js)` is exactly `['default']`.

2. **Update `tests/unit/plugin.test.ts`** to import from the new location.

3. **Harden the CI Node ESM smoke test** to assert default-only exports:

   ```js
   const exportKeys = Object.keys(m).sort()
   if (JSON.stringify(exportKeys) !== JSON.stringify(['default'])) {
     throw new Error(
       'Plugin entry must export only `default`. Got: ' +
       JSON.stringify(exportKeys) +
       '. Extra named exports break OpenCode plugin loading (the loader ' +
       'treats them as additional plugin factories and crashes when ' +
       'invoking them with no input). Move helpers to src/lib/.'
     )
   }
   ```

   This is the structural gate that would have caught both the v2.5.0 and v2.12.1 regressions, and now prevents the entire class for future PRs.

Also captures the pattern in `docs/solutions/integration-issues/opencode-plugin-named-exports-break-loader-2026-05-11.md` — including cross-references to the v2.5.0 incident, the PR #335 origin of `plugInOnce` (which PR #352 inverted into per-load registration), and the v2.9.2 agent-colors regression that shares the same "CI green → npm publish → user install breaks" failure mode.

## Verification

| Surface | Before | After |
|---|---|---|
| `Object.keys(dist/index.js)` | `['applyBootstrapContent', 'default']` ← regression | `['default']` ✓ |
| Plugin loads end-to-end | crash, zero skills | **51 agents + 45 commands + tool + transform** ✓ |
| typecheck | — | exit 0 ✓ |
| lint | — | 6 warnings (== main), 0 errors ✓ |
| unit tests | — | 723 pass / 0 fail ✓ |
| integration tests | — | 25 pass / 0 fail ✓ |
| content-integrity | — | clean ✓ |
| schema:drift | — | up to date ✓ |
| registry:drift | — | up to date ✓ |
| docs:build | — | 110 pages ✓ |

## Release impact

`fix:` commit triggers semantic-release patch → **v2.12.2**, which restores plugin load for everyone on v2.12.1.

## What this does not do

The Oracle-recommended `npm pack → install → launch-real-OpenCode` integration test is not included here. That gate would also catch the v2.9.2 agent-colors regression class. Scoped as a separate follow-up; the structural CI assertion in this PR already prevents the specific class of bug responsible for both v2.5.0 and v2.12.1.
