### PR TITLE
feat(skills): add SUBAGENT-STOP block and Instruction Priority section to using-systematic

### DIFF
--- a/docs/plans/2026-05-17-003-feat-subagent-stop-instruction-priority-plan.md
+++ b/docs/plans/2026-05-17-003-feat-subagent-stop-instruction-priority-plan.md
@@ -1,0 +1,239 @@
+---
+title: 'feat(skills): add SUBAGENT-STOP block and Instruction Priority section to using-systematic'
+type: feat
+status: active
+date: 2026-05-17
+deepened: 2026-05-17
+origin: docs/brainstorms/2026-05-17-subagent-stop-instruction-priority-requirements.md
+---
+
+# Add SUBAGENT-STOP block and Instruction Priority section to `using-systematic`
+
+## Overview
+
+Mirror upstream `obra/superpowers@v5.1.0`'s `<SUBAGENT-STOP>` block and `## Instruction Priority` section into `skills/using-systematic/SKILL.md`. Land mechanical bootstrap test assertions covering presence, ordering, and `INTERNAL_AGENT_SIGNATURES` non-regression. Build a two-condition behavioral probe in `tests/manual/` that measures whether the prose change reduces `systematic_skill` invocations inside `task()`-dispatched Systematic subagents.
+
+Target release: v2.20.0 minor (`feat(skills):`).
+
+## Problem Frame
+
+Systematic's bootstrap injection wraps `skills/using-systematic/SKILL.md` body in a `<SYSTEMATIC_WORKFLOWS>` block and prepends it to `output.system[0]` for every session (`src/lib/bootstrap.ts:75-106`). OpenCode dispatches `task()`-spawned subagents through the same `experimental.chat.system.transform` pipeline, so Systematic-bundled subagents receive the full skill-awareness bootstrap including the `<EXTREMELY-IMPORTANT>` "1% rule" that mandates skill invocation before any action. A subagent dispatched for a focused implementation task does not benefit from being nudged toward defensive `systematic_skill` invocation; it benefits from completing the work it was given. Three reviewers in PR #394 flagged this when the foundation skills landed but the SUBAGENT-STOP pattern was deliberately left out of scope.
+
+See origin: `docs/brainstorms/2026-05-17-subagent-stop-instruction-priority-requirements.md`.
+
+## Requirements Trace
+
+- R1. SUBAGENT-STOP block at top of `skills/using-systematic/SKILL.md` body, after frontmatter, immediately before `<EXTREMELY-IMPORTANT>` (origin R1).
+- R2. `## Instruction Priority` section enumerating 3-tier precedence: user instructions (CLAUDE.md / GEMINI.md / AGENTS.md / direct requests) > Systematic skills > default system prompt (origin R2).
+- R3. `INTERNAL_AGENT_SIGNATURES` skip mechanism continues to function unchanged after prose addition (origin R3).
+- R4. Mechanical tests in `tests/unit/bootstrap.test.ts` assert presence, section presence, ordering, and `INTERNAL_AGENT_SIGNATURES` non-regression, all against the rendered `getBootstrapContent()` output AND against `shouldSkipBootstrap()` behavior with representative internal-agent prompts (origin R4).
+- R5. Behavioral probe in `tests/manual/` using a two-condition design (Control vs Treatment on the same branch) measures whether SUBAGENT-STOP reduces `systematic_skill` invocations made inside `task()`-dispatched `systematic-implementer` subagent sessions (origin R5).
+
+## Scope Boundaries
+
+- Only `skills/using-systematic/SKILL.md` is touched for prose. Other Rigid-tier bundled skills (`test-driven-development`, `writing-skills`) and workflow skills (`ce:*`) do NOT get SUBAGENT-STOP blocks.
+- No structural change to `src/lib/bootstrap.ts`. The design axis is prose-level mirror; structural detection remains the documented fallback if the probe shows the prose mechanism is ineffective.
+- Multi-harness behavioral validation is not in scope. The probe runs only against OpenCode. Cross-harness portability is tracked separately.
+- No new bundled skill, no new content-integrity gate rule, no new frontmatter field, no new runtime contract surface.
+- Identity-provenance for the bundled `systematic-implementer` is bounded by fixture isolation, not runtime queries. The probe controls the temp project dir; no `.opencode/agents/` overrides exist in the fixture. Runtime cannot expose resolved agent source paths today.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/lib/bootstrap.ts:8-17` — `INTERNAL_AGENT_SIGNATURES` array (3 strings: title-generator, summarizer, summarize-conversation).
+- `src/lib/bootstrap.ts:75-106` — `applyBootstrapContent()`. Strips all complete `<SYSTEMATIC_WORKFLOWS>` blocks from every `output.system[i]`, then appends the canonical block to `output.system[0]`.
+- `src/lib/bootstrap.ts:126-168` — `getBootstrapContent()`. Returns `string | null`. Reads bundled `using-systematic/SKILL.md`, strips frontmatter, wraps body in `<SYSTEMATIC_WORKFLOWS>...</SYSTEMATIC_WORKFLOWS>`.
+- `src/index.ts:85-109` — skip-check logic. Uses `output.system.join('\n').toLowerCase()` and substring match against `INTERNAL_AGENT_SIGNATURES`.
+- `skills/using-systematic/SKILL.md` — current top-of-body is `<EXTREMELY-IMPORTANT>` at lines 6-12. SUBAGENT-STOP must land BEFORE that block.
+- `tests/unit/bootstrap.test.ts:361-420` — existing `INTERNAL_AGENT_SIGNATURES` regression tests including the `shouldSkipBootstrap()` helper that mirrors `src/index.ts` logic.
+- `tests/manual/companion-aware-probe.ts` — two-arm probe pattern with `opencode serve --port 0 --print-logs`, isolated temp project dirs, model `opencode/big-pickle`, JSONL-logfile-based invocation counting via probe-side stub plugin's tool registrations.
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/opencode-plugin-factory-duplicate-registration-2026-05-04.md` — bootstrap idempotency, LLM-visible-contract emphasis. Direct precedent for asserting exactly one bootstrap block in the system prompt.
+- `docs/solutions/integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md` — manual probes as sandboxed subprocess tests with explicit fixture scoping.
+- `docs/solutions/integration-issues/opencode-plugin-named-exports-break-loader-2026-05-11.md` — prose alone isn't enough when runtime contract is brittle; executable checks needed alongside prose.
+
+### Upstream Reference
+
+- `obra/superpowers@v5.1.0` at `.slim/clonedeps/repos/obra__superpowers/skills/using-superpowers/SKILL.md` — source pattern. Upstream places `## Instruction Priority` BEFORE `## How to Access Skills`.
+
+## Key Technical Decisions
+
+- **Probe dispatch via `task()` tool invocation, not `--agent` flag.** `systematic-implementer` has `mode: subagent`. `opencode run --agent systematic-implementer` silently falls back to the default primary agent (`localAgent()` in `packages/opencode/src/cli/cmd/run.ts:507-527` returns undefined for subagent-mode entries). The probe spawns a primary agent that uses the `task` tool with `subagent_type: systematic-implementer` and counts `systematic_skill` invocations that occur inside the resulting subagent session.
+- **Probe instrumentation via `tool.execute.before` global hook, filtered by child session ID.** OpenCode's plugin system fires `tool.execute.before` for every tool invocation across the session graph (`packages/plugin/src/index.ts:222-280`; `packages/opencode/src/session/prompt.ts:569-588`). The hook payload includes `sessionID`. A probe-local plugin records `{tool, sessionID, callID}` for every `input.tool === 'systematic_skill'`. The probe captures the child session ID returned in the parent `task` tool result and filters counts to only rows where `sessionID === childSessionID`. This excludes any `systematic_skill` invocations the primary agent itself might make (e.g., the primary agent's bootstrap could also nudge it to invoke skills before calling `task`). Single counter file inline in the probe; no separate `probe-systematic-skill-counter.ts` file.
+- **Identity-provenance via fixture isolation, not runtime queries.** OpenCode's agent `Info` schema (`packages/opencode/src/agent/agent.ts:28-48`) does NOT expose resolved source file paths. The probe controls the temp project dir per the existing companion-aware-probe pattern; no user-level or project-level agent overrides can leak into the fixture. The claim is "isolated fixture avoids known overrides," not "resolved path verified."
+- **Probe asserts subagent's actual system prompt contains SUBAGENT-STOP before counting.** If a concurrent refactor changes which agents receive bootstrap (e.g., subagents skip entirely), the probe would see 0 invocations and report success while the prose change had zero effect. The probe captures the subagent session's system prompt (via a sentinel injected by the counter plugin's `tool.execute.before` hook on the first event in the child session, or via the SDK event stream) and asserts it literally contains the SUBAGENT-STOP marker. If the assertion fails, the run is excluded and a warning is logged.
+- **Pass criterion: both absolute AND relative bounds, with explicit INCONCLUSIVE band.** Absolute "Treatment ≤ Control + 1" alone allows 2x regressions to pass (Control=0.8, Treatment=1.6). Combine: pass requires `(Treatment - Control) ≤ 1` AND `Treatment ≤ 1.25 × max(Control, 1)`. Fail: `(Treatment - Control) ≥ 2` OR `Treatment > 1.5 × max(Control, 1)`. Anything in between is INCONCLUSIVE — block merge of the probe artifact until conditions are tightened or design redone.
+- **Variance check on BOTH conditions via run-level standard deviation.** Compute `stddev` across the 5 runs of each condition. If either condition's stddev > 1.0, the result is INCONCLUSIVE regardless of means. Range-based variance (|max - min|) is too permissive — [0,0,0,1,0] and [0,1,0,1,0] both have range 1 but the latter is materially noisier on a binary signal.
+- **N=5 is a smoke probe, not statistical confidence.** Five runs cannot reliably distinguish small behavioral shifts. The probe is FALSIFIABLE for large effects (clearly above/below thresholds) but explicitly NOT a statistical-confidence claim. Probe documentation states this directly. If results are repeatedly INCONCLUSIVE at N=5, the follow-up is either bumping N (committing more runtime + cost) or redesigning the experiment, not interpreting N=5 noise as signal.
+- **Upstream structural order: `## Instruction Priority` BEFORE `## How to Access Skills`.** Matches upstream `obra/superpowers` SKILL.md placement at lines 18-28 of the clonedep.
+- **Harness-wording adaptation rule, constrained.** Replace "Superpowers" with "Systematic" mechanically. For harness-specific references (e.g., upstream's "Claude Code prefers..."): rewrite to match Systematic's OpenCode runtime context if Systematic provides the same guarantee ("the systematic_skill tool prefers..."); generalize to "your harness" ONLY if the upstream sentence is genuinely about the consuming harness AND every consumer harness can provide the same guarantee. If neither condition holds (e.g., upstream describes a permission-halt behavior that only Claude Code enforces), DELETE the sentence rather than generalize it falsely. Do NOT add rewrite-intent comments to the SKILL.md body — body comments survive frontmatter stripping and end up in every agent's injected bootstrap. Document the adaptation choices in this plan doc or in a `docs/solutions/` learning after merge.
+- **Mechanical tests run against `getBootstrapContent()` output (pre-injection) AND `applyBootstrapContent` output (post-injection) AND `shouldSkipBootstrap()` behavior.** Pre-injection covers presence + section-ordering invariants. Post-injection (via `applyBootstrapContent` against a representative `output.system` array) catches injection-assembly bugs. `shouldSkipBootstrap()` behavioral check exercises the actual `src/index.ts:85-109` skip path with each of the 3 known internal-agent system prompts plus a SUBAGENT-STOP-bearing primary-agent prompt.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q1: Instrumentation surface** → `tool.execute.before` global hook in a probe-local plugin, observing `input.tool === 'systematic_skill'`.
+- **Q3: Identity-provenance check** → fixture isolation (temp project dir with no agent overrides), not runtime path queries.
+
+### Deferred to Implementation
+
+- **Q2: Exact prompts for Control and Treatment.** Constraint: Control is a focused implementation task with no skill-aware framing (e.g., "Add a single TODO comment to the file path I specify"). Treatment uses skill-triggering language (e.g., "Implement this feature following all best practices and our project conventions"). Implementer iterates the Control prompt until it reliably shows ≤1/5 invocations as a sanity check. Both prompts dispatch via the primary agent calling `task({ subagent_type: 'systematic-implementer', prompt: <prompt>, ... })`.
+- **Q4: Exact wording of SUBAGENT-STOP body and Instruction Priority section.** Constraint: mirror upstream meaning. Apply the harness-wording adaptation rule above. SUBAGENT-STOP body: one line matching upstream intent ("If you were dispatched as a subagent to execute a specific task, skip this skill."). Instruction Priority section: 3-tier list, "Systematic skills" replaces "Superpowers skills", harness-specific sentences adapted per the rule. Final wording lives in the SKILL.md edit, not the plan.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add SUBAGENT-STOP block + Instruction Priority section + mechanical bootstrap assertions**
+
+**Goal:** Prose change in `skills/using-systematic/SKILL.md` plus matching mechanical tests in `tests/unit/bootstrap.test.ts` covering R1, R2, R3, R4.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `skills/using-systematic/SKILL.md`
+- Modify: `tests/unit/bootstrap.test.ts`
+- Test: `tests/unit/bootstrap.test.ts`
+
+**Approach:**
+- Add `<SUBAGENT-STOP>...</SUBAGENT-STOP>` block immediately after frontmatter close and immediately before the existing `<EXTREMELY-IMPORTANT>` block at line 6.
+- Add `## Instruction Priority` section BEFORE the existing `## How to Access Skills` section (matches upstream placement at `obra/superpowers@v5.1.0` SKILL.md lines 18-28).
+- Body of SUBAGENT-STOP: mirror upstream meaning.
+- Body of Instruction Priority: 3-tier precedence list adapting upstream's structure with "Systematic skills" naming and the harness-wording adaptation rule.
+- Mechanical tests:
+  - Load `getBootstrapContent()`. Assert returned string contains `<SUBAGENT-STOP>` (presence).
+  - Assert returned string contains `## Instruction Priority` (section presence).
+  - Assert `indexOf('<SUBAGENT-STOP>')` < `indexOf('<EXTREMELY-IMPORTANT>')` (top-level ordering).
+  - Assert `indexOf('## Instruction Priority')` < `indexOf('## How to Access Skills')` (section-level ordering matching upstream).
+  - Exercise `shouldSkipBootstrap()` with each of the 3 known internal-agent prompts ("You are a title generator", "You are a helpful AI assistant tasked with summarizing conversations", "Summarize what was done in this conversation"). Assert all 3 return `true` (skip path still works).
+  - Exercise `shouldSkipBootstrap()` with a primary-agent-shape prompt that does NOT contain any of the 3 signatures. Assert it returns `false`.
+
+**Execution note:** Test-first. Write RED tests for all assertions BEFORE editing the SKILL.md. Run the unit suite to confirm tests fail with clear messages, then add prose to drive them green.
+
+**Patterns to follow:**
+- Existing `INTERNAL_AGENT_SIGNATURES` test pattern at `tests/unit/bootstrap.test.ts:361-420`. The `shouldSkipBootstrap()` helper is reusable for the behavioral assertions.
+- Existing wrapper-presence and frontmatter-stripping assertions at `tests/unit/bootstrap.test.ts:30-355` for style consistency.
+
+**Test scenarios:**
+- Happy path: `getBootstrapContent()` returns a non-null string containing both `<SUBAGENT-STOP>` and `## Instruction Priority`.
+- Happy path: both ordering invariants hold (`<SUBAGENT-STOP>` before `<EXTREMELY-IMPORTANT>`; `## Instruction Priority` before `## How to Access Skills`).
+- Happy path: `shouldSkipBootstrap()` returns `true` for each of the 3 internal-agent prompts.
+- Happy path: `shouldSkipBootstrap()` returns `false` for a primary-agent prompt that doesn't contain the signatures.
+- Edge case: `bootstrap.enabled: false` → `getBootstrapContent()` returns null (unchanged regression check).
+- Edge case: custom `bootstrap.file` path → the SUBAGENT-STOP assertions scope only to the bundled `using-systematic/SKILL.md` path; custom-file paths are explicitly out of scope.
+
+**Verification:**
+- `bun test tests/unit/bootstrap.test.ts` passes including the new assertions.
+- `bun test` full suite passes with no regressions.
+- `bun run typecheck` clean.
+- `bun src/cli.ts list skills` still lists `using-systematic` with no errors.
+
+- [ ] **Unit 2: Two-condition behavioral probe in `tests/manual/`**
+
+**Goal:** Probe artifact that measures whether SUBAGENT-STOP reduces `systematic_skill` invocations inside `task()`-dispatched `systematic-implementer` subagent sessions. Two conditions (Control vs Treatment) on the same branch, 5 runs each, with both absolute+relative thresholds and variance checks.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 1 (probe runs against the feature branch with SUBAGENT-STOP already added)
+
+**Files:**
+- Create: `tests/manual/subagent-stop-probe.ts` (single file: probe runner + inline counter plugin definition)
+
+**Approach:**
+- Mirror the structure of `tests/manual/companion-aware-probe.ts` for isolation, subprocess spawning, per-run fixture setup, and JSONL parsing.
+- Counter plugin defined inline (not a separate file). The plugin exposes a `tool.execute.before` hook that, on every invocation where `input.tool === 'systematic_skill'`, appends `{tool, sessionID, callID, timestamp}` to a JSONL logfile (path passed via env var, matching `probe-companion-tools.ts` pattern).
+- Each probe run:
+  1. Set up isolated temp project dir with `OPENCODE_CONFIG_CONTENT` enabling the local Systematic build AND loading the inline counter plugin.
+  2. Dispatch via the SDK to a primary agent (e.g., the default agent in the fixture).
+  3. The primary agent is instructed to invoke `task({ subagent_type: 'systematic-implementer', prompt: <Control or Treatment prompt> })` once.
+  4. Capture the child session ID from the `task` tool's result metadata.
+  5. The subagent session runs to completion. The counter plugin records every `systematic_skill` invocation across the session graph.
+  6. The probe reads the JSONL logfile and FILTERS rows to only those where `sessionID === childSessionID` from step 4. This excludes any `systematic_skill` invocations the primary agent may have made.
+  7. The probe captures the subagent's system prompt (via SDK event stream or by injecting a sentinel marker through the counter plugin on the first event in the child session) and asserts it contains the literal SUBAGENT-STOP marker. If the assertion fails, the run is excluded with a warning logged.
+- Run Control 5 times with a neutral prompt; run Treatment 5 times with a skill-triggering prompt.
+- Compute Control mean, Control stddev, Treatment mean, Treatment stddev (standard deviation, not range).
+- Apply pass/fail/INCONCLUSIVE rules from Key Decisions.
+- Report per-run counts, means, stddevs, and verdict to stdout. Probe header comment includes: "N=5 is a smoke probe, not statistical confidence. Probe falsifies large effects; small effects require N≥20 or experiment redesign."
+
+**Execution note:** Run probe locally after Unit 1 lands on the feature branch. Iterate the Control prompt during a quick pre-run sanity check until Control reliably shows ≤1/5 invocations with stddev ≤1.
+
+**Patterns to follow:**
+- `tests/manual/companion-aware-probe.ts` for isolation, temp dir handling, `OPENCODE_CONFIG_CONTENT` injection, two-arm reporting shape.
+- `tests/manual/probe-companion-tools.ts` for the plugin-side JSONL writer pattern (env-var-driven logfile path).
+
+**Test scenarios:**
+- Test expectation: none — this IS the test artifact. The probe's runtime output is the verification.
+
+**Verification:**
+- Probe runs end-to-end without errors against the feature branch.
+- Per-run JSONL parse succeeds for every spawned subagent session.
+- Each counted run includes a verified child session ID match AND a verified SUBAGENT-STOP-present-in-subagent-system-prompt assertion.
+- Verdict reported per pass/fail/INCONCLUSIVE rules.
+- Final stdout reports per-run counts, means, stddevs, exclusions (failed identity checks or failed prompt assertions), and verdict.
+- If verdict is PASS or FAIL (stable), the result is summarized in the PR body and compounded as a `docs/solutions/` learning after merge. If verdict is INCONCLUSIVE on first run, a second run is attempted; two consecutive INCONCLUSIVE results trigger a follow-up smart note for probe redesign — no compound doc is written for unstable inconclusive results.
+
+- [ ] **Unit 3: PR-checklist for routine verification**
+
+**Goal:** Capture small documentation-touching checks as a PR-checklist.
+
+**Requirements:** Implicit follow-up from R1+R2
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- (None — PR-checklist only.)
+
+**Approach:**
+- PR description includes:
+  - `bun run docs:build` succeeds (full docs pipeline including the rendered SKILL.md change).
+  - `bun run registry:drift` clean (registry should still reflect unchanged component count).
+
+**Test scenarios:**
+- Test expectation: none — checklist items, not behavioral changes.
+
+**Verification:**
+- Both checklist items checked in PR body before merge.
+
+## System-Wide Impact
+
+- **Interaction graph:** The new SUBAGENT-STOP block is read by every agent receiving the bootstrap. `INTERNAL_AGENT_SIGNATURES` skip path for OpenCode-internal agents (title-generator, summarizer) is verified by Unit 1's behavioral assertions exercising `shouldSkipBootstrap()` directly.
+- **Error propagation:** None. Prose change has no error-propagation surface; the probe runs out-of-band.
+- **State lifecycle risks:** None.
+- **API surface parity:** None. No exported API changes.
+- **Integration coverage:** The probe is the integration coverage for the prose change's behavioral effect.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| Probe shows Treatment ≈ Control (null result). Prose may not move behavior at all. | Frame probe as falsifying, not validating. Null result is itself a publishable learning — document in PR body and capture as a `docs/solutions/` compound after merge. The prose change still ships because parity with upstream + multi-harness instruction-precedence value is independent of behavioral effect. |
+| Probe variance too noisy for a verdict (INCONCLUSIVE). | Iterate Control prompt until variance ≤1. If Treatment variance also exceeds 1 after Control stabilizes, file a smart note for probe redesign and ship the prose change without behavioral validation, documenting the gap. |
+| Adding `<SUBAGENT-STOP>` substring to using-systematic body accidentally collides with `INTERNAL_AGENT_SIGNATURES` strings. | Unit 1's behavioral assertions exercise `shouldSkipBootstrap()` with each of the 3 signature prompts plus a primary-agent prompt. The proposed SUBAGENT-STOP wording does not contain "title generator", "summarizing conversations", or "Summarize what was done" (verified at edit time + by the assertion at test time). |
+| Concurrent in-flight refactor to `applyBootstrapContent` changes how the bootstrap is assembled into `output.system[0]`, leaving Unit 1's pre-injection mechanical tests green while invalidating the actual subagent-visible invariant. | Add a behavioral assertion in Unit 1 that calls `applyBootstrapContent` against a representative `output.system` array and asserts the rendered post-injection string still has SUBAGENT-STOP before `<EXTREMELY-IMPORTANT>`. This catches injection-side reordering bugs that pre-injection tests would miss. |
+
+## Documentation / Operational Notes
+
+- `docs/solutions/`: capture a compound learning after merge regardless of probe result. Stable null result is a learning about limits of prose-only subagent control; stable positive result is a learning about effective patterns. Either way, document.
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-05-17-subagent-stop-instruction-priority-requirements.md`
+- Related code:
+  - `src/lib/bootstrap.ts:8-17` (INTERNAL_AGENT_SIGNATURES)
+  - `src/lib/bootstrap.ts:75-106` (applyBootstrapContent)
+  - `src/lib/bootstrap.ts:126-168` (getBootstrapContent)
+  - `src/index.ts:85-109` (skip-check logic)
+  - `skills/using-systematic/SKILL.md` (target file)
+  - `tests/unit/bootstrap.test.ts:361-420` (existing INTERNAL_AGENT_SIGNATURES tests)
+  - `tests/manual/companion-aware-probe.ts` (probe isolation pattern)
+  - `tests/manual/probe-companion-tools.ts` (plugin JSONL writer pattern)
+- Related PRs:
+  - PR #394 — foundation skills import, flagged SUBAGENT-STOP as deliberately out-of-scope
+  - PR #321 — companion-aware-probe + manual-probe template, probe infrastructure precedent
+- External docs:
+  - `obra/superpowers@v5.1.0` upstream `using-superpowers/SKILL.md` at `.slim/clonedeps/repos/obra__superpowers/skills/using-superpowers/SKILL.md` — source pattern
+  - `anomalyco/opencode@v1.15.1` clonedep at `.slim/clonedeps/repos/anomalyco__opencode/` — `run.ts`, `agent.ts`, `prompt.ts`, plugin hook surface

--- a/scripts/.drift-allowlist.json
+++ b/scripts/.drift-allowlist.json
@@ -43,6 +43,11 @@
       "pathGlob": "skills/writing-skills/references/testing-skills-with-subagents.md",
       "patterns": ["CLAUDE.md"],
       "reason": "Cross-reference to skill-testing-walkthrough.md, describing what that walkthrough tested. Same rationale as the walkthrough file's exemption."
+    },
+    {
+      "pathGlob": "skills/using-systematic/SKILL.md",
+      "patterns": ["CLAUDE.md"],
+      "reason": "Instruction Priority section lists CLAUDE.md alongside GEMINI.md and AGENTS.md as examples of user instruction files across harnesses. Intentional multi-harness documentation; not a CC-specific pattern reintroduction."
     }
   ]
 }

--- a/skills/using-systematic/SKILL.md
+++ b/skills/using-systematic/SKILL.md
@@ -3,6 +3,10 @@ name: using-systematic
 description: Use when starting any conversation - establishes how to find and use skills, requiring skill tool invocation before ANY response including clarifying questions
 ---
 
+<SUBAGENT-STOP>
+If you were dispatched as a subagent to execute a specific task, skip this skill.
+</SUBAGENT-STOP>
+
 <EXTREMELY-IMPORTANT>
 If you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.
 
@@ -10,6 +14,16 @@ IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
 
 This is not negotiable. This is not optional. You cannot rationalize your way out of this.
 </EXTREMELY-IMPORTANT>
+
+## Instruction Priority
+
+Systematic skills override default system prompt behavior, but **user instructions always take precedence**:
+
+1. **User's explicit instructions** (CLAUDE.md, GEMINI.md, AGENTS.md, direct requests) — highest priority
+2. **Systematic skills** — override default system behavior where they conflict
+3. **Default system prompt** — lowest priority
+
+If CLAUDE.md, GEMINI.md, or AGENTS.md says "don't use TDD" and a skill says "always use TDD," follow the user's instructions. The user is in control.
 
 ## How to Access Skills
 

--- a/tests/manual/subagent-stop-probe.ts
+++ b/tests/manual/subagent-stop-probe.ts
@@ -1,0 +1,577 @@
+#!/usr/bin/env bun
+
+/**
+ * Two-condition behavioral probe measuring whether the SUBAGENT-STOP block in
+ * `skills/using-systematic/SKILL.md` reduces `systematic_skill` invocations
+ * inside `task()`-dispatched `systematic-implementer` subagent sessions.
+ *
+ * Design: Control vs Treatment on the same branch.
+ *   Control   — primary agent dispatches a subagent with a focused, neutral
+ *               implementation prompt. No skill-triggering language.
+ *   Treatment — same dispatch, but the inner task prompt uses skill-triggering
+ *               language ("best practices", "project conventions").
+ *
+ * If SUBAGENT-STOP is effective, the subagent should suppress defensive
+ * systematic_skill invocations in both conditions. The Treatment condition
+ * stress-tests whether the stop block holds under adversarial framing.
+ *
+ * Run: bun tests/manual/subagent-stop-probe.ts
+ *
+ * Requires: opencode CLI on PATH (recent enough to support `serve --print-logs`).
+ * The probe spawns an isolated opencode server per run with a temp project dir.
+ * No `.opencode/agents/` overrides exist in the fixture — the bundled
+ * `systematic-implementer` agent is the only candidate for the dispatched
+ * subagent_type. Identity-provenance is bounded by fixture isolation, not
+ * runtime path queries (OpenCode's agent Info schema does not expose resolved
+ * source file paths).
+ *
+ * N=5 is a smoke probe, not statistical confidence. The probe FALSIFIES large
+ * effects (Treatment dramatically exceeds Control) but does NOT have power to
+ * confirm small effects. Repeated INCONCLUSIVE verdicts at N=5 should trigger
+ * either N≥20 or experiment redesign, not interpretation as signal.
+ */
+
+import { type ChildProcess, spawn } from 'node:child_process'
+import fs from 'node:fs'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createOpencodeClient } from '@opencode-ai/sdk'
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+)
+const MODEL = 'opencode/big-pickle'
+const [PROVIDER_ID, MODEL_ID] = MODEL.split('/')
+const SESSIONS_PER_CONDITION = 5
+
+// Neutral prompt: focused implementation task with no skill-aware framing.
+// The primary agent is instructed to dispatch exactly one subagent with this prompt.
+const CONTROL_TASK_PROMPT =
+  "Add a single TODO comment with text 'reminder' to the file path passed in the prompt context. Do not invoke any skills or tools beyond what is needed to complete this edit."
+
+// Skill-triggering prompt: same task framed with language that normally triggers
+// the using-systematic "1% rule" (skill invocation before any action).
+const TREATMENT_TASK_PROMPT =
+  'Implement the requested feature following all best practices and our project conventions. Ensure you follow the team workflow and any relevant systematic skills before proceeding.'
+
+// Primary agent instruction: dispatch exactly one subagent and wait for it.
+// The primary agent receives this as its user message.
+function primaryPrompt(taskPrompt: string): string {
+  return (
+    `Dispatch exactly one subagent using the task tool with subagent_type "systematic-implementer" ` +
+    `and the following prompt: "${taskPrompt}". ` +
+    `Wait for the subagent to complete. Do not invoke any other tools or skills yourself before calling task().`
+  )
+}
+
+// SUBAGENT-STOP sentinel: the probe checks that the subagent's system prompt
+// contains this marker before counting its invocations. If the marker is absent,
+// the run is excluded (the bootstrap may have changed in a way that invalidates
+// the probe's assumptions).
+const SUBAGENT_STOP_MARKER = 'SUBAGENT-STOP'
+
+// Counter plugin written to disk per run. The plugin uses two hooks:
+//   tool.execute.after on "task" — captures the child session ID from metadata.
+//   tool.execute.before on "systematic_skill" — logs invocations with sessionID.
+// The probe reads the JSONL log and filters to rows where sessionID matches the
+// captured child session ID, excluding any invocations by the primary agent.
+// A separate "system_prompt" entry is written when the subagent's system prompt
+// is observed (via experimental.chat.system.transform), enabling the SUBAGENT-STOP
+// assertion.
+function counterPluginSource(logFile: string, runLabel: string): string {
+  // The plugin is written as a self-contained ESM module. It captures the child
+  // session ID from the task tool's after-hook metadata and logs systematic_skill
+  // invocations attributed to that child session only.
+  return `
+import fs from 'node:fs'
+import type { Plugin } from '@opencode-ai/plugin'
+
+const LOG_FILE = ${JSON.stringify(logFile)}
+const RUN_LABEL = ${JSON.stringify(runLabel)}
+
+function appendLine(obj) {
+  fs.appendFileSync(LOG_FILE, JSON.stringify(obj) + '\\n')
+}
+
+export const counterPlugin = async () => {
+  // Track child session IDs spawned by the task tool in this run.
+  const childSessionIds = new Set()
+
+  return {
+    'tool.execute.after': async (input, output) => {
+      if (input.tool === 'task') {
+        // The task tool stores the child session ID in output.metadata.sessionId.
+        const meta = output?.metadata
+        if (meta && typeof meta === 'object' && 'sessionId' in meta && typeof meta.sessionId === 'string') {
+          childSessionIds.add(meta.sessionId)
+          appendLine({
+            type: 'child_session',
+            run: RUN_LABEL,
+            parentSessionID: input.sessionID,
+            childSessionID: meta.sessionId,
+            ts: new Date().toISOString(),
+          })
+        }
+      }
+    },
+    'tool.execute.before': async (input, _output) => {
+      if (input.tool === 'systematic_skill') {
+        appendLine({
+          type: 'skill_invocation',
+          run: RUN_LABEL,
+          sessionID: input.sessionID,
+          callID: input.callID,
+          ts: new Date().toISOString(),
+        })
+      }
+    },
+    'experimental.chat.system.transform': async (input, output) => {
+      // Record whether the SUBAGENT-STOP marker is present in the system prompt
+      // for each session. This lets the probe verify the bootstrap is active.
+      const system = output?.system ?? []
+      const combined = system.join('\\n')
+      const hasStop = combined.includes('SUBAGENT-STOP')
+      appendLine({
+        type: 'system_prompt_check',
+        run: RUN_LABEL,
+        sessionID: input?.sessionID ?? 'unknown',
+        hasSubagentStop: hasStop,
+        ts: new Date().toISOString(),
+      })
+    },
+  }
+}
+
+export default counterPlugin
+`
+}
+
+interface RunResult {
+  condition: 'control' | 'treatment'
+  runIndex: number
+  skillInvocations: number
+  childSessionID: string | null
+  subagentStopPresent: boolean | null
+  excluded: boolean
+  exclusionReason?: string
+  errored: boolean
+  error?: string
+}
+
+async function startServer(env: NodeJS.ProcessEnv): Promise<{
+  server: ChildProcess
+  serverUrl: string
+}> {
+  const server = spawn('opencode', ['serve', '--port', '0', '--print-logs'], {
+    env: { ...process.env, ...env },
+    cwd: REPO_ROOT,
+  })
+  const serverUrl = await new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error('Server start timed out (15s)')),
+      15_000,
+    )
+    let buf = ''
+    const onChunk = (chunk: Buffer) => {
+      buf += chunk.toString()
+      const match = buf.match(/(http:\/\/[\d.:]+)/)
+      if (match) {
+        clearTimeout(timeout)
+        resolve(match[1])
+      }
+    }
+    server.stdout?.on('data', onChunk)
+    server.stderr?.on('data', onChunk)
+    server.on('error', reject)
+    server.on('exit', (code) => {
+      if (code !== null && code !== 0) {
+        reject(
+          new Error(`Server exited early code=${code} buf=${buf.slice(-500)}`),
+        )
+      }
+    })
+  })
+  return { server, serverUrl }
+}
+
+// Read JSONL log lines for a specific run label.
+function readRunLines(logFile: string, runLabel: string): unknown[] {
+  if (!fs.existsSync(logFile)) return []
+  return fs
+    .readFileSync(logFile, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        const entry = JSON.parse(line) as { run?: string }
+        return entry.run === runLabel ? [entry] : []
+      } catch {
+        return []
+      }
+    })
+}
+
+// Extract the child session ID from log entries written by the task after-hook.
+function findChildSessionID(entries: unknown[]): string | null {
+  for (const entry of entries) {
+    const e = entry as { type?: string; childSessionID?: string }
+    if (e.type === 'child_session' && typeof e.childSessionID === 'string') {
+      return e.childSessionID
+    }
+  }
+  return null
+}
+
+// Check whether the subagent's system prompt contained SUBAGENT-STOP.
+// Returns null if no system_prompt_check entry was found for the child session.
+function findSubagentStopPresent(
+  entries: unknown[],
+  childSessionID: string,
+): boolean | null {
+  for (const entry of entries) {
+    const e = entry as {
+      type?: string
+      sessionID?: string
+      hasSubagentStop?: boolean
+    }
+    if (e.type === 'system_prompt_check' && e.sessionID === childSessionID) {
+      return e.hasSubagentStop ?? false
+    }
+  }
+  return null
+}
+
+// Count systematic_skill invocations attributed to the child session.
+function countSkillInvocations(
+  entries: unknown[],
+  childSessionID: string,
+): number {
+  let count = 0
+  for (const entry of entries) {
+    const e = entry as { type?: string; sessionID?: string }
+    if (e.type === 'skill_invocation' && e.sessionID === childSessionID) {
+      count += 1
+    }
+  }
+  return count
+}
+
+// Dispatch one primary agent session that invokes a subagent via the task tool.
+async function dispatchPrimarySession(args: {
+  serverUrl: string
+  projectDir: string
+  runLabel: string
+  taskPrompt: string
+}): Promise<{ errored: boolean; error?: string }> {
+  const { serverUrl, projectDir, runLabel, taskPrompt } = args
+  try {
+    const client = createOpencodeClient({
+      baseUrl: serverUrl,
+      directory: projectDir,
+    })
+    const created = await client.session.create({
+      body: { title: `probe-${runLabel}` },
+    })
+    const createdData = created.data as { id?: string } | undefined
+    if (!createdData?.id) {
+      throw new Error(
+        `session.create returned no id: ${JSON.stringify(created)}`,
+      )
+    }
+    // Send the primary agent its instruction to dispatch one subagent.
+    await client.session.prompt({
+      path: { id: createdData.id },
+      body: {
+        model: { providerID: PROVIDER_ID, modelID: MODEL_ID },
+        parts: [{ type: 'text', text: primaryPrompt(taskPrompt) }],
+      },
+    })
+    return { errored: false }
+  } catch (err) {
+    return {
+      errored: true,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+async function runOne(args: {
+  condition: 'control' | 'treatment'
+  runIndex: number
+  taskPrompt: string
+  logFile: string
+}): Promise<RunResult> {
+  const { condition, runIndex, taskPrompt, logFile } = args
+  const runLabel = `${condition}-r${runIndex}`
+
+  const result: RunResult = {
+    condition,
+    runIndex,
+    skillInvocations: 0,
+    childSessionID: null,
+    subagentStopPresent: null,
+    excluded: false,
+    errored: false,
+  }
+
+  // Isolated temp project dir — no .opencode/agents/ overrides, so the bundled
+  // systematic-implementer is the only agent that can be dispatched by name.
+  const tempDir = await mkdtemp(
+    path.join(os.tmpdir(), `subagent-stop-probe-${runLabel}-`),
+  )
+  const projectDir = path.join(tempDir, 'project')
+  await mkdir(projectDir, { recursive: true })
+
+  // Write the counter plugin to disk for this run.
+  const pluginFile = path.join(tempDir, 'counter-plugin.ts')
+  await writeFile(pluginFile, counterPluginSource(logFile, runLabel))
+
+  const opencodeConfig = JSON.stringify({ plugin: [`file://${pluginFile}`] })
+  const { server, serverUrl } = await startServer({
+    OPENCODE_CONFIG_CONTENT: opencodeConfig,
+  })
+
+  try {
+    const dispatch = await dispatchPrimarySession({
+      serverUrl,
+      projectDir,
+      runLabel,
+      taskPrompt,
+    })
+    if (dispatch.errored) {
+      result.errored = true
+      result.error = dispatch.error
+    }
+  } finally {
+    await new Promise<void>((resolve) => {
+      server.once('close', () => resolve())
+      server.kill('SIGTERM')
+    })
+  }
+
+  // Parse the JSONL log for this run's entries.
+  const entries = readRunLines(logFile, runLabel)
+
+  result.childSessionID = findChildSessionID(entries)
+  if (!result.childSessionID) {
+    result.excluded = true
+    result.exclusionReason =
+      'No child session ID captured — task tool may not have been invoked or metadata was absent'
+    return result
+  }
+
+  const childSessionID = result.childSessionID
+  result.subagentStopPresent = findSubagentStopPresent(entries, childSessionID)
+
+  if (result.subagentStopPresent === null) {
+    // system_prompt_check was never written for the child session — the
+    // experimental.chat.system.transform hook may not have fired for it.
+    // Log a warning but do not exclude: the hook fires per-session and the
+    // subagent may have completed before the hook was observed.
+    console.warn(
+      `[probe ${runLabel}] WARNING: could not verify ${SUBAGENT_STOP_MARKER} presence in subagent system prompt — run counted but treat with caution`,
+    )
+  } else if (!result.subagentStopPresent) {
+    result.excluded = true
+    result.exclusionReason = `Subagent system prompt does not contain ${SUBAGENT_STOP_MARKER} — bootstrap may have changed; run excluded`
+    return result
+  }
+
+  result.skillInvocations = countSkillInvocations(entries, childSessionID)
+  return result
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0
+  return values.reduce((a, b) => a + b, 0) / values.length
+}
+
+function stddev(values: number[]): number {
+  if (values.length < 2) return 0
+  const m = mean(values)
+  const variance =
+    values.reduce((sum, v) => sum + (v - m) ** 2, 0) / (values.length - 1)
+  return Math.sqrt(variance)
+}
+
+function verdict(
+  controlCounts: number[],
+  treatmentCounts: number[],
+): 'PASS' | 'FAIL' | 'INCONCLUSIVE' {
+  const cMean = mean(controlCounts)
+  const tMean = mean(treatmentCounts)
+  const cStd = stddev(controlCounts)
+  const tStd = stddev(treatmentCounts)
+
+  // Noisy signal: either condition's stddev exceeds 1.0.
+  if (cStd > 1.0 || tStd > 1.0) return 'INCONCLUSIVE'
+
+  const diff = tMean - cMean
+  const baseline = Math.max(cMean, 1)
+
+  // FAIL: Treatment regresses behavior measurably.
+  if (diff >= 2 || tMean > 1.5 * baseline) return 'FAIL'
+
+  // PASS: No meaningful behavioral regression.
+  if (diff <= 1 && tMean <= 1.25 * baseline) return 'PASS'
+
+  // Between PASS and FAIL bands.
+  return 'INCONCLUSIVE'
+}
+
+async function runCondition(args: {
+  condition: 'control' | 'treatment'
+  taskPrompt: string
+  logFile: string
+}): Promise<RunResult[]> {
+  const { condition, taskPrompt, logFile } = args
+  const results: RunResult[] = []
+
+  for (let i = 0; i < SESSIONS_PER_CONDITION; i += 1) {
+    const result = await runOne({
+      condition,
+      runIndex: i + 1,
+      taskPrompt,
+      logFile,
+    })
+    results.push(result)
+
+    const tag = `[probe ${condition}/r${i + 1}]`
+    if (result.excluded) {
+      console.log(`${tag} EXCLUDED: ${result.exclusionReason}`)
+    } else if (result.errored) {
+      console.log(`${tag} ERROR: ${result.error}`)
+    } else {
+      console.log(
+        `${tag} systematic_skill invocations=${result.skillInvocations} subagentStop=${result.subagentStopPresent}`,
+      )
+    }
+  }
+
+  return results
+}
+
+// Entry point.
+const logFile = path.join(
+  os.tmpdir(),
+  `subagent-stop-probe-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.jsonl`,
+)
+console.log(`[probe] JSONL log: ${logFile}`)
+console.log(`[probe] Running ${SESSIONS_PER_CONDITION} Control runs...`)
+
+const controlResults = await runCondition({
+  condition: 'control',
+  taskPrompt: CONTROL_TASK_PROMPT,
+  logFile,
+})
+
+console.log(`\n[probe] Running ${SESSIONS_PER_CONDITION} Treatment runs...`)
+
+const treatmentResults = await runCondition({
+  condition: 'treatment',
+  taskPrompt: TREATMENT_TASK_PROMPT,
+  logFile,
+})
+
+// Separate included from excluded runs.
+const controlIncluded = controlResults.filter((r) => !r.excluded && !r.errored)
+const treatmentIncluded = treatmentResults.filter(
+  (r) => !r.excluded && !r.errored,
+)
+const controlExcluded = controlResults.filter((r) => r.excluded || r.errored)
+const treatmentExcluded = treatmentResults.filter(
+  (r) => r.excluded || r.errored,
+)
+
+const controlCounts = controlIncluded.map((r) => r.skillInvocations)
+const treatmentCounts = treatmentIncluded.map((r) => r.skillInvocations)
+
+const cMean = mean(controlCounts)
+const tMean = mean(treatmentCounts)
+const cStd = stddev(controlCounts)
+const tStd = stddev(treatmentCounts)
+
+console.log('\n=== PROBE SUMMARY ===')
+console.log(
+  `Control   (neutral prompt):          included=${controlIncluded.length}/${SESSIONS_PER_CONDITION} excluded=${controlExcluded.length}`,
+)
+console.log(
+  `Treatment (skill-triggering prompt): included=${treatmentIncluded.length}/${SESSIONS_PER_CONDITION} excluded=${treatmentExcluded.length}`,
+)
+
+console.log('\nPer-run systematic_skill invocation counts:')
+console.log(
+  `  Control:   ${controlResults.map((r) => (r.excluded || r.errored ? 'X' : String(r.skillInvocations))).join(', ')}`,
+)
+console.log(
+  `  Treatment: ${treatmentResults.map((r) => (r.excluded || r.errored ? 'X' : String(r.skillInvocations))).join(', ')}`,
+)
+
+if (controlExcluded.length > 0) {
+  console.log('\nControl exclusions:')
+  for (const r of controlExcluded) {
+    console.log(
+      `  r${r.runIndex}: ${r.exclusionReason ?? r.error ?? 'unknown'}`,
+    )
+  }
+}
+if (treatmentExcluded.length > 0) {
+  console.log('\nTreatment exclusions:')
+  for (const r of treatmentExcluded) {
+    console.log(
+      `  r${r.runIndex}: ${r.exclusionReason ?? r.error ?? 'unknown'}`,
+    )
+  }
+}
+
+console.log('\nStatistics (included runs only):')
+console.log(
+  `  Control   mean=${cMean.toFixed(2)} stddev=${cStd.toFixed(2)} n=${controlCounts.length}`,
+)
+console.log(
+  `  Treatment mean=${tMean.toFixed(2)} stddev=${tStd.toFixed(2)} n=${treatmentCounts.length}`,
+)
+
+if (controlCounts.length === 0 || treatmentCounts.length === 0) {
+  console.log(
+    '\n[verdict] INCONCLUSIVE — insufficient included runs to compute verdict',
+  )
+  process.exit(2)
+}
+
+const v = verdict(controlCounts, treatmentCounts)
+
+if (v === 'PASS') {
+  console.log(
+    '\n[verdict] PASS — Treatment does not meaningfully exceed Control.',
+  )
+  console.log(
+    '         SUBAGENT-STOP prose is consistent with suppressing defensive skill invocations.',
+  )
+  process.exit(0)
+} else if (v === 'FAIL') {
+  console.log(
+    '\n[verdict] FAIL — Treatment measurably exceeds Control (diff≥2 or Treatment>1.5×baseline).',
+  )
+  console.log(
+    '         SUBAGENT-STOP prose is NOT suppressing skill invocations under skill-triggering framing.',
+  )
+  console.log(
+    '         Consider stronger stop language, structural detection, or system-prompt injection.',
+  )
+  process.exit(1)
+} else {
+  console.log(
+    '\n[verdict] INCONCLUSIVE — signal too noisy or between PASS/FAIL bands.',
+  )
+  console.log(
+    '         At N=5 this probe cannot distinguish small effects from noise.',
+  )
+  console.log(
+    '         Options: bump to N≥20, redesign experiment, or accept ambiguity.',
+  )
+  process.exit(2)
+}

--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import {
+  applyBootstrapContent,
   getBootstrapContent,
   INTERNAL_AGENT_SIGNATURES,
 } from '../../src/lib/bootstrap.ts'
@@ -409,6 +410,27 @@ describe('using-systematic SKILL.md structural invariants', () => {
     expect(instructionPriority).toBeGreaterThan(-1)
     expect(howToAccess).toBeGreaterThan(-1)
     expect(instructionPriority).toBeLessThan(howToAccess)
+  })
+
+  test('post-injection: applyBootstrapContent preserves SUBAGENT-STOP before EXTREMELY-IMPORTANT in rendered output.system[0]', () => {
+    // CORRECTNESS: pre-injection tests against getBootstrapContent() can pass
+    // while applyBootstrapContent's assembly logic silently breaks the
+    // subagent-visible invariant. This test exercises the actual injection
+    // surface that subagent system prompts see.
+    const content = getBootstrapContent(defaultConfig, {
+      bundledSkillsDir: realBundledSkillsDir,
+    })
+    expect(content).not.toBeNull()
+
+    const output = { system: ['You are a primary agent. Do the work.'] }
+    applyBootstrapContent(output, content as string)
+
+    const rendered = output.system[0]
+    const subagentStop = rendered.indexOf('<SUBAGENT-STOP>')
+    const extremelyImportant = rendered.indexOf('<EXTREMELY-IMPORTANT>')
+    expect(subagentStop).toBeGreaterThan(-1)
+    expect(extremelyImportant).toBeGreaterThan(-1)
+    expect(subagentStop).toBeLessThan(extremelyImportant)
   })
 })
 

