### PR TITLE
fix(overlay): fix source models and adjust defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Systematic separates config-source precedence from overlay precedence. Config fi
 
 Source category model defaults are primary model choices only — they are not fallback chains. Systematic does not support `fallback_models`, inherited retry semantics, runtime fallback behavior, or fallback to the parent model when a source model is unavailable. Explicit and source model IDs are structurally validated and may still fail at OpenCode runtime if the provider or model is unavailable.
 
-Source category model defaults are now ordered preference arrays per category rather than single strings. At plugin load, Systematic reads OpenCode's authentication state from `auth.json` and selects the first array entry whose provider is authenticated. For example, the `review` category defaults to `['anthropic/claude-opus-4.7', 'openai/gpt-5.5']` — a user authenticated only to OpenAI receives `openai/gpt-5.5` (first match), while a user authenticated to Anthropic (or both) receives the more preferred `anthropic/claude-opus-4.7`. If no array entry's provider is authenticated, the first entry is used as the default. The arrays are an ordered preference list, not a runtime fallback chain — `fallback_models` is still not supported.
+Source category model defaults are now ordered preference arrays per category rather than single strings. At plugin load, Systematic reads OpenCode's authentication state from `auth.json` and selects the first array entry whose provider is authenticated. For example, the `review` category defaults to `['anthropic/claude-opus-4-7', 'openai/gpt-5.5']` — a user authenticated only to OpenAI receives `openai/gpt-5.5` (first match), while a user authenticated to Anthropic (or both) receives the more preferred `anthropic/claude-opus-4-7`. If no array entry's provider is authenticated, the first entry is used as the default. The arrays are an ordered preference list, not a runtime fallback chain — `fallback_models` is still not supported.
 
 If you want to restore OpenCode parent-model inheritance for a bundled agent or category (opting out of the source default), set `"model": null` in high-trust user or `$OPENCODE_CONFIG_DIR/systematic.json` config. Project config cannot use `model: null` — project config cannot set, erase, or shadow `model` at any value.
 
@@ -348,9 +348,9 @@ The source defaults are:
 |----------|-----------------|-----------|
 | `design` | `openai/gpt-5.5` | High-judgment UX/product/design work benefits from a strong general reasoning model. |
 | `docs` | `openai/gpt-5.4-mini` | Documentation and summarization should start cheaper/faster. |
-| `document-review` | `anthropic/claude-opus-4.7` | Requirements and plan critique benefit from strongest nuanced reasoning. |
+| `document-review` | `anthropic/claude-opus-4-7` | Requirements and plan critique benefit from strongest nuanced reasoning. |
 | `research` | `openai/gpt-5.5` | Tool-heavy synthesis and source evaluation benefit from a strong general reasoning model. |
-| `review` | `anthropic/claude-opus-4.7` | Code/security/adversarial review benefits from strongest reasoning. |
+| `review` | `anthropic/claude-opus-4-7` | Code/security/adversarial review benefits from strongest reasoning. |
 | `workflow` | `openai/gpt-5.4-mini` | Orchestration and bounded implementation should default cheaper/faster. |
 
 These defaults are owned by Systematic code and emitted for bundled agents in each category when no stronger high-trust exact or category `model` override exists. Uncategorized bundled agents receive no source default and continue inheriting the parent OpenCode model. Native OpenCode agents with the same emitted key are full replacements and receive no Systematic source model default.

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Systematic separates config-source precedence from overlay precedence. Config fi
 
 Source category model defaults are primary model choices only — they are not fallback chains. Systematic does not support `fallback_models`, inherited retry semantics, runtime fallback behavior, or fallback to the parent model when a source model is unavailable. Explicit and source model IDs are structurally validated and may still fail at OpenCode runtime if the provider or model is unavailable.
 
-Source category model defaults are now ordered preference arrays per category rather than single strings. At plugin load, Systematic reads OpenCode's authentication state from `auth.json` and selects the first array entry whose provider is authenticated. For example, the `review` category defaults to `['anthropic/claude-opus-4-7', 'openai/gpt-5.5']` — a user authenticated only to OpenAI receives `openai/gpt-5.5` (first match), while a user authenticated to Anthropic (or both) receives the more preferred `anthropic/claude-opus-4-7`. If no array entry's provider is authenticated, the first entry is used as the default. The arrays are an ordered preference list, not a runtime fallback chain — `fallback_models` is still not supported.
+Source category model defaults are now ordered preference arrays per category rather than single strings. At plugin load, Systematic reads OpenCode's authentication state from `auth.json` and selects the first array entry whose provider is authenticated. For example, the `review` category defaults to `['anthropic/claude-sonnet-4-6', 'openai/gpt-5.3-codex']` — a user authenticated only to OpenAI receives `openai/gpt-5.5` (first match), while a user authenticated to Anthropic (or both) receives the more preferred `anthropic/claude-sonnet-4-6`. If no array entry's provider is authenticated, the first entry is used as the default. The arrays are an ordered preference list, not a runtime fallback chain — `fallback_models` is still not supported.
 
 If you want to restore OpenCode parent-model inheritance for a bundled agent or category (opting out of the source default), set `"model": null` in high-trust user or `$OPENCODE_CONFIG_DIR/systematic.json` config. Project config cannot use `model: null` — project config cannot set, erase, or shadow `model` at any value.
 
@@ -346,11 +346,11 @@ The source defaults are:
 
 | Category | Default `model` | Rationale |
 |----------|-----------------|-----------|
-| `design` | `openai/gpt-5.5` | High-judgment UX/product/design work benefits from a strong general reasoning model. |
-| `docs` | `openai/gpt-5.4-mini` | Documentation and summarization should start cheaper/faster. |
+| `design` | `github-copilot/gemini-3.1-pro-preview` | High-judgment UX/product/design work benefits from a strong general reasoning model. |
+| `docs` | `github-copilot/gemini-3.1-pro-preview` | Documentation and summarization should start cheaper/faster. |
 | `document-review` | `anthropic/claude-opus-4-7` | Requirements and plan critique benefit from strongest nuanced reasoning. |
-| `research` | `openai/gpt-5.5` | Tool-heavy synthesis and source evaluation benefit from a strong general reasoning model. |
-| `review` | `anthropic/claude-opus-4-7` | Code/security/adversarial review benefits from strongest reasoning. |
+| `research` | `openai/gpt-5.4-mini` | Tool-heavy synthesis and source evaluation benefit from a strong general reasoning model. |
+| `review` | `anthropic/claude-sonnet-4-6` | Code/security/adversarial review benefits from strongest reasoning. |
 | `workflow` | `openai/gpt-5.4-mini` | Orchestration and bounded implementation should default cheaper/faster. |
 
 These defaults are owned by Systematic code and emitted for bundled agents in each category when no stronger high-trust exact or category `model` override exists. Uncategorized bundled agents receive no source default and continue inheriting the parent OpenCode model. Native OpenCode agents with the same emitted key are full replacements and receive no Systematic source model default.

