### PR TITLE
docs(solutions): capture v2.20.0 cycle learnings on plan-spec rigor and gh CI polling

### DIFF
--- a/docs/solutions/developer-experience/gh-statuscheckrollup-conclusion-empty-for-in-progress-2026-05-18.md
+++ b/docs/solutions/developer-experience/gh-statuscheckrollup-conclusion-empty-for-in-progress-2026-05-18.md
@@ -113,6 +113,8 @@ fi
 
 ### Diagnostic — surface raw state when debugging
 
+The wrong/right blocks above hardcode the actual PR number (`405`) from the incident that prompted this doc. The diagnostic below uses `<num>` because it is general guidance — substitute the PR number under investigation.
+
 ```sh
 gh pr view <num> --json statusCheckRollup \
   -q '.statusCheckRollup[] | {name, status, conclusion}'

--- a/docs/solutions/developer-experience/gh-statuscheckrollup-conclusion-empty-for-in-progress-2026-05-18.md
+++ b/docs/solutions/developer-experience/gh-statuscheckrollup-conclusion-empty-for-in-progress-2026-05-18.md
@@ -1,0 +1,125 @@
+---
+title: gh statusCheckRollup conclusion is empty string for in-progress jobs, not a failure
+module: scripts (CI polling)
+date: 2026-05-18
+problem_type: developer_experience
+component: tooling
+severity: medium
+tags:
+  - gh-cli
+  - jq
+  - ci-polling
+  - pr-checks
+  - github-api
+applies_when:
+  - Writing scripts that poll `gh pr view --json statusCheckRollup` to wait for CI to settle
+  - Comparing `conclusion` field values against `"SUCCESS"` to count failures
+  - Implementing PR-merge gates or post-push wait loops in shell
+---
+
+# gh statusCheckRollup conclusion is empty string for in-progress jobs, not a failure
+
+## Context
+
+The `gh pr view --json statusCheckRollup` response carries one entry per CI check. Each entry has two fields that together describe its state:
+
+- `status`: `QUEUED`, `IN_PROGRESS`, or `COMPLETED`
+- `conclusion`: `SUCCESS`, `FAILURE`, `CANCELLED`, `SKIPPED`, `NEUTRAL`, `TIMED_OUT`, `ACTION_REQUIRED`, or `STARTUP_FAILURE` — but **only when** `status == "COMPLETED"`
+
+For checks that are still running, `conclusion` is the empty string `""`. Code that compares `conclusion != "SUCCESS"` to count failures will falsely flag every running job as a failure.
+
+This bit a polling loop during the PR #405 cycle. The script used:
+
+```sh
+CI_FAILED=$(gh pr view 405 --json statusCheckRollup \
+  -q '[.statusCheckRollup[]|select(.conclusion!="SUCCESS" and .conclusion!="NEUTRAL" and .conclusion!=null)]|length')
+```
+
+At iteration 1, three jobs were `IN_PROGRESS` (Fro Bot, CodeQL `Analyze (typescript)`, Docs Build). Each carried `conclusion: ""`, which did not match `"SUCCESS"`, `"NEUTRAL"`, or `null`. The script reported `ci_failed=4` and triggered the "✗ CI failure" break-out branch. There was no actual failure — all 11 checks went on to pass minutes later and the PR merged cleanly.
+
+## Guidance
+
+Filter by `status == "COMPLETED"` **before** evaluating `conclusion`. Two correct jq patterns:
+
+```sh
+# Count failed-after-completion (excludes in-progress, excludes SUCCESS, excludes NEUTRAL)
+CI_FAILED=$(gh pr view <num> --json statusCheckRollup \
+  -q '[.statusCheckRollup[]|select(.status=="COMPLETED" and .conclusion!="SUCCESS" and .conclusion!="NEUTRAL")]|length')
+
+# Count still-pending (jobs not yet COMPLETED)
+CI_PENDING=$(gh pr view <num> --json statusCheckRollup \
+  -q '[.statusCheckRollup[]|select(.status!="COMPLETED")]|length')
+```
+
+Treat `NEUTRAL` as non-failing (it covers SKIPPED-via-event-filter jobs and similar). `null` does not appear in normal `statusCheckRollup` responses but harmless to include defensively if desired.
+
+For the loop break-out condition, require BOTH:
+
+1. `ci_pending == 0` (every check has settled)
+2. `ci_failed == 0` (none of the settled checks failed)
+
+Failing either condition keeps polling. The merge-state-status check (`mergeStateStatus == "CLEAN"`) is a useful cross-check but is not a substitute — `mergeStateStatus` can lag the actual CI roll-up by a few seconds during the transition.
+
+## Why This Matters
+
+A false-positive CI failure in a polling script aborts the loop and triggers the wrong follow-up branch. In a one-off interactive use that may just look weird; in a longer-running automation it can:
+
+- Send a misleading status message to the operator
+- Skip the intended *success* branch (e.g., auto-merge, release-tag wait, follow-up dispatch)
+- Push the operator to investigate a fictional failure, wasting the very wall-time that polling was meant to save
+
+The shape of the bug is a classic "absent value vs sentinel value" trap: `conclusion: ""` is semantically *"not yet decided"*, not *"decided != SUCCESS"*. jq does not distinguish them when the only filter is `conclusion != "SUCCESS"`. Anchoring on the orthogonal `status` field disambiguates cleanly.
+
+## When to Apply
+
+- Any shell or automation script that polls `gh pr view --json statusCheckRollup`
+- Any logic that compares CI `conclusion` against a constant (success or failure)
+- Any merge-gate or release-gate that branches on CI roll-up state
+
+## Examples
+
+### Wrong — counts in-progress jobs as failures
+
+```sh
+# BAD: select(.conclusion != "SUCCESS")
+CI_FAILED=$(gh pr view 405 --json statusCheckRollup \
+  -q '[.statusCheckRollup[]|select(.conclusion!="SUCCESS" and .conclusion!="NEUTRAL" and .conclusion!=null)]|length')
+
+if [ "$CI_FAILED" -gt 0 ]; then
+  echo "✗ CI failure"   # ← fires while jobs are still running
+  break
+fi
+```
+
+### Right — status filter first
+
+```sh
+# GOOD: select(.status == "COMPLETED" and .conclusion != "SUCCESS")
+CI_PENDING=$(gh pr view 405 --json statusCheckRollup \
+  -q '[.statusCheckRollup[]|select(.status!="COMPLETED")]|length')
+CI_FAILED=$(gh pr view 405 --json statusCheckRollup \
+  -q '[.statusCheckRollup[]|select(.status=="COMPLETED" and .conclusion!="SUCCESS" and .conclusion!="NEUTRAL")]|length')
+
+if [ "$CI_FAILED" -gt 0 ]; then
+  echo "✗ CI failure"  # only fires when a COMPLETED check has a non-success conclusion
+  break
+fi
+
+if [ "$CI_PENDING" = "0" ]; then
+  echo "✓ All checks settled"
+  break
+fi
+```
+
+### Diagnostic — surface raw state when debugging
+
+```sh
+gh pr view <num> --json statusCheckRollup \
+  -q '.statusCheckRollup[] | {name, status, conclusion}'
+```
+
+This is the fastest way to verify the empty-string-conclusion behavior in your own environment. Run it against a PR that has at least one in-progress check.
+
+## Related
+
+- `docs/solutions/developer-experience/gh-api-heredoc-backtick-escape-2026-05-17.md` — another `gh` CLI rigor lesson, on heredoc body escaping when authoring PR/issue bodies via `gh api -F body=`. Different surface, same category of trap (treating the CLI's surface as a black box rather than verifying field semantics).

--- a/docs/solutions/workflow-issues/risks-table-rows-must-enforce-as-spec-checks-2026-05-18.md
+++ b/docs/solutions/workflow-issues/risks-table-rows-must-enforce-as-spec-checks-2026-05-18.md
@@ -1,0 +1,118 @@
+---
+title: Plan Risks-table rows must enforce as discrete spec checks, not informational notes
+module: ce-plan / ce-work
+date: 2026-05-18
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+tags:
+  - planning
+  - subagent-dispatch
+  - test-coverage
+  - plan-rigor
+  - mitigation
+applies_when:
+  - Writing implementation plans where the Risks & Dependencies table lists a mitigation
+  - Dispatching implementation work to a subagent (fixer / systematic-implementer)
+  - Reviewing subagent output before commit
+---
+
+# Plan Risks-table rows must enforce as discrete spec checks, not informational notes
+
+## Context
+
+When a plan's Risks & Dependencies table identifies a concrete mitigation for a risk, that mitigation has to land as a discrete, enumerated spec check in the implementation unit. Otherwise the subagent reads the plan, follows the unit-level spec to the letter, and silently omits the mitigation — because the spec did not enumerate it.
+
+This pattern surfaced on PR #405 (SUBAGENT-STOP / Instruction Priority sync). The plan's Risks & Dependencies table had a row that said in part:
+
+> Add a behavioral assertion in Unit 1 that calls `applyBootstrapContent` against a representative `output.system` array and asserts the rendered post-injection string still has SUBAGENT-STOP before `<EXTREMELY-IMPORTANT>`. This catches injection-side reordering bugs that pre-injection tests would miss.
+
+The implementation unit's test spec listed four assertions — all against `getBootstrapContent()` (pre-injection). The post-injection assertion against `applyBootstrapContent` was named in the Risks table mitigation column and not echoed into the Unit's enumerated test scenarios. The subagent landed exactly what the Unit spec described: four pre-injection tests. Fro Bot caught the gap on review with the verdict line *"The gap was identified during planning, accepted as a mitigation requirement, and then dropped during implementation."*
+
+## Guidance
+
+When writing a plan, treat the Risks & Dependencies table as **risk identification + mitigation framing**, not as a parallel spec surface. Every mitigation that involves new code or a new test MUST also appear as a discrete enumerated bullet under the relevant Implementation Unit's *Approach* or *Test Scenarios* section. The Risks-table cell tells the reader *why* the check exists; the Unit-spec bullet tells the implementer *what to write*.
+
+Concretely:
+
+1. After drafting the Risks table, scan each row's mitigation column for verbs like *"add a test"*, *"assert X"*, *"introduce a check"*, *"validate Y"*.
+2. For each such mitigation, find the Implementation Unit whose unit-level spec must enforce it.
+3. Add a discrete bullet to that Unit's test/scenario enumeration that paraphrases the mitigation. Do not assume the subagent will cross-reference the Risks table; the unit-level spec is the single source of truth for the implementer.
+4. During orchestrator audit before commit, run a quick scan: for each mitigation verb in the Risks table, grep the diff for the corresponding code or test artifact. Missing artifacts mean the mitigation dropped.
+
+## Why This Matters
+
+Subagents (`@fixer`, `@systematic-implementer`) are deliberately given a narrow, focused brief. They are not asked to reason across the whole plan document — that's the orchestrator's job. The Risks table sits structurally outside the per-Unit specs. A subagent reading the Risks table at all is a bonus, not a guarantee. Plans optimized for subagent execution should put mitigations where the subagent will read them: in the Unit spec.
+
+The cost of missing a mitigation depends on its purpose:
+
+- **Low cost**: a defensive test that would have caught a hypothetical future regression. The PR still ships; the missing test gets added in a follow-up commit or the next PR cycle.
+- **High cost**: a mitigation against a known-broken edge case. The PR ships a real bug. Fro Bot or a downstream consumer catches it.
+
+PR #405 was the *low cost* shape — pre-injection tests + the prose change still delivered the feature correctly. The missing post-injection test was a defensive guard, not a fix. But Fro Bot's review explicitly framed it as a *blocking* finding because the plan had identified the mitigation, the implementation had silently dropped it, and that mismatch erodes plan-as-contract.
+
+## When to Apply
+
+- **Always** for plans dispatched to `@fixer` or `@systematic-implementer`. These subagents follow the Unit spec narrowly.
+- **Always** for plans that have a Risks & Dependencies table with mitigations expressible as code or test artifacts.
+- **Less critical** for plans executed inline by the orchestrator — though even then, an enumerated Unit-spec bullet beats a Risks-table reference because the orchestrator will be juggling multiple Units and TODO items, and the most-recently-read text wins attention.
+
+## Examples
+
+### Before — Risks row carries the mitigation alone
+
+```markdown
+## Implementation Unit 1 — Prose + mechanical tests
+
+### Test Scenarios
+
+(a) bootstrap content contains <SUBAGENT-STOP> marker
+(b) bootstrap content contains ## Instruction Priority section
+(c) <SUBAGENT-STOP> appears before <EXTREMELY-IMPORTANT> in bootstrap output
+(d) ## Instruction Priority appears before ## How to Access Skills
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| Future refactor reorders `applyBootstrapContent` assembly silently | Add a behavioral assertion in Unit 1 that calls `applyBootstrapContent` against a representative `output.system` array and asserts the rendered post-injection string still has SUBAGENT-STOP before `<EXTREMELY-IMPORTANT>`. |
+```
+
+The subagent reads Unit 1's four scenarios and lands four pre-injection tests. The post-injection assertion in the Risks row is invisible to the focused brief.
+
+### After — mitigation enumerated in the Unit spec
+
+```markdown
+## Implementation Unit 1 — Prose + mechanical tests
+
+### Test Scenarios
+
+(a) bootstrap content contains <SUBAGENT-STOP> marker
+(b) bootstrap content contains ## Instruction Priority section
+(c) <SUBAGENT-STOP> appears before <EXTREMELY-IMPORTANT> in bootstrap output
+(d) ## Instruction Priority appears before ## How to Access Skills
+(e) post-injection: calling applyBootstrapContent against a representative output.system array,
+    the rendered output.system[0] still has <SUBAGENT-STOP> before <EXTREMELY-IMPORTANT>
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| Future refactor reorders `applyBootstrapContent` assembly silently | Test scenario (e) in Unit 1 catches injection-side reordering bugs that pre-injection tests would miss. |
+```
+
+The mitigation is now enumerated alongside the other unit-level scenarios. The Risks row remains as the *why* but defers the *what* to the Unit spec where the subagent will actually read it.
+
+### Orchestrator audit pattern
+
+Before committing subagent output:
+
+```sh
+# For each verb in the Risks table mitigation column...
+grep -nE 'add a test|assert|introduce a check|validate' docs/plans/<plan>.md
+
+# ...grep the diff for the corresponding artifact:
+git diff --staged | grep -E 'test\(.*applyBootstrapContent|expect\(.*applyBootstrapContent'
+```
+
+If no matches, the mitigation dropped. Add the missing artifact inline before commit, or kick back to the subagent with the gap enumerated.


### PR DESCRIPTION
Two institutional learnings from the v2.20.0 (SUBAGENT-STOP / Instruction Priority) release cycle. Both shipped as non-releasing `docs(solutions):` per the conventional-commits release map.

## `workflow-issues/risks-table-rows-must-enforce-as-spec-checks-2026-05-18.md`

When a plan's Risks & Dependencies table lists a mitigation that involves new code or new tests, that mitigation also has to appear as a discrete enumerated bullet in the relevant Implementation Unit's spec. Subagents (`@fixer`, `@systematic-implementer`) read the Unit spec narrowly. Mitigations that live only in the Risks table are invisible to the focused brief.

Direct evidence from PR #405's Fro Bot review:

> The gap was identified during planning, accepted as a mitigation requirement, and then dropped during implementation.

The doc shows a before/after example using the actual PR #405 plan structure and gives an orchestrator-audit grep pattern to catch the same shape pre-commit.

## `developer-experience/gh-statuscheckrollup-conclusion-empty-for-in-progress-2026-05-18.md`

`gh pr view --json statusCheckRollup` returns `conclusion: ""` for in-progress checks. A jq predicate that compares `conclusion != "SUCCESS"` without first filtering by `status == "COMPLETED"` falsely flags every running job as a failure. The polling loop I used during the PR #405 cycle hit this exact trap and triggered a "✗ CI failure" branch while three checks were still running cleanly.

Correct jq pattern (paired status-and-conclusion check):

```sh
CI_PENDING=$(gh pr view <num> --json statusCheckRollup \
  -q '[.statusCheckRollup[]|select(.status!="COMPLETED")]|length')
CI_FAILED=$(gh pr view <num> --json statusCheckRollup \
  -q '[.statusCheckRollup[]|select(.status=="COMPLETED" and .conclusion!="SUCCESS" and .conclusion!="NEUTRAL")]|length')
```

Cross-references the existing `gh-api-heredoc-backtick-escape-2026-05-17.md` learning as an adjacent `gh`-CLI rigor lesson.

## Verification

- `bun run typecheck`: clean
- `bun scripts/content-integrity.ts`: 0 warnings (167 md + 21 ts scanned)
- `bun run docs:build`: 112 pages built in 5.32s
- Both docs validated against `skills/ce-compound/references/schema.yaml` — knowledge track, valid enum values, required fields present
