### PR TITLE
feat(config): surface every Zod issue in top-level config error message

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -242,8 +242,10 @@ function throwTopLevelConfigSchemaError(
   rawInput: unknown,
 ): never {
   const issues = enrichUnrecognizedKeyIssues(rawIssues, rawInput)
-  const issue = issues[0]
-  if (!issue) {
+  // Defensive fallback. Zod 4 invariant: safeParse never returns success: false with an
+  // empty issues array, but enrichUnrecognizedKeyIssues is a pure transform and could in
+  // principle yield zero entries from a future Zod that emits issues we filter out.
+  if (issues.length === 0) {
     throw Object.assign(
       new Error(
         `Invalid Systematic config in ${filePath}: schema validation failed`,
@@ -251,11 +253,18 @@ function throwTopLevelConfigSchemaError(
       { _tag: 'ConfigSchemaError' as const, filePath, trust, issues },
     )
   }
-  const fieldPath =
-    issue.code === 'unrecognized_keys' ? null : issue.path.join('.')
-  const message = fieldPath
-    ? `Invalid Systematic config in ${filePath}: ${fieldPath} ${issue.message}`
-    : `Invalid Systematic config in ${filePath}: ${issue.message}`
+  const formatIssue = (issue: z.core.$ZodIssue): string => {
+    const fieldPath =
+      issue.code === 'unrecognized_keys' ? null : issue.path.join('.')
+    return fieldPath ? `${fieldPath} ${issue.message}` : issue.message
+  }
+  const formatted = issues.map(formatIssue)
+  // Single-issue case keeps the one-line shape for backward compatibility with existing
+  // user expectations. Multi-issue case uses a bullet list so every problem surfaces.
+  const message =
+    formatted.length === 1
+      ? `Invalid Systematic config in ${filePath}: ${formatted[0]}`
+      : `Invalid Systematic config in ${filePath}:\n${formatted.map((entry) => `  - ${entry}`).join('\n')}`
   throw Object.assign(new Error(message), {
     _tag: 'ConfigSchemaError' as const,
     filePath,

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1043,12 +1043,11 @@ describe('config', () => {
         } catch (err) {
           errorMessage = (err as Error).message
         }
-        // The first issue thrown should be enriched — either the agents typo or the
-        // disabled_agents typo. Both enrichments must be present in the issues array.
-        // We verify the thrown message is short (not a raw enum dump) and contains
-        // the docs URL, confirming at least one enrichment fired.
+        // Both issues are now surfaced in the message. We verify the message
+        // contains the docs URL (confirming enrichment fired) and is not a raw
+        // enum dump (which would be thousands of chars).
         expect(errorMessage).toContain(DOCS_URL)
-        expect(errorMessage.length).toBeLessThan(500)
+        expect(errorMessage.length).toBeLessThan(1000)
         // Must not dump the full enum list
         expect(errorMessage).not.toContain('adversarial-reviewer')
       })
@@ -1070,6 +1069,41 @@ describe('config', () => {
         // Must not dump the full valid-name list inline
         expect(errorMessage).not.toContain('oracle')
         expect(errorMessage).not.toContain('correctness-reviewer')
+      })
+
+      // #391 — surface every issue in the human-readable message
+
+      test('surfaces every issue when multiple Zod issues are returned', () => {
+        writeProjectConfig({
+          agents: { 'typo-agent-name': { color: 'primary' } },
+          disabled_agents: ['security-reviwer'],
+        })
+        let errorMessage = ''
+        try {
+          loadConfig(testDir)
+        } catch (e) {
+          errorMessage = (e as Error).message
+        }
+        // Both issues must surface in the human-readable message.
+        expect(errorMessage).toContain('typo-agent-name')
+        expect(errorMessage).toContain('security-reviwer')
+        // Multi-line format with bullet prefix when multiple issues exist.
+        expect(errorMessage).toMatch(/\n {2}-/)
+      })
+
+      test('preserves single-line format when only one issue is returned', () => {
+        writeProjectConfig({
+          agents: { 'typo-agent-name': { color: 'primary' } },
+        })
+        let errorMessage = ''
+        try {
+          loadConfig(testDir)
+        } catch (e) {
+          errorMessage = (e as Error).message
+        }
+        // No bullet prefix; backward-compat one-line format.
+        expect(errorMessage).not.toMatch(/\n {2}-/)
+        expect(errorMessage).toContain('typo-agent-name')
       })
     })
   })


### PR DESCRIPTION
Closes #391.

`SystematicConfigSchema.safeParse` returns every Zod issue when validation fails, but the loader only formatted the first one into the human-readable `.message`. A config with two typos produced an error describing only one of them — the user fixed it, re-ran, and was surprised by a second error. The full enriched issues array was already attached to the thrown error as `.issues`, so programmatic consumers were already complete; this change brings `.message` into parity.

## Behavior change

**Before** (single-issue example unchanged):
```
Invalid Systematic config in <path>: agents Unrecognized key 'typo-a'
```

**Before** (multi-issue — only the first surfaced):
```
Invalid Systematic config in <path>: agents Unrecognized key 'typo-a'
```

**After** (multi-issue — both surface in a bullet list):
```
Invalid Systematic config in <path>:
  - agents Unrecognized key 'typo-a'
  - disabled_agents.0 Invalid enum value 'security-reviwer'
```

Single-issue case preserves the existing one-line format. Bullet-list format only kicks in when there are 2+ issues.

## Implementation

- Extracted a local `formatIssue` helper so the single-issue and multi-issue branches use identical per-issue formatting logic
- Single-issue branch keeps the one-line shape for backward compatibility with existing user expectations
- Multi-issue branch joins issues with `\n  - ` prefix
- The `.issues` array on the thrown error is unchanged — programmatic consumers see no difference

## Tests

Two new TDD-driven tests in `tests/unit/config.test.ts`:

- `surfaces every issue when multiple Zod issues are returned` — writes a config with two distinct typos, asserts both surface in `.message` AND that the multi-line bullet format (`\n  -`) is present
- `preserves single-line format when only one issue is returned` — writes a config with a single typo, asserts the message stays one-line (no bullet prefix) for backward compatibility

Both tests were written first as RED, confirmed failing against the pre-change implementation, then drove the implementation to GREEN.

One existing regression test (`mixed agents typo and disabled_agents typo each produce their own enriched hint` from #390) had a `< 500` length guard implicit in the old single-issue assumption. Updated to `< 1000` with a revised comment now that both enriched issues land in the message.

## Release impact

Per `.releaserc.yaml`, `feat(config):` triggers a minor bump → **v2.18.0**. This release also flushes accumulated non-releasing commits from main:

- `refactor(schema):` PR #393 (factory pattern for SystematicConfigSchema)
- `docs(solutions):` PR #397 (3 compound learnings from v2.17.0)
- `build(dev):` PR #387, `chore(deps):` PRs #392/#395/#396 (renovate bumps)

## Verification

- `bun test tests/unit/` — 882 pass, 0 fail (was 880, +2 new)
- `bun run typecheck` — clean
- `bun run lint` — 0 errors, 5 warnings + 22 infos (pre-existing baseline)
- `bun scripts/content-integrity.ts` — clean (167 md + 21 ts, 0 warnings)
- `bun scripts/generate-config-schema.ts --check` — up to date (v2)
- `bun scripts/generate-registry.ts --check` — up to date (103 components)
- `bun run build` — clean
- Node ESM smoke test — `exports: ['default']`
- `bun run docs:build` — 112 pages
- plan-taxonomy audit on changed files — 0 hits