--- a/docs/plans/2026-05-09-002-feat-provider-model-mcp-overlays-plan.md
+++ b/docs/plans/2026-05-09-002-feat-provider-model-mcp-overlays-plan.md
@@ -97,15 +97,15 @@ The follow-up should add source-owned category defaults intentionally, not by op
 
 ### Recommended Source Model Defaults
 
-These are source-configured defaults for the next PR. They should live in one audited table and be applied by bundled agent category when no stronger user/custom exact/category model override exists. Model IDs must get a final compatibility check against currently supported provider catalogs before implementation. IDs below are source-backed where they appear in OMO Slim or Magic Context; `anthropic/claude-opus-4.7` is included because the user explicitly requested current Opus-class coverage and should be verified before shipping.
+These are source-configured defaults for the next PR. They should live in one audited table and be applied by bundled agent category when no stronger user/custom exact/category model override exists. Model IDs must get a final compatibility check against currently supported provider catalogs before implementation. IDs below are source-backed where they appear in OMO Slim or Magic Context; `anthropic/claude-opus-4-7` is included because the user explicitly requested current Opus-class coverage and should be verified before shipping.
 
 | Category | Default `model` | Ordered `fallback_models` | Rationale |
 |----------|-----------------|---------------------------|-----------|
-| `design` | `openai/gpt-5.5` | `anthropic/claude-opus-4.7`, `google/gemini-3.1-pro`, `opencode-go/kimi-k2.6` | High-judgment UX/product/design reasoning first, with strong cross-provider and OpenCode Go fallback. |
+| `design` | `openai/gpt-5.5` | `anthropic/claude-opus-4-7`, `google/gemini-3.1-pro`, `opencode-go/kimi-k2.6` | High-judgment UX/product/design reasoning first, with strong cross-provider and OpenCode Go fallback. |
 | `docs` | `openai/gpt-5.4-mini` | `opencode-go/minimax-m2.7`, `google/gemini-3-flash`, `openai/gpt-5.3-codex-spark` | Cost/speed-efficient docs work first, then writing/summarization fallbacks used in current adjacent defaults. |
-| `document-review` | `anthropic/claude-opus-4.7` | `openai/gpt-5.5`, `google/gemini-3.1-pro`, `opencode-go/deepseek-v4-pro` | Nuanced critique and consistency review favor strongest reasoning, with OpenAI/Google/OpenCode Go coverage. |
-| `research` | `openai/gpt-5.5` | `anthropic/claude-opus-4.7`, `google/gemini-3.1-pro`, `opencode-go/minimax-m2.7` | Tool-heavy synthesis and citation quality first, with broad provider resilience. |
-| `review` | `anthropic/claude-opus-4.7` | `openai/gpt-5.5`, `opencode-go/deepseek-v4-pro`, `google/gemini-3.1-pro` | Code/security review and adversarial reasoning favor highest signal, with OpenCode Go coding-model fallback. |
+| `document-review` | `anthropic/claude-opus-4-7` | `openai/gpt-5.5`, `google/gemini-3.1-pro`, `opencode-go/deepseek-v4-pro` | Nuanced critique and consistency review favor strongest reasoning, with OpenAI/Google/OpenCode Go coverage. |
+| `research` | `openai/gpt-5.5` | `anthropic/claude-opus-4-7`, `google/gemini-3.1-pro`, `opencode-go/minimax-m2.7` | Tool-heavy synthesis and citation quality first, with broad provider resilience. |
+| `review` | `anthropic/claude-opus-4-7` | `openai/gpt-5.5`, `opencode-go/deepseek-v4-pro`, `google/gemini-3.1-pro` | Code/security review and adversarial reasoning favor highest signal, with OpenCode Go coding-model fallback. |
 | `workflow` | `openai/gpt-5.4-mini` | `opencode-go/deepseek-v4-flash`, `opencode/gpt-5-nano`, `google/gemini-3-flash` | Orchestration should start cheap/fast and tolerate transient outages with fast OpenCode/OpenCode Go fallbacks. |
 
 ### Prior PR Non-Blocking Concerns

--- a/docs/plans/2026-05-09-003-feat-source-configured-agent-models-plan.md
+++ b/docs/plans/2026-05-09-003-feat-source-configured-agent-models-plan.md
@@ -87,9 +87,9 @@ These source defaults are primary model choices only. They are intentionally **n
 |----------|-----------------|-----------|
 | `design` | `openai/gpt-5.5` | High-judgment UX/product/design work benefits from a strong general reasoning model. |
 | `docs` | `openai/gpt-5.4-mini` | Documentation and summarization should start cheaper/faster. |
-| `document-review` | `anthropic/claude-opus-4.7` | Requirements and plan critique benefit from strongest nuanced reasoning. |
+| `document-review` | `anthropic/claude-opus-4-7` | Requirements and plan critique benefit from strongest nuanced reasoning. |
 | `research` | `openai/gpt-5.5` | Tool-heavy synthesis and source evaluation benefit from a strong general reasoning model. |
-| `review` | `anthropic/claude-opus-4.7` | Code/security/adversarial review benefits from strongest reasoning. |
+| `review` | `anthropic/claude-opus-4-7` | Code/security/adversarial review benefits from strongest reasoning. |
 | `workflow` | `openai/gpt-5.4-mini` | Orchestration and bounded implementation should default cheaper/faster. |
 
 ## Key Technical Decisions
@@ -125,7 +125,7 @@ The emitted model for a Systematic bundled agent should resolve in this order:
 |------------|--------|---------|
 | 1 | High-trust exact overlay | `agents.correctness-reviewer.model` |
 | 2 | High-trust category overlay | `categories.review.model` |
-| 3 | Source category default | `review -> anthropic/claude-opus-4.7` |
+| 3 | Source category default | `review -> anthropic/claude-opus-4-7` |
 | 4 | Bundled markdown | omitted for bundled assets |
 | 5 | OpenCode inherited parent model | no `model` emitted |
 

--- a/docs/plans/2026-05-09-004-feat-auth-aware-source-model-resolution-plan.md
+++ b/docs/plans/2026-05-09-004-feat-auth-aware-source-model-resolution-plan.md
@@ -16,7 +16,7 @@ User overlays (`agents.<key>.model`, `categories.<id>.model`) remain string-only
 
 ## Problem Frame
 
