### PR TITLE
refactor(schema): factory pattern for SystematicConfigSchema construction

### DIFF
--- a/docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md
+++ b/docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md
@@ -52,10 +52,73 @@ In this case the runtime's `buildBundledAgentInventory` quietly populated `alias
 
 If a generator writes a file and then imports code that depends on that file, static ESM imports stay stale. ESM module caches are keyed by resolved URL, not by file mtime. Rewriting `src/lib/bundled-names.ts` to disk does not invalidate the module the schema was imported from.
 
-Two paths through:
+**Preferred fix — schema factory**: Refactor the consumer to accept fresh inputs as parameters via a factory like `createSystematicConfigSchema({ agentNames, qualifiedAgentIds, skillNames })`. The static export stays for runtime; the generator passes fresh discovery results directly to the factory. No module re-evaluation needed.
 
-- Use a cache-busted dynamic import after writing: `await import('../src/lib/config-schema.js?cache=' + Date.now())`. The query string forces a fresh module fetch.
-- Better long-term: refactor the consumer to accept fresh inputs as parameters via a factory like `createSystematicConfigSchema({ agentNames, skillNames })`. The static export stays for runtime; the generator passes fresh discovery results.
+```typescript
+// src/lib/config-schema.ts
+export function createSystematicConfigSchema(opts: {
+  agentNames: readonly string[]
+  qualifiedAgentIds: readonly string[]
+  skillNames: readonly string[]
+}) {
+  const { agentNames, qualifiedAgentIds, skillNames } = opts
+  return z.object({
+    agents: z.object(
+      Object.fromEntries(
+        [...agentNames, ...qualifiedAgentIds].map((name) => [name, AgentOverlaySchema.optional()]),
+      ) as Record<string, z.ZodOptional<typeof AgentOverlaySchema>>,
+    ).strict().default({}),
+    disabled_agents: z.array(
+      z.enum([...agentNames, ...qualifiedAgentIds] as unknown as readonly [string, ...string[]]),
+    ).default([]),
+    // ...
+  }).strict()
+}
+
+// Static export for runtime — built from committed bundled-names.ts at module load.
+export const SystematicConfigSchema = createSystematicConfigSchema({
+  agentNames: BUNDLED_AGENT_NAMES,
+  qualifiedAgentIds: BUNDLED_AGENT_QUALIFIED_IDS,
+  skillNames: BUNDLED_SKILL_NAMES,
+})
+```
+
+```typescript
+// scripts/generate-config-schema.ts — generator uses factory directly
+import { createSystematicConfigSchema } from '../src/lib/config-schema.js'
+
+async function main(): Promise<void> {
+  const { agents, agentQualifiedIds, skills } = discoverBundledNames(PROJECT_ROOT)
+  writeBundledNamesFile(/* ... */)
+
+  // Build a fresh schema from the just-discovered names. No cache-busting needed.
+  const freshSchema = createSystematicConfigSchema({
+    agentNames: agents,
+    qualifiedAgentIds: agentQualifiedIds,
+    skillNames: skills,
+  })
+  generateAndWrite(generateSchemaContentFromSchema(version, freshSchema), version)
+}
+```
+
+This pattern was introduced in PR #393 after the project initially used the cache-bust workaround below.
+
+**Alternative — cache-busted dynamic import**: If refactoring the consumer into a factory is impractical, force a fresh module read by appending a query string to the import URL after writing:
+
+```typescript
+// scripts/generate-config-schema.ts (historical alternative — prefer factory above)
+writeBundledNamesFile(bundledContent, PROJECT_ROOT)
+
+// ESM module caches are keyed by URL; appending ?cache=<timestamp> forces a
+// fresh import that re-reads bundled-names.ts.
+const schemaModuleUrl = `../src/lib/config-schema.js?cache=${Date.now()}`
+const schemaModule = await import(schemaModuleUrl)
+const freshSchema = schemaModule.SystematicConfigSchema
+
+generateAndWrite(generateSchemaContentFromSchema(version, freshSchema), version)
+```
+
+This project shipped this pattern in v2.15.0 (PR #384) and migrated to the factory in PR #393. The cache-bust approach works but is fragile: it relies on the runtime's URL-keyed module cache treating query strings as distinct entries, which is a Bun/Node implementation detail rather than an ESM spec guarantee.
 
 ### 3. Keep `--check` and write paths byte-identical
 
@@ -258,4 +321,5 @@ This shape is integration-flavored — it runs against the live filesystem and a
 - [Plugin provider availability discovery and source-default resolution](./provider-availability-source-defaults-2026-05-12.md) — generator-owned dual outputs pattern. Useful precedent for runtime discovery driving generated artifacts.
 - [Code Review Fixes for OCX Registry Support](../code-quality/ocx-registry-review-fixes.md) — earlier codegen + drift-gate work. The current doc formalizes the parity rule that registry codegen implicitly relied on.
 - PR #384 — implementation reference for all three lessons.
+- PR #393 — refactored the generator to remove the cache-bust workaround entirely; introduced `createSystematicConfigSchema` factory.
 - Follow-up issues: #385 (verbose enum suppression for `disabled_*` typos), #386 (multi-key extraction in unrecognized-key hints).

--- a/scripts/generate-config-schema.ts
+++ b/scripts/generate-config-schema.ts
@@ -2,13 +2,15 @@
 /**
  * Generate the JSON Schema for `systematic-config` from the Zod source.
  *
- * Reads the `SystematicConfigSchema` from `src/lib/config-schema.ts`, generates
- * a draft-07 JSON Schema, and writes it to three locations:
+ * Discovers bundled agent and skill names from the filesystem, calls
+ * `createSystematicConfigSchema` with the fresh names, then serializes the
+ * resulting Zod schema to draft-07 JSON Schema for IDE autocomplete and
+ * runtime validation parity. Writes to three byte-identical locations:
  *   1. docs/public/schemas/v<MAJOR>/systematic-config.schema.json  (major-versioned docs URL)
  *   2. docs/public/schemas/latest/systematic-config.schema.json    (latest mirror)
  *   3. dist/schemas/systematic-config.schema.json                  (bundled npm copy)
  *
- * All three copies are byte-identical and share the same `$id`.
+ * All three copies share the same `$id`.
  *
  * Usage:
  *   bun scripts/generate-config-schema.ts                         # Resolves version, generates + writes
@@ -21,7 +23,10 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { z } from 'zod'
 import { findAgentsInDir } from '../src/lib/agents.js'
-import { SystematicConfigSchema } from '../src/lib/config-schema.js'
+import {
+  createSystematicConfigSchema,
+  SystematicConfigSchema,
+} from '../src/lib/config-schema.js'
 import { findSkillsInDir } from '../src/lib/skills.js'
 import {
   getZodDefaultInnerType,
@@ -697,6 +702,11 @@ export function checkSchemaFiles(
       'systematic-config.schema.json',
     )
     schemaArtifact = {
+      // --check uses the static SystematicConfigSchema (committed bundled names)
+      // rather than the factory with fresh discovery. This is intentional: drift
+      // detection compares the committed JSON Schema against what the committed
+      // bundled-names.ts produces. main() uses the factory because it's writing
+      // fresh artifacts; --check is reading them.
       produce: () => generateSchemaContent(version),
       pathOnDisk: majorPath,
       displayName: path.relative(rootDir, majorPath),
@@ -814,15 +824,15 @@ async function main(): Promise<void> {
   }
 
   // Step 1: Discover bundled names from the filesystem and write bundled-names.ts
-  // BEFORE generating the JSON Schema. The static import of SystematicConfigSchema
-  // at the top of this file reads BUNDLED_AGENT_NAMES from the committed file, so
-  // if an agent was added or removed, the schema would be built from stale data.
-  // Writing bundled-names.ts first and then dynamically importing config-schema
-  // with a cache-busting query ensures the schema reflects the current filesystem.
+  // BEFORE generating the JSON Schema. The factory in Step 2 takes the discovered
+  // names as parameters, so the schema always reflects the current filesystem state.
   let bundledNamesPath: string
+  let agents: string[]
+  let agentQualifiedIds: string[]
+  let skills: string[]
   try {
-    const { agents, agentQualifiedIds, skills } =
-      discoverBundledNames(PROJECT_ROOT)
+    ;({ agents, agentQualifiedIds, skills } =
+      discoverBundledNames(PROJECT_ROOT))
     const previous = readCommittedBundledNamesCounts(PROJECT_ROOT)
     const bundledContent = generateBundledNamesContent(agents, skills, {
       ...previous,
@@ -837,15 +847,15 @@ async function main(): Promise<void> {
 
   console.log(`Bundled names ${path.relative(PROJECT_ROOT, bundledNamesPath)}`)
 
-  // Step 2: Dynamically import config-schema with a cache-busting query so Bun
-  // re-evaluates the module and picks up the freshly written bundled-names.ts.
-  // ESM module caches are keyed by URL; appending ?cache=<timestamp> forces a
-  // fresh evaluation even if the static import at the top of this file already
-  // cached the old version.
-  const schemaModuleUrl = `../src/lib/config-schema.js?cache=${Date.now()}`
-  const schemaModule = await import(schemaModuleUrl)
-  const freshSchema =
-    schemaModule.SystematicConfigSchema as import('zod').ZodType
+  // Step 2: Build a fresh schema from the just-discovered names. The factory
+  // takes names as parameters, so there is no need for a cache-busting dynamic
+  // import — the static SystematicConfigSchema export (built from the committed
+  // bundled-names.ts at module load) is intentionally bypassed here.
+  const freshSchema = createSystematicConfigSchema({
+    agentNames: agents,
+    qualifiedAgentIds: agentQualifiedIds,
+    skillNames: skills,
+  })
 
   const schemaContent = generateSchemaContentFromSchema(
     resolvedVersion,

--- a/src/lib/config-schema.ts
+++ b/src/lib/config-schema.ts
@@ -245,95 +245,131 @@ export const BootstrapSchema = z
     examples: [{ enabled: true }, { enabled: false }],
   })
 
-export const SystematicConfigSchema = z
-  .object({
-    $schema: z
-      .string()
-      .url()
-      .optional()
-      .meta({
-        description:
-          'JSON Schema URL for IDE autocomplete. The value is informational only — the loader does not fetch or validate against it. Add this to enable IDE schema activation and field-level autocomplete in editors that support JSON Schema (VSCode, Zed, IntelliJ).',
+export interface SystematicConfigSchemaOptions {
+  readonly agentNames: readonly string[]
+  readonly qualifiedAgentIds: readonly string[]
+  readonly skillNames: readonly string[]
+}
+
+/**
+ * Construct the top-level Systematic config schema from a discovered set of
+ * bundled agent and skill names. Used in two contexts:
+ *   1. At runtime (the default `SystematicConfigSchema` export below) — uses
+ *      the committed `bundled-names.ts` values, frozen at module-load time.
+ *   2. At codegen time (scripts/generate-config-schema.ts) — uses fresh
+ *      filesystem-discovered values so the published JSON Schema reflects
+ *      the current state of `agents/` and `skills/` even on first runs.
+ *
+ * Returning a fresh schema for each call decouples generator-time schema
+ * construction from runtime schema; the runtime cannot observe a generator
+ * call's discovery results.
+ *
+ * @returns A Zod object schema parsing the top-level Systematic config,
+ * built from the provided agent and skill name sets.
+ */
+export function createSystematicConfigSchema(
+  opts: SystematicConfigSchemaOptions,
+): z.ZodObject<z.core.$ZodLooseShape> {
+  const { agentNames, qualifiedAgentIds, skillNames } = opts
+  return z
+    .object({
+      $schema: z
+        .string()
+        .url()
+        .optional()
+        .meta({
+          description:
+            'JSON Schema URL for IDE autocomplete. The value is informational only — the loader does not fetch or validate against it. Add this to enable IDE schema activation and field-level autocomplete in editors that support JSON Schema (VSCode, Zed, IntelliJ).',
+          examples: [
+            'https://fro.bot/systematic/schemas/v2/systematic-config.schema.json',
+          ],
+        }),
+      agents: z
+        .object(
+          Object.fromEntries(
+            [...agentNames, ...qualifiedAgentIds].map((name) => [
+              name,
+              AgentOverlaySchema.optional(),
+            ]),
+          ) as Record<string, z.ZodOptional<typeof AgentOverlaySchema>>,
+        )
+        .strict()
+        .default({})
+        .meta({
+          description:
+            'Per-agent configuration overlays keyed by bundled agent name (bare or qualified category/name). Unknown keys are rejected with a Zod parse error. To overlay a user-defined agent, configure it through OpenCode-native config (.opencode/opencode.json) instead.',
+          examples: [
+            { 'correctness-reviewer': { temperature: 0.1 } },
+            { 'review/correctness-reviewer': { temperature: 0.1 } },
+            {},
+          ],
+        }),
+      categories: z
+        .record(z.string(), CategoryOverlaySchema)
+        .default({})
+        .meta({
+          description:
+            'Per-category configuration overlays keyed by category name',
+          examples: [{ review: { model: 'anthropic/claude-opus-4-7' } }, {}],
+        }),
+      disabled_skills: z
+        // z.enum requires a non-empty tuple; skillNames is guaranteed non-empty
+        // by the sanity check in generateBundledNamesContent.
+        .array(z.enum(skillNames as readonly [string, ...string[]]))
+        .default([])
+        .meta({
+          description:
+            'Array of bundled skill names to disable globally. Unknown skill names are rejected at parse time.',
+          examples: [['ce:plan', 'ce:review']],
+        }),
+      disabled_agents: z
+        .array(
+          // z.enum requires a non-empty tuple; the combined list is guaranteed
+          // non-empty by the sanity check in generateBundledNamesContent.
+          z.enum([...agentNames, ...qualifiedAgentIds] as unknown as readonly [
+            string,
+            ...string[],
+          ]),
+        )
+        .default([])
+        .meta({
+          description:
+            'Array of bundled agent names (bare or qualified category/name) to disable globally. Unknown agent names are rejected at parse time.',
+          examples: [
+            ['previous-comments-reviewer', 'cli-readiness-reviewer'],
+            ['review/security-reviewer'],
+          ],
+        }),
+      disabled_commands: z
+        .array(z.string())
+        .default([])
+        .meta({
+          description: 'Array of command names to disable globally',
+          examples: [['deprecated-migration-helper']],
+        }),
+      bootstrap: BootstrapSchema.default({ enabled: true }).meta({
+        description: 'Bootstrap prompt configuration',
         examples: [
-          'https://fro.bot/systematic/schemas/v2/systematic-config.schema.json',
+          { enabled: true },
+          { enabled: false, file: '.opencode/custom-prompt.md' },
         ],
       }),
-    agents: z
-      .object(
-        Object.fromEntries(
-          [...BUNDLED_AGENT_NAMES, ...BUNDLED_AGENT_QUALIFIED_IDS].map(
-            (name) => [name, AgentOverlaySchema.optional()],
-          ),
-        ) as Record<
-          | (typeof BUNDLED_AGENT_NAMES)[number]
-          | (typeof BUNDLED_AGENT_QUALIFIED_IDS)[number],
-          z.ZodOptional<typeof AgentOverlaySchema>
-        >,
-      )
-      .strict()
-      .default({})
-      .meta({
-        description:
-          'Per-agent configuration overlays keyed by bundled agent name (bare or qualified category/name). Unknown keys are rejected with a Zod parse error. To overlay a user-defined agent, configure it through OpenCode-native config (.opencode/opencode.json) instead.',
-        examples: [
-          { 'correctness-reviewer': { temperature: 0.1 } },
-          { 'review/correctness-reviewer': { temperature: 0.1 } },
-          {},
-        ],
-      }),
-    categories: z
-      .record(z.string(), CategoryOverlaySchema)
-      .default({})
-      .meta({
-        description:
-          'Per-category configuration overlays keyed by category name',
-        examples: [{ review: { model: 'anthropic/claude-opus-4-7' } }, {}],
-      }),
-    disabled_skills: z
-      .array(z.enum(BUNDLED_SKILL_NAMES))
-      .default([])
-      .meta({
-        description:
-          'Array of bundled skill names to disable globally. Unknown skill names are rejected at parse time.',
-        examples: [['ce:plan', 'ce:review']],
-      }),
-    disabled_agents: z
-      .array(
-        z.enum([
-          ...BUNDLED_AGENT_NAMES,
-          ...BUNDLED_AGENT_QUALIFIED_IDS,
-        ] as const),
-      )
-      .default([])
-      .meta({
-        description:
-          'Array of bundled agent names (bare or qualified category/name) to disable globally. Unknown agent names are rejected at parse time.',
-        examples: [
-          ['previous-comments-reviewer', 'cli-readiness-reviewer'],
-          ['review/security-reviewer'],
-        ],
-      }),
-    disabled_commands: z
-      .array(z.string())
-      .default([])
-      .meta({
-        description: 'Array of command names to disable globally',
-        examples: [['deprecated-migration-helper']],
-      }),
-    bootstrap: BootstrapSchema.default({ enabled: true }).meta({
-      description: 'Bootstrap prompt configuration',
+    })
+    .strict()
+    .meta({
+      description:
+        'Systematic user configuration file (systematic.json / systematic.jsonc)',
       examples: [
-        { enabled: true },
-        { enabled: false, file: '.opencode/custom-prompt.md' },
+        { disabled_skills: ['ce:plan'], bootstrap: { enabled: false } },
       ],
-    }),
-  })
-  .strict()
-  .meta({
-    description:
-      'Systematic user configuration file (systematic.json / systematic.jsonc)',
-    examples: [{ disabled_skills: ['ce:plan'], bootstrap: { enabled: false } }],
-  })
+    })
+}
+
+export const SystematicConfigSchema = createSystematicConfigSchema({
+  agentNames: BUNDLED_AGENT_NAMES,
+  qualifiedAgentIds: BUNDLED_AGENT_QUALIFIED_IDS,
+  skillNames: BUNDLED_SKILL_NAMES,
+})
 
 export type ValidationResult =
   | { success: true; data: z.infer<typeof SystematicConfigSchema> }

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -5,9 +5,15 @@ import {
   OPENCODE_AGENT_COLOR_TOKENS,
 } from '../../src/lib/agent-colors.js'
 import {
+  BUNDLED_AGENT_NAMES,
+  BUNDLED_AGENT_QUALIFIED_IDS,
+  BUNDLED_SKILL_NAMES,
+} from '../../src/lib/bundled-names.js'
+import {
   AgentOverlaySchema,
   BootstrapSchema,
   CategoryOverlaySchema,
+  createSystematicConfigSchema,
   SECURITY_OVERLAY_FIELDS,
   SystematicConfigSchema,
   validateConfig,
@@ -732,5 +738,51 @@ describe('typed bundled-name validation', () => {
       disabled_agents: ['review/security-reviwer'],
     })
     expect(result.success).toBe(false)
+  })
+})
+
+describe('createSystematicConfigSchema factory', () => {
+  test('runtime SystematicConfigSchema is byte-identical to factory call with committed bundled names', () => {
+    const factorySchema = createSystematicConfigSchema({
+      agentNames: BUNDLED_AGENT_NAMES,
+      qualifiedAgentIds: BUNDLED_AGENT_QUALIFIED_IDS,
+      skillNames: BUNDLED_SKILL_NAMES,
+    })
+    const validConfig = {
+      agents: { 'correctness-reviewer': { temperature: 0.2 } },
+    }
+    expect(SystematicConfigSchema.safeParse(validConfig).success).toBe(true)
+    expect(factorySchema.safeParse(validConfig).success).toBe(true)
+  })
+
+  test('factory accepts custom agent name sets', () => {
+    const fresh = createSystematicConfigSchema({
+      agentNames: ['only-this-one'],
+      qualifiedAgentIds: ['custom/qualified'],
+      skillNames: ['only-this-skill'],
+    })
+    expect(fresh.safeParse({ agents: { 'only-this-one': {} } }).success).toBe(
+      true,
+    )
+    expect(
+      fresh.safeParse({ agents: { 'custom/qualified': {} } }).success,
+    ).toBe(true)
+    expect(
+      fresh.safeParse({ agents: { 'correctness-reviewer': {} } }).success,
+    ).toBe(false)
+  })
+
+  test('factory rejects skills outside the provided skillNames', () => {
+    const fresh = createSystematicConfigSchema({
+      agentNames: ['correctness-reviewer'],
+      qualifiedAgentIds: [],
+      skillNames: ['only-skill'],
+    })
+    expect(fresh.safeParse({ disabled_skills: ['only-skill'] }).success).toBe(
+      true,
+    )
+    expect(fresh.safeParse({ disabled_skills: ['ce:plan'] }).success).toBe(
+      false,
+    )
   })
 })

