### PR TITLE
docs(solutions): compound 3 learnings from PR #394 / v2.17.0

### DIFF
--- a/docs/solutions/best-practices/third-party-bundled-skills-light-adaptation-2026-05-17.md
+++ b/docs/solutions/best-practices/third-party-bundled-skills-light-adaptation-2026-05-17.md
@@ -157,7 +157,7 @@ head -3 skills/writing-skills/references/anthropic-best-practices-distilled.md |
 head -3 skills/writing-skills/references/anthropic-best-practices-distilled.md | grep -c 'docs.claude.com'
 # 1 ✓
 
-# Heading 1:1 match check
+# Heading 1:1 match check (substitute your upstream clone path)
 comm -12 \
   <(grep '^## ' skills/writing-skills/references/anthropic-best-practices-distilled.md | sort -u) \
   <(grep '^## ' .slim/clonedeps/repos/obra__superpowers/skills/writing-skills/anthropic-best-practices.md | sort -u) | wc -l

--- a/docs/solutions/best-practices/third-party-bundled-skills-light-adaptation-2026-05-17.md
+++ b/docs/solutions/best-practices/third-party-bundled-skills-light-adaptation-2026-05-17.md
@@ -1,0 +1,214 @@
+---
+title: Import third-party bundled skills with light adaptation and CC-BY-4.0 originality discipline
+date: 2026-05-17
+category: best-practices
+module: bundled-skills + ATTRIBUTIONS.md
+problem_type: best_practice
+component: documentation
+severity: medium
+applies_when:
+  - Bundling third-party MIT-licensed skills or content into a published package
+  - Producing a derivative reference document from CC-BY-4.0 source material
+  - Dispatching a librarian-style subagent to draft licensed-content distillations
+  - Designing an attribution surface for multi-source licensed bundling
+  - Verifying license compliance before release
+tags:
+  - third-party-imports
+  - cc-by-4-0
+  - mit
+  - derivative-work
+  - attribution
+  - licensing
+  - librarian-dispatch
+---
+
+# Import third-party bundled skills with light adaptation and CC-BY-4.0 originality discipline
+
+## Context
+
+Bundling third-party content into a published package — bundled skills, reference documentation, executable utilities — is a recurring pattern, and it has three failure modes that compound if not handled deliberately:
+
+1. **Adaptation drift.** Upstream content uses different namespacing conventions, force-load syntax, harness-specific paths, and naming conventions than the host project. Rewriting too much (destructive transformation) loses upstream rigor and breaks future refresh diffs. Rewriting too little leaves alien artifacts that confuse users.
+2. **Licensing compliance.** MIT-derived content requires reproducing the upstream license text alongside the derivative. CC-BY-4.0-derived content additionally requires explicit attribution, "modified" labeling for transformations, and a derivative-work standard that distinguishes a transformative redistribution from a thinly disguised copy.
+3. **Distillation discipline.** Producing a derivative reference from CC-BY-4.0 source material via an LLM is fast and produces plausible-looking output that may be a paraphrase rather than a transformation. Without explicit originality checks, the derivative is structurally a copy with rearranged sentences.
+
+This guidance captures the discipline used when Systematic imported `test-driven-development` and `writing-skills` from `obra/superpowers@v5.1.0` (MIT) and distilled a derivative reference from Anthropic's published Skill authoring docs (CC-BY-4.0) in PR #394 (v2.17.0). The pattern generalizes to any project bundling third-party documentation, executable utilities, or skill-style assets.
+
+## Guidance
+
+### Light-adaptation pattern: empirical counting
+
+Before any rewriting, **count every category of upstream artifact that needs rewriting**. Common categories:
+
+- Force-load syntax (e.g., `@filename.md` markers that auto-load referenced files into context)
+- Namespace cross-references (e.g., `upstream-namespace:skill-name`)
+- Harness-specific paths (e.g., `~/.claude/skills/` when targeting OpenCode's `~/.agents/skills/`)
+- Descriptive filename renames (e.g., `CLAUDE_MD_TESTING.md` → `skill-testing-walkthrough.md`)
+
+Run the count BEFORE adaptation. Re-run AFTER adaptation. Each category should hit zero remaining matches plus zero over-conversion. The empirical step matters because estimates are wrong: in this case the brainstorm estimated 3 `@filename` force-loads but reality was 4 — the regex used `\.md` only and missed `@graphviz-conventions.dot`. Defensive grep pattern: `@[a-z][a-z-]+\.(md|dot|js|sh|py)` not just `@[a-z-]+\.md`.
+
+When upstream content historically references something the host project bans (e.g., a worked example that documents testing `CLAUDE.md` documentation variants), don't strip — **preserve historical fidelity via drift-allowlist entries** with explicit reason fields. The original content is documenting what was tested, not prescribing what to test.
+
+### Two-layer originality check for CC-BY-4.0 derivatives
+
+Layer 1 is **mechanical** (orchestrator runs literal checks):
+
+1. Size in target range (e.g., 3500-6000 bytes for a ~4.5KB target)
+2. Attribution + license URL in first 3 lines (literal `CC-BY-4.0` + license URL + canonical source URL)
+3. Heading 1:1 match count = 0 (extract `^## ` lines from distilled file AND upstream; intersection must be empty)
+4. Heading order divergence (distilled sequence does NOT map 1:1 to upstream sequence)
+5. Per-paragraph longest-line `grep -F` against upstream returns zero hits for any line >120 chars
+
+Layer 2 is **reviewer assertions** (orchestrator judges true/false per item):
+
+1. Distilled file introduces ≥2 organizing categories not present in upstream
+2. Distilled file drops ≥3 upstream topic areas wholesale (not "summarizes briefly" — wholesale drops)
+3. Distilled file presents by the host project's relevant authoring tasks, NOT in upstream document order
+4. No section is merely a paragraph-level paraphrase of one upstream section
+
+Layer 1 alone is gameable — an LLM can satisfy "headings differ" by trivial renaming. Layer 2 alone is too subjective — what counts as "merely a paraphrase"? Combined, they catch the failure modes that each misses individually.
+
+### Librarian retry-budget branch routing
+
+LLM-driven distillation needs a bounded retry policy. The trap: open-ended re-drafting loops on the assumption that the next pass will fix the failure mode. They usually don't — failures cluster around structural issues that prose tweaks can't fix.
+
+The pattern: **max 2 librarian re-draft passes**. Draft #3 routes to one of these branches based on the failure mode, not generic re-draft:
+
+| Failure mode | Branch | Action |
+|---|---|---|
+| Attribution missing or malformed | **fix directly** | Orchestrator edits the first 3 lines; no re-draft. |
+| Size out of range, originality OK | **hand-edit** | Orchestrator compresses or expands prose. |
+| Literal originality fails on isolated paragraphs | **hand-edit** | Orchestrator rephrases the offending paragraphs once. |
+| Literal originality fails across multiple sections | **shrink scope** | Reduce the distillation to a fixed subset. |
+| Structural originality fails (mirroring upstream) | **shrink + re-outline** | Restructure around fewer use-case headings; don't line-edit. |
+| Legal or license uncertainty | **escalate** | Build an escalation artifact + surface to a human. |
+
+Escalation artifact format (what the human receives):
+
+- Best current draft (full content)
+- Exact failed criterion (which mechanical check OR reviewer assertion failed)
+- Concise failure evidence (specific line/heading match, byte count, etc.)
+- Re-draft attempt count
+- Recommended next move with named scope: (a) accept exception, (b) shrink to a named subset (specify which sections to keep), (c) drop derivative entirely, or (d) approve additional manual-rewrite time
+
+The escalation artifact prevents the "what do I do with this?" friction that turns escalation into another draft round.
+
+### ATTRIBUTIONS.md anatomy
+
+A single canonical attribution surface beats per-file comment headers for three reasons: (1) attribution is reviewable in one place; (2) license-absence semantics are explicit (see below); (3) per-file comments are noise on content files that get edited frequently.
+
+Required structure per third-party source:
+
+- **Identification**: source URL or repo URL, pinned commit SHA, license name + URL, copyright line
+- **License text**: full upstream license text reproduced verbatim (MIT requires this; CC-BY-4.0 doesn't but inclusion is defensive)
+- **File inventory**: list of derived files in your project's tree
+- **Adaptation notes**: brief summary of the adaptation deltas applied (what was rewritten, what was renamed, what was preserved)
+- **License absence clarification**: explicit statement that absence of `license:` frontmatter on other bundled content means "unspecified host-project-originated," NOT "proprietary" or "unlicensed"
+- **Future refresh discipline**: explicit statement that future refreshes from upstream are human-reviewed events, not automatic syncs
+
+For CC-BY-4.0 derivative documentation, add a **Distillation Outline** section: the source-material → host-use-case-category mapping. This makes future re-distillation passes (after the upstream source updates) have a stable scaffold instead of starting from scratch.
+
+`license: MIT` frontmatter on the entry-point file (e.g., `SKILL.md`) is appropriate when the project's runtime loader recognizes the field. Sub-files (reference markdown, scripts, graphviz definitions) typically don't carry frontmatter and inherit license via ATTRIBUTIONS.md.
+
+## Why This Matters
+
+The legal compliance story is the floor: MIT requires reproducing the license text, CC-BY-4.0 requires attribution + modification disclosure. The host project ships content; the host project must satisfy these obligations correctly. Skipping the rigor lets a bundled MIT-derived file ship without the upstream notice — defensible only if "we'll add it later" is more credible than "we didn't notice."
+
+The compounding story is the ceiling: a discipline that treats third-party content as a first-class durable surface scales. The first import requires writing the ATTRIBUTIONS.md scaffolding; the third import drops into the same shape, the same retry-budget routing, the same originality check. The eighth import is mechanical.
+
+The two-layer originality check specifically defends against a real failure mode: LLM-generated distillations are surface-fluent but structurally adjacent to source material. Layer 1's heading-comparison + longest-line `grep -F` catch the obvious copies. Layer 2's reviewer assertions catch the subtle ones (the document that satisfies all mechanical checks but presents content in upstream's exact section order, with paragraphs that paraphrase upstream 1:1). Both are cheap to apply.
+
+The librarian retry-budget routing prevents the most expensive failure mode: open-ended LLM re-draft loops where each pass fixes the previous failure but introduces a new one. Bounded retries with branch routing force the orchestrator to decide between "this is a small fix" and "this is a scope problem" — and structural problems don't survive scope-shrinking, so they surface immediately.
+
+## When to Apply
+
+- Bundling any third-party content (MIT, CC-BY, Apache, BSD) into a published package
+- Producing derivative documentation from licensed source material
+- Dispatching a librarian subagent or LLM workflow to draft content with quality gates
+- Designing the attribution surface for the first third-party import in a project — get the shape right before the second import
+- Reviewing an existing third-party import for compliance gaps
+
+The two-layer originality check applies specifically to CC-BY-4.0 derivative work — MIT and Apache derivatives have license-text reproduction requirements but no originality bar. The light-adaptation pattern and ATTRIBUTIONS.md anatomy apply to all third-party imports regardless of license.
+
+## Examples
+
+**Light-adaptation deltas** (actual from PR #394):
+
+| Upstream | Adapted | Count |
+|---|---|---|
+| `@testing-anti-patterns.md` (force-load) | `references/testing-anti-patterns.md` (repo-local path) | 1 |
+| `@graphviz-conventions.dot` (force-load, non-md) | `references/graphviz-conventions.dot` | 1 (missed by initial regex) |
+| `superpowers:test-driven-development` (namespace) | `test-driven-development` (bare; namespace added at load time) | 5 |
+| `~/.claude/skills` (Claude Code harness path) | `~/.agents/skills/` (canonical OpenCode path) | 13+ |
+| `examples/CLAUDE_MD_TESTING.md` (descriptive rename) | `references/examples/skill-testing-walkthrough.md` | 1 |
+
+**Originality check applied** to the distilled `anthropic-best-practices-distilled.md`:
+
+Layer 1 (mechanical):
+
+```bash
+# Size check
+wc -c skills/writing-skills/references/anthropic-best-practices-distilled.md
+# 5991 bytes — within 3500-6000 range ✓
+
+# Attribution check
+head -3 skills/writing-skills/references/anthropic-best-practices-distilled.md | grep -c 'CC-BY-4.0'
+# 1 ✓
+head -3 skills/writing-skills/references/anthropic-best-practices-distilled.md | grep -c 'docs.claude.com'
+# 1 ✓
+
+# Heading 1:1 match check
+comm -12 \
+  <(grep '^## ' skills/writing-skills/references/anthropic-best-practices-distilled.md | sort -u) \
+  <(grep '^## ' .slim/clonedeps/repos/obra__superpowers/skills/writing-skills/anthropic-best-practices.md | sort -u) | wc -l
+# 0 ✓
+```
+
+Layer 2 (reviewer assertions):
+
+| Assertion | Verdict |
+|---|---|
+| Introduces ≥2 organizing categories not in upstream | ✓ — "Triggering Skills Through Precise Descriptions", "Matching Skill Rigidity to Task Variance" |
+| Drops ≥3 upstream topic areas wholesale | ✓ — model-specific testing, executable-code patterns (PDF/BigQuery/DOCX), MCP refs |
+| Presents by host project's authoring tasks, NOT upstream order | ✓ — completely different sequence |
+| No section merely paraphrases one upstream section | ✓ — confirmed via zero verbatim long-line hits |
+
+**Retry budget application** (actual from PR #394):
+
+Draft #1 came back at 6,490 bytes (490 over the 6,000-byte ceiling), all other checks passing. Per routing: "Size out of range, originality OK → hand-edit." Orchestrator removed a bonus "Anti-Patterns" section beyond the 6-category outline, dropping to 5,944 bytes. **Draft #1 + 1 hand-edit accepted. Retry budget consumed: 0 librarian re-drafts.**
+
+**ATTRIBUTIONS.md structure** (excerpt):
+
+```markdown
+## obra/superpowers — MIT
+
+**Source repository:** [obra/superpowers](https://github.com/obra/superpowers)
+**Pinned commit:** `f2cbfbefebbfef77321e4c9abc9e949826bea9d7` (tag `v5.1.0`)
+**License:** MIT
+**Copyright:** Copyright (c) 2025 Jesse Vincent
+
+### Files derived
+- skills/test-driven-development/SKILL.md
+- skills/test-driven-development/references/testing-anti-patterns.md
+- ...
+
+### Upstream MIT license text
+[full upstream license text reproduced verbatim]
+
+## Anthropic — CC-BY-4.0
+**Source page:** [Skill authoring best practices](https://docs.claude.com/...)
+**License:** [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)
+**Retrieved:** 2026-05-17
+
+### Distillation Outline
+[6 host-use-case categories + wholesale-drop list — durable scaffold for future refreshes]
+```
+
+## Related
+
+- [`docs/solutions/best-practices/destructive-to-nondestructive-converter-Systematic-20260209.md`](destructive-to-nondestructive-converter-Systematic-20260209.md) — adjacent "light adaptation, preserve unknowns" precedent from the CEP→Systematic conversion era. This doc extends it with explicit licensing + originality discipline.
+- [`docs/solutions/workflow-issues/reconciliation-sync-reference-integrity-20260417.md`](../workflow-issues/reconciliation-sync-reference-integrity-20260417.md) — verify the reference graph after any sync. Same defensive pattern applied here: don't trust the import; verify every cross-reference resolves on disk.
+- [`docs/solutions/workflow-issues/sync-cep-missing-sub-files-SyncCEP-20260219.md`](../workflow-issues/sync-cep-missing-sub-files-SyncCEP-20260219.md) — earlier integrity-check precedent for multi-file imports (some content archived).
+- [`docs/solutions/integration-issues/converter-code-block-tool-name-capitalization-20260210.md`](../integration-issues/converter-code-block-tool-name-capitalization-20260210.md) — manual audit backstop after mechanical conversion.
+- [`ATTRIBUTIONS.md`](../../../ATTRIBUTIONS.md) — the canonical attribution surface in this repo, structured per this guidance.
+- PR [#394](https://github.com/marcusrbrown/systematic/pull/394) — the merge that landed both bundled skills + the distilled CC-BY-4.0 reference + ATTRIBUTIONS.md.

--- a/docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md
+++ b/docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md
@@ -1,6 +1,7 @@
 ---
-title: 'Build-time codegen for typed config validation: three traps to avoid'
+title: 'Build-time codegen for typed config validation: four traps to avoid'
 date: 2026-05-16
+last_updated: 2026-05-17
 category: best-practices
 module: scripts/generate-config-schema.ts + src/lib/config-schema.ts
 problem_type: best_practice
@@ -14,6 +15,7 @@ applies_when:
   - emitting committed code that other build steps import immediately
   - designing drift checks across multiple generated artifacts
   - exposing alias or qualified-ID surfaces in config validation
+  - parsing or introspecting formatter-controlled auto-generated code
 tags:
   - config-validation
   - codegen
@@ -22,9 +24,11 @@ tags:
   - schema-generation
   - alias-resolution
   - tooling
+  - formatter-introspection
+  - latent-bugs
 ---
 
-# Build-time codegen for typed config validation: three traps to avoid
+# Build-time codegen for typed config validation: four traps to avoid
 
 ## Context
 
@@ -37,6 +41,8 @@ The migration looked simple — walk `agents/` and `skills/` at codegen time, em
 - the drift gate's `--check` callback and the `main()` write path called the producer function with different option shapes, so drift detection misfired immediately after a fresh regeneration
 
 That combination produced a nasty failure mode: configs that worked in v2.14.x became invalid under the new schema, the first run of the generator after an agents/ change shipped a stale published schema, and the safety check that should have caught both failed for the wrong reason.
+
+A fourth trap surfaced in PR #394 (v2.17.0) when Fro Bot's review caught a latent bug in the same generator: a regex used to count bundled entries in the auto-generated source file was quote-style-sensitive but the file was formatter-controlled. The shrink-protection guard built on top of that regex was silently inert. This update folds that learning in as Trap #4 alongside the original three.
 
 ## Guidance
 
@@ -120,7 +126,57 @@ generateAndWrite(generateSchemaContentFromSchema(version, freshSchema), version)
 
 This project shipped this pattern in v2.15.0 (PR #384) and migrated to the factory in PR #393. The cache-bust approach works but is fragile: it relies on the runtime's URL-keyed module cache treating query strings as distinct entries, which is a Bun/Node implementation detail rather than an ESM spec guarantee.
 
-### 3. Keep `--check` and write paths byte-identical
+### 3. Don't introspect formatter-controlled auto-generated code with quote-sensitive regex
+
+If the generator parses its own committed output to make decisions (count entries, detect shrinks, compare prior state), the parser must match the formatter's actual output style — not what the source code looks like before formatting.
+
+In this case, `readCommittedBundledNamesCounts(rootDir)` parsed the committed `src/lib/bundled-names.ts` file and counted entries in the `BUNDLED_AGENT_NAMES` and `BUNDLED_SKILL_NAMES` arrays. The inner counter was:
+
+```ts
+// Broken — single-quote only:
+const countEntries = (block: string): number =>
+  block.split('\n').filter((line) => /^\s*'[^']+',\s*$/.test(line)).length
+```
+
+But the generated file is Biome-formatted before commit. Biome's default output uses **double quotes**:
+
+```ts
+export const BUNDLED_AGENT_NAMES = [
+  "adversarial-document-reviewer",
+  "adversarial-reviewer",
+  // ...
+]
+```
+
+So `countEntries` returned 0 for every entry. The function's caller — the shrink guard that prevents accidental removal of bundled agents or skills without an explicit `--allow-shrink` flag — was effectively dead code. Every regeneration looked like a first run with no committed-counts baseline, so the shrink protection silently passed through.
+
+The fix is quote-agnostic:
+
+```ts
+// Works with both single and double quote styles:
+const countEntries = (block: string): number =>
+  block.split('\n').filter((line) => /^\s*['"][^'"]+['"],\s*$/.test(line)).length
+```
+
+The general lesson generalizes beyond quotes. Any code that introspects auto-generated source by regex is vulnerable to formatter output changes:
+
+- Quote style (`'` vs `"`)
+- Trailing comma policy
+- Whitespace conventions (indentation, padding inside brackets)
+- Semicolon style
+- Comment style (`//` vs `/*`)
+- Line-ending style (`\n` vs `\r\n`)
+
+Defensive patterns:
+
+- Make regexes quote-agnostic, whitespace-tolerant, trailing-character-tolerant
+- Test against actual formatter output, NOT against synthetic fixtures hand-written in your IDE
+- Prefer side-channel metadata over scraping: emit a separate `.json` count file alongside the generated source, or include a structured comment header like `// COUNT: 50`
+- Best of all: parse the AST. If you control the generator, you already know the shape
+
+The shrink guard's failure mode here was the most insidious kind: a guard that silently returns "no baseline" / "first run" / "empty result" rather than throwing. The bug doesn't fire on its own — it just makes the guard inert. You only notice when something else catches the consequence, or by code review from someone who knows what the formatter emits.
+
+### 4. Keep `--check` and write paths byte-identical
 
 A drift gate works by computing "expected" content fresh from sources, reading the on-disk file, and comparing. For this to be sound, both call sites — the `--check` `produce()` callback and the `main()` write path — must call the producer with identical option shapes and defaults. Any divergence in inputs, defaults, sort order, or formatting and drift detection silently misfires.
 

--- a/docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md
+++ b/docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md
@@ -46,7 +46,7 @@ A fourth trap surfaced in PR #394 (v2.17.0) when Fro Bot's review caught a laten
 
 ## Guidance
 
-Before migrating permissive config to strict validation, three rules need to hold simultaneously.
+Before migrating permissive config to strict validation, four rules need to hold simultaneously.
 
 ### 1. Audit the runtime's full input surface, not just the documented happy path
 
@@ -184,15 +184,16 @@ Best long-term shape: factor the shared option-derivation into a single helper t
 
 ## Why This Matters
 
-The meta-principle is straightforward: **moving from permissive to strict validation freezes runtime behavior into a contract.** If the contract misses any of the three surfaces below, it lies.
+The meta-principle is straightforward: **moving from permissive to strict validation freezes runtime behavior into a contract.** If the contract misses any of the four surfaces below, it lies.
 
 | Surface | Failure shape |
 |---|---|
 | Hidden runtime flexibility | Schema rejects inputs the runtime would have accepted; users hit parse errors with no migration guidance. |
 | Generator read-after-write ordering | First-run output is stale; CI drift gate catches it but only after the artifact ships. |
+| Formatter-controlled introspection | Regex-based parsers built on the wrong quote/style assumptions silently return empty results; guards built on top of them become dead code. |
 | Drift-gate call-site parity | `--check` reports drift right after a clean regenerate; humans waste time chasing a phantom. |
 
-The damage is asymmetric. The runtime surface miss breaks users in production. The codegen ordering trap ships stale artifacts. The drift-gate asymmetry erodes trust in the safety check. Each trap is independently fixable but, taken together, the three define a small playbook for strict-validation migrations.
+The damage is asymmetric. The runtime surface miss breaks users in production. The codegen ordering trap ships stale artifacts. The formatter-introspection trap turns a safety guard into a no-op without any visible signal. The drift-gate asymmetry erodes trust in the safety check. Each trap is independently fixable but, taken together, the four define a small playbook for strict-validation migrations.
 
 ## When to Apply
 

--- a/docs/solutions/best-practices/zod-json-schema-ref-dedup-postprocessors-2026-05-17.md
+++ b/docs/solutions/best-practices/zod-json-schema-ref-dedup-postprocessors-2026-05-17.md
@@ -1,0 +1,234 @@
+---
+title: Zod JSON Schema $ref deduplication needs ref-aware post-processors
+date: 2026-05-17
+category: best-practices
+module: scripts/generate-config-schema.ts
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - Emitting JSON Schema from Zod 4 with `reused: 'ref'` enabled
+  - Post-processing the emitted schema by walking property paths
+  - Mutating `required` arrays, injecting `allOf` conditionals, or otherwise rewriting schema nodes after emission
+  - Schemas carry `.describe()` / `.default()` / `.examples()` metadata alongside structural bodies
+  - Maintaining AJV/runtime parity between Zod validation and the generated JSON Schema
+tags:
+  - json-schema
+  - zod
+  - schema-generation
+  - ref-dedup
+  - code-generation
+---
+
+# Zod JSON Schema $ref deduplication needs ref-aware post-processors
+
+## Context
+
+Zod 4's `z.toJSONSchema(schema, { reused: 'ref' })` changes the shape of the emitted schema tree. Schemas that appear multiple times (overlay shapes used across N config keys, shared union branches, etc.) are extracted to a `definitions` block once and referenced via `$ref` everywhere they appear. The default `reused: 'inline'` keeps every reuse inlined, producing tractable-looking but enormous schemas.
+
+The published Systematic config schema collapsed from **16,749 lines to 1,508 lines (91% reduction)** by flipping that one option. The agent overlay shape was inlined ~100 times (50 bundled agents × 2 contexts: `agents.<bundled-name>` direct + `categories.<id>.agents.<id>`). After dedup, every referrer points at a single `definitions/__schemaN` entry.
+
+The friction surfaces immediately afterward. Any code that walks the emitted schema by property path — `schema.properties.agents.properties[name].properties.model.anyOf` — stops working because intermediate levels become `{$ref: ...}` nodes without their own `properties`. Worse, when a Zod schema carries metadata (`.describe()`, `.default()`, `.examples()`), the emitter wraps the structural body in `allOf: [{$ref: ...}]`: the metadata sits on the wrapper, the structural body sits in the referenced definition. So a single resolution step is not enough — walkers must unwrap *both* the ref AND the metadata wrapper to reach the schema's real structure.
+
+This breaks any post-processor that ran on inline schemas: cross-field constraint injection, required-array pruning, reference rewriting, and anything else that mutates emitted nodes by path traversal. The size win is real, but the post-processor retrofit is mandatory — and the failure mode is silent: the schema gets smaller, and validation contract drift is the bug.
+
+## Guidance
+
+When you flip `reused: 'ref'`, do these four things together:
+
+1. **Add a single canonical `resolveRef` helper** that follows BOTH `$ref` indirection AND single-element `allOf: [{$ref}]` metadata-wrapper unwrapping. Loop-bounded with a generous safety cap.
+2. **Thread the schema root into every post-processor** so they can resolve refs (refs are root-relative paths like `#/definitions/__schemaN`).
+3. **Mutate the resolved shared definition once** — propagation via ref happens automatically when N referrers all point at the same object. Use a `WeakSet` to de-dup mutations across multiple call sites that resolve to the same definition.
+4. **Warn loudly on depth exhaustion**. Silent ref-resolution failure means silently dropped constraints. A bounded loop without observability is a future regression in a bottle.
+
+```ts
+const result = z.toJSONSchema(schema, {
+  target: 'draft-7',
+  // Deduplicate repeated schema shapes by extracting them to definitions.
+  // Without this, the agents.<key> overlay (and its embedded sub-schemas)
+  // is inlined once per bundled agent (~100x), bloating the schema by ~15K
+  // lines. With `reused: 'ref'`, repeated shapes become a single definition
+  // referenced via $ref, collapsing the schema to a fraction of its size.
+  reused: 'ref',
+  override: (ctx) => {
+    if (ctx.path.length === 0) {
+      ctx.jsonSchema.$id = schemaId
+    }
+  },
+})
+```
+
+```ts
+/**
+ * Upper bound on how many levels of `$ref` / `allOf-wrapper` indirection
+ * resolveRef() will follow before giving up. Set generously above observed
+ * Zod-emitted chains (ref → wrapper → ref → ... ~3 levels in practice) to
+ * absorb future generator changes without becoming a magic-number cliff.
+ */
+const MAX_SCHEMA_REF_RESOLUTION_DEPTH = 8
+
+function resolveRef(
+  root: Record<string, unknown>,
+  node: Record<string, unknown>,
+): Record<string, unknown> | null {
+  let current: Record<string, unknown> | null = node
+
+  for (
+    let i = 0;
+    current !== null && i < MAX_SCHEMA_REF_RESOLUTION_DEPTH;
+    i++
+  ) {
+    const ref = current['$ref']
+    if (typeof ref === 'string') {
+      const prefix = '#/definitions/'
+      if (!ref.startsWith(prefix)) return null
+      const defKey = ref.slice(prefix.length)
+      const definitions = asObject(root.definitions)
+      if (definitions === null) return null
+      current = asObject(definitions[defKey])
+      continue
+    }
+
+    // Unwrap a trivial single-ref allOf wrapper. Zod uses this shape when a
+    // schema has metadata (description, default, examples) at the wrapper
+    // level and the structural body (properties, additionalProperties) at the
+    // wrapped level.
+    const allOf = current['allOf']
+    if (Array.isArray(allOf) && allOf.length === 1) {
+      const wrapped = asObject(allOf[0])
+      if (wrapped !== null && '$ref' in wrapped) {
+        current = wrapped
+        continue
+      }
+    }
+
+    return current
+  }
+
+  console.warn(
+    `[generate-config-schema] resolveRef exhausted MAX_SCHEMA_REF_RESOLUTION_DEPTH (${MAX_SCHEMA_REF_RESOLUTION_DEPTH}). ` +
+      'A schema node was not resolved; downstream post-processors will skip it. ' +
+      'If this triggers after a Zod upgrade, raise the depth bound.',
+  )
+  return null
+}
+```
+
+For post-processors that need to mutate the resolved definition:
+
+```ts
+const mutated = new WeakSet<Record<string, unknown>>()
+
+const applyConstraint = (node: Record<string, unknown> | null): void => {
+  if (node === null) return
+  const target = resolveRef(root, node)
+  if (target === null || mutated.has(target)) return
+  mutated.add(target)
+  injectMyConstraint(root, target)
+}
+```
+
+The WeakSet matters because a single definition may be referenced from many call sites (each agent overlay key + the category overlay context, in this case). Without it, the same `allOf` block gets injected N times into one definition.
+
+## Why This Matters
+
+`reused: 'ref'` is the difference between a schema you can publish on a CDN and one that bricks IDE autocomplete and clogs npm tarballs. The 91% reduction here is not unusual — any schema with bundled-name enums or shared overlay shapes will see similar wins.
+
+But the cost of skipping the post-processor retrofit is silent correctness drift. In one specific case in this repo:
+
+- `addOverlayCrossFieldConstraints` (variant-requires-explicit-model) — failed to fire after the refactor because `properties.agents.properties.<bundled-name>` was now `{$ref: ...}` not an object with its own `properties`. The cross-field validation gap was caught only because AJV parity tests covered the variant-without-model rejection path.
+- `removeDefaultFieldsFromRequired` (prune defaulted fields from `required` arrays) — same class of bug; `bootstrap.required` incorrectly listed `enabled` despite the field having a runtime default. Caught by a parity test that asserted `bootstrap: {}` should be accepted.
+
+Both bugs were "the schema got smaller and superficially worked" — exactly the kind of regression that ships without intervention. AJV parity tests are the cheap, mechanical insurance: assert byte-identical accept/reject behavior between `SystematicConfigSchema.safeParse()` and AJV's `validate()` over a fixture set covering happy paths, defaults, refinements, and cross-field constraints.
+
+The `console.warn` on depth exhaustion is observability insurance. The current emitted chain depth is ~3 (ref → wrapper → ref). The safety bound is 8. If a future Zod version starts emitting deeper chains, the warning surfaces it instead of silently losing post-processing mutations on the affected nodes.
+
+## When to Apply
+
+- You emit JSON Schema from Zod 4 with `reused: 'ref'`
+- You post-process the emitted schema by walking property paths
+- Your schemas use `.default()`, `.describe()`, or `.examples()` (these are what trigger the `allOf: [{$ref}]` wrapper shape)
+- You need AJV / runtime parity, especially for cross-field constraints or required-array semantics
+
+If your generator does no post-processing — pure Zod-to-JSON-Schema emission with no mutation afterward — `reused: 'ref'` is a free win. The retrofit cost only applies when you walk and mutate.
+
+## Examples
+
+**Before** (works only with `reused: 'inline'`):
+
+```ts
+const modelNode = schema.properties.agents.properties[name].properties.model
+const anyOf = modelNode.anyOf  // undefined when intermediate levels are $ref
+```
+
+**After** (works with both):
+
+```ts
+const agentsNode = getSchemaNode(root, ['properties', 'agents'])
+const agentsBody = agentsNode === null ? null : resolveRef(root, agentsNode)
+const agentProperties = asObject(agentsBody?.['properties'])
+if (agentProperties !== null) {
+  for (const key of Object.keys(agentProperties)) {
+    const overlay = asObject(agentProperties[key])
+    if (overlay === null) continue
+    const resolved = resolveRef(root, overlay)
+    // ... safe to walk resolved.properties.model.anyOf now
+  }
+}
+```
+
+**Actual post-processor pattern** from `scripts/generate-config-schema.ts`:
+
+```ts
+function getNonNullModelBranch(
+  root: Record<string, unknown>,
+  overlayNode: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const properties = asObject(overlayNode.properties)
+  const modelNode = asObject(properties?.model)
+  if (modelNode === null) return null
+
+  // With `reused: 'ref'`, the model field is several layers of ref/wrapper
+  // indirection (overlay.properties.model → ref → allOf wrapper → ref → anyOf).
+  const modelBody = resolveRef(root, modelNode)
+  const anyOf = modelBody?.anyOf
+  if (!Array.isArray(anyOf)) return null
+
+  for (const candidate of anyOf) {
+    const branch = asObject(candidate)
+    if (branch === null) continue
+    // The string branch may itself be a $ref to a definition holding the
+    // type/pattern constraints; resolve it before checking type.
+    const resolved = resolveRef(root, branch)
+    if (resolved?.type === 'string') return cloneSchemaNode(resolved)
+  }
+
+  return null
+}
+```
+
+**Verification pattern.** Pair the refactor with AJV parity tests that cover the post-processed paths. Sample fixture (using `bun:test` style):
+
+```ts
+test('parity: bundled agent variant-without-model rejected', () => {
+  const config = { agents: { 'correctness-reviewer': { variant: 'v2' } } }
+  expect(SystematicConfigSchema.safeParse(config).success).toBe(false)
+  expect(ajvValidate(config)).toBe(false)
+})
+
+test('parity: bootstrap empty object accepted (enabled has runtime default)', () => {
+  const config = { bootstrap: {} }
+  expect(SystematicConfigSchema.safeParse(config).success).toBe(true)
+  expect(ajvValidate(config)).toBe(true)
+})
+```
+
+If either parity check disagrees post-refactor, a post-processor has gone ref-blind. The fix is always: thread `root` into the post-processor, resolve the node via `resolveRef`, mutate the resolved definition.
+
+## Related
+
+- [docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md](typed-config-validation-build-time-codegen-2026-05-16.md) — sibling doc covering schema-factory pattern + `--check` drift prevention. This doc extends it with `$ref` dedup and ref-aware post-processing.
+- [docs/solutions/integration-issues/opencode-config-schema-rejects-ad-hoc-agent-colors-2026-05-09.md](../integration-issues/opencode-config-schema-rejects-ad-hoc-agent-colors-2026-05-09.md) — example of downstream schema validation breakage when emitted config / schema contracts drift.
+- [docs/solutions/workflow-issues/reconciliation-sync-reference-integrity-20260417.md](../workflow-issues/reconciliation-sync-reference-integrity-20260417.md) — general reference-integrity precedent: post-process verification that every reference resolves on disk.
+- GitHub issue [#389](https://github.com/marcusrbrown/systematic/issues/389) — `Refactor: factory-pattern for SystematicConfigSchema to remove cache-busting workaround` (closed by PR #393, which set up the factory pattern this doc's $ref refactor depends on).
+- PR [#394](https://github.com/marcusrbrown/systematic/pull/394) — the merge that shipped the $ref dedup + ref-aware post-processors as part of v2.17.0.


### PR DESCRIPTION
Compounds three reusable patterns from the import-superpowers-foundation-skills session arc (PR #394 / v2.17.0) into `docs/solutions/`.

## What's new

### `zod-json-schema-ref-dedup-postprocessors-2026-05-17.md` (new)

JSON Schema `$ref` deduplication via Zod 4's `reused: 'ref'` + ref-aware post-processor pattern. The published schema collapsed from 16,749 lines to 1,508 lines (91% reduction) by flipping that one option — but two post-processors that walked the schema needed retrofit because they were structurally ref-blind. Documents:

- The trap: any code walking the emitted schema by property path (`schema.properties.agents.properties[name].properties.model.anyOf`) breaks after `reused: 'ref'` because intermediate levels become `{$ref: ...}` nodes.
- The `allOf: [{$ref}]` metadata wrapper Zod emits when a schema carries `.describe()` / `.default()` / `.examples()` — metadata sits on the wrapper, structural body sits in the wrapped definition. `resolveRef` must unwrap both layers.
- WeakSet-based mutation de-dup so injecting an `allOf` constraint into a shared definition propagates through every referrer without N-times duplication.
- `console.warn` on depth exhaustion as future-Zod-upgrade insurance.
- AJV parity tests as the mechanical verification discipline that catches retrofit failures.

### `third-party-bundled-skills-light-adaptation-2026-05-17.md` (new)

The pattern for bundling third-party MIT-licensed content + producing CC-BY-4.0 derivative documentation. Documents:

- **Light-adaptation pattern**: empirically count rewrite categories BEFORE editing, verify zero remaining hits AFTER. Regex must cover non-md extensions (`@filename.dot`, `@filename.js`).
- **Two-layer CC-BY-4.0 originality check**: Layer 1 (mechanical — size, attribution, heading comparison, longest-line `grep -F`); Layer 2 (reviewer assertion checklist — 4 true/false items covering structural divergence). Defends against the LLM-distillation failure mode where output is surface-fluent but structurally adjacent to source.
- **Librarian retry-budget branch routing**: bounded re-draft loop (max 2 passes) with explicit branch routes per failure mode (fix directly / hand-edit / shrink scope / shrink + re-outline / escalate). Escalation artifact format specified.
- **ATTRIBUTIONS.md anatomy**: per-source structure, full upstream license text reproduced, Distillation Outline durability for CC-BY-derived content, license-absence semantics.

### `typed-config-validation-build-time-codegen-2026-05-16.md` (extended)

Trap #4 added: "Don't introspect formatter-controlled auto-generated code with quote-sensitive regex." Folds in the Fro Bot-caught `countEntries` regex bug (single-quote pattern vs Biome's double-quote output) and generalizes the failure class to quote style + trailing commas + whitespace + semicolons + line-endings. Doc count in title updated from "three traps" to "four traps"; `last_updated: 2026-05-17` added.

## Why this doc, not three new docs

Doc C content fit naturally as Trap #4 in the existing typed-config-validation doc — same `scripts/generate-config-schema.ts` surface, same "build-time codegen discipline" theme, High overlap on the related-docs-finder scoring (5/5 dimensions matched). Updating the existing doc beat creating a fourth file that would immediately need consolidation.

Docs A and B opened new territory: `$ref` dedup is a schema-emission concern Zod-side, distinct from the build-time codegen patterns in the typed-config-validation doc; third-party bundling is a licensing + originality discipline, distinct from any existing solution doc.

## Verification

- `bun scripts/content-integrity.ts` — clean (167 md + 21 ts, 45 exempt, 0 warnings)
- `bun run docs:build` — 112 pages built in 7.06s
- Plan-taxonomy audit on the new sources — 0 hits
- Branched on top of fresh `origin/main` per the standing fetch-before-push rule (PR #396 renovate bump merged during writing; main was at `ff11080` before this branch was created)
- Per `.releaserc.yaml`: `docs(solutions):` is non-releasing — this PR accumulates on main alongside PR #395 / #396 `chore(deps):` commits until the next `feat:` / `fix:` flushes them