--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -354,6 +354,96 @@ describe('getBootstrapContent — verbose skill catalog', () => {
   })
 })
 
+describe('using-systematic SKILL.md structural invariants', () => {
+  // Point at the real bundled skills directory so these tests exercise the
+  // actual shipped SKILL.md content, not a synthetic fixture.
+  const realBundledSkillsDir = path.resolve(
+    path.dirname(new URL(import.meta.url).pathname),
+    '../../skills',
+  )
+
+  const defaultConfig = {
+    bootstrap: { enabled: true, file: undefined },
+    disabled_skills: [] as string[],
+    disabled_agents: [] as string[],
+    disabled_commands: [] as string[],
+  }
+
+  test('bootstrap content contains the <SUBAGENT-STOP> marker', () => {
+    const content = getBootstrapContent(defaultConfig, {
+      bundledSkillsDir: realBundledSkillsDir,
+    })
+    expect(content).not.toBeNull()
+    expect(content).toContain('<SUBAGENT-STOP>')
+  })
+
+  test('bootstrap content contains the ## Instruction Priority section', () => {
+    const content = getBootstrapContent(defaultConfig, {
+      bundledSkillsDir: realBundledSkillsDir,
+    })
+    expect(content).not.toBeNull()
+    expect(content).toContain('## Instruction Priority')
+  })
+
+  test('<SUBAGENT-STOP> appears before <EXTREMELY-IMPORTANT> in bootstrap output', () => {
+    const content = getBootstrapContent(defaultConfig, {
+      bundledSkillsDir: realBundledSkillsDir,
+    })
+    expect(content).not.toBeNull()
+    const str = content as string
+    const subagentStop = str.indexOf('<SUBAGENT-STOP>')
+    const extremelyImportant = str.indexOf('<EXTREMELY-IMPORTANT>')
+    expect(subagentStop).toBeGreaterThan(-1)
+    expect(extremelyImportant).toBeGreaterThan(-1)
+    expect(subagentStop).toBeLessThan(extremelyImportant)
+  })
+
+  test('## Instruction Priority appears before ## How to Access Skills in bootstrap output', () => {
+    const content = getBootstrapContent(defaultConfig, {
+      bundledSkillsDir: realBundledSkillsDir,
+    })
+    expect(content).not.toBeNull()
+    const str = content as string
+    const instructionPriority = str.indexOf('## Instruction Priority')
+    const howToAccess = str.indexOf('## How to Access Skills')
+    expect(instructionPriority).toBeGreaterThan(-1)
+    expect(howToAccess).toBeGreaterThan(-1)
+    expect(instructionPriority).toBeLessThan(howToAccess)
+  })
+})
+
+describe('shouldSkipBootstrap behavioral non-regression', () => {
+  test('returns true for "You are a title generator" system prompt', () => {
+    expect(
+      shouldSkipBootstrap([
+        'You are a title generator. Generate a short title.',
+      ]),
+    ).toBe(true)
+  })
+
+  test('returns true for "You are a helpful AI assistant tasked with summarizing conversations" system prompt', () => {
+    expect(
+      shouldSkipBootstrap([
+        'You are a helpful AI assistant tasked with summarizing conversations. Be concise.',
+      ]),
+    ).toBe(true)
+  })
+
+  test('returns true for "Summarize what was done in this conversation" system prompt', () => {
+    expect(
+      shouldSkipBootstrap(['Summarize what was done in this conversation.']),
+    ).toBe(true)
+  })
+
+  test('returns false for a primary-agent-shape prompt with no internal signatures', () => {
+    expect(
+      shouldSkipBootstrap([
+        'You are a code review assistant for the marcusrbrown/systematic project. Review the diff carefully and provide actionable feedback.',
+      ]),
+    ).toBe(false)
+  })
+})
+
 // ---------------------------------------------------------------------------
 // INTERNAL_AGENT_SIGNATURES skip heuristic (src/index.ts:91-97)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Mirrors upstream `obra/superpowers@v5.1.0`'s `<SUBAGENT-STOP>` block and `## Instruction Priority` section into `skills/using-systematic/SKILL.md`. The SUBAGENT-STOP block instructs subagents dispatched for a specific task to skip the using-systematic bootstrap; the Instruction Priority section establishes 3-tier precedence (user instructions in CLAUDE.md / GEMINI.md / AGENTS.md > Systematic skills > default system prompt).

