### PR TITLE
feat(config): tighten unrecognized-key and invalid-value error UX

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -138,37 +138,110 @@ const TYPED_KEY_FIELDS = new Set([
 ])
 
 /**
+ * Format the human-readable hint for unrecognized-key issues. Requires a
+ * non-empty `badKeys` array — Zod 4's $ZodIssueUnrecognizedKeys carries at
+ * least one key by construction, so the empty case is unreachable in practice.
+ */
+function formatUnrecognizedKeysHint(
+  badKeys: readonly string[],
+  topField: string,
+): string {
+  if (badKeys.length === 0) {
+    // Defensive: Zod 4's $ZodIssueUnrecognizedKeys always carries non-empty
+    // keys; this branch is unreachable under the current Zod 4 contract.
+    throw new Error('formatUnrecognizedKeysHint requires non-empty keys')
+  }
+  if (badKeys.length === 1) {
+    return `Unrecognized key '${badKeys[0]}' in \`${topField}\`. This must be a bundled name. See ${TYPED_VALIDATION_DOCS_URL} for the full list of valid names.`
+  }
+  const joined = badKeys.map((k) => `'${k}'`).join(', ')
+  return `Unrecognized keys ${joined} in \`${topField}\`. These must be bundled names. See ${TYPED_VALIDATION_DOCS_URL} for the full list of valid names.`
+}
+
+/**
  * Post-process Zod issues to enrich unrecognized-key errors on typed fields
  * (agents, disabled_agents, disabled_skills) with a pointer to the docs URL
  * where the full list of valid bundled names is published.
+ *
+ * Also suppresses the verbose enum list that Zod emits for invalid_value
+ * issues on disabled_agents and disabled_skills, replacing it with a short
+ * hint that surfaces the bad value and points at the docs URL.
  *
  * Returns the issues array unchanged when no enrichment is needed.
  */
 function enrichUnrecognizedKeyIssues(
   issues: readonly z.core.$ZodIssue[],
+  rawInput: unknown,
 ): readonly z.core.$ZodIssue[] {
   return issues.map((issue) => {
-    if (issue.code !== 'unrecognized_keys') return issue
-    // issue.path[0] is the top-level field name (e.g., 'agents')
     const topField = issue.path[0]
     if (typeof topField !== 'string' || !TYPED_KEY_FIELDS.has(topField)) {
       return issue
     }
-    // Extract the bad key from the default Zod message ("Unrecognized key: \"foo\"")
-    const badKey = issue.message.match(/"([^"]+)"/)?.[1] ?? ''
-    const hint = badKey
-      ? `Unrecognized key '${badKey}' in \`${topField}\`. This must be a bundled name. See ${TYPED_VALIDATION_DOCS_URL} for the full list of valid names.`
-      : `${issue.message} See ${TYPED_VALIDATION_DOCS_URL} for the full list of valid names.`
-    return { ...issue, message: hint }
+
+    // Handle unrecognized_keys (typo'd agents overlay keys).
+    // Use issue.keys (Zod 4 structured field) — avoids regex and handles any key value.
+    if (issue.code === 'unrecognized_keys') {
+      const hint = formatUnrecognizedKeysHint(issue.keys, topField)
+      return { ...issue, message: hint }
+    }
+
+    // Handle invalid_value (typo'd disabled_agents / disabled_skills entries) —
+    // suppress the verbose enum list Zod emits by default.
+    // Zod 4's $ZodIssueInvalidValue does not carry the bad value in the issue
+    // object itself, so we resolve it from the raw input via the issue path.
+    if (
+      issue.code === 'invalid_value' &&
+      (topField === 'disabled_agents' || topField === 'disabled_skills')
+    ) {
+      const badValue = resolveValueAtPath(rawInput, issue.path)
+      const kind = topField === 'disabled_agents' ? 'agent' : 'skill'
+      const hint =
+        typeof badValue === 'string'
+          ? `Unrecognized ${kind} name '${badValue}' in \`${topField}\`. This must be a bundled name. See ${TYPED_VALIDATION_DOCS_URL} for the full list of valid names.`
+          : `Invalid value in \`${topField}\`. See ${TYPED_VALIDATION_DOCS_URL} for the full list of valid names.`
+      return { ...issue, message: hint }
+    }
+
+    return issue
   })