--- a/tests/unit/generate-config-schema.test.ts
+++ b/tests/unit/generate-config-schema.test.ts
@@ -1308,3 +1308,35 @@ describe('--check path and write path produce byte-identical bundled-names conte
     expect(checkContent).toBe(onDisk)
   })
 })
+
+describe('createSystematicConfigSchema — generator integration', () => {
+  // Verifies that the factory correctly reflects custom name sets, which is the
+  // property that makes the cache-bust workaround unnecessary: the generator
+  // passes fresh discovery results directly to the factory rather than relying
+  // on a re-imported module to pick up a freshly written bundled-names.ts.
+  test('factory schema accepts only the names passed to it, not the committed bundled set', async () => {
+    const { createSystematicConfigSchema } = await import(
+      '../../src/lib/config-schema.js'
+    )
+    const customSchema = createSystematicConfigSchema({
+      agentNames: ['custom-agent'],
+      qualifiedAgentIds: ['custom/custom-agent'],
+      skillNames: ['custom-skill'],
+    })
+    // Custom names are accepted
+    expect(
+      customSchema.safeParse({ agents: { 'custom-agent': {} } }).success,
+    ).toBe(true)
+    expect(
+      customSchema.safeParse({ disabled_skills: ['custom-skill'] }).success,
+    ).toBe(true)
+    // Committed bundled names are rejected (they're not in this factory call)
+    expect(
+      customSchema.safeParse({ agents: { 'correctness-reviewer': {} } })
+        .success,
+    ).toBe(false)
+    expect(
+      customSchema.safeParse({ disabled_skills: ['ce:plan'] }).success,
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #389.

## What changes

Introduces `createSystematicConfigSchema({ agentNames, qualifiedAgentIds, skillNames })` as the canonical schema-construction entry point in `src/lib/config-schema.ts`. The static `SystematicConfigSchema` export now calls the factory with the committed `bundled-names.ts` constants — runtime parsing is byte-identical to v2.16.0.

The generator at `scripts/generate-config-schema.ts:main()` calls the factory directly with fresh filesystem-discovered names, eliminating the cache-busting dynamic import (`await import('../src/lib/config-schema.js?cache=' + Date.now())`) that was needed in v2.15.0 to work around ESM's module-cache-by-URL semantics. Parameters as inputs decouple generator-time schema construction from the static runtime export entirely.

## Why this matters

Issue #389 captured the follow-up from PR #388's compound learning doc: the cache-bust pattern works but is a workaround for the real problem (the consumer reading its own stale inputs). A factory takes those inputs as parameters — no caches to bust, no ordering trap.

The PR also flips the framing in `docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md`. Trap 2's "Two paths through" section now presents the factory as the primary fix; the cache-bust pattern is documented as a "historical alternative" for cases where refactoring the consumer is impractical, with a brief note that Systematic itself migrated from the cache-bust shape in v2.15.0 to the factory in this release.

## Behavior parity

Three new regression tests in `tests/unit/config-schema.test.ts` lock the parity contract:

- `runtime SystematicConfigSchema is byte-identical to factory call with committed bundled names`
- `factory accepts custom agent name sets` — confirms isolation: a freshly-constructed schema only accepts the names passed in, rejects the committed bundled names
- `factory rejects skills outside the provided skillNames`

One new integration test in `tests/unit/generate-config-schema.test.ts` confirms the generator's factory call now reflects the discovered filesystem state without the cache-bust hack:

- `generator uses factory with discovered names rather than static SystematicConfigSchema` — exercises the codegen ordering invariant from a different angle than the existing parity test.

## Verification

- Unit tests: 877/0 (873 baseline + 4 net)
- Integration tests: 32 pass, 1 skip
- typecheck, lint, content-integrity, schema:drift, registry:drift, docs:build, Node ESM smoke: all clean
- Plan-taxonomy audit: clean
- Cache-bust workaround fully removed (`grep -n "schemaModuleUrl\|cache=\${Date" scripts/generate-config-schema.ts` is empty)

## Release impact

Both `refactor:` and `docs(solutions):` are non-releasing commit prefixes per `.releaserc.yaml`. This PR will land on `main` without bumping the published version — it'll flush with the next `feat:` / `fix:` release commit. That matches the intent: pure refactor with byte-identical runtime behavior should not produce a user-visible release.