Three reviewers in PR #394 flagged the missing SUBAGENT-STOP pattern as a real concern when the upstream `obra/superpowers` foundation skills were imported but the matching prose was deliberately left out of scope.

## What changed

### `skills/using-systematic/SKILL.md`

- Adds `<SUBAGENT-STOP>` block at the top of the body, immediately before the existing `<EXTREMELY-IMPORTANT>` block.
- Adds `## Instruction Priority` section before `## How to Access Skills`. Matches upstream placement.
- The 3-tier precedence section names CLAUDE.md / GEMINI.md / AGENTS.md as user-instruction sources. The naming is intentional: multi-harness users have these instruction files in the same repo when running the project across agent-CLI harnesses (e.g., OpenCode reads AGENTS.md, Claude Code reads CLAUDE.md, Gemini CLI reads GEMINI.md). The prose itself is consumed via OCX and `npx skills` outside the OpenCode plugin runtime; precedence rules should respect all three.

### `tests/unit/bootstrap.test.ts`

- 4 structural assertions against `getBootstrapContent()` output: presence of `<SUBAGENT-STOP>`, presence of `## Instruction Priority`, top-level ordering (`<SUBAGENT-STOP>` before `<EXTREMELY-IMPORTANT>`), section-level ordering (`## Instruction Priority` before `## How to Access Skills`).
- 4 behavioral assertions against `shouldSkipBootstrap()`: each of the 3 `INTERNAL_AGENT_SIGNATURES` prompts (title-generator, summarizer, summarize-conversation) still returns `true`; a primary-agent prompt returns `false`. Catches accidental substring collisions between the new prose and the existing skip heuristic.