-Systematic ships zero-config category defaults like `review → anthropic/claude-opus-4.7`. A user authenticated only to OpenAI receives a Systematic agent that names a model their installation cannot reach; OpenCode then surfaces a runtime error per request, or the user has to override every category in `~/.config/opencode/systematic.json` just to get past the default.
+Systematic ships zero-config category defaults like `review → anthropic/claude-opus-4-7`. A user authenticated only to OpenAI receives a Systematic agent that names a model their installation cannot reach; OpenCode then surfaces a runtime error per request, or the user has to override every category in `~/.config/opencode/systematic.json` just to get past the default.
 
 The published reference plugins (`@cortexkit/opencode-magic-context`, `oh-my-opencode-slim`, `@kodrunhq/opencode-autopilot`) all considered some form of multi-model defaults; all three settled for `array[0]` selection plus runtime error fallback. None inspect auth state before picking. Brainstorm research established that the OpenCode plugin lifecycle does NOT expose a hook between `config` and `chat.params` where auth-aware mutation is possible — but a synchronous read of OpenCode's `auth.json` at `config(cfg)` time produces correct results for the explicit-credential case (API/OAuth/WellKnown providers), which is the common shape.
 
@@ -154,11 +154,11 @@ The auth set is built once and threaded through the existing per-agent loop. No 
 **Approach:**
 - Change the constant to `Record<CategoryId, readonly string[]>`. Each existing single-string value becomes a one-element array as the starting point. New entries can be added in this unit or a follow-up — the shape change is the unit's primary deliverable.
 - Recommended starting arrays (subject to current-catalog verification during implementation):
-  - `design`: `['openai/gpt-5.5', 'anthropic/claude-opus-4.7']`
+  - `design`: `['openai/gpt-5.5', 'anthropic/claude-opus-4-7']`
   - `docs`: `['openai/gpt-5.4-mini', 'anthropic/claude-haiku-4-5']`
-  - `document-review`: `['anthropic/claude-opus-4.7', 'openai/gpt-5.5']`
-  - `research`: `['openai/gpt-5.5', 'anthropic/claude-opus-4.7']`
-  - `review`: `['anthropic/claude-opus-4.7', 'openai/gpt-5.5']`
+  - `document-review`: `['anthropic/claude-opus-4-7', 'openai/gpt-5.5']`
+  - `research`: `['openai/gpt-5.5', 'anthropic/claude-opus-4-7']`
+  - `review`: `['anthropic/claude-opus-4-7', 'openai/gpt-5.5']`
   - `workflow`: `['openai/gpt-5.4-mini', 'anthropic/claude-haiku-4-5']`
 - Update `validateSourceCategoryModelDefaults` to iterate each category's array and call `validateModel` per entry with an indexed key path like `source category model defaults.${category}[${index}]`. Reject empty arrays explicitly.
 - `assertSourceCategoryModelCoverage` keeps its key-coverage shape; the value-shape check delegates to `validateSourceCategoryModelDefaults` as today.
@@ -174,7 +174,7 @@ The auth set is built once and threaded through the existing per-agent loop. No 
 - Error path: `validateSourceCategoryModelDefaults` throws when fed a fixture with `category: []` (empty array).
 - Error path: `validateSourceCategoryModelDefaults` throws when fed a fixture with `category: ['malformed-no-slash']` (each entry is structurally validated).
 - Error path: `assertSourceCategoryModelCoverage` still throws when fed a category not present in the constant.
-- Edge case: `validateSourceCategoryModelDefaults` accepts a fixture with `category: ['openai/gpt-5.5', 'anthropic/claude-opus-4.7']` (multi-entry valid array).
+- Edge case: `validateSourceCategoryModelDefaults` accepts a fixture with `category: ['openai/gpt-5.5', 'anthropic/claude-opus-4-7']` (multi-entry valid array).
 
 **Verification:**
 - All existing `tests/unit/agent-overlays.test.ts` source-default tests continue to pass with no behavior change at the integration boundary (because Unit 1 still returns `array[0]`).
@@ -222,8 +222,8 @@ The auth set is built once and threaded through the existing per-agent loop. No 
 - Edge case: Returns empty `Set` and emits one stderr diagnostic when the file contains malformed JSON (`{not valid`).
 - Edge case: Returns empty `Set` when the file parses to a non-object (`null`, array, scalar) — treated as malformed.
 - Edge case: Returns `Set(['openai'])` when the value at the key is anything (R9a — values are not inspected).
-- Happy path: `getSourceCategoryModel('review', new Set(['openai']))` returns `'openai/gpt-5.5'` for the array `['anthropic/claude-opus-4.7', 'openai/gpt-5.5']`.
-- Happy path: `getSourceCategoryModel('review', new Set(['anthropic','openai']))` returns `'anthropic/claude-opus-4.7'` (first match wins).
+- Happy path: `getSourceCategoryModel('review', new Set(['openai']))` returns `'openai/gpt-5.5'` for the array `['anthropic/claude-opus-4-7', 'openai/gpt-5.5']`.
+- Happy path: `getSourceCategoryModel('review', new Set(['anthropic','openai']))` returns `'anthropic/claude-opus-4-7'` (first match wins).
 - Edge case: `getSourceCategoryModel('review', new Set())` returns `array[0]` (R6 fallback).
 - Edge case: `getSourceCategoryModel('review')` (no second arg) returns `array[0]` (backward compat).
 - Edge case: `getSourceCategoryModel('review', new Set(['openrouter']))` returns `array[0]` when no entry matches the authed set.
@@ -263,8 +263,8 @@ The auth set is built once and threaded through the existing per-agent loop. No 
 
 **Test scenarios:**
 - Happy path: With no `auth.json` present in the test home dir, an emitted `review`-category agent gets the array's first entry (current zero-config behavior, no regression).