+}
+
+/**
+ * Walk a path of string/number keys into a nested object/array structure and
+ * return the value at that location, or undefined if any step is missing.
+ */
+function resolveValueAtPath(
+  root: unknown,
+  path: readonly (string | number | symbol)[],
+): unknown {
+  let current: unknown = root
+  for (const segment of path) {
+    if (typeof segment === 'symbol') {
+      // Defensive: Zod 4's path type includes symbol, but issues never carry
+      // symbol segments at runtime. If a future Zod release changes that, this
+      // returns undefined so the fallback "Invalid value" hint is used instead
+      // of crashing.
+      return undefined
+    }
+    if (typeof segment === 'number') {
+      if (!Array.isArray(current)) return undefined
+      current = current[segment]
+    } else {
+      if (!isRecord(current)) return undefined
+      current = current[segment]
+    }
+  }
+  return current
 }
 
 function throwTopLevelConfigSchemaError(
   filePath: string,
   trust: ConfigSource['trust'],
   rawIssues: readonly z.core.$ZodIssue[],
+  rawInput: unknown,
 ): never {
-  const issues = enrichUnrecognizedKeyIssues(rawIssues)
+  const issues = enrichUnrecognizedKeyIssues(rawIssues, rawInput)
   const issue = issues[0]
   if (!issue) {
     throw Object.assign(
@@ -200,7 +273,12 @@ function loadConfigSource(
 
   const result = SystematicConfigSchema.safeParse(rawConfig)
   if (!result.success) {
-    throwTopLevelConfigSchemaError(filePath, trust, result.error.issues)
+    throwTopLevelConfigSchemaError(
+      filePath,
+      trust,
+      result.error.issues,
+      rawConfig,
+    )
   }
 
   // Validation succeeded; propagate raw parsed JSONC so the merge layer

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -938,6 +938,140 @@ describe('config', () => {
       // The error should still name the file and the invalid field path.
       expect(errorMessage).toContain('disabled_agents')
     })
+
+    describe('enrichUnrecognizedKeyIssues — verbose enum suppression and multi-key handling', () => {
+      const DOCS_URL =
+        'https://systematic.fro.bot/getting-started/configuration#typed-validation'
+
+      // #385 — suppress verbose enum list in disabled_agents / disabled_skills errors
+
+      test('typo in disabled_agents produces a short message with the bad value and docs URL, not the full enum list', () => {
+        writeProjectConfig({ disabled_agents: ['security-reviwer'] })
+        let errorMessage = ''
+        try {
+          loadConfig(testDir)
+        } catch (err) {
+          errorMessage = (err as Error).message
+        }
+        expect(errorMessage).toContain('security-reviwer')
+        expect(errorMessage).toContain('disabled_agents')
+        expect(errorMessage).toContain(DOCS_URL)
+        expect(errorMessage.length).toBeLessThan(500)
+        // Must NOT dump the full valid-name list inline
+        expect(errorMessage).not.toContain('adversarial-reviewer')
+        expect(errorMessage).not.toContain('architecture-strategist')
+      })
+
+      test('typo in disabled_skills produces a short message with the bad value and docs URL', () => {
+        writeProjectConfig({ disabled_skills: ['typed-config-validatoin'] })
+        let errorMessage = ''
+        try {
+          loadConfig(testDir)
+        } catch (err) {
+          errorMessage = (err as Error).message
+        }
+        expect(errorMessage).toContain('typed-config-validatoin')
+        expect(errorMessage).toContain('disabled_skills')
+        expect(errorMessage).toContain(DOCS_URL)
+        expect(errorMessage.length).toBeLessThan(500)
+        // Must NOT dump the full valid-name list inline
+        expect(errorMessage).not.toContain('ce:plan')
+        expect(errorMessage).not.toContain('ce:brainstorm')
+      })
+
+      test('valid disabled_agents entry passes through enrichment unchanged', () => {
+        writeProjectConfig({ disabled_agents: ['correctness-reviewer'] })
+        expect(() => loadConfig(testDir)).not.toThrow()
+        const result = loadConfig(testDir)
+        expect(result.disabled_agents).toContain('correctness-reviewer')
+      })
+
+      // #386 — surface every unknown key in unrecognized_keys hints
+
+      test("multiple typo'd agent keys produce a hint listing all of them", () => {
+        writeProjectConfig({ agents: { 'typo-a': {}, 'typo-b': {} } })
+        let errorMessage = ''
+        try {
+          loadConfig(testDir)
+        } catch (err) {
+          errorMessage = (err as Error).message
+        }
+        expect(errorMessage).toContain('typo-a')
+        expect(errorMessage).toContain('typo-b')
+        expect(errorMessage).toContain('Unrecognized keys')
+      })
+
+      test("single typo'd agent key still produces singular form", () => {
+        writeProjectConfig({ agents: { 'typo-a': {} } })
+        let errorMessage = ''
+        try {
+          loadConfig(testDir)
+        } catch (err) {
+          errorMessage = (err as Error).message
+        }
+        expect(errorMessage).toContain('typo-a')
+        expect(errorMessage).toMatch(/Unrecognized key '/)
+        expect(errorMessage).not.toMatch(/Unrecognized keys '/)
+      })
+
+      test("three typo'd agent keys produce a comma-separated list", () => {
+        writeProjectConfig({
+          agents: { 'typo-a': {}, 'typo-b': {}, 'typo-c': {} },
+        })
+        let errorMessage = ''
+        try {
+          loadConfig(testDir)
+        } catch (err) {
+          errorMessage = (err as Error).message
+        }
+        expect(errorMessage).toContain('typo-a')
+        expect(errorMessage).toContain('typo-b')
+        expect(errorMessage).toContain('typo-c')
+        expect(errorMessage).toContain('Unrecognized keys')
+      })
+
+      // Finding 2 — mixed issues regression
+      test('mixed agents typo and disabled_agents typo each produce their own enriched hint', () => {
+        // Both unrecognized_keys (agents) and invalid_value (disabled_agents) in one config
+        writeProjectConfig({
+          agents: { 'typo-a': {}, 'typo-b': {} },
+          disabled_agents: ['security-reviwer'],
+        })
+        let errorMessage = ''
+        try {
+          loadConfig(testDir)
+        } catch (err) {
+          errorMessage = (err as Error).message
+        }
+        // The first issue thrown should be enriched — either the agents typo or the
+        // disabled_agents typo. Both enrichments must be present in the issues array.
+        // We verify the thrown message is short (not a raw enum dump) and contains
+        // the docs URL, confirming at least one enrichment fired.
+        expect(errorMessage).toContain(DOCS_URL)
+        expect(errorMessage.length).toBeLessThan(500)
+        // Must not dump the full enum list
+        expect(errorMessage).not.toContain('adversarial-reviewer')
+      })
+
+      // Finding 3 — non-string disabled_agents entry edge case
+      test('non-string disabled_agents entry produces a short generic hint', () => {
+        // null is not a valid string entry — exercises the fallback branch where
+        // resolveValueAtPath returns a non-string value
+        writeProjectConfig({ disabled_agents: [null] })
+        let errorMessage = ''
+        try {
+          loadConfig(testDir)
+        } catch (err) {
+          errorMessage = (err as Error).message
+        }
+        expect(errorMessage).toContain('disabled_agents')
+        expect(errorMessage).toContain(DOCS_URL)
+        expect(errorMessage.length).toBeLessThan(500)
+        // Must not dump the full valid-name list inline
+        expect(errorMessage).not.toContain('oracle')
+        expect(errorMessage).not.toContain('correctness-reviewer')
+      })
+    })
   })
 
   describe('merge precedence after schema validation', () => {


### PR DESCRIPTION
Closes #385.
Closes #386.

## Two related error-message improvements

Both targets land in `enrichUnrecognizedKeyIssues` (introduced in #384) and improve the UX when a config has typos in `agents`, `disabled_agents`, or `disabled_skills`.

### #385 — Suppress verbose enum list on `disabled_*` typos

Before: a typo in `disabled_agents` (e.g., `["security-reviwer"]`) produced a Zod `invalid_value` error whose default message enumerates all 102 valid agent names inline (~3KB wall of text). Same for `disabled_skills` and its 45-name enum.

After: the post-processor adds an `invalid_value` branch that surfaces the bad value and points at the published documentation URL where the full valid-name list is maintained.

```
Unrecognized agent name 'security-reviwer' in `disabled_agents`. This must be a bundled name. See https://systematic.fro.bot/getting-started/configuration#typed-validation for the full list of valid names.
```

### #386 — Surface every unknown key in multi-key hints

Before: when two unknown agent keys appeared simultaneously (`{ agents: { 'typo-a': {}, 'typo-b': {} } }`), Zod consolidated them into one issue with message `Unrecognized keys: "typo-a", "typo-b"`. The previous regex extracted only the first key, so the hint said `Unrecognized key 'typo-a'…` and silently omitted `typo-b` (though the raw message was still appended).

After: switched the extraction from a regex on `issue.message` to Zod 4's structured `$ZodIssueUnrecognizedKeys.keys: string[]`. The hint now uses singular `Unrecognized key '…'` for one key, plural `Unrecognized keys '…', '…'` for two or more.

## Implementation notes

- **Zod 4 `invalid_value` issue shape**: empirically, this issue type does NOT carry an `input` or `received` field — only `code`, `values` (the allowed enum), `path`, and `message`. The bad value is recovered by walking the original input via `issue.path` using a new `resolveValueAtPath(root, path)` helper.
- **Type narrowing**: `resolveValueAtPath` uses an `isRecord` type guard plus `Array.isArray` discrimination for numeric path segments — no `as` casts on `unknown` data.
- **Threading `unknown`**: `rawInput` flows through `loadConfigSource → throwTopLevelConfigSchemaError → enrichUnrecognizedKeyIssues → resolveValueAtPath` as `unknown` from start to finish; no narrower-than-needed types, no avoidable casts.

## Tests

8 new regression tests in `tests/unit/config.test.ts` covering:
- typo in `disabled_agents` produces short message with bad value + docs URL
- typo in `disabled_skills` produces short message with bad value + docs URL
- valid `disabled_agents` / `disabled_skills` entries pass through unchanged
- single typo in `agents` keeps singular `Unrecognized key '…'` phrasing
- multiple typos in `agents` use plural `Unrecognized keys '…', '…'` phrasing
- three or more typos produce comma-separated list
- mixed `unrecognized_keys` (from `agents`) and `invalid_value` (from `disabled_agents`) each get their own enriched hint
- non-string entry (`disabled_agents: [null]`) exercises the generic-fallback branch

## Verification

- Unit tests: 873/0 (was 865 baseline, +8 net)
- typecheck: clean
- lint: 0 errors (4 pre-existing warnings)
- content-integrity, schema:drift, registry:drift: all clean
- docs:build: 110 pages
- Node ESM smoke: `exports: ['default']`
- plan-taxonomy audit: clean