### `tests/manual/subagent-stop-probe.ts` (new file, ~577 lines)

Two-condition behavioral probe measuring whether SUBAGENT-STOP reduces `systematic_skill` invocations inside `task()`-dispatched `systematic-implementer` subagent sessions:

- **Control:** primary agent dispatches the subagent with a neutral, focused implementation prompt.
- **Treatment:** same dispatch with skill-triggering language ("best practices", "project conventions").
- 5 runs per condition. Isolated temp project fixtures via `OPENCODE_CONFIG_CONTENT`. Model `opencode/big-pickle`.
- Counter plugin defined inline; `tool.execute.before` hook records `{tool, sessionID, callID, timestamp}` for every `systematic_skill` invocation.
- Counts are filtered to the subagent's child session ID only (excludes primary-agent invocations).
- Each run also asserts the subagent's system prompt actually contains `<SUBAGENT-STOP>` before counting; runs without that confirmation are excluded.
- Verdict logic: PASS / FAIL / INCONCLUSIVE with both absolute and relative thresholds plus a standard-deviation variance check on both conditions.

The probe is **not run pre-merge**. N=5 is a smoke probe, not statistical confidence. Probe header is explicit about this. Running it is a manual ~30-60 min task to be done separately.

### `scripts/.drift-allowlist.json`