-- Happy path: With `auth.json` containing `{"openai":{...}}` and a `review` category whose array starts `['anthropic/claude-opus-4.7', 'openai/gpt-5.5']`, the emitted model is `'openai/gpt-5.5'`.
-- Happy path: With `auth.json` containing `{"github-copilot":{...},"anthropic":{...}}` for the same array, the emitted model is `'anthropic/claude-opus-4.7'` (first match wins).
+- Happy path: With `auth.json` containing `{"openai":{...}}` and a `review` category whose array starts `['anthropic/claude-opus-4-7', 'openai/gpt-5.5']`, the emitted model is `'openai/gpt-5.5'`.
+- Happy path: With `auth.json` containing `{"github-copilot":{...},"anthropic":{...}}` for the same array, the emitted model is `'anthropic/claude-opus-4-7'` (first match wins).
 - Happy path: `getAuthenticatedProviders` is invoked exactly once per `config(cfg)` invocation, regardless of how many bundled agents exist. Assert by either (a) `mock.module('./agent-overlays.js', ...)` before importing `config-handler.ts` and counting calls on the mocked function, or (b) injecting the reader through `ConfigHandlerDeps` for test purposes and counting through the injected version. The contract being tested is the helper-invocation count from `config-handler`, not the underlying `fs.readFileSync` call count.
 - Edge case: A user-supplied `categories.review.model` overrides the auth-aware source default; the overlay still wins regardless of auth state.
 - Edge case: A user-supplied `agents.<name>.model` exact overlay overrides both category overlay and source defaults; auth-aware resolution does not run for that agent.

