### PR TITLE
fix(config): require model for variant overlays

### DIFF
--- a/docs/public/schemas/v2/systematic-config.schema.json
+++ b/docs/public/schemas/v2/systematic-config.schema.json
@@ -166,6 +166,23 @@
             "temperature": 0.1,
             "mode": "subagent"
           }
+        ],
+        "allOf": [
+          {
+            "if": {
+              "required": ["variant"]
+            },
+            "then": {
+              "required": ["model"],
+              "properties": {
+                "model": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "^[^\\s/]+\\/\\S+$"
+                }
+              }
+            }
+          }
         ]
       }
     },
@@ -318,6 +335,23 @@
           {
             "model": "anthropic/claude-opus-4-7",
             "temperature": 0.1
+          }
+        ],
+        "allOf": [
+          {
+            "if": {
+              "required": ["variant"]
+            },
+            "then": {
+              "required": ["model"],
+              "properties": {
+                "model": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "^[^\\s/]+\\/\\S+$"
+                }
+              }
+            }
           }
         ]
       }

--- a/scripts/generate-config-schema.ts
+++ b/scripts/generate-config-schema.ts
@@ -219,6 +219,77 @@ function removeDefaultFieldsFromRequired(
   }
 }
 
+function asObject(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null
+  }
+  return value as Record<string, unknown>
+}
+
+function getSchemaNode(
+  root: Record<string, unknown>,
+  path: readonly string[],
+): Record<string, unknown> | null {
+  let current: Record<string, unknown> | null = root
+  for (const segment of path) {
+    current = asObject(current?.[segment])
+    if (current === null) return null
+  }
+  return current
+}
+
+function cloneSchemaNode(
+  node: Record<string, unknown>,
+): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(node)) as Record<string, unknown>
+}
+
+function getNonNullModelBranch(
+  overlayNode: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const properties = asObject(overlayNode.properties)
+  const modelNode = asObject(properties?.model)
+  const anyOf = modelNode?.anyOf
+  if (!Array.isArray(anyOf)) return null
+
+  for (const candidate of anyOf) {
+    const branch = asObject(candidate)
+    if (branch?.type === 'string') return cloneSchemaNode(branch)
+  }
+
+  return null
+}
+
+function addVariantRequiresExplicitModel(
+  overlayNode: Record<string, unknown>,
+): void {
+  const modelStringBranch = getNonNullModelBranch(overlayNode)
+  if (modelStringBranch === null) return
+
+  const variantRequiresModel: Record<string, unknown> = {
+    if: { required: ['variant'] },
+  }
+  variantRequiresModel['then'] = {
+    required: ['model'],
+    properties: {
+      model: modelStringBranch,
+    },
+  }
+
+  const allOf = Array.isArray(overlayNode.allOf) ? overlayNode.allOf : []
+  overlayNode.allOf = [...allOf, variantRequiresModel]
+}
+
+function addOverlayCrossFieldConstraints(root: Record<string, unknown>): void {
+  for (const path of [
+    ['properties', 'agents', 'additionalProperties'],
+    ['properties', 'categories', 'additionalProperties'],
+  ] as const) {
+    const overlayNode = getSchemaNode(root, path)
+    if (overlayNode !== null) addVariantRequiresExplicitModel(overlayNode)
+  }
+}
+
 /**
  * Generate the JSON Schema content string for the given version.
  *
@@ -258,6 +329,7 @@ export function generateSchemaContent(version: string): string {
     clean as Record<string, unknown>,
     SystematicConfigSchema,
   )
+  addOverlayCrossFieldConstraints(clean as Record<string, unknown>)
 
   const raw = `${JSON.stringify(clean, null, 2)}\n`
   return formatJsonWithBiome(raw, 'systematic-config.schema.json')

--- a/src/lib/config-schema.ts
+++ b/src/lib/config-schema.ts
@@ -148,6 +148,26 @@ function trustProtected<T extends z.ZodType>(schema: T): T {
   return schema.meta({ trust: 'project-or-higher' }) as T
 }
 
+interface OverlayModelVariantFields {
+  model?: string | null
+  variant?: string
+}
+
+function enforceVariantHasExplicitModel(
+  overlay: OverlayModelVariantFields,
+  ctx: z.RefinementCtx,
+): void {
+  if (overlay.variant === undefined) return
+  if (typeof overlay.model === 'string') return
+
+  ctx.addIssue({
+    code: 'custom',
+    path: ['variant'],
+    message:
+      'variant requires a non-null model in the same overlay; remove variant or set model explicitly',
+  })
+}
+
 export const AgentOverlaySchema = z
   .object({
     model: trustProtected(modelSchema).optional(),
@@ -163,6 +183,7 @@ export const AgentOverlaySchema = z
     permission: trustProtected(permissionSchema).optional(),
   })
   .strict()
+  .superRefine(enforceVariantHasExplicitModel)
   .meta({
     description: 'Per-agent configuration overlay',
     examples: [
@@ -188,6 +209,7 @@ export const CategoryOverlaySchema = z
     permission: trustProtected(permissionSchema).optional(),
   })
   .strict()
+  .superRefine(enforceVariantHasExplicitModel)
   .meta({
     description:
       'Per-category configuration overlay (same fields as agent minus disable)',

--- a/tests/unit/agent-overlays.test.ts
+++ b/tests/unit/agent-overlays.test.ts
@@ -672,9 +672,9 @@ describe('variant emission via overlay flow', () => {
     })
   })
 
-  test('integration: variant override at category level wins over source', async () => {
+  test('integration: explicit model and variant override at category level wins over source', async () => {
     await withVariantTestEnv(
-      { categories: { review: { variant: 'high' } } },
+      { categories: { review: { model: 'openai/gpt-5.5', variant: 'high' } } },
       async (agentsDir, projectDir) => {
         const handler = createConfigHandler({
           directory: projectDir,
@@ -688,6 +688,7 @@ describe('variant emission via overlay flow', () => {
         const agent = (config.agent as Record<string, unknown> | undefined)?.[
           'correctness-reviewer'
         ] as Record<string, unknown> | undefined
+        expect(agent?.model).toBe('openai/gpt-5.5')
         expect(agent?.variant).toBe('high')
       },
     )

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -290,6 +290,28 @@ describe('validateConfig wrapper', () => {
       throw new Error('Expected failure')
     }
   })
+
+  test('rejects agent variant without same-overlay model', () => {
+    const result = validateConfig({
+      agents: { explorer: { variant: 'high' } },
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.errors[0].path).toEqual(['agents', 'explorer', 'variant'])
+      expect(result.errors[0].message).toContain('model')
+    }
+  })
+
+  test('rejects category variant without same-overlay model', () => {
+    const result = validateConfig({
+      categories: { review: { variant: 'high' } },
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.errors[0].path).toEqual(['categories', 'review', 'variant'])
+      expect(result.errors[0].message).toContain('model')
+    }
+  })
 })
 
 describe('AgentOverlaySchema', () => {
@@ -301,6 +323,33 @@ describe('AgentOverlaySchema', () => {
   test('accepts null model (opt-out)', () => {
     const result = AgentOverlaySchema.safeParse({ model: null })
     expect(result.success).toBe(true)
+  })
+
+  test('accepts variant with same-overlay model', () => {
+    const result = AgentOverlaySchema.safeParse({
+      model: 'openai/gpt-5.5',
+      variant: 'high',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('rejects variant without same-overlay model', () => {
+    const result = AgentOverlaySchema.safeParse({ variant: 'high' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain('model')
+    }
+  })
+
+  test('rejects variant with model null inheritance opt-out', () => {
+    const result = AgentOverlaySchema.safeParse({
+      model: null,
+      variant: 'high',
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain('model')
+    }
   })
 
   test('rejects unknown fields via strict mode', () => {
@@ -327,6 +376,38 @@ describe('CategoryOverlaySchema', () => {
       model: 'anthropic/claude-3',
     })
     expect(result.success).toBe(true)
+  })
+
+  test('accepts null model (opt-out)', () => {
+    const result = CategoryOverlaySchema.safeParse({ model: null })
+    expect(result.success).toBe(true)
+  })
+
+  test('accepts variant with same-overlay model', () => {
+    const result = CategoryOverlaySchema.safeParse({
+      model: 'openai/gpt-5.5',
+      variant: 'high',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('rejects variant without same-overlay model', () => {
+    const result = CategoryOverlaySchema.safeParse({ variant: 'high' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain('model')
+    }
+  })
+
+  test('rejects variant with model null inheritance opt-out', () => {
+    const result = CategoryOverlaySchema.safeParse({
+      model: null,
+      variant: 'high',
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain('model')
+    }
   })
 
   test('rejects disable field (only valid for agents)', () => {

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -454,10 +454,17 @@ describe('config', () => {
         for (const config of [
           {
             agents: {
-              'correctness-reviewer': { variant: 'large-context' },
+              'correctness-reviewer': {
+                model: 'openai/gpt-5',
+                variant: 'large-context',
+              },
             },
           },
-          { categories: { review: { variant: 'small' } } },
+          {
+            categories: {
+              review: { model: 'openai/gpt-5', variant: 'small' },
+            },
+          },
         ]) {
           fs.writeFileSync(projectConfigPath, JSON.stringify(config))
 
@@ -481,6 +488,7 @@ describe('config', () => {
           },
           categories: {
             review: {
+              model: 'openai/gpt-5',
               variant: 'small',
               temperature: 0.2,
             },
@@ -506,6 +514,7 @@ describe('config', () => {
         })
         expect(result.config.categories?.review).toEqual({
           temperature: 0.5,
+          model: 'openai/gpt-5',
           variant: 'small',
         })
       })

--- a/tests/unit/generate-config-schema.test.ts
+++ b/tests/unit/generate-config-schema.test.ts
@@ -596,6 +596,31 @@ describe('AJV parity: Zod runtime contract vs generated JSON Schema', () => {
       accepted: false,
     },
     {
+      name: 'agent variant without explicit model rejected by both',
+      value: { agents: { foo: { variant: 'high' } } },
+      accepted: false,
+    },
+    {
+      name: 'category variant without explicit model rejected by both',
+      value: { categories: { review: { variant: 'high' } } },
+      accepted: false,
+    },
+    {
+      name: 'agent variant with model:null rejected by both',
+      value: { agents: { foo: { model: null, variant: 'high' } } },
+      accepted: false,
+    },
+    {
+      name: 'category variant with model:null rejected by both',
+      value: { categories: { review: { model: null, variant: 'high' } } },
+      accepted: false,
+    },
+    {
+      name: 'variant with explicit model accepted by both',
+      value: { agents: { foo: { model: 'openai/gpt-5.5', variant: 'high' } } },
+      accepted: true,
+    },
+    {
       // SystematicConfigSchema uses .strict() so unknown top-level keys are rejected.
       name: 'unknown top-level field "agnts" rejected by both (strict mode)',
       value: { agnts: {} },

--- a/tests/unit/source-model-defaults.test.ts
+++ b/tests/unit/source-model-defaults.test.ts
@@ -473,7 +473,10 @@ describe('user-facing variantSchema bounds (config-schema.ts)', () => {
 
   test('happy path: variant of exactly 128 chars in AgentOverlaySchema passes', () => {
     const maxVariant = 'a'.repeat(128)
-    const result = AgentOverlaySchema.safeParse({ variant: maxVariant })
+    const result = AgentOverlaySchema.safeParse({
+      model: 'openai/gpt-5.5',
+      variant: maxVariant,
+    })
     expect(result.success).toBe(true)
   })
 
@@ -495,7 +498,10 @@ describe('user-facing variantSchema bounds (config-schema.ts)', () => {
 
   test('happy path: variant of exactly 128 chars in CategoryOverlaySchema passes', () => {
     const maxVariant = 'a'.repeat(128)
-    const result = CategoryOverlaySchema.safeParse({ variant: maxVariant })
+    const result = CategoryOverlaySchema.safeParse({
+      model: 'openai/gpt-5.5',
+      variant: maxVariant,
+    })
     expect(result.success).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- require every `variant` overlay to include an explicit non-null `model` in the same agent/category overlay
- keep generated JSON Schema validation aligned with runtime config validation
- update overlay and schema tests for variant/model combinations

## Verification

- `bun test tests/unit/source-model-defaults.test.ts tests/unit/config-schema.test.ts tests/unit/generate-config-schema.test.ts tests/unit/agent-overlays.test.ts tests/unit/config.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run docs:build`
- `bun run build`
- `bun test`
