### PR TITLE
chore(deps): bump cloned OpenCode source to v1.15.1

### DIFF
--- a/.slim/clonedeps.json
+++ b/.slim/clonedeps.json
@@ -1,24 +1,24 @@
 {
   "version": "1.0.0",
-  "updatedAt": "2026-05-12T21:59:00.000Z",
+  "updatedAt": "2026-05-16T10:00:00.000Z",
   "dependencies": [
     {
       "name": "@opencode-ai/sdk",
-      "resolvedVersion": "1.14.41",
+      "resolvedVersion": "1.15.1",
       "repoUrl": "https://github.com/anomalyco/opencode.git",
-      "ref": "v1.14.41",
+      "ref": "v1.15.1",
       "path": ".slim/clonedeps/repos/anomalyco__opencode",
       "packagePath": "packages/sdk/js",
-      "reason": "Inspect OpencodeClient construction, client.provider.list() and client.model.list() runtime behavior — unknowns deferred to Unit 2 implementation in the active client-API source-model resolution plan"
+      "reason": "Inspect OpencodeClient construction, client.provider.list() and client.model.list() runtime behavior — supports provider-availability hardening work and future plan deferred-to-implementation questions"
     },
     {
       "name": "@opencode-ai/plugin",
-      "resolvedVersion": "1.14.41",
+      "resolvedVersion": "1.15.1",
       "repoUrl": "https://github.com/anomalyco/opencode.git",
-      "ref": "v1.14.41",
+      "ref": "v1.15.1",
       "path": ".slim/clonedeps/repos/anomalyco__opencode",
       "packagePath": "packages/plugin",
-      "reason": "Inspect plugin loader hook iteration order, PluginInput.client construction site, and config-hook invocation lifecycle — verifies the FIFO assumption and per-invocation freshness contract from PR #352"
+      "reason": "Inspect plugin loader hook iteration order, PluginInput.client construction site, and config-hook invocation lifecycle — verifies the FIFO assumption and per-invocation freshness contract from PR #352 and resolves multi-source plugin-loader topology questions for the DX hardening brainstorm"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,4 +184,4 @@ The top-level `commands/` directory has been removed (all bundled commands were 
 
 Read-only dependency source repositories are available under `.slim/clonedeps/repos/` for inspection. Do not edit these clones.
 
-- `.slim/clonedeps/repos/anomalyco__opencode/` — `anomalyco/opencode` at `v1.14.41`; OpenCode monorepo containing `packages/sdk/js` (the `OpencodeClient` runtime that `client.provider.list()` and `client.model.list()` are dispatched through) and `packages/plugin` (the `PluginInput` type definitions and the plugin loader/hook iteration semantics — useful for verifying the FIFO assumption and `output` reference-sharing contract from PR #352).
+- `.slim/clonedeps/repos/anomalyco__opencode/` — `anomalyco/opencode` at `v1.15.1`; OpenCode monorepo containing `packages/sdk/js` (the `OpencodeClient` runtime that `client.provider.list()` and `client.model.list()` are dispatched through) and `packages/plugin` (the `PluginInput` type definitions and the plugin loader/hook iteration semantics — useful for verifying the FIFO assumption and `output` reference-sharing contract from PR #352).


### PR DESCRIPTION
Bumps the locally-inspected OpenCode upstream source from `v1.14.41` (2026-05-12) to `v1.15.1` (2026-05-16) under `.slim/clonedeps/repos/anomalyco__opencode/`.

This is a tooling artifact — read-only source kept around so I can inspect plugin-loader internals, the SDK runtime client, and other upstream surfaces directly. The pinned clone does not ship as part of the npm package and does not affect runtime behavior.

## Why bump now

I needed to verify the plugin-loader topology (specifically `PluginInput.client` lifetime and how multi-source plugin loads share state) against the freshest upstream. The empirical finding — `client` is built once per OpenCode process at `packages/opencode/src/plugin/index.ts:128-150` and shared by reference across every plugin factory — sharpened the design of an upcoming memoization plan.

## What changed

- `.slim/clonedeps/repos/anomalyco__opencode/` checked out to `v1.15.1` (SHA `be12b43`) via shallow fetch; previously `v1.14.41` (SHA `8ba2a91`). 10 upstream releases bridged (v1.14.42–v1.14.51, v1.15.0, v1.15.1).
- `.slim/clonedeps.json` updated:
  - Both entries (`@opencode-ai/sdk`, `@opencode-ai/plugin`) bumped to `resolvedVersion: "1.15.1"` and `ref: "v1.15.1"`
  - Manifest reasons refined; the prior reasons referenced a completed plan and no longer reflected current use
- `AGENTS.md` updated to reference `v1.15.1` in the Cloned Dependency Source section

## Verification

- Tag `v1.15.1` verified upstream via `git ls-remote` before fetch
- Origin URL matches the approved value (`https://github.com/anomalyco/opencode.git`)
- Shallow status preserved (`--depth=1 --no-tags`); clone footprint grew from 137M to 152M
- Both `packages/sdk/js` and `packages/plugin` still present at the new tag
- `bun scripts/content-integrity.ts` passes — no banned-pattern regressions from the upstream content
- `.gitignore` and `.ignore` marker blocks unchanged — git still ignores `repos/`, OpenCode can still read it

## Release impact

None. The `chore(deps):` prefix triggers no semantic-release bump per the project's release rules; `.slim/clonedeps/repos/` is gitignored and the only tracked changes are the two metadata files above.