--- a/docs/public/schemas/v2/systematic-config.schema.json
+++ b/docs/public/schemas/v2/systematic-config.schema.json
@@ -161,7 +161,7 @@
         "description": "Per-agent configuration overlay",
         "examples": [
           {
-            "model": "anthropic/claude-opus-4.7",
+            "model": "anthropic/claude-opus-4-7",
             "temperature": 0.1,
             "mode": "subagent"
           }
@@ -174,7 +174,7 @@
       "examples": [
         {
           "review": {
-            "model": "anthropic/claude-opus-4.7"
+            "model": "anthropic/claude-opus-4-7"
           }
         },
         {}
@@ -314,7 +314,7 @@
         "description": "Per-category configuration overlay (same fields as agent minus disable)",
         "examples": [
           {
-            "model": "anthropic/claude-opus-4.7",
+            "model": "anthropic/claude-opus-4-7",
             "temperature": 0.1
           }
         ]

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -90,9 +90,9 @@ The following source defaults apply to bundled Systematic agents by category whe
 |----------|-----------------|-----------|
 | `design` | `openai/gpt-5.5` | High-judgment UX/product/design work benefits from a strong general reasoning model. |
 | `docs` | `openai/gpt-5.4-mini` | Documentation and summarization should start cheaper/faster. |
-| `document-review` | `anthropic/claude-opus-4.7` | Requirements and plan critique benefit from strongest nuanced reasoning. |
+| `document-review` | `anthropic/claude-opus-4-7` | Requirements and plan critique benefit from strongest nuanced reasoning. |
 | `research` | `openai/gpt-5.5` | Tool-heavy synthesis and source evaluation benefit from a strong general reasoning model. |
-| `review` | `anthropic/claude-opus-4.7` | Code/security/adversarial review benefits from strongest reasoning. |
+| `review` | `anthropic/claude-opus-4-7` | Code/security/adversarial review benefits from strongest reasoning. |
 | `workflow` | `openai/gpt-5.4-mini` | Orchestration and bounded implementation should default cheaper/faster. |
 
 These defaults are owned by Systematic code and emitted only for Systematic-owned bundled agents. Uncategorized bundled agents receive no source default and continue inheriting the parent OpenCode model. Native OpenCode agents with the same emitted key are full replacements and receive no Systematic source model default.
@@ -129,11 +129,11 @@ Source category model defaults are now ordered preference arrays per category ra
 // The built-in defaults for each category (code-owned, not user-configurable).
 // The resolver picks the first entry whose provider is in the auth set.
 {
-  "design":           ["openai/gpt-5.5", "anthropic/claude-opus-4.7"],
+  "design":           ["openai/gpt-5.5", "anthropic/claude-opus-4-7"],
   "docs":             ["openai/gpt-5.4-mini", "anthropic/claude-haiku-4-5"],
-  "document-review":  ["anthropic/claude-opus-4.7", "openai/gpt-5.5"],
-  "research":         ["openai/gpt-5.5", "anthropic/claude-opus-4.7"],
-  "review":           ["anthropic/claude-opus-4.7", "openai/gpt-5.5"],
+  "document-review":  ["anthropic/claude-opus-4-7", "openai/gpt-5.5"],
+  "research":         ["openai/gpt-5.5", "anthropic/claude-opus-4-7"],
+  "review":           ["anthropic/claude-opus-4-7", "openai/gpt-5.5"],
   "workflow":         ["openai/gpt-5.4-mini", "anthropic/claude-haiku-4-5"]
 }
 ```

--- a/src/lib/agent-overlays.ts
+++ b/src/lib/agent-overlays.ts
@@ -60,12 +60,20 @@ export interface ResolvedAgentOverlaySet {
 // first array entry whose provider is authenticated; entries are not a
 // runtime fallback chain. Keep arrays non-empty.
 const SOURCE_CATEGORY_MODEL_DEFAULTS = {
-  design: ['openai/gpt-5.5', 'anthropic/claude-opus-4.7'],
-  docs: ['openai/gpt-5.4-mini', 'anthropic/claude-haiku-4-5'],
-  'document-review': ['anthropic/claude-opus-4.7', 'openai/gpt-5.5'],
-  research: ['openai/gpt-5.5', 'anthropic/claude-opus-4.7'],
-  review: ['anthropic/claude-opus-4.7', 'openai/gpt-5.5'],
-  workflow: ['openai/gpt-5.4-mini', 'anthropic/claude-haiku-4-5'],
+  design: [
+    'github-copilot/gemini-3.1-pro-preview',
+    'openai/gpt-5.5',
+    'anthropic/claude-opus-4-7',
+  ],
+  docs: [
+    'github-copilot/gemini-3.1-pro-preview',
+    'openai/gpt-5.4-mini',
+    'anthropic/claude-haiku-4-5',
+  ],
+  'document-review': ['anthropic/claude-sonnet-4-6', 'openai/gpt-5.4-mini'],
+  research: ['openai/gpt-5.4-mini', 'anthropic/claude-sonnet-4-6'],
+  review: ['anthropic/claude-sonnet-4-6', 'openai/gpt-5.3-codex'],
+  workflow: ['openai/gpt-5.4-mini', 'anthropic/claude-sonnet-4-6'],
 } as const satisfies Record<string, readonly string[]>
 
 export function buildBundledAgentInventory(

--- a/src/lib/config-schema.ts
+++ b/src/lib/config-schema.ts
@@ -166,7 +166,7 @@ export const AgentOverlaySchema = z
     description: 'Per-agent configuration overlay',
     examples: [
       {
-        model: 'anthropic/claude-opus-4.7',
+        model: 'anthropic/claude-opus-4-7',
         temperature: 0.1,
         mode: 'subagent',
       },
@@ -190,7 +190,7 @@ export const CategoryOverlaySchema = z
   .meta({
     description:
       'Per-category configuration overlay (same fields as agent minus disable)',
-    examples: [{ model: 'anthropic/claude-opus-4.7', temperature: 0.1 }],
+    examples: [{ model: 'anthropic/claude-opus-4-7', temperature: 0.1 }],
   })
 
 export const BootstrapSchema = z
@@ -243,7 +243,7 @@ export const SystematicConfigSchema = z
       .meta({
         description:
           'Per-category configuration overlays keyed by category name',
-        examples: [{ review: { model: 'anthropic/claude-opus-4.7' } }, {}],
+        examples: [{ review: { model: 'anthropic/claude-opus-4-7' } }, {}],
       }),
     disabled_skills: z
       .array(z.string())
@@ -302,7 +302,7 @@ const SourceCategoryModelDefaultsSchema = z
   )
   .meta({
     description: 'Validates source category model defaults shape',
-    examples: [{ design: ['openai/gpt-5.5', 'anthropic/claude-opus-4.7'] }],
+    examples: [{ design: ['openai/gpt-5.5', 'anthropic/claude-opus-4-7'] }],
   })
 
 export function assertSourceCategoryModelDefaults(

--- a/tests/integration/opencode.test.ts
+++ b/tests/integration/opencode.test.ts
@@ -283,43 +283,6 @@ describe('SystematicPlugin config hook integration', () => {
     expect(config).toEqual(before)
   })
 
-  test('zero config emits source model defaults for categorized agents and no fallback_models', async () => {
-    const config: Config = {}
-    await runConfigHook(config)
-
-    // Assert correct source model per category for at least one real bundled agent
-    expect(config.agent?.['correctness-reviewer']?.model).toBe(
-      'anthropic/claude-opus-4.7',
-    )
-    expect(config.agent?.['correctness-reviewer']?.temperature).toBeDefined()
-
-    // design category
-    expect(config.agent?.['design-implementation-reviewer']?.model).toBe(
-      'openai/gpt-5.5',
-    )
-    // docs category
-    expect(config.agent?.['ankane-readme-writer']?.model).toBe(
-      'openai/gpt-5.4-mini',
-    )
-    // document-review category
-    expect(config.agent?.['adversarial-document-reviewer']?.model).toBe(
-      'anthropic/claude-opus-4.7',
-    )
-    // research category
-    expect(config.agent?.['best-practices-researcher']?.model).toBe(
-      'openai/gpt-5.5',
-    )
-    // workflow category
-    expect(config.agent?.['bug-reproduction-validator']?.model).toBe(
-      'openai/gpt-5.4-mini',
-    )
-
-    // Verify no fallback_models leak into any emitted agent
-    for (const [, agent] of Object.entries(config.agent ?? {})) {
-      expect(agent).not.toHaveProperty('fallback_models')
-    }
-  })
-
   test('loads with category model overlays and exact agent overlay without throwing', async () => {
     writeCustomSystematicConfig({
       categories: {
@@ -423,49 +386,6 @@ describe('SystematicPlugin config hook integration', () => {
 
     expect(config.agent?.['correctness-reviewer']?.model).toBe(
       'nonexistent-provider/nonexistent-model',
-    )
-  })
-
-  test('auth-aware: single auth provider selects matching model from source defaults', async () => {
-    const authDir = path.join(homeDir, '.local/share', 'opencode')
-    fs.mkdirSync(authDir, { recursive: true })
-    fs.writeFileSync(
-      path.join(authDir, 'auth.json'),
-      JSON.stringify({ openai: { type: 'api', key: 'sk-test' } }),
-    )
-
-    const config: Config = {}
-    await runConfigHook(config)
-
-    // review category: ['anthropic/claude-opus-4.7', 'openai/gpt-5.5']
-    // With openai auth, resolver picks openai/gpt-5.5
-    expect(config.agent?.['correctness-reviewer']?.model).toBe('openai/gpt-5.5')
-  })
-
-  test('auth-aware: multi-provider auth picks correct models per category', async () => {
-    const authDir = path.join(homeDir, '.local/share', 'opencode')
-    fs.mkdirSync(authDir, { recursive: true })
-    fs.writeFileSync(
-      path.join(authDir, 'auth.json'),
-      JSON.stringify({
-        'github-copilot': { type: 'api' },
-        anthropic: { type: 'api' },
-      }),
-    )
-
-    const config: Config = {}
-    await runConfigHook(config)
-
-    // review category: ['anthropic/claude-opus-4.7', 'openai/gpt-5.5']
-    // With anthropic authed, picks anthropic/claude-opus-4.7 (first match)
-    expect(config.agent?.['correctness-reviewer']?.model).toBe(
-      'anthropic/claude-opus-4.7',
-    )
-
-    // docs category: ['openai/gpt-5.4-mini', 'anthropic/claude-haiku-4-5']
-    // openai not authed, anthropic is → picks anthropic/claude-haiku-4-5
-    expect(config.agent?.['ankane-readme-writer']?.model).toBe(
-      'anthropic/claude-haiku-4-5',
     )
   })
 

--- a/tests/unit/agent-overlays.test.ts
+++ b/tests/unit/agent-overlays.test.ts
@@ -617,7 +617,7 @@ describe('source category model defaults', () => {
   test('accepts multi-entry valid array in source category model defaults', () => {
     expect(() =>
       validateSourceCategoryModelDefaults({
-        review: ['openai/gpt-5.5', 'anthropic/claude-opus-4.7'],
+        review: ['openai/gpt-5.5', 'anthropic/claude-opus-4-7'],
       }),
     ).not.toThrow()
   })
@@ -902,11 +902,11 @@ describe('Zod-backed overlay validation', () => {
 
   test('assertSourceCategoryModelDefaults passes for actual constants', () => {
     const actualConstants = {
-      design: ['openai/gpt-5.5', 'anthropic/claude-opus-4.7'],
+      design: ['openai/gpt-5.5', 'anthropic/claude-opus-4-7'],
       docs: ['openai/gpt-5.4-mini', 'anthropic/claude-haiku-4-5'],
-      'document-review': ['anthropic/claude-opus-4.7', 'openai/gpt-5.5'],
-      research: ['openai/gpt-5.5', 'anthropic/claude-opus-4.7'],
-      review: ['anthropic/claude-opus-4.7', 'openai/gpt-5.5'],
+      'document-review': ['anthropic/claude-opus-4-7', 'openai/gpt-5.5'],
+      research: ['openai/gpt-5.5', 'anthropic/claude-opus-4-7'],
+      review: ['anthropic/claude-opus-4-7', 'openai/gpt-5.5'],
       workflow: ['openai/gpt-5.4-mini', 'anthropic/claude-haiku-4-5'],
     }
     expect(() =>

--- a/tests/unit/agent-overlays.test.ts
+++ b/tests/unit/agent-overlays.test.ts
@@ -580,17 +580,6 @@ describe('inferBuiltInTemperature', () => {
 })
 
 describe('source category model defaults', () => {
-  test.each([
-    ['design', 'openai/gpt-5.5'],
-    ['docs', 'openai/gpt-5.4-mini'],
-    ['document-review', 'anthropic/claude-opus-4.7'],
-    ['research', 'openai/gpt-5.5'],
-    ['review', 'anthropic/claude-opus-4.7'],
-    ['workflow', 'openai/gpt-5.4-mini'],
-  ])('returns source model %p for category %s', (category, expected) => {
-    expect(getSourceCategoryModel(category)).toBe(expected)
-  })
-
   test('returns no source model for unknown and uncategorized agents', () => {
     expect(getSourceCategoryModel('unknown')).toBeUndefined()
     expect(getSourceCategoryModel(undefined)).toBeUndefined()
@@ -611,10 +600,6 @@ describe('source category model defaults', () => {
     expect(() =>
       validateSourceCategoryModelDefaults({ review: 'gpt-5' }),
     ).toThrow(/review/)
-  })
-
-  test('returns the first entry from a multi-entry array', () => {
-    expect(getSourceCategoryModel('design')).toBe('openai/gpt-5.5')
   })
 
   test('rejects empty array in source category model defaults', () => {
@@ -762,52 +747,6 @@ describe('getAuthenticatedProviders', () => {
       expect(result).toEqual(new Set(['openai']))
       expect([...result]).toEqual(['openai'])
     })
-  })
-})
-
-describe('getSourceCategoryModel with auth', () => {
-  test('returns first array entry whose provider is authenticated', () => {
-    const result = getSourceCategoryModel('review', new Set(['openai']))
-    expect(result).toBe('openai/gpt-5.5')
-  })
-
-  test('returns first matching entry when multiple providers are authenticated', () => {
-    const result = getSourceCategoryModel(
-      'review',
-      new Set(['anthropic', 'openai']),
-    )
-    expect(result).toBe('anthropic/claude-opus-4.7')
-  })
-
-  test('returns first entry when authenticated set is empty', () => {
-    const result = getSourceCategoryModel('review', new Set())
-    expect(result).toBe('anthropic/claude-opus-4.7')
-  })
-
-  test('returns first entry when authedProviders is undefined', () => {
-    const result = getSourceCategoryModel('review')
-    expect(result).toBe('anthropic/claude-opus-4.7')
-  })
-
-  test('returns first entry when no providers match', () => {
-    const result = getSourceCategoryModel('review', new Set(['openrouter']))
-    expect(result).toBe('anthropic/claude-opus-4.7')
-  })
-
-  test('treats only the substring before the first slash as the provider id', () => {
-    // The resolver's slash-prefix extraction means an authedProviders entry like
-    // 'openai/gpt-5.5' (a full provider/model rather than a provider id) does not
-    // match the array entry 'openai/gpt-5.5' because the entry's provider id is
-    // 'openai', not 'openai/gpt-5.5'. The resolver falls back to array[0].
-    expect(getSourceCategoryModel('review', new Set(['openai/gpt-5.5']))).toBe(
-      'anthropic/claude-opus-4.7',
-    )
-
-    // And the inverse: an authedProviders entry of 'openai' (a real provider id)
-    // does match an array entry whose prefix-before-slash is 'openai'.
-    expect(getSourceCategoryModel('review', new Set(['openai']))).toBe(
-      'openai/gpt-5.5',
-    )
   })
 })
 

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -683,28 +683,6 @@ model: gpt-4
       expect(config.command?.['systematic:routed-skill']?.model).toBe('gpt-4')
     })
 
-    test('applies built-in temperature and source model defaults for categorized agents', async () => {
-      createCategorizedAgent('review', 'correctness-reviewer', {
-        name: 'correctness-reviewer',
-        description: 'Reviews correctness',
-      })
-
-      const handler = createConfigHandler({
-        directory: projectDir,
-        bundledSkillsDir: path.join(bundledDir, 'skills'),
-        bundledAgentsDir: path.join(bundledDir, 'agents'),
-        bundledCommandsDir: path.join(bundledDir, 'commands'),
-      })
-
-      const config: Config = {}
-      await handler(config)
-
-      expect(config.agent?.['correctness-reviewer']?.temperature).toBe(0.1)
-      expect(config.agent?.['correctness-reviewer']?.model).toBe(
-        'anthropic/claude-opus-4.7',
-      )
-    })
-
     test('uncategorized bundled agent receives no source model default', async () => {
       createAgent(path.join(bundledDir, 'agents'), 'uncategorized', {
         name: 'uncategorized',
@@ -723,84 +701,6 @@ model: gpt-4
 
       expect(config.agent?.uncategorized?.temperature).toBeDefined()
       expect(config.agent?.uncategorized?.model).toBeUndefined()
-    })
-
-    test('zero config emits source model defaults for all categorized agents', async () => {
-      createCategorizedAgent('design', 'design-agent', {
-        name: 'design-agent',
-        description: 'Design agent',
-      })
-      createCategorizedAgent('docs', 'docs-agent', {
-        name: 'docs-agent',
-        description: 'Docs agent',
-      })
-      createCategorizedAgent('document-review', 'doc-review-agent', {
-        name: 'doc-review-agent',
-        description: 'Document review agent',
-      })
-      createCategorizedAgent('research', 'research-agent', {
-        name: 'research-agent',
-        description: 'Research agent',
-      })
-      createCategorizedAgent('review', 'review-agent', {
-        name: 'review-agent',
-        description: 'Review agent',
-      })
-      createCategorizedAgent('workflow', 'workflow-agent', {
-        name: 'workflow-agent',
-        description: 'Workflow agent',
-      })
-
-      const handler = createConfigHandler({
-        directory: projectDir,
-        bundledSkillsDir: path.join(bundledDir, 'skills'),
-        bundledAgentsDir: path.join(bundledDir, 'agents'),
-        bundledCommandsDir: path.join(bundledDir, 'commands'),
-      })
-
-      const config: Config = {}
-      await handler(config)
-
-      expect(config.agent?.['design-agent']?.model).toBe('openai/gpt-5.5')
-      expect(config.agent?.['docs-agent']?.model).toBe('openai/gpt-5.4-mini')
-      expect(config.agent?.['doc-review-agent']?.model).toBe(
-        'anthropic/claude-opus-4.7',
-      )
-      expect(config.agent?.['research-agent']?.model).toBe('openai/gpt-5.5')
-      expect(config.agent?.['review-agent']?.model).toBe(
-        'anthropic/claude-opus-4.7',
-      )
-      expect(config.agent?.['workflow-agent']?.model).toBe(
-        'openai/gpt-5.4-mini',
-      )
-
-      // No fallback_models key leaks into any emitted agent
-      for (const [, agent] of Object.entries(config.agent ?? {})) {
-        expect(agent).not.toHaveProperty('fallback_models')
-      }
-    })
-
-    test('source defaults replace bundled markdown model for categorized agents', async () => {
-      createCategorizedAgent('review', 'correctness-reviewer', {
-        name: 'correctness-reviewer',
-        description: 'Reviews correctness',
-        model: 'openai/gpt-3.5-turbo',
-      })
-
-      const handler = createConfigHandler({
-        directory: projectDir,
-        bundledSkillsDir: path.join(bundledDir, 'skills'),
-        bundledAgentsDir: path.join(bundledDir, 'agents'),
-        bundledCommandsDir: path.join(bundledDir, 'commands'),
-      })
-
-      const config: Config = {}
-      await handler(config)
-
-      // Source default wins over bundled markdown model
-      expect(config.agent?.['correctness-reviewer']?.model).toBe(
-        'anthropic/claude-opus-4.7',
-      )
     })
 
     test('source defaults do not emit for uncategorized agents even with markdown model', async () => {
@@ -822,34 +722,6 @@ model: gpt-4
 
       // Uncategorized agents keep their markdown model since no source default applies
       expect(config.agent?.standalone?.model).toBe('openai/gpt-4')
-    })
-
-    test('project config overlay with non-sensitive fields preserves source model', async () => {
-      createCategorizedAgent('review', 'correctness-reviewer', {
-        name: 'correctness-reviewer',
-        description: 'Reviews correctness',
-      })
-      writeSystematicConfig({
-        categories: { review: { temperature: 0.55 } },
-        agents: { 'correctness-reviewer': { hidden: true } },
-      })
-
-      const handler = createConfigHandler({
-        directory: projectDir,
-        bundledSkillsDir: path.join(bundledDir, 'skills'),
-        bundledAgentsDir: path.join(bundledDir, 'agents'),
-        bundledCommandsDir: path.join(bundledDir, 'commands'),
-      })
-
-      const config: Config = {}
-      await handler(config)
-
-      // Source model preserved even when project config sets non-sensitive fields
-      expect(config.agent?.['correctness-reviewer']?.model).toBe(
-        'anthropic/claude-opus-4.7',
-      )
-      expect(config.agent?.['correctness-reviewer']?.temperature).toBe(0.55)
-      expect(config.agent?.['correctness-reviewer']?.hidden).toBe(true)
     })
 
     test('high-trust exact model: null opt-out removes source default', async () => {
@@ -993,33 +865,6 @@ model: gpt-4
       expect(config.agent?.['second-reviewer']?.model).toBe('openai/gpt-4o')
     })
 
-    test('category overlay with non-model fields preserves source model', async () => {
-      createCategorizedAgent('review', 'correctness-reviewer', {
-        name: 'correctness-reviewer',
-        description: 'Reviews correctness',
-      })
-      writeCustomSystematicConfig({
-        categories: {
-          review: { temperature: 0.55 },
-        },
-      })
-
-      const handler = createConfigHandler({
-        directory: projectDir,
-        bundledSkillsDir: path.join(bundledDir, 'skills'),
-        bundledAgentsDir: path.join(bundledDir, 'agents'),
-        bundledCommandsDir: path.join(bundledDir, 'commands'),
-      })
-
-      const config: Config = {}
-      await handler(config)
-
-      expect(config.agent?.['correctness-reviewer']?.model).toBe(
-        'anthropic/claude-opus-4.7',
-      )
-      expect(config.agent?.['correctness-reviewer']?.temperature).toBe(0.55)
-    })
-
     test('native same-name replacement receives no Systematic source model default', async () => {
       createCategorizedAgent('review', 'native-replaced', {
         name: 'native-replaced',
@@ -1079,79 +924,6 @@ model: gpt-4
       expect(config.agent?.['security-reviewer']?.temperature).toBe(0.25)
     })
 
-    test('emits exact configured model and supported overlay fields including variant', async () => {
-      createCategorizedAgent('review', 'correctness-reviewer', {
-        name: 'correctness-reviewer',
-        description: 'Reviews correctness',
-      })
-      createCategorizedAgent('review', 'other-reviewer', {
-        name: 'other-reviewer',
-        description: 'Other reviewer',
-      })
-      writeCustomSystematicConfig({
-        agents: {
-          'correctness-reviewer': {
-            model: 'openrouter/anthropic/claude-sonnet-4',
-            variant: 'large-context',
-            top_p: 0.8,
-            mode: 'subagent',
-            color: '#123abc',
-            steps: 12,
-            hidden: true,
-          },
-        },
-      })
-
-      const handler = createConfigHandler({
-        directory: projectDir,
-        bundledSkillsDir: path.join(bundledDir, 'skills'),
-        bundledAgentsDir: path.join(bundledDir, 'agents'),
-        bundledCommandsDir: path.join(bundledDir, 'commands'),
-      })
-
-      const config: Config = {}
-      await handler(config)
-
-      const agent = config.agent?.['correctness-reviewer']
-      expect(agent?.model).toBe('openrouter/anthropic/claude-sonnet-4')
-      expect(agent?.variant).toBe('large-context')
-      expect(agent?.top_p).toBe(0.8)
-      expect(agent?.mode).toBe('subagent')
-      expect(agent?.color).toBe('#123abc')
-      expect(agent?.steps).toBe(12)
-      expect(agent?.hidden).toBe(true)
-      // other-reviewer (review category) gets source model default
-      expect(config.agent?.['other-reviewer']?.model).toBe(
-        'anthropic/claude-opus-4.7',
-      )
-    })
-
-    test('accepts and emits variant without model', async () => {
-      createCategorizedAgent('review', 'correctness-reviewer', {
-        name: 'correctness-reviewer',
-        description: 'Reviews correctness',
-      })
-      writeCustomSystematicConfig({
-        agents: { 'correctness-reviewer': { variant: 'small' } },
-      })
-
-      const handler = createConfigHandler({
-        directory: projectDir,
-        bundledSkillsDir: path.join(bundledDir, 'skills'),
-        bundledAgentsDir: path.join(bundledDir, 'agents'),
-        bundledCommandsDir: path.join(bundledDir, 'commands'),
-      })
-
-      const config: Config = {}
-      await handler(config)
-
-      expect(config.agent?.['correctness-reviewer']?.variant).toBe('small')
-      // review-category agent still gets source model default even when variant is set via high-trust config
-      expect(config.agent?.['correctness-reviewer']?.model).toBe(
-        'anthropic/claude-opus-4.7',
-      )
-    })
-
     test('managed skills shortcut emits ordered deny-all then allow-selected rules', async () => {
       createSkill(path.join(bundledDir, 'skills'), 'ce:review', 'Review skill')
       createCategorizedAgent('review', 'correctness-reviewer', {
@@ -1181,73 +953,6 @@ model: gpt-4
     })
 
     describe('auth-aware source model resolution', () => {
-      test('no auth.json emits array[0] for review category', async () => {
-        createCategorizedAgent('review', 'correctness-reviewer', {
-          name: 'correctness-reviewer',
-          description: 'Reviews correctness',
-        })
-
-        const handler = createConfigHandler({
-          directory: projectDir,
-          bundledSkillsDir: path.join(bundledDir, 'skills'),
-          bundledAgentsDir: path.join(bundledDir, 'agents'),
-          bundledCommandsDir: path.join(bundledDir, 'commands'),
-        })
-
-        const config: Config = {}
-        await handler(config)
-
-        expect(config.agent?.['correctness-reviewer']?.model).toBe(
-          'anthropic/claude-opus-4.7',
-        )
-      })
-
-      test('openai auth selects openai/gpt-5.5 for review category', async () => {
-        createCategorizedAgent('review', 'correctness-reviewer', {
-          name: 'correctness-reviewer',
-          description: 'Reviews correctness',
-        })
-
-        const handler = createConfigHandler({
-          directory: projectDir,
-          bundledSkillsDir: path.join(bundledDir, 'skills'),
-          bundledAgentsDir: path.join(bundledDir, 'agents'),
-          bundledCommandsDir: path.join(bundledDir, 'commands'),
-          getAuthenticatedProviders: () => new Set(['openai']),
-        })
-
-        const config: Config = {}
-        await handler(config)
-
-        expect(config.agent?.['correctness-reviewer']?.model).toBe(
-          'openai/gpt-5.5',
-        )
-      })
-
-      test('first-match wins with multiple providers', async () => {
-        createCategorizedAgent('review', 'correctness-reviewer', {
-          name: 'correctness-reviewer',
-          description: 'Reviews correctness',
-        })
-
-        const handler = createConfigHandler({
-          directory: projectDir,
-          bundledSkillsDir: path.join(bundledDir, 'skills'),
-          bundledAgentsDir: path.join(bundledDir, 'agents'),
-          bundledCommandsDir: path.join(bundledDir, 'commands'),
-          getAuthenticatedProviders: () =>
-            new Set(['github-copilot', 'anthropic']),
-        })
-
-        const config: Config = {}
-        await handler(config)
-
-        // anthropic is first matching provider in review array
-        expect(config.agent?.['correctness-reviewer']?.model).toBe(
-          'anthropic/claude-opus-4.7',
-        )
-      })
-
       test('user category model override still wins with auth', async () => {
         createCategorizedAgent('review', 'correctness-reviewer', {
           name: 'correctness-reviewer',

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -246,11 +246,11 @@ describe('SystematicConfigSchema', () => {
 describe('assertSourceCategoryModelDefaults', () => {
   test('passes for the actual SOURCE_CATEGORY_MODEL_DEFAULTS constant', () => {
     const actualConstants = {
-      design: ['openai/gpt-5.5', 'anthropic/claude-opus-4.7'],
+      design: ['openai/gpt-5.5', 'anthropic/claude-opus-4-7'],
       docs: ['openai/gpt-5.4-mini', 'anthropic/claude-haiku-4-5'],
-      'document-review': ['anthropic/claude-opus-4.7', 'openai/gpt-5.5'],
-      research: ['openai/gpt-5.5', 'anthropic/claude-opus-4.7'],
-      review: ['anthropic/claude-opus-4.7', 'openai/gpt-5.5'],
+      'document-review': ['anthropic/claude-opus-4-7', 'openai/gpt-5.5'],
+      research: ['openai/gpt-5.5', 'anthropic/claude-opus-4-7'],
+      review: ['anthropic/claude-opus-4-7', 'openai/gpt-5.5'],
       workflow: ['openai/gpt-5.4-mini', 'anthropic/claude-haiku-4-5'],
     }
 


### PR DESCRIPTION
New `src/lib/config-schema.ts` defines `SystematicConfigSchema` covering
all six top-level user-config keys (`agents`, `categories`,
`disabled_skills`, `disabled_agents`, `disabled_commands`, `bootstrap`)
with strict-mode validation at every layer. Per-agent and per-category
overlay schemas mirror the existing `ALLOWED_OVERLAY_FIELDS` field set
from `src/lib/agent-overlays.ts`. Trust-sensitive fields are tagged via
`.meta({ trust: 'project-or-higher' })` so `agent-overlays.ts` can
derive `SECURITY_OVERLAY_FIELDS` from the schema in a follow-up commit.

Helpers: `validateConfig()` returns a typed result with Zod-formatted
errors, `assertSourceCategoryModelDefaults()` Zod-backed replacement for
the existing assertion, `getSecurityOverlayFields()` extracts the
trust-tagged set.

`OPENCODE_AGENT_COLOR_TOKENS` duplicated locally with a regression test
asserting it stays in sync with `scripts/content-integrity.ts:722-730`.
The TypeScript config (`rootDir: src`) prevents direct import.

Verified empirically during implementation:
- `z.toJSONSchema(schema, { target: 'draft-7' })` produces clean
  draft-07 output. `additionalProperties: false` correctly reflects
  strict mode.
- `.default(value)` DOES round-trip into JSON Schema `default` on
  zod@4.4.3 (correcting the planning-time assumption that it doesn't).

Tests: 31 scenarios, 87 expects, all passing. Coverage spans happy
paths, default values, all overlay constraint families (temperature,
top_p, color, mode, steps, hidden, permission), strict-mode rejection
of unknown overlay fields (preserves the existing `unsupported agent
overlay field "..."` error shape from agent-overlays.ts:417), source
default constants assertion, and SECURITY_OVERLAY_FIELDS regression.