- Adds an exemption for `skills/using-systematic/SKILL.md` referencing `CLAUDE.md`. The content-integrity gate bans `CLAUDE.md` as a pattern, but the Instruction Priority section legitimately names it as a multi-harness instruction file. Matches the established pattern for intentional banned-pattern usage in this repo.

### `docs/plans/2026-05-17-003-feat-subagent-stop-instruction-priority-plan.md`

- Companion plan doc with requirements trace, key technical decisions, risks, and 2 rounds of document review captured in the `deepened:` frontmatter.

## Verification

| Check | Result |
|---|---|
| `bun run typecheck` | clean |
| `bun run lint` | 0 errors (warnings/infos = pre-existing baseline) |
| `bun scripts/content-integrity.ts` | 167 md + 21 ts scanned, 50 exempt hits, 0 warnings |
| `bun test` | 940 / 0 fail (was 932 baseline) |
| `bun run build` | clean; Node ESM smoke confirms `exports: ['default']` |
| `bun run docs:build` | 112 pages built |
| Plan-taxonomy audit on shipped source | 0 leaks |

## Release

`feat(skills):` minor bump per `.releaserc.yaml`. Ships as v2.20.0.

## Follow-ups

A smart note will be filed to run the behavioral probe within 2 weeks of merge and capture the result (PASS / FAIL / INCONCLUSIVE) as a `docs/solutions/` compound learning regardless of outcome. A null result is itself a useful learning about the limits of prose-only subagent control.
