### PR TITLE
feat(bootstrap): move skill catalog into system prompt

### DIFF
--- a/docs/plans/2026-05-13-001-feat-bootstrap-message0-skill-catalog-plan.md
+++ b/docs/plans/2026-05-13-001-feat-bootstrap-message0-skill-catalog-plan.md
@@ -1,0 +1,288 @@
+---
+title: feat: Move Systematic bootstrap and skill catalog into first system message
+type: feat
+status: active
+date: 2026-05-13
+origin: docs/brainstorms/2026-05-13-bootstrap-message0-skill-catalog-requirements.md
+---
+
+# feat: Move Systematic bootstrap and skill catalog into first system message
+
+## Overview
+
+Systematic should place its default workflow bootstrap at the end of the first OpenCode system message and expose bundled skill availability in the same default bootstrap using a native-style verbose catalog. `systematic_skill` remains the execution tool, but its description becomes a compact fallback rather than the main catalog carrier. This is prompt-shape alignment with OpenCode's native skill presentation, not a measured cache-performance improvement.
+
+## Problem Frame
+
+The origin document frames this as a prompt-ordering and skill-discovery problem: Systematic currently appends bootstrap content to the last system entry, while OpenCode treats the first entry as the stable header for normal chat construction. OpenCode's native skill system also presents verbose skill availability in the system prompt and keeps the tool description compact. Systematic should align with that split without claiming measured cache-performance gains or rewriting its foundational skill policy (see origin: `docs/brainstorms/2026-05-13-bootstrap-message0-skill-catalog-requirements.md`).
+
+## Requirements Trace
+
+- R1. Append new bootstrap content to `output.system[0]` when a system entry exists and no complete bootstrap marker is present.
+- R2. Normalize complete existing `<SYSTEMATIC_WORKFLOWS>` blocks to exactly one current block in `output.system[0]`; leave malformed marker fragments untouched.
+- R3. Preserve safe empty-system fallback by pushing bootstrap content as the sole entry.
+- R4. Preserve disabled bootstrap, custom bootstrap content generation, frontmatter stripping, missing-custom-file fallback, and internal/title-generation skip behavior.
+- R5. Add a native-style verbose Systematic skill catalog to default bootstrap content only.
+- R6. Build catalog entries from one deterministic static discoverability source: bundled skills sorted by name, excluding disabled skills and `disableModelInvocation === true`.
+- R7. Preserve `systematic_skill` execution semantics: prefixed/unprefixed resolution, permission prompt, metadata, and `<skill_content name="systematic:...">` output.
+- R8. Slim `systematic_skill` description/parameter hint while retaining a compact available-skills fallback.
+- R9. Preserve mandatory skill invocation before response/action when a skill may apply.
+- R10. Keep the existing `using-systematic` decision flow semantically unchanged.
+- R11. Keep a clear tool distinction in bootstrap/tool prose: `systematic_skill` for bundled Systematic skills; native `skill` for non-Systematic skills.
+- R12. Test first-entry insertion, complete-marker normalization, malformed-marker non-normalization, empty fallback, and preserved config/skip behavior.
+- R13. Test catalog sorting/filtering, verbose default-bootstrap placement, and compact tool fallback.
+- R14. Test the slimmed `systematic_skill` contract without changing load behavior.
+- R15. Test duplicate Systematic registration from user and project OpenCode config so bundled skills remain discoverable and `systematic_skill` remains callable in OpenCode's visible tool surface.
+
+## Scope Boundaries
+
+- Do not change OpenCode internals, native `skill`, or native system prompt generation.
+- Do not inject the default verbose skill catalog into user-authored custom bootstrap files.
+- Do not claim measured cache improvement or add provider-specific cache metrics.
+- Do not edit `skills/using-systematic/SKILL.md` in this plan unless a failing test demonstrates a direct contradiction introduced by the catalog/tool split. The default implementation path leaves the skill body unchanged.
+- Do not add live reload of skill/config changes; bootstrap and tool descriptions remain snapshot-per-plugin-instance behavior.
+- Do not introduce new duplicate-skill-name semantics. Preserve current discovery behavior and sort the resulting discoverable list deterministically.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/lib/bootstrap.ts` owns bootstrap content construction, marker lookup, and `applyBootstrapContent` insertion behavior. Existing code uses literal `indexOf`/`slice` operations and should stay linear-time.
+- `src/index.ts` snapshots `bootstrapContent` once during plugin initialization, skips internal/title-generation prompts, and calls `applyBootstrapContent` only when content is truthy.
+- `src/lib/skill-tool.ts` currently owns discovery/filter/sort for `systematic_skill`, builds the verbose tool description, caches description/hint per tool instance, and preserves prefixed/unprefixed execution.
+- `src/lib/skills.ts`, `src/lib/skill-loader.ts`, and related tests provide discovery/frontmatter/body-loading seams.
+- `tests/unit/bootstrap.test.ts`, `tests/unit/plugin.test.ts`, and `tests/unit/skill-tool.test.ts` are the primary regression suites to extend.
+
+### Institutional Learnings
+
+- `docs/solutions/security-issues/redos-after-plugin-trust-boundary-inversion-2026-05-11.md`: keep bootstrap delimiter handling literal and linear-time; avoid regex-based delimiter parsing.
+- `docs/solutions/integration-issues/opencode-plugin-named-exports-break-loader-2026-05-11.md`: keep helpers out of `src/index.ts`; plugin entry exports only `default`.
+- `docs/solutions/integration-issues/opencode-plugin-factory-duplicate-registration-2026-05-04.md`: duplicate plugin registration can happen; marker idempotency must preserve most-recent hook output.
+- `docs/solutions/workflow-issues/reconciliation-sync-reference-integrity-20260417.md`: generated/catalog-style content needs deterministic verification, not manual review.
+
+### External References
+
+- `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/src/session/llm.ts`: OpenCode builds `system: string[]`, invokes `experimental.chat.system.transform`, and maps each system entry to model system messages.
+- `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/src/session/system.ts`: native skills are presented verbosely in the system prompt.
+- `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/src/tool/skill.ts` and `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/src/tool/registry.ts`: native `skill` keeps execution output compatible with `<skill_content>` and uses a compact tool description.
+
+## Key Technical Decisions
+
+- **Shared catalog helper:** Create one small pure helper for discoverable Systematic skill catalog data and render modes. This avoids bootstrap/tool drift without introducing a broad catalog framework.
+- **Catalog source:** Use raw skill discovery/frontmatter metadata for catalog entries. Do not use `loadSkill()`'s formatted description path for catalog text, because that path adds Systematic formatting intended for loaded skill content rather than native-style availability lists.
+- **Complete-block normalization:** Treat complete `<SYSTEMATIC_WORKFLOWS>...</SYSTEMATIC_WORKFLOWS>` blocks as Systematic-owned marker blocks, remove all such complete blocks across all system entries, then append the current block once to `output.system[0]`. This makes duplicate registration and prior last-entry placement converge to the new canonical location.
+- **Malformed marker stance:** Treat partial/malformed markers as ordinary text. Do not attempt cleanup that could delete user or plugin content incorrectly.
+- **Default-bootstrap-only verbose catalog:** Default bootstrap gets verbose XML. Custom bootstrap content remains verbatim and relies on `systematic_skill`'s compact fallback for discoverability.
+- **Snapshot contract:** Skill/config changes require a fresh plugin instance/OpenCode restart to refresh bootstrap/tool descriptions. No live refresh in this change.
+- **Later hook wins:** Under duplicate registration, later Systematic hooks win because each invocation removes complete prior blocks and appends its own current content.
+- **First-entry ownership:** Systematic does not own `output.system[0]`. The selected contract is still to append to the first entry OpenCode/earlier plugins provide, because prompt priority is the goal. This may keep later system entries split; do not present it as a cache optimization.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should complete marker blocks be normalized across all system entries? Yes. Remove every complete block and write exactly one current block to `output.system[0]`.
+- Should first-entry insertion be treated as a prompt-ordering change rather than a cache benchmark? Yes. Do not claim measured cache benefit.
+- Should custom bootstrap files receive an injected default skill catalog? No. Custom bootstrap files remain verbatim.
+- Should tool descriptions refresh live after config/skill-file changes? No. Preserve snapshot-per-plugin-instance behavior.
+
+### Deferred to Implementation
+
+- Exact helper names and export boundaries: decide while editing `src/lib/*`, keeping helpers out of `src/index.ts`.
+- Exact compact fallback rendering: keep it short enough to reduce tool-description weight while still listing discoverable skill names.
+- Whether `using-systematic` needs any prose edit at all after the catalog/tool split: change only if the final bootstrap would otherwise duplicate or contradict existing wording.
+
+## Implementation Units
+
+- [ ] **Unit 1: Shared Systematic skill catalog data and renderers**
+
+**Goal:** Establish one deterministic source for discoverable bundled-skill catalog entries and both verbose/compact renderings.
+
+**Requirements:** R5, R6, R8, R13
+
+**Dependencies:** None
+
+**Files:**
+- Create: `src/lib/skill-catalog.ts`
+- Test: `tests/unit/skill-catalog.test.ts`
+- Modify: `src/lib/skill-tool.ts` only if needed to consume the helper without changing execution behavior
+
+**Approach:**
+- Derive discoverable entries from `findSkillsInDir()`/frontmatter metadata rather than `loadSkill()`'s loaded-content formatting path.
+- Preserve current static filters: configured disabled skills and `disableModelInvocation === true`.
+- Sort by skill name before rendering.
+- Provide verbose native-style XML for bootstrap and compact fallback output for tool descriptions.
+- Pin the compact fallback shape to:
+  - heading: `## Available Systematic Skills`
+  - one bullet per skill: `- <prefixed-name>: <description>`
+  - empty-state text: `No Systematic skills are currently available.`
+- Do not add new duplicate-name policy beyond sorting the existing discoverable entries.
+
+**Execution note:** Implement behavior test-first; start with helper tests that fail before adding production helper code.
+
+**Patterns to follow:**
+- `src/lib/skill-tool.ts` discovery/filter/sort behavior
+- `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/src/skill/index.ts` native verbose/compact shape
+- `tests/unit/skill-tool.test.ts` temp skill fixtures
+
+**Test scenarios:**
+- Happy path: enabled bundled skills render in sorted order for verbose and compact modes.
+- Edge case: configured disabled skills are absent from both render modes.
+- Edge case: `disable-model-invocation: true` skills are absent from both render modes.
+- Edge case: zero discoverable skills renders an explicit no-skills message rather than malformed XML/markdown.
+
+**Verification:**
+- Bootstrap and tool code can consume one catalog source without duplicating filtering logic.
+
+- [ ] **Unit 2: First-entry bootstrap insertion and marker normalization**
+
+**Goal:** Make `applyBootstrapContent` place one canonical bootstrap block at the end of `output.system[0]`, preserving existing skip/configuration behavior.
+
+**Requirements:** R1, R2, R3, R4, R12
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `src/lib/bootstrap.ts`
+- Test: `tests/unit/bootstrap.test.ts`
+- Test: `tests/unit/plugin.test.ts`
+
+**Approach:**
+- Replace the current first-match replacement behavior with complete-block collection/removal across all system entries.
+- Append the latest bootstrap content to `output.system[0]` when system entries exist; push when empty.
+- Leave malformed or partial marker fragments untouched.
+- Preserve the current `src/index.ts` truthy-content guard and internal-agent skip behavior.
+- Rewrite existing tests that currently assert last-entry insertion or in-place later-entry replacement; those assertions encode the old contract and should fail under the new one.
+
+**Execution note:** Characterization-first: add tests for current empty/custom/skip behavior before changing insertion behavior where coverage is missing, then add failing tests for first-entry insertion and multi-block normalization.
+
+**Patterns to follow:**
+- Existing literal delimiter logic in `src/lib/bootstrap.ts`
+- Existing bootstrap and plugin tests in `tests/unit/bootstrap.test.ts` and `tests/unit/plugin.test.ts`
+- ReDoS learning in `docs/solutions/security-issues/redos-after-plugin-trust-boundary-inversion-2026-05-11.md`
+
+**Test scenarios:**
+- Happy path: two system entries with no marker result in bootstrap appended to `system[0]`, leaving `system[1]` unchanged.
+- Edge case: empty `system` pushes bootstrap as the sole entry.
+- Edge case: complete markers in multiple entries and multiple complete blocks in one entry are removed, then one current block is appended to `system[0]`.
+- Edge case: malformed/open-only marker fragments remain untouched while one current complete block is appended to `system[0]`.
+- Integration: duplicate Systematic transform invocations converge to one block, with the later invocation's content winning.
+- Integration: complete marker blocks in a later entry and in `system[0]` are both removed before one current block is appended to `system[0]`.
+- Regression: disabled bootstrap, custom bootstrap, missing custom fallback, frontmatter stripping, and internal/title-generation skip behavior remain unchanged.
+
+**Verification:**
+- The bootstrap marker appears exactly once after repeated transforms when complete prior blocks exist.
+- No regex-based delimiter parsing is introduced.
+
+- [ ] **Unit 3: Default bootstrap verbose catalog**
+
+**Goal:** Include verbose Systematic skill availability in default bootstrap content while preserving custom bootstrap content generation semantics.
+
+**Requirements:** R5, R6, R8, R13
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `src/lib/bootstrap.ts`
+- Modify: `src/index.ts` only if wiring needs to pass catalog dependencies explicitly
+- Test: `tests/unit/bootstrap.test.ts`
+
+**Approach:**
+- Insert the verbose catalog inside the default `<SYSTEMATIC_WORKFLOWS>` block with native-style XML structure.
+- Generate the catalog from the shared helper's static discoverability set.
+- Do not add the verbose catalog to custom bootstrap file content.
+- Preserve current fallback when a configured custom file path does not exist: default bundled bootstrap content is still used and therefore includes the catalog.
+
+**Execution note:** Test-first for default/custom contrast; write a failing custom-bootstrap test before adding catalog insertion.
+
+**Patterns to follow:**
+- `getBootstrapContent()` default/custom branching in `src/lib/bootstrap.ts`
+- Native verbose skill catalog in `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/src/skill/index.ts`
+
+**Test scenarios:**
+- Happy path: default bootstrap contains `<available_skills>` with skill name, description, and file URL/location entries.
+- Edge case: disabled and non-invocable skills are absent from the default bootstrap catalog.
+- Edge case: custom bootstrap file content is returned verbatim and does not get a forced verbose catalog.
+- Edge case: missing custom bootstrap path still falls through to default bootstrap with catalog.
+
+**Verification:**
+- Default bootstrap has workflow guidance plus verbose catalog; custom bootstrap behavior remains verbatim.
+
+- [ ] **Unit 4: Compact `systematic_skill` fallback and behavior guards**
+
+**Goal:** Slim the `systematic_skill` tool description while preserving load behavior and guarding the unchanged `using-systematic` workflow discipline.
+
+**Requirements:** R7, R8, R9, R10, R11, R14, R15
+
+**Dependencies:** Unit 1, Unit 3
+
+**Files:**
+- Modify: `src/lib/skill-tool.ts`
+- Test: `tests/unit/skill-tool.test.ts`
+- Test: `tests/unit/bootstrap.test.ts` if bootstrap/tool wording consistency changes
+- Test: `tests/unit/plugin.test.ts`
+- Test: `tests/integration/opencode.test.ts` if OpenCode exposes enough tool-surface state to assert host-visible duplicate registration behavior
+
+**Approach:**
+- Replace the verbose XML catalog in the tool description with compact fallback availability derived from the shared helper.
+- Keep the tool purpose, argument hint, permission ask, metadata, error suggestions, prefixed/unprefixed resolution, sampled file list, and `<skill_content>` output unchanged.
+- Do not edit `skills/using-systematic/SKILL.md` unless a new failing test proves the bootstrap/tool split introduced contradictory tool-access guidance.
+- Preserve the current multi-registration contract: repeated Systematic plugin factories expose usable hooks/tools rather than returning empty hooks. Add a host-visible guard where feasible so user-level plus project-level plugin registration does not make `systematic_skill` unavailable or ambiguous.
+
+**Execution note:** Behavior test-first; existing load tests should stay green while new description-weight/fallback tests fail before the description change.
+
+**Patterns to follow:**
+- `src/lib/skill-tool.ts` native-compatible output shape
+- `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/src/tool/skill.ts` execution output
+- `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/src/tool/registry.ts` compact native skill tool description
+
+**Test scenarios:**
+- Happy path: prefixed and unprefixed `systematic_skill` invocations still load the same skill output.
+- Edge case: unknown skill errors still list discoverable Systematic skill names.
+- Edge case: compact description contains discoverable skill names but not the full verbose XML catalog.
+- Edge case: disabled/non-invocable skills are excluded from compact fallback.
+- Regression: the rendered default bootstrap still includes `using-systematic` instructions that require skill invocation before response/action and preserve process-skill priority.
+- Integration: existing OpenCode integration coverage for loading `systematic:setup` through `systematic_skill` remains green after moving catalog placement.
+- Integration: duplicate plugin registration through representative user/project config still leaves `systematic_skill` callable and bundled skills discoverable; if OpenCode's public surface exposes tool IDs, assert there is no ambiguous duplicate visible entry.
+
+**Verification:**
+- Tool execution output remains stable while description weight and catalog location change.
+
+## System-Wide Impact
+
+- **Interaction graph:** `src/index.ts` initializes config, bootstrap content, and tool definitions; `experimental.chat.system.transform` applies bootstrap per conversation; `systematic_skill` uses the same discoverable skill set for fallback descriptions and execution-time loading.
+- **Error propagation:** Missing bundled skill files and unreadable directories should continue to degrade as today; the catalog helper should not turn optional skill discovery failures into plugin-load crashes.
+- **State lifecycle risks:** Bootstrap and tool descriptions remain cached per plugin instance. Users must restart OpenCode to pick up skill/config changes.
+- **API surface parity:** `systematic_skill` remains the public tool surface for bundled skills. Native `skill` remains separate for non-Systematic skills.
+- **Integration coverage:** Duplicate plugin registration and repeated transform invocation must be covered because user/project OpenCode configs can register Systematic more than once. Coverage should include both bootstrap idempotency and `systematic_skill` availability.
+- **Unchanged invariants:** `src/index.ts` exports only default; custom bootstrap content generation remains verbatim; malformed marker fragments are not deleted; `using-systematic`'s mandatory workflow discipline remains intact.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Moving bootstrap into `system[0]` changes OpenCode's split-system-message shape when other plugins append later entries. | Treat this as an intentional prompt-ordering change; test structural `output.system` behavior and avoid cache-performance claims. |
+| Shared catalog helper becomes unnecessary abstraction. | Keep it small and pure: one producer, two render modes, no framework or runtime registry. |
+| Catalog/tool descriptions drift. | Derive both verbose and compact renderings from the same helper and assert sorting/filtering in tests. |
+| Custom bootstrap users do not get the verbose default catalog. | Preserve custom content generation semantics and rely on compact `systematic_skill` fallback for discoverability. |
+| Marker cleanup accidentally deletes unrelated prompt content. | Only remove complete literal marker blocks; leave malformed fragments untouched. |
+| Duplicate plugin registration leaves users without bundled skills after preset/config changes. | Add a plugin/tool-surface guard that keeps `systematic_skill` callable under repeated registration. |
+
+## Documentation / Operational Notes
+
+- Update docs only if existing public configuration or README text describes bootstrap or `systematic_skill` catalog placement.
+- No release migration note is required for config shape; behavior changes are prompt/tool-description semantics only.
+- PR description should explicitly avoid claiming measured cache improvements.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-13-bootstrap-message0-skill-catalog-requirements.md](../brainstorms/2026-05-13-bootstrap-message0-skill-catalog-requirements.md)
+- `src/lib/bootstrap.ts`
+- `src/lib/skill-tool.ts`
+- `tests/unit/bootstrap.test.ts`
+- `tests/unit/plugin.test.ts`
+- `tests/unit/skill-tool.test.ts`
+- `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/src/session/llm.ts`
+- `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/src/session/system.ts`
+- `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/src/tool/skill.ts`
+- `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/src/tool/registry.ts`

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -22,7 +22,7 @@ const BOOTSTRAP_MARKER_CLOSE = '</SYSTEMATIC_WORKFLOWS>'
 const findBootstrapMarkerBlock = (
   entry: string,
   fromIndex = 0,
-): { start: number; end: number } | null => {
+): { start: number; closeStart: number; end: number } | null => {
   const start = entry.indexOf(BOOTSTRAP_MARKER_OPEN, fromIndex)
   if (start === -1) return null
   const closeStart = entry.indexOf(
@@ -30,7 +30,7 @@ const findBootstrapMarkerBlock = (
     start + BOOTSTRAP_MARKER_OPEN.length,
   )
   if (closeStart === -1) return null
-  return { start, end: closeStart + BOOTSTRAP_MARKER_CLOSE.length }
+  return { start, closeStart, end: closeStart + BOOTSTRAP_MARKER_CLOSE.length }
 }
 
 const removeCompleteBootstrapBlocks = (entry: string): string => {
@@ -39,6 +39,18 @@ const removeCompleteBootstrapBlocks = (entry: string): string => {
   let block = findBootstrapMarkerBlock(entry, cursor)
 
   while (block !== null) {
+    const nestedStart = entry.indexOf(
+      BOOTSTRAP_MARKER_OPEN,
+      block.start + BOOTSTRAP_MARKER_OPEN.length,
+    )
+
+    if (nestedStart !== -1 && nestedStart < block.closeStart) {
+      segments.push(entry.slice(cursor, nestedStart))
+      cursor = nestedStart
+      block = findBootstrapMarkerBlock(entry, cursor)
+      continue
+    }
+
     segments.push(entry.slice(cursor, block.start))
     cursor = block.end
     block = findBootstrapMarkerBlock(entry, cursor)

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -3,6 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import type { SystematicConfig } from './config.js'
 import { parseFrontmatter } from './frontmatter.js'
+import { renderCatalogVerbose } from './skill-catalog.js'
 
 // Signatures used to identify OpenCode internal agents (title generator,
 // summarizer, etc.) so bootstrap injection can be skipped. Exported for
@@ -133,6 +134,11 @@ export function getBootstrapContent(
   const { body } = parseFrontmatter(fullContent)
   const content = body.trim()
   const toolMapping = getToolMappingTemplate()
+  const catalog = renderCatalogVerbose({
+    bundledSkillsDir,
+    disabledSkills: config.disabled_skills,
+  })
+  const catalogSection = catalog.length > 0 ? `\n\n${catalog}` : ''
 
   return `<SYSTEMATIC_WORKFLOWS>
 You have access to structured engineering workflows via the systematic plugin.
@@ -141,6 +147,6 @@ You have access to structured engineering workflows via the systematic plugin.
 
 ${content}
 
-${toolMapping}
+${toolMapping}${catalogSection}
 </SYSTEMATIC_WORKFLOWS>`
 }

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -37,6 +37,7 @@ const removeCompleteBootstrapBlocks = (entry: string): string => {
   const segments: string[] = []
   let cursor = 0
   let block = findBootstrapMarkerBlock(entry, cursor)
+  let hadNestedBlock = false
 
   while (block !== null) {
     const nestedStart = entry.indexOf(
@@ -45,6 +46,7 @@ const removeCompleteBootstrapBlocks = (entry: string): string => {
     )
 
     if (nestedStart !== -1 && nestedStart < block.closeStart) {
+      hadNestedBlock = true
       segments.push(entry.slice(cursor, nestedStart))
       cursor = nestedStart
       block = findBootstrapMarkerBlock(entry, cursor)
@@ -58,7 +60,16 @@ const removeCompleteBootstrapBlocks = (entry: string): string => {
 
   if (cursor === 0) return entry
   segments.push(entry.slice(cursor))
-  return segments.join('')
+  const result = segments.join('')
+
+  // When nested blocks are removed, previously truncated outer open/close
+  // markers may now form a complete block. Recurse once to clean up in a
+  // single call rather than requiring a second transform invocation.
+  if (hadNestedBlock) {
+    return removeCompleteBootstrapBlocks(result)
+  }
+
+  return result
 }
 
 /**

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -20,8 +20,9 @@ const BOOTSTRAP_MARKER_CLOSE = '</SYSTEMATIC_WORKFLOWS>'
 
 const findBootstrapMarkerBlock = (
   entry: string,
+  fromIndex = 0,
 ): { start: number; end: number } | null => {
-  const start = entry.indexOf(BOOTSTRAP_MARKER_OPEN)
+  const start = entry.indexOf(BOOTSTRAP_MARKER_OPEN, fromIndex)
   if (start === -1) return null
   const closeStart = entry.indexOf(
     BOOTSTRAP_MARKER_CLOSE,
@@ -31,10 +32,31 @@ const findBootstrapMarkerBlock = (
   return { start, end: closeStart + BOOTSTRAP_MARKER_CLOSE.length }
 }
 
+const removeCompleteBootstrapBlocks = (entry: string): string => {
+  const segments: string[] = []
+  let cursor = 0
+  let block = findBootstrapMarkerBlock(entry, cursor)
+
+  while (block !== null) {
+    segments.push(entry.slice(cursor, block.start))
+    cursor = block.end
+    block = findBootstrapMarkerBlock(entry, cursor)
+  }
+
+  if (cursor === 0) return entry
+  segments.push(entry.slice(cursor))
+  return segments.join('')
+}
+
 /**
- * Inject bootstrap content into the system prompt array, replacing any
- * existing `<SYSTEMATIC_WORKFLOWS>` block. Multi-load idempotency is via
- * the marker — most-recently-registered plugin wins under FIFO hook order.
+ * Inject bootstrap content into the system prompt array, placing exactly one
+ * canonical block at the end of `output.system[0]`.
+ *
+ * All complete `<SYSTEMATIC_WORKFLOWS>…</SYSTEMATIC_WORKFLOWS>` blocks are
+ * removed from every system entry first, then the current content is appended
+ * once to `output.system[0]`. Partial/malformed marker fragments are left
+ * untouched. This makes duplicate registration and prior last-entry placement
+ * converge to the new canonical location; later invocations win.
  *
  * Exported for test access — must NOT be re-exported from the plugin entry
  * point (src/index.ts) because OpenCode's plugin loader expects a single
@@ -45,20 +67,18 @@ export const applyBootstrapContent = (
   output: { system: string[] },
   content: string,
 ): void => {
+  // Remove every complete marker block from every entry.
   for (let i = 0; i < output.system.length; i++) {
-    const entry = output.system[i]
-    const block = findBootstrapMarkerBlock(entry)
-    if (block !== null) {
-      output.system[i] =
-        entry.slice(0, block.start) + content + entry.slice(block.end)
-      return
-    }
+    output.system[i] = removeCompleteBootstrapBlocks(output.system[i])
   }
-  if (output.system.length > 0) {
-    output.system[output.system.length - 1] += `\n\n${content}`
-  } else {
+
+  if (output.system.length === 0) {
     output.system.push(content)
+    return
   }
+
+  const first = output.system[0]
+  output.system[0] = first.length > 0 ? `${first}\n\n${content}` : content
 }
 
 export interface BootstrapDeps {

--- a/src/lib/skill-catalog.ts
+++ b/src/lib/skill-catalog.ts
@@ -2,6 +2,15 @@ import { pathToFileURL } from 'node:url'
 import { formatSkillCommandName } from './skill-loader.js'
 import { findSkillsInDir } from './skills.js'
 
+/**
+ * Escape XML special characters (&, <, >) in text content.
+ * Quotes are not escaped because catalog names and descriptions are rendered
+ * as element text, not attribute values.
+ */
+export function escapeXml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
 export interface CatalogEntry {
   name: string
   prefixedName: string
@@ -47,8 +56,8 @@ export function renderCatalogVerbose(options: CatalogOptions): string {
 
   const skillLines = entries.flatMap((entry) => [
     '  <skill>',
-    `    <name>${entry.prefixedName}</name>`,
-    `    <description>${entry.description}</description>`,
+    `    <name>${escapeXml(entry.prefixedName)}</name>`,
+    `    <description>${escapeXml(entry.description)}</description>`,
     `    <location>${pathToFileURL(entry.path).href}</location>`,
     '  </skill>',
   ])

--- a/src/lib/skill-catalog.ts
+++ b/src/lib/skill-catalog.ts
@@ -1,0 +1,77 @@
+import { pathToFileURL } from 'node:url'
+import { formatSkillCommandName } from './skill-loader.js'
+import { findSkillsInDir } from './skills.js'
+
+export interface CatalogEntry {
+  name: string
+  prefixedName: string
+  description: string
+  path: string
+  skillFile: string
+}
+
+export interface CatalogOptions {
+  bundledSkillsDir: string
+  disabledSkills: string[]
+}
+
+/**
+ * Discovers and filters bundled Systematic skills into catalog entries.
+ * Excludes disabled skills and skills with disableModelInvocation === true.
+ * Returns entries sorted by name.
+ */
+export function buildCatalogEntries(options: CatalogOptions): CatalogEntry[] {
+  const { bundledSkillsDir, disabledSkills } = options
+
+  return findSkillsInDir(bundledSkillsDir)
+    .filter((s) => !disabledSkills.includes(s.name))
+    .filter((s) => s.disableModelInvocation !== true)
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((s) => ({
+      name: s.name,
+      prefixedName: formatSkillCommandName(s.name),
+      description: s.description,
+      path: s.path,
+      skillFile: s.skillFile,
+    }))
+}
+
+/**
+ * Renders discoverable skills as native-style verbose XML for bootstrap content.
+ * Returns empty string when no skills are available.
+ */
+export function renderCatalogVerbose(options: CatalogOptions): string {
+  const entries = buildCatalogEntries(options)
+
+  if (entries.length === 0) return ''
+
+  const skillLines = entries.flatMap((entry) => [
+    '  <skill>',
+    `    <name>${entry.prefixedName}</name>`,
+    `    <description>${entry.description}</description>`,
+    `    <location>${pathToFileURL(entry.path).href}</location>`,
+    '  </skill>',
+  ])
+
+  return ['<available_skills>', ...skillLines, '</available_skills>'].join('\n')
+}
+
+/**
+ * Renders discoverable skills as a compact markdown list for tool descriptions.
+ * Always includes the heading; renders an explicit no-skills message when empty.
+ */
+export function renderCatalogCompact(options: CatalogOptions): string {
+  const entries = buildCatalogEntries(options)
+
+  const heading = '## Available Systematic Skills'
+
+  if (entries.length === 0) {
+    return `${heading}\n\nNo Systematic skills are currently available.`
+  }
+
+  const bullets = entries
+    .map((entry) => `- ${entry.prefixedName}: ${entry.description}`)
+    .join('\n')
+
+  return `${heading}\n\n${bullets}`
+}

--- a/src/lib/skill-tool.ts
+++ b/src/lib/skill-tool.ts
@@ -3,7 +3,11 @@ import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import type { ToolDefinition } from '@opencode-ai/plugin'
 import { tool } from '@opencode-ai/plugin/tool'
-import { renderCatalogCompact } from './skill-catalog.js'
+import {
+  buildCatalogEntries,
+  escapeXml,
+  renderCatalogCompact,
+} from './skill-catalog.js'
 import {
   extractSkillBody,
   formatSkillCommandName,
@@ -28,8 +32,8 @@ export function formatSkillsXml(skills: SkillInfo[]): string {
   // Uses space-delimited join with indented XML structure
   const skillLines = skills.flatMap((skill) => [
     '  <skill>',
-    `    <name>${formatSkillCommandName(skill.name)}</name>`,
-    `    <description>${skill.description}</description>`,
+    `    <name>${escapeXml(formatSkillCommandName(skill.name))}</name>`,
+    `    <description>${escapeXml(skill.description)}</description>`,
     `    <location>${pathToFileURL(skill.path).href}</location>`,
     '  </skill>',
   ])
@@ -97,10 +101,6 @@ export function createSkillTool(options: SkillToolOptions): ToolDefinition {
       .sort((a, b) => a.name.localeCompare(b.name))
   }
 
-  const getDiscoverableSkills = (): LoadedSkill[] => {
-    return getAllSkills().filter((s) => s.disableModelInvocation !== true)
-  }
-
   const buildDescription = (): string => {
     const catalog = renderCatalogCompact({ bundledSkillsDir, disabledSkills })
 
@@ -116,8 +116,8 @@ ${catalog}`
   }
 
   const buildParameterHint = (): string => {
-    const skills = getDiscoverableSkills()
-    const examples = skills
+    const entries = buildCatalogEntries({ bundledSkillsDir, disabledSkills })
+    const examples = entries
       .slice(0, 3)
       .map((s) => `'${s.prefixedName}'`)
       .join(', ')
@@ -156,9 +156,10 @@ ${catalog}`
       const matchedSkill = skills.find((s) => s.name === normalizedName)
 
       if (!matchedSkill) {
-        const availableSystematic = getDiscoverableSkills().map(
-          (s) => s.prefixedName,
-        )
+        const availableSystematic = buildCatalogEntries({
+          bundledSkillsDir,
+          disabledSkills,
+        }).map((s) => s.prefixedName)
         throw new Error(
           `Skill "${requestedName}" not found. Available systematic skills: ${availableSystematic.join(', ')}`,
         )

--- a/src/lib/skill-tool.ts
+++ b/src/lib/skill-tool.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import type { ToolDefinition } from '@opencode-ai/plugin'
 import { tool } from '@opencode-ai/plugin/tool'
+import { renderCatalogCompact } from './skill-catalog.js'
 import {
   extractSkillBody,
   formatSkillCommandName,
@@ -101,34 +102,17 @@ export function createSkillTool(options: SkillToolOptions): ToolDefinition {
   }
 
   const buildDescription = (): string => {
-    const skills = getDiscoverableSkills()
+    const catalog = renderCatalogCompact({ bundledSkillsDir, disabledSkills })
 
-    if (skills.length === 0) {
-      return 'Load a skill to get detailed instructions for a specific task. No skills are currently available.'
-    }
+    return `Load a specialized skill that provides domain-specific instructions and workflows.
 
-    const skillInfos = skills.map((s) => ({
-      name: s.name,
-      description: s.description,
-      path: s.path,
-      skillFile: s.skillFile,
-    }))
-    const systematicXml = formatSkillsXml(skillInfos)
+When you recognize that a task matches one of the available skills listed below, use this tool to load the full skill instructions.
 
-    return [
-      'Load a specialized skill that provides domain-specific instructions and workflows.',
-      '',
-      'When you recognize that a task matches one of the available skills listed below, use this tool to load the full skill instructions.',
-      '',
-      'The skill will inject detailed instructions, workflows, and access to bundled resources (scripts, references, templates) into the conversation context.',
-      '',
-      'Tool output includes a `<skill_content name="...">` block with the loaded content.',
-      '',
-      'The following skills provide specialized sets of instructions for particular tasks.',
-      'Invoke this tool to load a skill when a task matches one of the available skills listed below:',
-      '',
-      systematicXml,
-    ].join('\n')
+The skill will inject detailed instructions, workflows, and access to bundled resources (scripts, references, templates) into the conversation context.
+
+Tool output includes a \`<skill_content name="...">\` block with the loaded content.
+
+${catalog}`
   }
 
   const buildParameterHint = (): string => {

--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -181,7 +181,7 @@ describe('getBootstrapContent', () => {
     expect(content).not.toContain('description: Test skill')
   })
 
-  test('embeds bundledSkillsDir absolute path in the tool-mapping template', () => {
+  test('tool-mapping template does not embed bundledSkillsDir as a raw path', () => {
     const bundledSkillsDir = makeBundledSkillsDir(
       '---\nname: using-systematic\n---\nbody',
     )
@@ -194,10 +194,170 @@ describe('getBootstrapContent', () => {
     const content = getBootstrapContent(config, { bundledSkillsDir })
 
     expect(content).not.toBeNull()
-    expect(content).not.toContain(bundledSkillsDir)
+    // The tool-mapping prose must not embed the raw path. Slice from the
+    // heading up to the catalog block (or end of string if no catalog).
+    const toolMappingHeading = '**Tool Mapping for OpenCode:**'
+    const toolMappingStart = (content ?? '').indexOf(toolMappingHeading)
+    expect(toolMappingStart).toBeGreaterThan(-1)
+    const afterHeading = (content ?? '').slice(toolMappingStart)
+    const catalogStart = afterHeading.indexOf('<available_skills>')
+    const toolMappingProse =
+      catalogStart >= 0 ? afterHeading.slice(0, catalogStart) : afterHeading
+    expect(toolMappingProse).not.toContain(bundledSkillsDir)
     expect(content).toContain(
       'Bundled skills ship with the Systematic plugin and are discoverable via `systematic_skill`.',
     )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Verbose skill catalog in default bootstrap
+// ---------------------------------------------------------------------------
+
+describe('getBootstrapContent — verbose skill catalog', () => {
+  let testDir: string
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'systematic-bootstrap-catalog-'),
+    )
+  })
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true })
+  })
+
+  function makeSkillsDir(
+    skills: Array<{ name: string; description: string; extra?: string }>,
+  ): string {
+    const bundledSkillsDir = path.join(testDir, 'skills')
+    fs.mkdirSync(path.join(bundledSkillsDir, 'using-systematic'), {
+      recursive: true,
+    })
+    fs.writeFileSync(
+      path.join(bundledSkillsDir, 'using-systematic', 'SKILL.md'),
+      '---\nname: using-systematic\ndescription: Use when starting any conversation\n---\nBootstrap body.',
+    )
+    for (const skill of skills) {
+      const dir = path.join(bundledSkillsDir, skill.name)
+      fs.mkdirSync(dir, { recursive: true })
+      const extra = skill.extra ?? ''
+      fs.writeFileSync(
+        path.join(dir, 'SKILL.md'),
+        `---\nname: ${skill.name}\ndescription: ${skill.description}${extra}\n---\nBody.`,
+      )
+    }
+    return bundledSkillsDir
+  }
+
+  test('default bootstrap contains <available_skills> with skill name, description, and file URL', () => {
+    const bundledSkillsDir = makeSkillsDir([
+      { name: 'git-commit', description: 'Create a git commit' },
+      { name: 'ce:plan', description: 'Create structured plans' },
+    ])
+    const config = {
+      bootstrap: { enabled: true, file: undefined },
+      disabled_skills: [] as string[],
+      disabled_agents: [] as string[],
+      disabled_commands: [] as string[],
+    }
+
+    const content = getBootstrapContent(config, { bundledSkillsDir })
+
+    expect(content).not.toBeNull()
+    expect(content).toContain('<available_skills>')
+    expect(content).toContain('</available_skills>')
+    // Skills appear with prefixed names
+    expect(content).toContain('<name>systematic:git-commit</name>')
+    expect(content).toContain('<description>Create a git commit</description>')
+    expect(content).toContain('<location>file://')
+    expect(content).toContain('git-commit')
+    // ce:plan already has a colon so it keeps its name
+    expect(content).toContain('<name>ce:plan</name>')
+  })
+
+  test('disabled skills are absent from the default bootstrap catalog', () => {
+    const bundledSkillsDir = makeSkillsDir([
+      { name: 'git-commit', description: 'Create a git commit' },
+      { name: 'ce:plan', description: 'Create structured plans' },
+    ])
+    const config = {
+      bootstrap: { enabled: true, file: undefined },
+      disabled_skills: ['git-commit'] as string[],
+      disabled_agents: [] as string[],
+      disabled_commands: [] as string[],
+    }
+
+    const content = getBootstrapContent(config, { bundledSkillsDir })
+
+    expect(content).not.toBeNull()
+    expect(content).not.toContain('<name>systematic:git-commit</name>')
+    expect(content).toContain('<name>ce:plan</name>')
+  })
+
+  test('skills with disableModelInvocation are absent from the default bootstrap catalog', () => {
+    const bundledSkillsDir = makeSkillsDir([
+      { name: 'git-commit', description: 'Create a git commit' },
+      {
+        name: 'internal-tool',
+        description: 'Internal only',
+        extra: '\ndisable-model-invocation: true',
+      },
+    ])
+    const config = {
+      bootstrap: { enabled: true, file: undefined },
+      disabled_skills: [] as string[],
+      disabled_agents: [] as string[],
+      disabled_commands: [] as string[],
+    }
+
+    const content = getBootstrapContent(config, { bundledSkillsDir })
+
+    expect(content).not.toBeNull()
+    expect(content).toContain('<name>systematic:git-commit</name>')
+    expect(content).not.toContain('<name>systematic:internal-tool</name>')
+  })
+
+  test('custom bootstrap file content is returned verbatim without verbose catalog', () => {
+    const bundledSkillsDir = makeSkillsDir([
+      { name: 'git-commit', description: 'Create a git commit' },
+    ])
+    const customPath = path.join(testDir, 'custom-bootstrap.md')
+    fs.writeFileSync(customPath, 'CUSTOM bootstrap content — no catalog here')
+
+    const config = {
+      bootstrap: { enabled: true, file: customPath },
+      disabled_skills: [] as string[],
+      disabled_agents: [] as string[],
+      disabled_commands: [] as string[],
+    }
+
+    const content = getBootstrapContent(config, { bundledSkillsDir })
+
+    expect(content).toBe('CUSTOM bootstrap content — no catalog here')
+    expect(content).not.toContain('<available_skills>')
+  })
+
+  test('missing custom bootstrap path falls through to default bootstrap with catalog', () => {
+    const bundledSkillsDir = makeSkillsDir([
+      { name: 'git-commit', description: 'Create a git commit' },
+    ])
+    const config = {
+      bootstrap: {
+        enabled: true,
+        file: path.join(testDir, 'does-not-exist.md'),
+      },
+      disabled_skills: [] as string[],
+      disabled_agents: [] as string[],
+      disabled_commands: [] as string[],
+    }
+
+    const content = getBootstrapContent(config, { bundledSkillsDir })
+
+    expect(content).not.toBeNull()
+    expect(content).toContain('<SYSTEMATIC_WORKFLOWS>')
+    expect(content).toContain('<available_skills>')
+    expect(content).toContain('<name>systematic:git-commit</name>')
   })
 })
 

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -508,14 +508,14 @@ describe('applyBootstrapContent marker-based idempotency', () => {
   const MARKER_CLOSE = '</SYSTEMATIC_WORKFLOWS>'
   const wrap = (body: string) => `${MARKER_OPEN}${body}${MARKER_CLOSE}`
 
-  test('pushes content when system array is empty', () => {
+  test('pushes content as sole entry when system array is empty', () => {
     const output = { system: [] as string[] }
     applyBootstrapContent(output, wrap('NEW CONTENT'))
     expect(output.system).toHaveLength(1)
     expect(output.system[0]).toBe(wrap('NEW CONTENT'))
   })
 
-  test('appends content to last entry when no prior marker block exists', () => {
+  test('appends content to system[0] when no prior marker block exists', () => {
     const output = { system: ['existing system prompt'] }
     applyBootstrapContent(output, wrap('NEW CONTENT'))
     expect(output.system).toHaveLength(1)
@@ -524,7 +524,15 @@ describe('applyBootstrapContent marker-based idempotency', () => {
     )
   })
 
-  test('replaces existing marker block in-place, keeping array length at 1', () => {
+  test('two system entries with no marker: bootstrap appended to system[0], system[1] unchanged', () => {
+    const output = { system: ['slot 0 content', 'slot 1 content'] }
+    applyBootstrapContent(output, wrap('NEW CONTENT'))
+    expect(output.system).toHaveLength(2)
+    expect(output.system[0]).toBe(`slot 0 content\n\n${wrap('NEW CONTENT')}`)
+    expect(output.system[1]).toBe('slot 1 content')
+  })
+
+  test('removes existing marker block from system[0] then appends current content', () => {
     const output = {
       system: [`existing prompt with ${wrap('OLD CONTENT')} embedded`],
     }
@@ -538,23 +546,36 @@ describe('applyBootstrapContent marker-based idempotency', () => {
     expect(result).not.toContain('OLD CONTENT')
   })
 
-  test('replaces marker block in a non-last slot when found there', () => {
+  test('removes complete marker block from a non-first slot and appends current content to system[0]', () => {
     const output = {
       system: ['slot 0', `slot 1 with ${wrap('OLD CONTENT')}`, 'slot 2'],
     }
     applyBootstrapContent(output, wrap('NEW CONTENT'))
     expect(output.system).toHaveLength(3)
-    expect(output.system[1]).toContain('NEW CONTENT')
+    // Block removed from slot 1
     expect(output.system[1]).not.toContain('OLD CONTENT')
+    expect(output.system[1]).not.toContain(MARKER_OPEN)
+    // Current content appended to slot 0
+    expect(output.system[0]).toContain('NEW CONTENT')
+    expect(output.system[0]).toContain(MARKER_OPEN)
+    // slot 2 unchanged
     expect(output.system[2]).toBe('slot 2')
   })
 
-  test('non-greedy regex stops at first closing tag, leaving subsequent blocks untouched', () => {
+  test('removes all complete blocks across all entries then appends one current block to system[0]', () => {
     const twoBlocks = `${wrap('A')}B${wrap('C')}`
-    const output = { system: [twoBlocks] }
+    const output = { system: [twoBlocks, wrap('D')] }
     applyBootstrapContent(output, wrap('X'))
-    const result = output.system[0]
-    expect(result).toBe(`${wrap('X')}B${wrap('C')}`)
+    // Both complete blocks in system[0] removed, block in system[1] removed
+    const openTagCount = (
+      output.system.join('\n').match(new RegExp(MARKER_OPEN, 'g')) ?? []
+    ).length
+    expect(openTagCount).toBe(1)
+    expect(output.system[0]).toContain('X')
+    expect(output.system[0]).not.toContain(wrap('A'))
+    expect(output.system[0]).not.toContain(wrap('C'))
+    expect(output.system[1]).not.toContain(wrap('D'))
+    expect(output.system[1]).not.toContain(MARKER_OPEN)
   })
 
   test('fully replaces an entry that is only the marker block', () => {
@@ -574,6 +595,27 @@ describe('applyBootstrapContent marker-based idempotency', () => {
     expect(openTagCount).toBe(1)
     expect(joined).toContain('SECOND REGISTRATION')
     expect(joined).not.toContain('FIRST REGISTRATION')
+  })
+
+  test('malformed open-only marker fragment is left untouched while current block is appended to system[0]', () => {
+    const malformed = `${MARKER_OPEN} trailing content with no close`
+    const output = { system: [malformed] }
+    applyBootstrapContent(output, wrap('NEW CONTENT'))
+    // No complete block matched, so the fragment remains and content is appended
+    expect(output.system).toHaveLength(1)
+    expect(output.system[0]).toContain(MARKER_OPEN)
+    expect(output.system[0]).toContain('trailing content with no close')
+    expect(output.system[0]).toContain('NEW CONTENT')
+    // Exactly one complete block (the appended one)
+    const openTagCount = (
+      output.system[0].match(new RegExp(MARKER_OPEN, 'g')) ?? []
+    ).length
+    const closeTagCount = (
+      output.system[0].match(new RegExp(MARKER_CLOSE, 'g')) ?? []
+    ).length
+    expect(closeTagCount).toBe(1)
+    // Two open tags: one from the malformed fragment, one from the appended block
+    expect(openTagCount).toBe(2)
   })
 
   test('completes in linear time on malicious input with many opening markers and no closing tag', () => {

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -618,6 +618,22 @@ describe('applyBootstrapContent marker-based idempotency', () => {
     expect(openTagCount).toBe(2)
   })
 
+  test('malformed open-only marker fragment survives sequential transforms', () => {
+    const malformed = `${MARKER_OPEN} USER FRAGMENT KEEP`
+    const output = { system: [malformed] }
+
+    applyBootstrapContent(output, wrap('FIRST REGISTRATION'))
+    applyBootstrapContent(output, wrap('SECOND REGISTRATION'))
+
+    const result = output.system[0]
+    expect(result).toContain(malformed)
+    expect(result).toContain('SECOND REGISTRATION')
+    expect(result).not.toContain('FIRST REGISTRATION')
+    const closeTagCount = (result.match(new RegExp(MARKER_CLOSE, 'g')) ?? [])
+      .length
+    expect(closeTagCount).toBe(1)
+  })
+
   test('completes in linear time on malicious input with many opening markers and no closing tag', () => {
     // Regression: the prior regex implementation was vulnerable to ReDoS on
     // inputs starting with the opening marker repeated and missing a closing

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -634,6 +634,91 @@ describe('applyBootstrapContent marker-based idempotency', () => {
     expect(closeTagCount).toBe(1)
   })
 
+  test('removes nested complete blocks in a single call', () => {
+    const nested = `${MARKER_OPEN}outer ${wrap('inner')} tail${MARKER_CLOSE}`
+    const output = { system: [nested] }
+    applyBootstrapContent(output, wrap('NEW'))
+
+    const joined = output.system.join('\n')
+    const openTagCount = (joined.match(new RegExp(MARKER_OPEN, 'g')) ?? [])
+      .length
+    expect(openTagCount).toBe(1)
+    // Only the appended block remains
+    expect(output.system[0]).toBe(wrap('NEW'))
+  })
+
+  test('nested block with surrounding content converges in one call', () => {
+    const nested = `intro ${MARKER_OPEN}outer ${wrap('inner')} tail${MARKER_CLOSE} more`
+    const output = { system: [nested] }
+    applyBootstrapContent(output, wrap('NEW'))
+
+    const joined = output.system.join('\n')
+    const openTagCount = (joined.match(new RegExp(MARKER_OPEN, 'g')) ?? [])
+      .length
+    expect(openTagCount).toBe(1)
+    // User text outside the outermost block survives
+    expect(output.system[0]).toContain('intro')
+    expect(output.system[0]).toContain('more')
+    // Text inside the outermost block is removed with it
+    expect(output.system[0]).not.toContain('outer')
+    expect(output.system[0]).not.toContain('tail')
+  })
+
+  test('two levels of nesting converge in one call', () => {
+    const nested = `${MARKER_OPEN}${MARKER_OPEN}${wrap('deep')}${MARKER_CLOSE}${MARKER_CLOSE}`
+    const output = { system: [nested] }
+    applyBootstrapContent(output, wrap('NEW'))
+
+    const joined = output.system.join('\n')
+    const openTagCount = (joined.match(new RegExp(MARKER_OPEN, 'g')) ?? [])
+      .length
+    expect(openTagCount).toBe(1)
+    expect(output.system[0]).toBe(wrap('NEW'))
+  })
+
+  test('malformed open-only fragment survives even when nesting is also present', () => {
+    // No outer close tag — the outer open is an orphan fragment that should
+    // survive, while the complete inner block is removed.
+    const mixed = `${MARKER_OPEN}keep me ${wrap('inner')}`
+    const output = { system: [mixed] }
+    applyBootstrapContent(output, wrap('NEW'))
+
+    // The fragment open tag survives (no matching close for outermost)
+    expect(output.system[0]).toContain(MARKER_OPEN)
+    expect(output.system[0]).toContain('keep me')
+    // The appended block exists
+    expect(output.system[0]).toContain('NEW')
+    // The inner block is removed — only fragment + appended block remain
+    const openTagCount = (
+      output.system[0].match(new RegExp(MARKER_OPEN, 'g')) ?? []
+    ).length
+    expect(openTagCount).toBe(2)
+    const closeTagCount = (
+      output.system[0].match(new RegExp(MARKER_CLOSE, 'g')) ?? []
+    ).length
+    expect(closeTagCount).toBe(1)
+  })
+
+  test('malformed open-only fragment survives sequential transforms when nesting preceeded it', () => {
+    // No outer close tag — the outer open is an orphan that should survive
+    // across sequential transforms.
+    const mixed = `${MARKER_OPEN}keep me ${wrap('first')}`
+    const output = { system: [mixed] }
+
+    applyBootstrapContent(output, wrap('FIRST'))
+    applyBootstrapContent(output, wrap('SECOND'))
+
+    // Fragment still survives after second transform
+    expect(output.system[0]).toContain('keep me')
+    expect(output.system[0]).toContain('SECOND')
+    expect(output.system[0]).not.toContain('FIRST')
+    // One complete block (the appended second one)
+    const closeTagCount = (
+      output.system[0].match(new RegExp(MARKER_CLOSE, 'g')) ?? []
+    ).length
+    expect(closeTagCount).toBe(1)
+  })
+
   test('completes in linear time on malicious input with many opening markers and no closing tag', () => {
     // Regression: the prior regex implementation was vulnerable to ReDoS on
     // inputs starting with the opening marker repeated and missing a closing

--- a/tests/unit/skill-catalog.test.ts
+++ b/tests/unit/skill-catalog.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  buildCatalogEntries,
+  renderCatalogCompact,
+  renderCatalogVerbose,
+  type CatalogOptions,
+} from '../../src/lib/skill-catalog.js'
+
+function writeSkill(
+  dir: string,
+  name: string,
+  description: string,
+  extra = '',
+): string {
+  const skillDir = path.join(dir, name)
+  fs.mkdirSync(skillDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(skillDir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: ${description}\n${extra}---\n\n# ${name}\n`,
+  )
+  return skillDir
+}
+
+describe('skill-catalog', () => {
+  let testDir: string
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'systematic-skill-catalog-test-'),
+    )
+  })
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true })
+  })
+
+  describe('buildCatalogEntries', () => {
+    test('returns skills sorted by name', () => {
+      writeSkill(testDir, 'zebra-skill', 'Zebra description')
+      writeSkill(testDir, 'alpha-skill', 'Alpha description')
+      writeSkill(testDir, 'middle-skill', 'Middle description')
+
+      const entries = buildCatalogEntries({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      expect(entries.map((e) => e.name)).toEqual([
+        'alpha-skill',
+        'middle-skill',
+        'zebra-skill',
+      ])
+    })
+
+    test('excludes configured disabled skills', () => {
+      writeSkill(testDir, 'git-commit', 'Commit skill')
+      writeSkill(testDir, 'ce-brainstorm', 'Brainstorm skill')
+      writeSkill(testDir, 'ce-plan', 'Plan skill')
+
+      const entries = buildCatalogEntries({
+        bundledSkillsDir: testDir,
+        disabledSkills: ['ce-brainstorm'],
+      })
+
+      const names = entries.map((e) => e.name)
+      expect(names).not.toContain('ce-brainstorm')
+      expect(names).toContain('git-commit')
+      expect(names).toContain('ce-plan')
+    })
+
+    test('excludes skills with disable-model-invocation: true', () => {
+      writeSkill(testDir, 'git-commit', 'Commit skill')
+      writeSkill(
+        testDir,
+        'internal-only',
+        'Internal skill',
+        'disable-model-invocation: true\n',
+      )
+
+      const entries = buildCatalogEntries({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      const names = entries.map((e) => e.name)
+      expect(names).not.toContain('internal-only')
+      expect(names).toContain('git-commit')
+    })
+
+    test('returns empty array when no skills are discoverable', () => {
+      const entries = buildCatalogEntries({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      expect(entries).toEqual([])
+    })
+
+    test('returns empty array when all skills are disabled', () => {
+      writeSkill(testDir, 'git-commit', 'Commit skill')
+
+      const entries = buildCatalogEntries({
+        bundledSkillsDir: testDir,
+        disabledSkills: ['git-commit'],
+      })
+
+      expect(entries).toEqual([])
+    })
+
+    test('each entry has prefixedName with systematic: prefix', () => {
+      writeSkill(testDir, 'ce-plan', 'Plan skill')
+
+      const entries = buildCatalogEntries({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      expect(entries[0]?.prefixedName).toBe('systematic:ce-plan')
+    })
+  })
+
+  describe('renderCatalogVerbose', () => {
+    test('renders skills in sorted order as XML', () => {
+      writeSkill(testDir, 'zebra-skill', 'Zebra description')
+      writeSkill(testDir, 'alpha-skill', 'Alpha description')
+
+      const opts: CatalogOptions = {
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      }
+      const result = renderCatalogVerbose(opts)
+
+      const alphaPos = result.indexOf('systematic:alpha-skill')
+      const zebraPos = result.indexOf('systematic:zebra-skill')
+      expect(alphaPos).toBeGreaterThanOrEqual(0)
+      expect(zebraPos).toBeGreaterThanOrEqual(0)
+      expect(alphaPos).toBeLessThan(zebraPos)
+    })
+
+    test('renders XML with available_skills wrapper', () => {
+      writeSkill(testDir, 'git-commit', 'Create a git commit')
+
+      const result = renderCatalogVerbose({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      expect(result).toContain('<available_skills>')
+      expect(result).toContain('</available_skills>')
+      expect(result).toContain('<name>systematic:git-commit</name>')
+      expect(result).toContain('<description>Create a git commit</description>')
+    })
+
+    test('excludes disabled skills from verbose output', () => {
+      writeSkill(testDir, 'git-commit', 'Commit skill')
+      writeSkill(testDir, 'ce-brainstorm', 'Brainstorm skill')
+
+      const result = renderCatalogVerbose({
+        bundledSkillsDir: testDir,
+        disabledSkills: ['ce-brainstorm'],
+      })
+
+      expect(result).not.toContain('systematic:ce-brainstorm')
+      expect(result).toContain('systematic:git-commit')
+    })
+
+    test('excludes disable-model-invocation skills from verbose output', () => {
+      writeSkill(testDir, 'git-commit', 'Commit skill')
+      writeSkill(
+        testDir,
+        'internal-only',
+        'Internal skill',
+        'disable-model-invocation: true\n',
+      )
+
+      const result = renderCatalogVerbose({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      expect(result).not.toContain('systematic:internal-only')
+      expect(result).toContain('systematic:git-commit')
+    })
+
+    test('returns empty string when no skills are discoverable', () => {
+      const result = renderCatalogVerbose({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      expect(result).toBe('')
+    })
+  })
+
+  describe('renderCatalogCompact', () => {
+    test('renders heading and bullet list in sorted order', () => {
+      writeSkill(testDir, 'zebra-skill', 'Zebra description')
+      writeSkill(testDir, 'alpha-skill', 'Alpha description')
+
+      const result = renderCatalogCompact({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      expect(result).toContain('## Available Systematic Skills')
+      const alphaPos = result.indexOf('systematic:alpha-skill')
+      const zebraPos = result.indexOf('systematic:zebra-skill')
+      expect(alphaPos).toBeLessThan(zebraPos)
+    })
+
+    test('renders bullet format: - prefixedName: description', () => {
+      writeSkill(testDir, 'git-commit', 'Create a git commit')
+
+      const result = renderCatalogCompact({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      expect(result).toContain('- systematic:git-commit: Create a git commit')
+    })
+
+    test('excludes disabled skills from compact output', () => {
+      writeSkill(testDir, 'git-commit', 'Commit skill')
+      writeSkill(testDir, 'ce-brainstorm', 'Brainstorm skill')
+
+      const result = renderCatalogCompact({
+        bundledSkillsDir: testDir,
+        disabledSkills: ['ce-brainstorm'],
+      })
+
+      expect(result).not.toContain('systematic:ce-brainstorm')
+      expect(result).toContain('systematic:git-commit')
+    })
+
+    test('excludes disable-model-invocation skills from compact output', () => {
+      writeSkill(testDir, 'git-commit', 'Commit skill')
+      writeSkill(
+        testDir,
+        'internal-only',
+        'Internal skill',
+        'disable-model-invocation: true\n',
+      )
+
+      const result = renderCatalogCompact({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      expect(result).not.toContain('systematic:internal-only')
+      expect(result).toContain('systematic:git-commit')
+    })
+
+    test('renders no-skills message when no skills are discoverable', () => {
+      const result = renderCatalogCompact({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      expect(result).toContain('## Available Systematic Skills')
+      expect(result).toContain('No Systematic skills are currently available.')
+    })
+
+    test('renders no-skills message when all skills are disabled', () => {
+      writeSkill(testDir, 'git-commit', 'Commit skill')
+
+      const result = renderCatalogCompact({
+        bundledSkillsDir: testDir,
+        disabledSkills: ['git-commit'],
+      })
+
+      expect(result).toContain('No Systematic skills are currently available.')
+    })
+  })
+})

--- a/tests/unit/skill-catalog.test.ts
+++ b/tests/unit/skill-catalog.test.ts
@@ -2,11 +2,12 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+
 import {
   buildCatalogEntries,
+  type CatalogOptions,
   renderCatalogCompact,
   renderCatalogVerbose,
-  type CatalogOptions,
 } from '../../src/lib/skill-catalog.js'
 
 function writeSkill(

--- a/tests/unit/skill-catalog.test.ts
+++ b/tests/unit/skill-catalog.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path'
 import {
   buildCatalogEntries,
   type CatalogOptions,
+  escapeXml,
   renderCatalogCompact,
   renderCatalogVerbose,
 } from '../../src/lib/skill-catalog.js'
@@ -273,6 +274,40 @@ describe('skill-catalog', () => {
       })
 
       expect(result).toContain('No Systematic skills are currently available.')
+    })
+  })
+
+  describe('escapeXml', () => {
+    test('escapes &, <, > characters', () => {
+      expect(escapeXml('A & B <test>')).toBe('A &amp; B &lt;test&gt;')
+    })
+
+    test('passes through text without special chars', () => {
+      expect(escapeXml('normal text')).toBe('normal text')
+    })
+
+    test('escapes multiple occurrences', () => {
+      expect(escapeXml('<a> & <b>')).toBe('&lt;a&gt; &amp; &lt;b&gt;')
+    })
+
+    test('handles empty string', () => {
+      expect(escapeXml('')).toBe('')
+    })
+  })
+
+  describe('renderCatalogVerbose XML escaping', () => {
+    test('escapes XML special chars in name and description', () => {
+      writeSkill(testDir, 'a&b', 'Skill with A & B <special> chars')
+
+      const result = renderCatalogVerbose({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      expect(result).toContain('<name>systematic:a&amp;b</name>')
+      expect(result).toContain(
+        '<description>Skill with A &amp; B &lt;special&gt; chars</description>',
+      )
     })
   })
 })

--- a/tests/unit/skill-tool.test.ts
+++ b/tests/unit/skill-tool.test.ts
@@ -102,6 +102,22 @@ describe('skill-tool', () => {
       expect(result).toContain('<name>ce:plan</name>')
       expect(result).not.toContain('<name>systematic:ce:plan</name>')
     })
+
+    test('escapes XML special chars in name and description', () => {
+      const result = formatSkillsXml([
+        {
+          path: '/test/path',
+          skillFile: '/test/path/SKILL.md',
+          name: 'a&b',
+          description: 'A & B <special>',
+        },
+      ])
+
+      expect(result).toContain('<name>systematic:a&amp;b</name>')
+      expect(result).toContain(
+        '<description>A &amp; B &lt;special&gt;</description>',
+      )
+    })
   })
 
   describe('createSkillTool', () => {
@@ -219,6 +235,70 @@ disable-model-invocation: true
 
       expect(tool.description).toContain('systematic:visible-skill')
       expect(tool.description).not.toContain('systematic:hidden-skill')
+    })
+
+    test('compact description and execution loadability agree on disabled vs disable-model-invocation skills', async () => {
+      const normalDir = path.join(testDir, 'normal-skill')
+      const disabledDir = path.join(testDir, 'disabled-skill')
+      const hiddenDir = path.join(testDir, 'hidden-skill')
+      fs.mkdirSync(normalDir)
+      fs.mkdirSync(disabledDir)
+      fs.mkdirSync(hiddenDir)
+
+      fs.writeFileSync(
+        path.join(normalDir, 'SKILL.md'),
+        `---
+name: normal-skill
+description: Normal skill
+---
+# Normal`,
+      )
+
+      fs.writeFileSync(
+        path.join(disabledDir, 'SKILL.md'),
+        `---
+name: disabled-skill
+description: Disabled skill
+---
+# Disabled`,
+      )
+
+      fs.writeFileSync(
+        path.join(hiddenDir, 'SKILL.md'),
+        `---
+name: hidden-skill
+description: Hidden skill
+disable-model-invocation: true
+---
+# Hidden`,
+      )
+
+      const tool = createSkillTool({
+        bundledSkillsDir: testDir,
+        disabledSkills: ['disabled-skill'],
+      })
+
+      // Disabled: not in description, not loadable
+      expect(tool.description).not.toContain('systematic:disabled-skill')
+      await expect(
+        tool.execute({ name: 'systematic:disabled-skill' }, mockContext),
+      ).rejects.toThrow()
+
+      // Hidden (disableModelInvocation): not in description, IS loadable
+      expect(tool.description).not.toContain('systematic:hidden-skill')
+      const hiddenResult = await tool.execute(
+        { name: 'systematic:hidden-skill' },
+        mockContext,
+      )
+      expect(hiddenResult).toContain('# Hidden')
+
+      // Normal: in description, loadable
+      expect(tool.description).toContain('systematic:normal-skill')
+      const normalResult = await tool.execute(
+        { name: 'systematic:normal-skill' },
+        mockContext,
+      )
+      expect(normalResult).toContain('# Normal')
     })
   })
 

--- a/tests/unit/skill-tool.test.ts
+++ b/tests/unit/skill-tool.test.ts
@@ -126,6 +126,34 @@ description: A test skill for unit testing
       expect(tool.description).toContain('A test skill for unit testing')
     })
 
+    test('description uses compact catalog format, not verbose XML', () => {
+      const skillDir = path.join(testDir, 'ce-brainstorm')
+      fs.mkdirSync(skillDir)
+      fs.writeFileSync(
+        path.join(skillDir, 'SKILL.md'),
+        `---
+name: ce:brainstorm
+description: Explore requirements and approaches through collaborative dialogue
+---
+# Brainstorm Content`,
+      )
+
+      const tool = createSkillTool({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      // Compact format: markdown bullet list
+      expect(tool.description).toContain('ce:brainstorm')
+      expect(tool.description).toContain(
+        'Explore requirements and approaches through collaborative dialogue',
+      )
+      // Must NOT contain verbose XML catalog
+      expect(tool.description).not.toContain('<available_skills>')
+      expect(tool.description).not.toContain('</available_skills>')
+      expect(tool.description).not.toContain('<location>')
+    })
+
     test('filters out disabled skills from description', () => {
       const skill1Dir = path.join(testDir, 'enabled-skill')
       const skill2Dir = path.join(testDir, 'disabled-skill')


### PR DESCRIPTION
## Summary

- Moves the Systematic bootstrap block into the first system message and normalizes duplicate bootstrap markers into one current block.
- Adds a shared bundled-skill catalog renderer used by the default bootstrap and the `systematic_skill` tool description.
- Keeps custom bootstrap files verbatim while default bootstrap now includes a verbose native-style skill catalog.
- Slims the `systematic_skill` tool description to a compact fallback catalog.

## Verification

- `bun run typecheck`
- `bun run build`
- `bun test`
- `bun run docs:build`
- `bun run registry:validate`
- `bun run registry:drift`
- `bun scripts/content-integrity.ts`
- `bunx biome check docs/plans/2026-05-13-001-feat-bootstrap-message0-skill-catalog-plan.md src/lib/bootstrap.ts src/lib/skill-catalog.ts src/lib/skill-tool.ts tests/unit/bootstrap.test.ts tests/unit/plugin.test.ts tests/unit/skill-catalog.test.ts tests/unit/skill-tool.test.ts`
- `git diff --check`

🤖 Generated with [Systematic](https://github.com/marcusrbrown/systematic)
