### PR TITLE
docs(solutions): compound 3 lessons from v2.19.0 release cycle

### DIFF
--- a/docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md
+++ b/docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md
@@ -1,0 +1,159 @@
+---
+title: Content-integrity gate should mirror runtime drop rules, not check raw YAML
+module: scripts/content-integrity.ts
+date: 2026-05-17
+problem_type: best_practice
+component: tooling
+severity: medium
+tags:
+  - content-integrity
+  - frontmatter-validation
+  - skill-loader
+  - gate-discipline
+  - bundled-skills
+applies_when:
+  - Adding a new frontmatter field that the runtime parser handles permissively (silent drops on malformed values)
+  - Extending content-integrity to validate that bundled assets are usable at runtime
+  - Designing a CI gate that checks a subset of fields without modeling the runtime's full validation rules
+---
+
+# Content-integrity gate should mirror runtime drop rules, not check raw YAML
+
+## Context
+
+Systematic's runtime skill-frontmatter parser (`src/lib/skills.ts:extractFrontmatter`) is intentionally permissive: it parses YAML, validates each field against the allow-list, and silently drops malformed values rather than throwing. This protects third-party skill consumers from crashes when a user's hand-edited SKILL.md has a malformed sub-field.
+
+The content-integrity gate (`scripts/content-integrity.ts`) runs in CI against bundled skills only (`skills/<name>/SKILL.md`) and enforces stricter contracts that the runtime parser does not.
+
+When adding the new `deprecated: { since, removal, replacement?, reason? }` block (v2.19.0, PR #401), the first gate implementation only required `reason` to be a non-empty string on bundled skills. The runtime parser, in contrast, drops the **entire** `deprecated:` block if `since` or `removal` is missing or non-string — because a deprecation warning without a version reference is meaningless.
+
+This created a silent disconnect: a bundled skill could be authored with `deprecated: { reason: "...some prose..." }` (no `since`, no `removal`), pass the CI gate cleanly, and emit **zero** runtime deprecation warning at all. The author would see a green CI build and assume the deprecation cycle was working. A future contributor adding a deprecated block would hit this trap silently.
+
+Fro Bot's review on PR #401 caught the gap before merge.
+
+## Guidance
+
+**When a content-integrity gate validates a field that the runtime parser handles permissively, the gate must enforce the same minimum field set that the runtime requires to NOT silently drop the value. Otherwise the gate gives false confidence — CI passes but the runtime behavior the gate is meant to protect (here: emitting a deprecation warning) doesn't actually happen.**
+
+Concretely: do not check the raw `data['field']` object for the gate-specific sub-field while ignoring whatever sub-fields the runtime requires for the block to survive parsing. Read the runtime parser's drop rules and mirror them at the gate.
+
+Mechanics that made the fix clean:
+
+1. Add a new violation rule alongside the original one (so the message is specific to "missing the runtime-required fields", not conflated with "missing the gate-specific field").
+2. Run the runtime-required-field check first; continue to the gate-specific check after. An author with multiple gaps sees all of them in one CI run instead of having to fix them in sequence.
+3. Use the existing bundled-skill predicate (here: `isSkillEntryFile`) so the rule scope stays bundled-only — third-party skills retain runtime-permissive behavior.
+
+## Why This Matters
+
+A gate that doesn't match the runtime's invariants is worse than no gate — it actively misleads. The author trusts the green CI and ships frontmatter that the runtime silently ignores. Two failure modes follow:
+
+1. **Silent feature-non-delivery**: The deprecation warning never emits. Users of the deprecated skill never see the migration prompt. The deprecation cycle becomes a no-op.
+2. **Compounding drift**: Future contributors copy the working-looking pattern. Each new "deprecated" block is dead code on the runtime side. By the time someone notices, fixing it means auditing every bundled deprecation back to v2.19.0.
+
+The cost of mirroring runtime drop rules at the gate is small: a handful of lines that mirror the runtime's own `typeof === 'string' && .trim() !== ''` check. The cost of not mirroring is dressed-up dead code shipping in production.
+
+## When to Apply
+
+- Whenever a new frontmatter (or config) field is added to a runtime parser that uses **permissive drop-on-malformed** semantics, plan the matching gate rule before merging the runtime change.
+- When extending an existing gate, audit the runtime parser for fields it now silently drops. If the gate doesn't catch those, write a regression test that fails the gate against a fixture with the dropped field omitted.
+- When reviewing a PR that adds a frontmatter field, ask: "what does the runtime do with a malformed value here? what does the gate do? are they consistent for bundled skills?"
+
+## Examples
+
+### Wrong: gate checks raw YAML, ignores runtime requirements
+
+```ts
+function checkDeprecatedReasonForBundled(
+  relPath: string,
+  data: Record<string, unknown>,
+  violations: FrontmatterViolation[],
+): void {
+  if (!isSkillEntryFile(relPath)) return
+  if (!Object.hasOwn(data, 'deprecated')) return
+  const deprecated = data['deprecated']
+  if (!isRecord(deprecated)) return
+  // Only checks reason. Runtime requires since + removal too.
+  const reason = deprecated['reason']
+  if (typeof reason === 'string' && reason.trim() !== '') return
+  violations.push({
+    file: relPath,
+    rule: 'deprecated-reason-missing',
+    field: 'deprecated.reason',
+    message: 'Bundled skill deprecated block must include a non-empty reason string.',
+    remediation: FRONTMATTER_REMEDIATION,
+  })
+}
+```
+
+A bundled skill with `deprecated: { reason: "Targets Claude Code." }` passes this gate but produces no runtime warning.
+
+### Right: gate mirrors runtime drop rules
+
+```ts
+function checkDeprecatedBlockForBundled(
+  relPath: string,
+  data: Record<string, unknown>,
+  violations: FrontmatterViolation[],
+): void {
+  if (!isSkillEntryFile(relPath)) return
+  if (!Object.hasOwn(data, 'deprecated')) return
+  const deprecated = data['deprecated']
+  if (!isRecord(deprecated)) return
+
+  // Mirror the runtime parser's drop rules (src/lib/skills.ts). The runtime
+  // silently drops the entire deprecated block if since or removal is missing
+  // or non-string. A bundled skill that passes the gate must produce a runtime
+  // warning, so require the same minimum field set here.
+  const since = deprecated['since']
+  const removal = deprecated['removal']
+  const sinceValid = typeof since === 'string' && since.trim() !== ''
+  const removalValid = typeof removal === 'string' && removal.trim() !== ''
+  if (!sinceValid || !removalValid) {
+    const missing: string[] = []
+    if (!sinceValid) missing.push('since')
+    if (!removalValid) missing.push('removal')
+    violations.push({
+      file: relPath,
+      rule: 'deprecated-missing-required-fields',
+      field: `deprecated.${missing.join(', deprecated.')}`,
+      message: `Bundled skill deprecated block must include non-empty string fields: ${missing.join(', ')}. Runtime would silently drop this block.`,
+      remediation: FRONTMATTER_REMEDIATION,
+    })
+  }
+
+  // Gate-specific check (reason is required for bundled even though runtime
+  // accepts it as optional). Run after the runtime-mirror check so an author
+  // with multiple gaps sees both in one pass.
+  const reason = deprecated['reason']
+  if (typeof reason === 'string' && reason.trim() !== '') return
+  violations.push({
+    file: relPath,
+    rule: 'deprecated-reason-missing',
+    field: 'deprecated.reason',
+    message: 'Bundled skill deprecated block must include a non-empty reason string.',
+    remediation: FRONTMATTER_REMEDIATION,
+  })
+}
+```
+
+The gate now catches both classes of gap. The error message explicitly names "Runtime would silently drop this block" so future authors can connect the gate failure to the runtime behavior.
+
+### Regression test fixture
+
+```ts
+test('deprecated block missing since+removal triggers deprecated-missing-required-fields violation', () => {
+  const fixture = makeBundledSkill({
+    deprecated: { reason: 'Old API no longer supported.' },
+  })
+  const violations = runGate(fixture)
+  expect(violations).toContainEqual(
+    expect.objectContaining({ rule: 'deprecated-missing-required-fields' }),
+  )
+})
+```
+
+## Related
+
+- `docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md` — adjacent precedent for build-time codegen + runtime validation alignment
+- `docs/solutions/workflow-issues/reconciliation-sync-reference-integrity-20260417.md` — moderate adjacency on the broader theme of CI catching post-write integrity gaps
+- PR #401 — v2.19.0 deprecation surface where this lesson surfaced

--- a/docs/solutions/developer-experience/gh-api-heredoc-backtick-escape-2026-05-17.md
+++ b/docs/solutions/developer-experience/gh-api-heredoc-backtick-escape-2026-05-17.md
@@ -1,0 +1,154 @@
+---
+title: gh api PR/issue body with heredoc escapes backticks visibly
+module: scripts (PR/issue authoring)
+date: 2026-05-17
+problem_type: developer_experience
+component: tooling
+severity: low
+tags:
+  - gh-cli
+  - heredoc
+  - bash-quoting
+  - pr-body
+  - github-api
+applies_when:
+  - Authoring PR or issue body content via `gh api -X POST ... -f body=...` with a shell heredoc
+  - Using `gh pr create --body "$(cat <<EOF ... EOF)"` patterns
+  - Migrating existing PR-creation scripts and seeing escaped backticks render on GitHub
+---
+
+# gh api PR/issue body with heredoc escapes backticks visibly
+
+## Context
+
+When `gh pr create` fails to GraphQL rate limits, the documented workaround is the REST API path: `gh api -X POST repos/<owner>/<repo>/pulls -f body=...`. The simplest way to assemble a multi-line body is a heredoc.
+
+There's a subtle bash trap here that GitHub renders visibly in the PR body. The escape requirements depend on the heredoc's quoting style, and getting it wrong means the rendered Markdown shows literal backslashes everywhere inline code and code fences should be.
+
+This bit twice during the v2.19.0 release sprint — once on PR #401's initial body, then again before the squash-commit body was finalized. The fix is mechanical once you see the pattern. The trap is that the heredoc looks plausible and the failure surfaces only after the PR is created.
+
+## Guidance
+
+**For `gh api -F body=...` (and any `-f body=`) content, prefer the temp-file pattern over inline heredoc command substitution. Write the body to a file with a single-quoted heredoc using zero backtick escapes, then pass `-F body=@FILE`.**
+
+The single-quoted heredoc (`<<'EOF'`) suppresses ALL shell interpretation including command substitution, so backticks need no escape. The `-F body=@FILE` form reads the file verbatim without further interpretation. Together they remove every escape concern.
+
+If you must use inline command substitution (`--body "$(cat <<EOF ... EOF)"`), the heredoc quoting matters:
+
+| Heredoc form | Backticks | Triple-backtick fence |
+|---|---|---|
+| `<<'EOF'` (single-quoted) | Literal — DO NOT escape | Literal — DO NOT escape |
+| `<<EOF` (unquoted) | Command substitution — MUST escape with `` \` `` | Must escape every backtick |
+
+The most common mistake is using `<<'EOF'` (correct quoting) but then ALSO escaping backticks out of habit, producing visible backslashes in the rendered output.
+
+## Why This Matters
+
+GitHub renders the literal backslash in the PR body as a visible character. A PR body that should show:
+
+````
+```yaml
+deprecated:
+  since: v2.19.0
+```
+````
+
+...instead shows:
+
+````
+\`\`\`yaml
+deprecated:
+  since: v2.19.0
+\`\`\`
+````
+
+The PR description loses its formatted code blocks. Inline code references like `` `orchestrating-swarms` `` render as `` \`orchestrating-swarms\` ``. The review reads as if the author can't write Markdown, which undermines the value of detailed PR descriptions.
+
+The fix is gh `api -X PATCH repos/.../pulls/N -F body=@FILE` after the fact, but the cleaner habit is to use the temp-file pattern up front.
+
+## When to Apply
+
+- Whenever authoring PR or issue bodies that contain Markdown code blocks via `gh` CLI
+- When authoring release notes via `gh release create --notes-file` or `gh release edit --notes-file`
+- When authoring squash-commit messages via `gh pr merge --body-file`
+- Whenever a generated body is more than a few lines and includes any backticks
+
+## Examples
+
+### Wrong: single-quoted heredoc with escaped backticks (looks safe, isn't)
+
+```bash
+gh api -X POST repos/owner/repo/pulls \
+  -f title="..." \
+  -f head="..." \
+  -f base="main" \
+  -f body="$(cat <<'EOF'
+Run \`bun test\` first.
+
+\`\`\`yaml
+deprecated:
+  since: v2.19.0
+\`\`\`
+EOF
+)"
+```
+
+Single-quoted heredoc suppresses interpolation already. The backslashes survive verbatim into the API payload. GitHub renders them.
+
+### Right: temp-file with single-quoted heredoc, no backtick escapes
+
+```bash
+BODY_FILE=$(mktemp -t pr-body-XXXXXX.md)
+cat > "$BODY_FILE" <<'EOF'
+Run `bun test` first.
+
+```yaml
+deprecated:
+  since: v2.19.0
+```
+EOF
+
+gh api -X POST repos/owner/repo/pulls \
+  -f title="..." \
+  -f head="..." \
+  -f base="main" \
+  -F body=@"$BODY_FILE"
+
+rm -f "$BODY_FILE"
+```
+
+Backticks land as literal backticks. Code fences render correctly. No escape thinking needed.
+
+### Right: inline unquoted heredoc with proper escapes
+
+```bash
+gh api -X POST repos/owner/repo/pulls \
+  -f title="..." \
+  -f head="..." \
+  -f base="main" \
+  -f body="$(cat <<EOF
+Run \`bun test\` first.
+
+\`\`\`yaml
+deprecated:
+  since: v2.19.0
+\`\`\`
+EOF
+)"
+```
+
+Unquoted heredoc DOES interpolate, so the escapes are necessary here to preserve backticks as literals. Equivalent output, but more fragile — any future contributor who adds `$VAR` or `$(cmd)` content has to keep track of two different escape rules in the same heredoc.
+
+### Verification after PR creation
+
+```bash
+gh pr view N --json body --jq '.body' | grep -c '\\`'
+# Should print: 0
+# If it prints anything else, the body has escape damage — patch via:
+gh api -X PATCH repos/owner/repo/pulls/N -F body=@FILE
+```
+
+## Related
+
+- `docs/solutions/developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md` — sibling lesson from the same release; both about `gh` CLI body content for PRs and releases
+- PR #401 — where the trap was caught mid-flight

--- a/docs/solutions/developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md
+++ b/docs/solutions/developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md
@@ -1,0 +1,143 @@
+---
+title: semantic-release release-notes-generator ignores commit bodies; patch with gh release edit
+module: .releaserc.yaml + release-pipeline
+date: 2026-05-17
+problem_type: developer_experience
+component: tooling
+severity: medium
+tags:
+  - semantic-release
+  - release-notes
+  - changelog
+  - gh-cli
+  - conventional-commits
+applies_when:
+  - A release needs an audience-facing narrative (deprecation cycle, migration steps, breaking changes) beyond the auto-generated commit-subject bullets
+  - Authoring a squash-commit message body intending for it to appear in the GitHub release notes
+  - Validating release-notes content after a semantic-release publish
+---
+
+# semantic-release release-notes-generator ignores commit bodies; patch with gh release edit
+
+## Context
+
+Systematic's release pipeline uses `@semantic-release/release-notes-generator` with the `conventionalcommits` preset. The plugin reads the conventional-commits in the release range, groups commit SUBJECT lines under section headers configured in `presetConfig.types[]` (`Features`, `Bug Fixes`, `Build System`, etc.), and writes the result to the GitHub release body via `@semantic-release/github`.
+
+The common mistaken assumption — held by this author across multiple session arcs before being empirically falsified — is that the BODY of each conventional-commit also flows into the release notes. It does not. Only the subject line plus PR/commit links is included.
+
+This matters when a release ships an audience-facing narrative — a deprecation announcement, a migration guide, a breaking-change explanation. Authoring that narrative inside the squash-commit body looks right (the body IS in git history, and it survives the squash), but the GitHub release notes show only:
+
+```
+### Features
+
+* **skills:** deprecation surface + mark orchestrating-swarms and claude-permissions-optimizer (#401) (402ef5c)
+```
+
+The detailed `## Deprecations` section in the commit body never reaches users browsing the v2.19.0 release page or the npm release notes.
+
+## Guidance
+
+**`@semantic-release/release-notes-generator` (conventionalcommits preset) does NOT ingest commit body text into release notes. It emits only the commit subject lines grouped by section.** When a release needs an audience-facing narrative, plan to post-process the release body via `gh release edit --notes-file <file>` immediately after the release publishes.
+
+The release-pipeline polling should NOT exit until the release notes are reviewed and patched if narrative is needed. Surface this as an explicit step in the release flow, not a hope.
+
+Mechanics that make this clean:
+
+1. **Author the narrative once**, in a temp file. The same content can be used for the PR body (reviewer context), the squash-commit body (git history), and the patched release notes (audience-facing).
+2. **Let semantic-release auto-generate the initial release notes** — that gives you the correctly-linked commit bullets grouped by section.
+3. **Patch with `gh release edit <tag> --notes-file <file>`** — prepend the narrative above the auto-generated bullets and preserve the bullets verbatim below.
+
+Alternatives considered and rejected:
+
+- `@semantic-release/release-notes-generator`'s `writerOpts.transform` to inject body content. This is a `.releaserc.yaml` config change with broader semver implications across all future releases. Too heavy for the narrative-once-in-a-while case.
+- A CHANGELOG.md committed alongside the release. Not maintained in this repo and reintroducing it means adding `@semantic-release/changelog` to the plugin chain. More churn than the manual patch.
+
+## Why This Matters
+
+A release without its narrative is a release that doesn't communicate. Users browsing v2.19.0 on GitHub see only "deprecation surface + mark orchestrating-swarms and claude-permissions-optimizer" with no indication that:
+
+- The skills remain functional for v2.19.x
+- The migration path is v2.18.x downgrade if v3.0.0 breaks something
+- The v3.0.0 deletion has no committed timeline
+- What replacement is planned for each
+
+The detailed PR body is reviewer-facing, not audience-facing. The squash-commit body is git-history-facing, not audience-facing. The GitHub release page IS the audience-facing surface. Without a post-publish patch, the audience sees nothing.
+
+The cost of the patch is small: a `gh release edit` call after the release-pipeline run completes. The cost of skipping it is users hitting v3.0.0 surprised, opening issues, and the maintainer linking them to a commit body they didn't know existed.
+
+## When to Apply
+
+- Whenever a release ships a deprecation cycle, a migration step, a breaking change, or any other audience-facing narrative
+- When validating any release that has more substance than a routine bugfix or dependency bump
+- During release-pipeline monitoring: after the workflow reports success, check `gh release view <tag> --json body --jq '.body'` and verify the narrative is present
+
+## Examples
+
+### Wrong: assume the commit body makes it into the release notes
+
+```bash
+# Squash-commit body carries the Deprecations narrative.
+gh pr merge 401 --squash --body-file deprecations-narrative.md
+
+# Wait for release-pipeline. Assume the narrative is in v2.19.0 release notes.
+# It is not. The release body has only the bullet summary.
+```
+
+### Right: patch release notes after publish
+
+```bash
+# 1. Author the narrative once.
+RELEASE_FILE=$(mktemp -t v2.19.0-release-XXXXXX.md)
+cat > "$RELEASE_FILE" <<'EOF'
+## [2.19.0](.../compare/v2.18.0...v2.19.0) (2026-05-18)
+
+### Deprecations
+
+Two bundled skills are now marked deprecated with removal: v3.0.0 ...
+
+[full narrative here, including migration guidance]
+
+### Features
+
+* **skills:** deprecation surface + mark orchestrating-swarms and claude-permissions-optimizer (#401) (402ef5c)
+EOF
+
+# 2. Squash-merge normally (commit body still lands in git history).
+gh pr merge 401 --squash --body-file "$RELEASE_FILE"
+
+# 3. Wait for release-pipeline to publish v2.19.0.
+# (poll the workflow until status=completed conclusion=success)
+
+# 4. Patch release notes with the narrative-first version.
+gh release edit v2.19.0 --notes-file "$RELEASE_FILE"
+
+# 5. Verify.
+gh release view v2.19.0 --json body --jq '.body | length'
+# Should be substantially longer than the auto-generated bullet-only version.
+
+rm -f "$RELEASE_FILE"
+```
+
+### Release-monitoring checklist
+
+Add this step to release-pipeline monitoring for any narrative-bearing release:
+
+```bash
+# After workflow success, check the body length.
+# Threshold rationale: a typical bullet-only release body for this repo
+# (3-5 conventional-commit subjects + section headers + the compare-link
+# header) lands in the ~600-1000 char range. A narrative-bearing release
+# (Deprecations section + migration guidance + feature explanation) should
+# clear 1500+. Calibrate to your own release history if this is reused.
+RELEASE_BODY_LEN=$(gh release view v2.19.0 --json body --jq '.body | length')
+if [ "$RELEASE_BODY_LEN" -lt 1500 ]; then
+  echo "WARN: release body is short ($RELEASE_BODY_LEN chars). Did the narrative land?"
+  echo "Run: gh release edit v2.19.0 --notes-file <narrative.md>"
+fi
+```
+
+## Related
+
+- `docs/solutions/developer-experience/gh-api-heredoc-backtick-escape-2026-05-17.md` — sibling lesson from the same release; both involve `gh` CLI body content
+- `.releaserc.yaml` — the source of truth for the plugin chain and section mapping
+- PR #401 / v2.19.0 — where this lesson was empirically verified


### PR DESCRIPTION
Captures three independent lessons from the v2.19.0 deprecation-surface work (PR #401) as separate solution docs. Each lesson was caught and corrected mid-flight; documenting them now means the next session that hits any of these traps spends minutes, not hours.

## What's compounded

### 1. Content-integrity gate must mirror runtime drop rules

`docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md`

When a runtime parser handles a field permissively (silent drops on malformed values), a CI gate that only checks gate-specific sub-fields gives false confidence. PR #401's initial deprecation-block gate checked `reason` but ignored `since`/`removal` — fields the runtime silently drops the entire block on if missing. A bundled skill could pass CI but emit no runtime warning at all. Fro Bot caught this before merge.

Guidance: read the runtime parser's drop rules and mirror them at the gate. Run runtime-mirror checks before gate-specific checks so authors see all gaps in one CI run. Cross-references the typed-config-validation precedent (PR #384) and the reference-integrity sync lesson (PR #290).

### 2. `gh api -F body=...` heredoc escapes backticks visibly

`docs/solutions/developer-experience/gh-api-heredoc-backtick-escape-2026-05-17.md`

Bit twice during v2.19.0: PR #401's initial body shipped with `\`backtick\`` and ``\`\`\`yaml`` rendered literally on GitHub. Single-quoted heredocs (`<<'EOF'`) suppress all interpretation, so backticks need no escape — but escaping anyway out of habit ships backslashes into the API payload.

Guidance: use the temp-file pattern. Write body content with `cat > FILE <<'EOF'` using zero escapes, pass `-F body=@FILE`. Removes every escape concern. Includes a verification one-liner: `gh pr view N --json body --jq '.body' | grep -c '\\\`'` should return 0.

### 3. `semantic-release/release-notes-generator` ignores commit bodies

`docs/solutions/developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md`

Memory had been wrong on this. The conventionalcommits preset emits ONLY commit subjects into release notes — never the body. v2.19.0's squash-commit carried a detailed `## Deprecations` narrative in the body that never reached the GitHub release page or npm release notes.

Guidance: when a release ships an audience-facing narrative, plan to patch the release body via `gh release edit <tag> --notes-file` immediately after the workflow publishes. Release-pipeline monitoring should include a body-length sanity check.

## Why three docs, not one

The three lessons are conceptually independent (gate discipline, shell quoting, release-tooling behavior). Forcing them into one doc would obscure discoverability via filename keyword search — each is the kind of lesson a future session lands on by grepping the solutions corpus.

## Verification

- `bun run docs:build` — 112 pages built cleanly
- `bun scripts/content-integrity.ts` — 0 violations
- All 3 docs use the canonical YAML frontmatter from `skills/ce-compound/references/schema.yaml`
- AGENTS.md already surfaces `docs/solutions/` to fresh agents (PR #314), so discoverability is intact

## Releasing semantics

This PR is `docs(solutions):` which is NOT in the patch-bump map in `.releaserc.yaml` (only `docs` with scope `readme`, `readme.md`, `skill`, `skills`, `agents`, or `commands` triggers a patch). Mirrors PR #388 and PR #397 — both `docs(solutions):` merged cleanly without publishing a new release. The accumulated commits flush with the next `feat:`/`fix:`/`build:`.

## Related

- PR #401 — v2.19.0 deprecation surface where all three lessons were caught
- PR #384 / PR #290 — adjacent precedents cited in lesson 1
- Memory IDs `#3171`, `#3172` capture the same content as durable cross-session lessons
