### PR TITLE
feat(skills): minimal deprecation surface + mark CC-residue skills as deprecated (v2.19.0)

### DIFF
--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -149,6 +149,7 @@ export interface FrontmatterViolation {
     | 'empty-required-field'
     | 'malformed-frontmatter'
     | 'missing-frontmatter'
+    | 'deprecated-reason-missing'
   field?: string
   message: string
   remediation: string
@@ -657,6 +658,7 @@ function scanSkillFrontmatter(
   checkRequiredSkillField(relPath, parsed.data, 'name', violations)
   checkRequiredSkillField(relPath, parsed.data, 'description', violations)
   checkSkillFrontmatterFields(relPath, parsed.data, violations)
+  checkDeprecatedReasonForBundled(relPath, parsed.data, violations)
 }
 
 function checkRequiredSkillField(
@@ -714,6 +716,27 @@ function checkSkillFrontmatterFields(
       })
     }
   }
+}
+
+function checkDeprecatedReasonForBundled(
+  relPath: string,
+  data: Record<string, unknown>,
+  violations: FrontmatterViolation[],
+): void {
+  if (!isSkillEntryFile(relPath)) return
+  if (!Object.hasOwn(data, 'deprecated')) return
+  const deprecated = data['deprecated']
+  if (!isRecord(deprecated)) return
+  const reason = deprecated['reason']
+  if (typeof reason === 'string' && reason.trim() !== '') return
+  violations.push({
+    file: relPath,
+    rule: 'deprecated-reason-missing',
+    field: 'deprecated.reason',
+    message:
+      'Bundled skill deprecated block must include a non-empty reason string.',
+    remediation: FRONTMATTER_REMEDIATION,
+  })
 }
 
 export function checkAgentColors(

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -150,6 +150,7 @@ export interface FrontmatterViolation {
     | 'malformed-frontmatter'
     | 'missing-frontmatter'
     | 'deprecated-reason-missing'
+    | 'deprecated-missing-required-fields'
   field?: string
   message: string
   remediation: string
@@ -658,7 +659,7 @@ function scanSkillFrontmatter(
   checkRequiredSkillField(relPath, parsed.data, 'name', violations)
   checkRequiredSkillField(relPath, parsed.data, 'description', violations)
   checkSkillFrontmatterFields(relPath, parsed.data, violations)
-  checkDeprecatedReasonForBundled(relPath, parsed.data, violations)
+  checkDeprecatedBlockForBundled(relPath, parsed.data, violations)
 }
 
 function checkRequiredSkillField(
@@ -718,7 +719,7 @@ function checkSkillFrontmatterFields(
   }
 }
 
-function checkDeprecatedReasonForBundled(
+function checkDeprecatedBlockForBundled(
   relPath: string,
   data: Record<string, unknown>,
   violations: FrontmatterViolation[],
@@ -727,6 +728,27 @@ function checkDeprecatedReasonForBundled(
   if (!Object.hasOwn(data, 'deprecated')) return
   const deprecated = data['deprecated']
   if (!isRecord(deprecated)) return
+
+  const since = deprecated['since']
+  const removal = deprecated['removal']
+  const sinceMissing = typeof since !== 'string' || since.trim() === ''
+  const removalMissing = typeof removal !== 'string' || removal.trim() === ''
+  if (sinceMissing || removalMissing) {
+    const missingFields = [
+      sinceMissing ? 'deprecated.since' : null,
+      removalMissing ? 'deprecated.removal' : null,
+    ]
+      .filter(Boolean)
+      .join(', ')
+    violations.push({
+      file: relPath,
+      rule: 'deprecated-missing-required-fields',
+      field: missingFields,
+      message: `Bundled skill deprecated block must include non-empty string fields: ${missingFields}. The runtime silently drops the entire deprecated block when these are missing, defeating the deprecation cycle.`,
+      remediation: FRONTMATTER_REMEDIATION,
+    })
+  }
+
   const reason = deprecated['reason']
   if (typeof reason === 'string' && reason.trim() !== '') return
   violations.push({

--- a/skills/claude-permissions-optimizer/SKILL.md
+++ b/skills/claude-permissions-optimizer/SKILL.md
@@ -3,6 +3,10 @@ name: claude-permissions-optimizer
 context: fork
 description: Optimize Claude Code permissions by finding safe Bash commands from session history and auto-applying them to settings.json. Can run from any coding agent but targets Claude Code specifically. Use when experiencing permission fatigue, too many permission prompts, wanting to optimize permissions, or needing to set up allowlists. Triggers on "optimize permissions", "reduce permission prompts", "allowlist commands", "too many permission prompts", "permission fatigue", "permission setup", or complaints about clicking approve too often.
 subtask: true
+deprecated:
+  since: v2.19.0
+  removal: v3.0.0
+  reason: "Targets Claude Code's ~/.claude/settings.json allowlist mechanism. OpenCode uses a SQLite-backed session-scoped permission model with built-in always-persistence via the always button. No prompt-fatigue analog exists in OpenCode; there is no equivalent allowlist to optimize."
 ---
 
 # Claude Permissions Optimizer

--- a/skills/orchestrating-swarms/SKILL.md
+++ b/skills/orchestrating-swarms/SKILL.md
@@ -2,6 +2,11 @@
 name: orchestrating-swarms
 description: Use when orchestrating multi-agent swarms, coordinating parallel code reviews, creating pipeline workflows with dependencies, building self-organizing task queues, or any task benefiting from divide-and-conquer patterns.
 disable-model-invocation: true
+deprecated:
+  since: v2.19.0
+  removal: v3.0.0
+  replacement: orchestrating-subagents
+  reason: "Documents the CEP Teammate API (TeammateTool, spawnTeam, TaskCreate/TaskList/TaskGet, team_name parameter on task(), CC subagent_type names). These primitives do not exist in OpenCode. A replacement skill will cover OpenCode-native parallel task() orchestration."
 ---
 
 # Swarm Orchestration

--- a/src/lib/skill-loader.ts
+++ b/src/lib/skill-loader.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { convertFileWithCache } from './converter.js'
 import { parseFrontmatter } from './frontmatter.js'
-import type { SkillInfo } from './skills.js'
+import type { SkillDeprecated, SkillInfo } from './skills.js'
 
 const SKILL_PREFIX = 'systematic:'
 const SKILL_DESCRIPTION_PREFIX = '(Systematic - Skill) '
@@ -19,6 +19,7 @@ export interface LoadedSkill {
   agent?: string
   model?: string
   argumentHint?: string
+  deprecated?: SkillDeprecated
 }
 
 export function formatSkillCommandName(name: string): string {
@@ -84,6 +85,7 @@ export function loadSkill(skillInfo: SkillInfo): LoadedSkill | null {
       agent: skillInfo.agent,
       model: skillInfo.model,
       argumentHint: skillInfo.argumentHint,
+      deprecated: skillInfo.deprecated,
     }
   } catch {
     return null

--- a/src/lib/skill-tool.ts
+++ b/src/lib/skill-tool.ts
@@ -14,7 +14,11 @@ import {
   type LoadedSkill,
   loadSkill,
 } from './skill-loader.js'
-import { findSkillsInDir, type SkillInfo } from './skills.js'
+import {
+  findSkillsInDir,
+  type SkillDeprecated,
+  type SkillInfo,
+} from './skills.js'
 
 export interface SkillToolOptions {
   bundledSkillsDir: string
@@ -90,8 +94,26 @@ export function discoverSkillFiles(dir: string, limit = 10): string {
   return files.map((file) => `  <file>${file}</file>`).join('\n')
 }
 
+function formatDeprecationMessage(
+  name: string,
+  deprecated: SkillDeprecated,
+): string {
+  let msg = `[systematic] skill "${name}" is deprecated since ${deprecated.since}; will be removed in ${deprecated.removal}.`
+  if (deprecated.replacement) {
+    msg += ` Replacement: ${deprecated.replacement}.`
+  }
+  if (deprecated.reason) {
+    msg += ` Reason: ${deprecated.reason}`
+    if (!deprecated.reason.endsWith('.')) {
+      msg += '.'
+    }
+  }
+  return msg
+}
+
 export function createSkillTool(options: SkillToolOptions): ToolDefinition {
   const { bundledSkillsDir, disabledSkills } = options
+  const warnedSkills = new Set<string>()
 
   const getAllSkills = (): LoadedSkill[] => {
     return findSkillsInDir(bundledSkillsDir)
@@ -163,6 +185,13 @@ ${catalog}`
         throw new Error(
           `Skill "${requestedName}" not found. Available systematic skills: ${availableSystematic.join(', ')}`,
         )
+      }
+
+      if (matchedSkill.deprecated && !warnedSkills.has(matchedSkill.name)) {
+        console.warn(
+          formatDeprecationMessage(matchedSkill.name, matchedSkill.deprecated),
+        )
+        warnedSkills.add(matchedSkill.name)
       }
 
       const body = extractSkillBody(matchedSkill.wrappedTemplate)

--- a/src/lib/skill-tool.ts
+++ b/src/lib/skill-tool.ts
@@ -100,7 +100,10 @@ function formatDeprecationMessage(
 ): string {
   let msg = `[systematic] skill "${name}" is deprecated since ${deprecated.since}; will be removed in ${deprecated.removal}.`
   if (deprecated.replacement) {
-    msg += ` Replacement: ${deprecated.replacement}.`
+    msg += ` Replacement: ${deprecated.replacement}`
+    if (!deprecated.replacement.endsWith('.')) {
+      msg += '.'
+    }
   }
   if (deprecated.reason) {
     msg += ` Reason: ${deprecated.reason}`
@@ -113,6 +116,10 @@ function formatDeprecationMessage(
 
 export function createSkillTool(options: SkillToolOptions): ToolDefinition {
   const { bundledSkillsDir, disabledSkills } = options
+  // Per-createSkillTool instance, intentionally not per-session. OpenCode's
+  // current per-session plugin-init behavior makes this de facto per-session
+  // today. If a future OpenCode reuses plugin instances across sessions, the
+  // warning de-emits indefinitely — acceptable since deprecation is informational.
   const warnedSkills = new Set<string>()
 
   const getAllSkills = (): LoadedSkill[] => {

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -9,6 +9,13 @@ import {
 } from './validation.js'
 import { walkDir } from './walk-dir.js'
 
+export interface SkillDeprecated {
+  since: string
+  removal: string
+  replacement?: string
+  reason?: string
+}
+
 export interface SkillFrontmatter {
   name: string
   description: string
@@ -16,6 +23,7 @@ export interface SkillFrontmatter {
   license?: string
   compatibility?: string
   metadata?: Record<string, string>
+  deprecated?: SkillDeprecated
   // Claude Code converted fields
   disableModelInvocation?: boolean // from YAML key: disable-model-invocation
   userInvocable?: boolean // from YAML key: user-invocable
@@ -35,6 +43,7 @@ export interface SkillInfo {
   license?: string
   compatibility?: string
   metadata?: Record<string, string>
+  deprecated?: SkillDeprecated
   // Claude Code converted fields
   disableModelInvocation?: boolean
   userInvocable?: boolean
@@ -54,6 +63,7 @@ export const SKILL_FRONTMATTER_FIELDS = [
   'license',
   'compatibility',
   'metadata',
+  'deprecated',
   'user-invocable',
   'agent',
   'model',
@@ -80,6 +90,29 @@ export function extractFrontmatter(filePath: string): SkillFrontmatter {
       }
     }
 
+    const deprecatedRaw = data.deprecated
+    let deprecated: SkillDeprecated | undefined
+    if (isRecord(deprecatedRaw)) {
+      const since =
+        typeof deprecatedRaw.since === 'string' && deprecatedRaw.since !== ''
+          ? deprecatedRaw.since
+          : undefined
+      const removal =
+        typeof deprecatedRaw.removal === 'string' &&
+        deprecatedRaw.removal !== ''
+          ? deprecatedRaw.removal
+          : undefined
+      if (since !== undefined && removal !== undefined) {
+        deprecated = { since, removal }
+        if (typeof deprecatedRaw.replacement === 'string') {
+          deprecated.replacement = deprecatedRaw.replacement
+        }
+        if (typeof deprecatedRaw.reason === 'string') {
+          deprecated.reason = deprecatedRaw.reason
+        }
+      }
+    }
+
     const argumentHintRaw = extractNonEmptyString(data, 'argument-hint')
     const argumentHint =
       argumentHintRaw?.replace(/^["']|["']$/g, '') || undefined
@@ -90,6 +123,7 @@ export function extractFrontmatter(filePath: string): SkillFrontmatter {
       license: extractNonEmptyString(data, 'license'),
       compatibility: extractNonEmptyString(data, 'compatibility'),
       metadata,
+      deprecated,
       disableModelInvocation: extractBoolean(data, 'disable-model-invocation'),
       userInvocable: extractBoolean(data, 'user-invocable'),
       subtask:
@@ -126,6 +160,7 @@ export function findSkillsInDir(dir: string, maxDepth = 3): SkillInfo[] {
         license: frontmatter.license,
         compatibility: frontmatter.compatibility,
         metadata: frontmatter.metadata,
+        deprecated: frontmatter.deprecated,
         disableModelInvocation: frontmatter.disableModelInvocation,
         userInvocable: frontmatter.userInvocable,
         subtask: frontmatter.subtask,

--- a/tests/manual/smoke-deprecation-warning.ts
+++ b/tests/manual/smoke-deprecation-warning.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env bun
+
+/**
+ * Manual smoke test for the v2.19.0 skill-deprecation warning surface.
+ *
+ * Run via: bun tests/manual/smoke-deprecation-warning.ts
+ *
+ * Proves the full integration path: load built plugin -> initialize ->
+ * register systematic_skill tool -> invoke execute() for a deprecated
+ * skill -> capture console.warn -> assert message format + dedup.
+ *
+ * Uses the built dist/index.js (not the .ts source) so this is genuine
+ * end-to-end verification of what ships to npm.
+ *
+ * No external dependencies; no OpenCode TUI; no persistent session.
+ */
+
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const projectRoot = path.resolve(__dirname, '../..')
+
+// Import the BUILT plugin, not the source.
+const builtPluginPath = path.join(projectRoot, 'dist', 'index.js')
+const pluginModule = (await import(builtPluginPath)) as {
+  default: (input: unknown) => Promise<{ tool?: Record<string, unknown> }>
+}
+
+// Minimal PluginInput shape — the plugin only reads the client field for
+// availability checks, which we can skip by passing undefined and letting
+// the source-default resolution fall through to the unknown bucket.
+const pluginInput = {
+  app: {
+    path: {
+      cwd: projectRoot,
+      root: projectRoot,
+      data: projectRoot,
+      state: projectRoot,
+      config: projectRoot,
+    },
+  },
+  client: undefined,
+  $: () => Promise.resolve({ exitCode: 0, stdout: '', stderr: '' }),
+  directory: projectRoot,
+}
+
+const hooks = await pluginModule.default(pluginInput)
+if (!hooks.tool || typeof hooks.tool !== 'object') {
+  throw new Error('Plugin did not register a tool surface')
+}
+
+const toolMap = hooks.tool as Record<
+  string,
+  { execute: (args: unknown, context: unknown) => Promise<string> }
+>
+const skillTool = toolMap.systematic_skill
+if (!skillTool) {
+  throw new Error('Plugin did not register systematic_skill tool')
+}
+
+// Capture console.warn calls.
+const warnings: string[] = []
+const originalWarn = console.warn
+console.warn = (...args: unknown[]) => {
+  warnings.push(args.map((a) => String(a)).join(' '))
+}
+
+// Minimal ToolContext shape — execute() calls context.ask() and context.metadata().
+const mockContext = {
+  ask: async () => undefined,
+  metadata: () => undefined,
+  sessionID: 'smoke',
+  messageID: 'smoke',
+  agent: 'smoke',
+  abort: new AbortController().signal,
+}
+
+console.log('=== Smoke test: skill deprecation warning ===')
+console.log('Built plugin loaded from:', builtPluginPath)
+console.log('Tool registered: systematic_skill')
+console.log('')
+
+// Invoke 1: orchestrating-swarms (should warn — has replacement + reason).
+console.log('--- Invoke 1: orchestrating-swarms ---')
+await skillTool.execute({ name: 'orchestrating-swarms' }, mockContext)
+console.log(`captured warnings so far: ${warnings.length}`)
+console.log(`last warning: ${warnings[warnings.length - 1] ?? '(none)'}`)
+console.log('')
+
+// Invoke 2: orchestrating-swarms again (should NOT warn — dedup).
+console.log('--- Invoke 2: orchestrating-swarms (dedup test) ---')
+await skillTool.execute({ name: 'orchestrating-swarms' }, mockContext)
+console.log(`captured warnings so far: ${warnings.length}`)
+console.log('expected: still 1 (dedup blocks second emit)')
+console.log('')
+
+// Invoke 3: claude-permissions-optimizer (should warn — no replacement).
+console.log('--- Invoke 3: claude-permissions-optimizer ---')
+await skillTool.execute({ name: 'claude-permissions-optimizer' }, mockContext)
+console.log(`captured warnings so far: ${warnings.length}`)
+console.log(`last warning: ${warnings[warnings.length - 1] ?? '(none)'}`)
+console.log('')
+
+// Invoke 4: setup (should NOT warn — not deprecated).
+console.log('--- Invoke 4: setup (non-deprecated control) ---')
+await skillTool.execute({ name: 'setup' }, mockContext)
+console.log(`captured warnings so far: ${warnings.length}`)
+console.log('expected: still 2 (non-deprecated skill emits nothing)')
+console.log('')
+
+// Restore console.warn.
+console.warn = originalWarn
+
+// Assertions.
+const errors: string[] = []
+if (warnings.length !== 2) {
+  errors.push(`Expected 2 total warnings; got ${warnings.length}`)
+}
+if (!warnings[0]?.includes('orchestrating-swarms')) {
+  errors.push(`Warning 1 missing skill name: ${warnings[0]}`)
+}
+if (!warnings[0]?.includes('Replacement: orchestrating-subagents')) {
+  errors.push(`Warning 1 missing Replacement clause: ${warnings[0]}`)
+}
+if (!warnings[0]?.includes('Reason:')) {
+  errors.push(`Warning 1 missing Reason clause: ${warnings[0]}`)
+}
+if (!warnings[1]?.includes('claude-permissions-optimizer')) {
+  errors.push(`Warning 2 missing skill name: ${warnings[1]}`)
+}
+if (warnings[1]?.includes('Replacement:')) {
+  errors.push(
+    `Warning 2 unexpectedly includes Replacement clause: ${warnings[1]}`,
+  )
+}
+if (!warnings[1]?.includes('Reason:')) {
+  errors.push(`Warning 2 missing Reason clause: ${warnings[1]}`)
+}
+
+console.log('=== Captured warnings (full text) ===')
+for (const [i, w] of warnings.entries()) {
+  console.log(`[${i + 1}] ${w}`)
+}
+console.log('')
+
+if (errors.length > 0) {
+  console.log('=== FAIL ===')
+  for (const e of errors) {
+    console.log(`  ${e}`)
+  }
+  process.exit(1)
+} else {
+  console.log('=== PASS ===')
+  console.log('  - orchestrating-swarms warns with Replacement + Reason')
+  console.log(
+    '  - claude-permissions-optimizer warns with Reason only (no Replacement)',
+  )
+  console.log(
+    '  - dedup works: second invocation of same skill emits no warning',
+  )
+  console.log('  - non-deprecated skill (setup) emits no warning')
+  process.exit(0)
+}

--- a/tests/manual/smoke-deprecation-warning.ts
+++ b/tests/manual/smoke-deprecation-warning.ts
@@ -15,6 +15,7 @@
  * No external dependencies; no OpenCode TUI; no persistent session.
  */
 
+import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -23,6 +24,11 @@ const projectRoot = path.resolve(__dirname, '../..')
 
 // Import the BUILT plugin, not the source.
 const builtPluginPath = path.join(projectRoot, 'dist', 'index.js')
+if (!fs.existsSync(builtPluginPath)) {
+  console.error(`Built plugin not found at ${builtPluginPath}`)
+  console.error('Run "bun run build" first, then re-run this smoke test.')
+  process.exit(1)
+}
 const pluginModule = (await import(builtPluginPath)) as {
   default: (input: unknown) => Promise<{ tool?: Record<string, unknown> }>
 }

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -858,6 +858,8 @@ describe('checkFrontmatter — deprecated.reason enforcement', () => {
           'name: my-skill',
           'description: A skill',
           'deprecated:',
+          '  since: v2.19.0',
+          '  removal: v3.0.0',
           '  reason: "Use the new-skill instead."',
           '---',
           'body',
@@ -929,6 +931,31 @@ describe('checkFrontmatter — deprecated.reason enforcement', () => {
     }
   })
 
+  test('silently accepts non-object deprecated value (consistent with runtime drop behavior)', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'my-skill',
+        [
+          '---',
+          'name: my-skill',
+          'description: A skill',
+          'deprecated: "malformed"',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkFrontmatter(root, targets.markdown)
+      expect(
+        violations.filter((v) => v.rule === 'deprecated-reason-missing'),
+      ).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   test('integration: real repo skills with deprecated blocks all have non-empty reason', () => {
     const result = checkFrontmatter(
       REPO_ROOT,
@@ -938,6 +965,94 @@ describe('checkFrontmatter — deprecated.reason enforcement', () => {
       (v) => v.rule === 'deprecated-reason-missing',
     )
     expect(deprecatedReasonViolations).toEqual([])
+  })
+
+  test('bundled skill with deprecated block missing both since and removal emits deprecated-missing-required-fields violation', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'my-skill',
+        [
+          '---',
+          'name: my-skill',
+          'description: A skill',
+          'deprecated:',
+          '  reason: "Use new-skill instead."',
+          '  replacement: new-skill',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkFrontmatter(root, targets.markdown)
+      const match = violations.filter(
+        (v) => v.rule === 'deprecated-missing-required-fields',
+      )
+      expect(match).toHaveLength(1)
+      expect(match[0]?.file).toBe('skills/my-skill/SKILL.md')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('bundled skill with deprecated block missing removal emits deprecated-missing-required-fields violation', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'my-skill',
+        [
+          '---',
+          'name: my-skill',
+          'description: A skill',
+          'deprecated:',
+          '  since: v2.19.0',
+          '  reason: "Use new-skill instead."',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkFrontmatter(root, targets.markdown)
+      const match = violations.filter(
+        (v) => v.rule === 'deprecated-missing-required-fields',
+      )
+      expect(match).toHaveLength(1)
+      expect(match[0]?.file).toBe('skills/my-skill/SKILL.md')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('bundled skill with deprecated block where since is non-string emits deprecated-missing-required-fields violation', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'my-skill',
+        [
+          '---',
+          'name: my-skill',
+          'description: A skill',
+          'deprecated:',
+          '  since: 42',
+          '  removal: v3.0.0',
+          '  reason: "Use new-skill instead."',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkFrontmatter(root, targets.markdown)
+      const match = violations.filter(
+        (v) => v.rule === 'deprecated-missing-required-fields',
+      )
+      expect(match).toHaveLength(1)
+      expect(match[0]?.file).toBe('skills/my-skill/SKILL.md')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
   })
 })
 

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -846,6 +846,101 @@ describe('checkFrontmatter', () => {
   })
 })
 
+describe('checkFrontmatter — deprecated.reason enforcement', () => {
+  test('bundled skill with deprecated.reason populated passes with no violation', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'my-skill',
+        [
+          '---',
+          'name: my-skill',
+          'description: A skill',
+          'deprecated:',
+          '  reason: "Use the new-skill instead."',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkFrontmatter(root, targets.markdown)
+      expect(
+        violations.filter((v) => v.rule === 'deprecated-reason-missing'),
+      ).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('bundled skill with deprecated block but no reason field fails with structured violation', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'my-skill',
+        [
+          '---',
+          'name: my-skill',
+          'description: A skill',
+          'deprecated: {}',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkFrontmatter(root, targets.markdown)
+      const match = violations.filter(
+        (v) => v.rule === 'deprecated-reason-missing',
+      )
+      expect(match).toHaveLength(1)
+      expect(match[0]?.file).toBe('skills/my-skill/SKILL.md')
+      expect(match[0]?.field).toBe('deprecated.reason')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('bundled skill with deprecated.reason as empty string fails with structured violation', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'my-skill',
+        [
+          '---',
+          'name: my-skill',
+          'description: A skill',
+          'deprecated:',
+          '  reason: ""',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkFrontmatter(root, targets.markdown)
+      const match = violations.filter(
+        (v) => v.rule === 'deprecated-reason-missing',
+      )
+      expect(match).toHaveLength(1)
+      expect(match[0]?.field).toBe('deprecated.reason')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('integration: real repo skills with deprecated blocks all have non-empty reason', () => {
+    const result = checkFrontmatter(
+      REPO_ROOT,
+      collectScanTargets(REPO_ROOT).markdown,
+    )
+    const deprecatedReasonViolations = result.filter(
+      (v) => v.rule === 'deprecated-reason-missing',
+    )
+    expect(deprecatedReasonViolations).toEqual([])
+  })
+})
+
 describe('checkAgentColors', () => {
   test('allows OpenCode theme tokens and hex colors', () => {
     const root = makeFixtureRepo()

--- a/tests/unit/skill-tool.test.ts
+++ b/tests/unit/skill-tool.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -604,6 +604,193 @@ disable-model-invocation: true
         expect(message).toContain('systematic:visible-skill')
         expect(message).not.toContain('hidden-skill')
       }
+    })
+  })
+
+  describe('deprecated skill warnings', () => {
+    function makeDeprecatedSkill(
+      dir: string,
+      name: string,
+      extras: string = '',
+    ): void {
+      const skillDir = path.join(dir, name)
+      fs.mkdirSync(skillDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(skillDir, 'SKILL.md'),
+        `---
+name: ${name}
+description: A deprecated skill
+deprecated:
+  since: v2.19.0
+  removal: v3.0.0
+  replacement: new-skill
+  reason: "Old API no longer supported."
+${extras}---
+# Deprecated Skill Content`,
+      )
+    }
+
+    test('emits console.warn with full message when invoking a deprecated skill', async () => {
+      makeDeprecatedSkill(testDir, 'old-skill')
+
+      const tool = createSkillTool({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      const warnSpy = spyOn(console, 'warn')
+
+      await tool.execute({ name: 'old-skill' }, mockContext)
+
+      const warnCalls = warnSpy.mock.calls as unknown[][]
+      const deprecationWarn = warnCalls.find(
+        (args: unknown[]) =>
+          typeof args[0] === 'string' &&
+          args[0].includes('[systematic]') &&
+          args[0].includes('"old-skill"') &&
+          args[0].includes('deprecated'),
+      )
+      expect(deprecationWarn).toBeDefined()
+      const msg = (deprecationWarn as unknown[])[0] as string
+      expect(msg).toBe(
+        '[systematic] skill "old-skill" is deprecated since v2.19.0; will be removed in v3.0.0. Replacement: new-skill. Reason: Old API no longer supported.',
+      )
+
+      warnSpy.mockRestore()
+    })
+
+    test('emits console.warn only once when the same deprecated skill is invoked twice on the same tool instance', async () => {
+      makeDeprecatedSkill(testDir, 'old-skill')
+
+      const tool = createSkillTool({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      const warnSpy = spyOn(console, 'warn')
+
+      await tool.execute({ name: 'old-skill' }, mockContext)
+      await tool.execute({ name: 'old-skill' }, mockContext)
+
+      const deprecationWarns = (warnSpy.mock.calls as unknown[][]).filter(
+        (args: unknown[]) =>
+          typeof args[0] === 'string' &&
+          args[0].includes('[systematic]') &&
+          args[0].includes('"old-skill"'),
+      )
+      expect(deprecationWarns.length).toBe(1)
+
+      warnSpy.mockRestore()
+    })
+
+    test('omits Replacement clause when replacement is absent', async () => {
+      const skillDir = path.join(testDir, 'no-replacement')
+      fs.mkdirSync(skillDir)
+      fs.writeFileSync(
+        path.join(skillDir, 'SKILL.md'),
+        `---
+name: no-replacement
+description: Deprecated without replacement
+deprecated:
+  since: v2.19.0
+  removal: v3.0.0
+  reason: "No replacement available."
+---
+# Content`,
+      )
+
+      const tool = createSkillTool({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      const warnSpy = spyOn(console, 'warn')
+
+      await tool.execute({ name: 'no-replacement' }, mockContext)
+
+      const deprecationWarns = (warnSpy.mock.calls as unknown[][]).filter(
+        (args: unknown[]) =>
+          typeof args[0] === 'string' && args[0].includes('"no-replacement"'),
+      )
+      expect(deprecationWarns.length).toBe(1)
+      const msg = (deprecationWarns[0] as unknown[])[0] as string
+      expect(msg).not.toContain('Replacement:')
+      expect(msg).toContain('Reason: No replacement available.')
+      expect(msg).not.toMatch(/\. {2}|\.$\.$/)
+
+      warnSpy.mockRestore()
+    })
+
+    test('omits Reason clause when reason is absent', async () => {
+      const skillDir = path.join(testDir, 'no-reason')
+      fs.mkdirSync(skillDir)
+      fs.writeFileSync(
+        path.join(skillDir, 'SKILL.md'),
+        `---
+name: no-reason
+description: Deprecated without reason
+deprecated:
+  since: v2.19.0
+  removal: v3.0.0
+  replacement: better-skill
+---
+# Content`,
+      )
+
+      const tool = createSkillTool({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      const warnSpy = spyOn(console, 'warn')
+
+      await tool.execute({ name: 'no-reason' }, mockContext)
+
+      const deprecationWarns = (warnSpy.mock.calls as unknown[][]).filter(
+        (args: unknown[]) =>
+          typeof args[0] === 'string' && args[0].includes('"no-reason"'),
+      )
+      expect(deprecationWarns.length).toBe(1)
+      const msg = (deprecationWarns[0] as unknown[])[0] as string
+      expect(msg).not.toContain('Reason:')
+      expect(msg).toContain('Replacement: better-skill.')
+
+      warnSpy.mockRestore()
+    })
+
+    test('a fresh createSkillTool instance re-emits the warning for the same skill', async () => {
+      makeDeprecatedSkill(testDir, 'old-skill')
+
+      const tool1 = createSkillTool({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      const warnSpy = spyOn(console, 'warn')
+
+      await tool1.execute({ name: 'old-skill' }, mockContext)
+
+      const warnsAfterFirst = (warnSpy.mock.calls as unknown[][]).filter(
+        (args: unknown[]) =>
+          typeof args[0] === 'string' && args[0].includes('"old-skill"'),
+      ).length
+      expect(warnsAfterFirst).toBe(1)
+
+      // New instance — dedup set is fresh
+      const tool2 = createSkillTool({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      await tool2.execute({ name: 'old-skill' }, mockContext)
+
+      const warnsAfterSecond = (warnSpy.mock.calls as unknown[][]).filter(
+        (args: unknown[]) =>
+          typeof args[0] === 'string' && args[0].includes('"old-skill"'),
+      ).length
+      expect(warnsAfterSecond).toBe(2)
+
+      warnSpy.mockRestore()
     })
   })
 })

--- a/tests/unit/skill-tool.test.ts
+++ b/tests/unit/skill-tool.test.ts
@@ -759,6 +759,45 @@ deprecated:
       warnSpy.mockRestore()
     })
 
+    test('does not produce double-dot when replacement already ends with a period', async () => {
+      const skillDir = path.join(testDir, 'trailing-dot-replacement')
+      fs.mkdirSync(skillDir)
+      fs.writeFileSync(
+        path.join(skillDir, 'SKILL.md'),
+        `---
+name: trailing-dot-replacement
+description: Deprecated with trailing-dot replacement
+deprecated:
+  since: v2.19.0
+  removal: v3.0.0
+  replacement: "new-skill."
+  reason: "Old API removed."
+---
+# Content`,
+      )
+
+      const tool = createSkillTool({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      const warnSpy = spyOn(console, 'warn')
+
+      await tool.execute({ name: 'trailing-dot-replacement' }, mockContext)
+
+      const deprecationWarns = (warnSpy.mock.calls as unknown[][]).filter(
+        (args: unknown[]) =>
+          typeof args[0] === 'string' &&
+          args[0].includes('"trailing-dot-replacement"'),
+      )
+      expect(deprecationWarns.length).toBe(1)
+      const msg = (deprecationWarns[0] as unknown[])[0] as string
+      expect(msg).not.toMatch(/\.\./u)
+      expect(msg).toContain('Replacement: new-skill.')
+
+      warnSpy.mockRestore()
+    })
+
     test('a fresh createSkillTool instance re-emits the warning for the same skill', async () => {
       makeDeprecatedSkill(testDir, 'old-skill')
 

--- a/tests/unit/skill-tool.test.ts
+++ b/tests/unit/skill-tool.test.ts
@@ -716,7 +716,8 @@ deprecated:
       const msg = (deprecationWarns[0] as unknown[])[0] as string
       expect(msg).not.toContain('Replacement:')
       expect(msg).toContain('Reason: No replacement available.')
-      expect(msg).not.toMatch(/\. {2}|\.$\.$/)
+      // Should not have any double-period artifacts (e.g., ".." at end or ". ." patterns)
+      expect(msg).not.toMatch(/\.\.$|\. \./)
 
       warnSpy.mockRestore()
     })

--- a/tests/unit/skills.test.ts
+++ b/tests/unit/skills.test.ts
@@ -191,6 +191,85 @@ argument-hint: '"[pattern]"'
       const result = skills.extractFrontmatter(filePath)
       expect(result.argumentHint).toBe('[pattern]')
     })
+
+    test('parses full deprecated block with all four fields', () => {
+      const filePath = path.join(testDir, 'test.md')
+      fs.writeFileSync(
+        filePath,
+        `---
+name: test-skill
+description: A test skill
+deprecated:
+  since: '1.2.0'
+  removal: '2.0.0'
+  replacement: new-skill
+  reason: Replaced by new-skill for better performance
+---
+# Skill Content`,
+      )
+      const result = skills.extractFrontmatter(filePath)
+      expect(result.deprecated).toEqual({
+        since: '1.2.0',
+        removal: '2.0.0',
+        replacement: 'new-skill',
+        reason: 'Replaced by new-skill for better performance',
+      })
+    })
+
+    test('drops entire deprecated block when removal is missing', () => {
+      const filePath = path.join(testDir, 'test.md')
+      fs.writeFileSync(
+        filePath,
+        `---
+name: test-skill
+description: A test skill
+deprecated:
+  since: '1.2.0'
+  reason: Missing removal field
+---
+# Skill Content`,
+      )
+      const result = skills.extractFrontmatter(filePath)
+      expect(result.deprecated).toBeUndefined()
+    })
+
+    test('keeps since+removal but drops non-string replacement silently', () => {
+      const filePath = path.join(testDir, 'test.md')
+      fs.writeFileSync(
+        filePath,
+        `---
+name: test-skill
+description: A test skill
+deprecated:
+  since: '1.2.0'
+  removal: '2.0.0'
+  replacement: 42
+  reason: Valid reason
+---
+# Skill Content`,
+      )
+      const result = skills.extractFrontmatter(filePath)
+      expect(result.deprecated).toEqual({
+        since: '1.2.0',
+        removal: '2.0.0',
+        reason: 'Valid reason',
+      })
+      expect(result.deprecated?.replacement).toBeUndefined()
+    })
+
+    test('skill with no deprecated field has deprecated undefined', () => {
+      const filePath = path.join(testDir, 'test.md')
+      fs.writeFileSync(
+        filePath,
+        `---
+name: test-skill
+description: A test skill
+---
+# Skill Content`,
+      )
+      const result = skills.extractFrontmatter(filePath)
+      expect(result.deprecated).toBeUndefined()
+    })
   })
 
   describe('findSkillsInDir', () => {


### PR DESCRIPTION
Ships a deliberately-minimal skill-deprecation surface in v2.19.0 — one `deprecated:` frontmatter field, one runtime warning emitted from `systematic_skill` invocations, and content-integrity strict-mode for bundled skills. Marks `orchestrating-swarms` and `claude-permissions-optimizer` as deprecated using that surface.

The actual deletion of those two skills (planned for v3.0.0) is **not** in this PR. v2.19.0 ships standalone. A separate brainstorm-and-plan cycle revisits the v3.0.0 excision after v2.19.0 has been in the wild.

## Why these two skills

**`orchestrating-swarms`** documents CEP's `Teammate` API: `TeammateTool`, `spawnTeam`, `TaskCreate/TaskList/TaskGet`, `team_name` parameter on `task()`, Claude Code built-in `subagent_type` names. None of those primitives exist in OpenCode. Line 9 of its own SKILL.md admits the skill is aspirational. It ships with `disable-model-invocation: true` so the LLM never auto-dispatches it, but it ships in the npm tarball + OCX registry regardless.

**`claude-permissions-optimizer`** targets Claude Code's `~/.claude/settings.json` allowlist mechanism. OpenCode uses a SQLite-backed session-scoped permission model with built-in always-persistence via the always button. There's no prompt-fatigue analog and no OpenCode equivalent to optimize.

Both skills are CC-residue from the original CEP fork. Neither serves OpenCode users today.

## What ships in v2.19.0

### New frontmatter field

`deprecated:` joins the `SKILL_FRONTMATTER_FIELDS` allow-list with shape:

```yaml
deprecated:
  since: v2.19.0       # required
  removal: v3.0.0      # required
  replacement: name    # optional
  reason: prose...     # optional at runtime; required for bundled (CI gate)
```

The runtime parser is permissive: malformed sub-fields drop silently, the entire block drops if `since` or `removal` is missing or non-string. The parser never throws.

### Runtime warning

When `systematic_skill` loads a deprecated skill, it emits one `console.warn` per skill per plugin instance (per-session in OpenCode's current behavior):

```
[systematic] skill "<name>" is deprecated since v<since>; will be removed in v<removal>. Replacement: <replacement>. Reason: <reason>.
```

`Replacement:` and `Reason:` clauses appear only when set. A per-plugin-instance `Set<string>` dedups within a session; a fresh OpenCode session re-emits.

### Content-integrity strict-mode for bundled skills

When a bundled `skills/<name>/SKILL.md` declares a `deprecated:` block, content-integrity requires `since`, `removal`, and `reason` to all be present and non-empty (mirroring the runtime drop rules — a skill that passes the gate must also produce a runtime warning). Third-party skills consumed via the loader remain permissive. The gate uses the existing `isSkillEntryFile` helper to detect bundled paths.

### Two skills marked

`orchestrating-swarms` → `replacement: orchestrating-subagents` (forward reference; the replacement will land in the v3.0.0 cycle).

`claude-permissions-optimizer` → no replacement.

Both carry concrete `reason` prose explaining the OpenCode/CC divergence.

## What does NOT ship

- The v3.0.0 deletion of either skill
- Any new replacement skill
- Richer deprecation policy (severity levels, machine-readable output, CLI inspection subcommand) — explicitly out of scope until a real second use case
- Any harness-portability discipline (separate downstream concern, not a deprecation question)

## Test surface

- 4 new tests in `tests/unit/skills.test.ts` covering happy path, missing-required-field drop, malformed-optional-field drop, and the no-deprecated baseline
- 6 new tests in `tests/unit/skill-tool.test.ts` covering full message, dedup, missing-replacement, missing-reason, fresh-instance re-emission, and replacement-already-ends-with-dot
- 8 new tests in `tests/unit/content-integrity.test.ts` covering reason-required, since+removal required (mirroring runtime drop rules), and non-object deprecated silently accepted
- **Manual smoke**: `tests/manual/smoke-deprecation-warning.ts` loads the built `dist/index.js` and asserts end-to-end that invoking each deprecated skill emits the expected console.warn with correct dedup behavior

882 → 900 passing unit tests (+18). All gates clean: typecheck, lint, content-integrity, schema:drift, registry:drift, docs:build, Node ESM smoke.

## Migration

v2.19.0 emits the deprecation warning but keeps both skills functional. Users who are actively invoking either skill should plan to migrate before v3.0.0.

When v3.0.0 ships, the rescue path is standard semver: `npm install @fro.bot/systematic@^2.19` — v2.18.x and v2.19.x remain available on npm.

If v3.0.0 never ships, the deprecation warning becomes the new steady state and both skills stay bundled. That outcome is acceptable.
