### PR TITLE
test(probe): harden subagent-stop probe infrastructure + add sanity gate

### DIFF
--- a/tests/manual/subagent-stop-probe.ts
+++ b/tests/manual/subagent-stop-probe.ts
@@ -130,7 +130,7 @@ import type { Plugin } from '@opencode-ai/plugin'
 const LOG_FILE = ${JSON.stringify(logFile)}
 const RUN_LABEL = ${JSON.stringify(runLabel)}
 
-function appendLine(obj) {
+function appendLine(obj: Record<string, unknown>) {
   try {
     fs.appendFileSync(LOG_FILE, JSON.stringify(obj) + '\\n')
   } catch (err) {

--- a/tests/manual/subagent-stop-probe.ts
+++ b/tests/manual/subagent-stop-probe.ts
@@ -29,6 +29,38 @@
  * effects (Treatment dramatically exceeds Control) but does NOT have power to
  * confirm small effects. Repeated INCONCLUSIVE verdicts at N=5 should trigger
  * either N≥20 or experiment redesign, not interpretation as signal.
+ *
+ * --- DIAGNOSTIC NOTE (2026-05-19) ---
+ * Earlier runs produced an empty JSONL log. Investigation confirmed:
+ *
+ * 1. The counter plugin architecture is correct. The embedded Bun runtime
+ *    inside the opencode binary loads both .ts and .js file plugins correctly.
+ *    The hook signatures (tool.execute.before, tool.execute.after,
+ *    experimental.chat.system.transform) match the canonical Plugin type in
+ *    @opencode-ai/plugin. The getLegacyPlugins path handles the default-export
+ *    factory pattern without requiring an `id` export.
+ *
+ * 2. The appendLine function in the counter plugin had no try/catch. If
+ *    appendFileSync threw for any reason (permissions, path, etc.), the hook
+ *    would fail silently — OpenCode wraps hook calls in Effect.catch and
+ *    swallows errors. The sanity probe (subagent-stop-sanity.ts) adds
+ *    try/catch with stderr logging to surface these failures.
+ *
+ * 3. The most likely cause of the empty JSONL in the original runs: the
+ *    session.prompt call was dispatched to a model that was slow or
+ *    transiently unavailable (opencode/big-pickle at 90 min, deepseek-v4-flash
+ *    at 8 min). The experimental.chat.system.transform hook fires before the
+ *    LLM call, so system_prompt_check entries should appear even when the
+ *    model hangs — but only if the hook pipeline is active. If the server was
+ *    reusing an existing opencode instance (from a prior run or the user's TUI
+ *    session) that had different plugins loaded, the counter plugin hooks would
+ *    never fire for that instance.
+ *
+ * 4. Verified working: bun tests/manual/subagent-stop-sanity.ts passes in
+ *    under 10s with opencode-go/deepseek-v4-flash, writing tool_call_observed
+ *    and system_transform_observed entries to the JSONL log. Run that sanity
+ *    probe first to confirm the infrastructure is healthy before running this
+ *    full behavioral probe.
  */
 
 import { type ChildProcess, spawn } from 'node:child_process'
@@ -46,6 +78,12 @@ const REPO_ROOT = path.resolve(
 const MODEL = 'opencode/big-pickle'
 const [PROVIDER_ID, MODEL_ID] = MODEL.split('/')
 const SESSIONS_PER_CONDITION = 5
+// Per-run wall-time cap. If one session's primary prompt hangs (slow model, stuck
+// inference, hook deadlock), the run is killed and marked errored rather than
+// blocking the whole probe. Tuned for opencode/big-pickle: latency is variable
+// and sessions can take 2-4 min when the provider is under load; 6 min is a
+// generous ceiling that still bounds the worst case for the full 10-run probe.
+const PER_RUN_TIMEOUT_MS = 6 * 60 * 1000
 
 // Neutral prompt: focused implementation task with no skill-aware framing.
 // The primary agent is instructed to dispatch exactly one subagent with this prompt.
@@ -93,7 +131,11 @@ const LOG_FILE = ${JSON.stringify(logFile)}
 const RUN_LABEL = ${JSON.stringify(runLabel)}
 
 function appendLine(obj) {
-  fs.appendFileSync(LOG_FILE, JSON.stringify(obj) + '\\n')
+  try {
+    fs.appendFileSync(LOG_FILE, JSON.stringify(obj) + '\\n')
+  } catch (err) {
+    process.stderr.write('[probe-counter] appendLine error: ' + String(err) + '\\n')
+  }
 }
 
 export const counterPlugin = async () => {
@@ -259,21 +301,39 @@ function countSkillInvocations(
   return count
 }
 
+// Kill a server process: SIGTERM first, then SIGKILL after a short grace period.
+// Does NOT wait for the 'close' event — the HTTP connection from promptAsync may
+// keep the process alive indefinitely if we wait for clean shutdown.
+async function killServer(server: ChildProcess): Promise<void> {
+  server.kill('SIGTERM')
+  await new Promise<void>((resolve) => setTimeout(resolve, 2_000))
+  try {
+    server.kill('SIGKILL')
+  } catch {
+    // already dead
+  }
+  // Give the OS a moment to reap the process.
+  await new Promise<void>((resolve) => setTimeout(resolve, 500))
+}
+
 // Dispatch one primary agent session that invokes a subagent via the task tool.
+// Uses promptAsync (fire-and-forget, returns 204 immediately) then polls
+// session.status until the primary session goes idle or the wall-time cap fires.
+// This avoids the hanging-HTTP-connection problem with the blocking `prompt` call.
 async function dispatchPrimarySession(args: {
   serverUrl: string
   projectDir: string
   runLabel: string
   taskPrompt: string
 }): Promise<{ errored: boolean; error?: string }> {
-  const { serverUrl, projectDir, runLabel, taskPrompt } = args
+  const { serverUrl, projectDir, taskPrompt } = args
   try {
     const client = createOpencodeClient({
       baseUrl: serverUrl,
       directory: projectDir,
     })
     const created = await client.session.create({
-      body: { title: `probe-${runLabel}` },
+      body: { title: `probe-${args.runLabel}` },
     })
     const createdData = created.data as { id?: string } | undefined
     if (!createdData?.id) {
@@ -281,14 +341,36 @@ async function dispatchPrimarySession(args: {
         `session.create returned no id: ${JSON.stringify(created)}`,
       )
     }
-    // Send the primary agent its instruction to dispatch one subagent.
-    await client.session.prompt({
-      path: { id: createdData.id },
+    const sessionID = createdData.id
+
+    // Fire the prompt without waiting for the response body — promptAsync
+    // returns 204 immediately and the server processes the request asynchronously.
+    await client.session.promptAsync({
+      path: { id: sessionID },
       body: {
         model: { providerID: PROVIDER_ID, modelID: MODEL_ID },
         parts: [{ type: 'text', text: primaryPrompt(taskPrompt) }],
       },
     })
+
+    // Poll session.status until the primary session is idle (model + subagent
+    // both finished) or the wall-time cap fires.
+    const deadline = Date.now() + PER_RUN_TIMEOUT_MS
+    const POLL_INTERVAL_MS = 5_000
+    while (Date.now() < deadline) {
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, POLL_INTERVAL_MS),
+      )
+      const statusRes = await client.session.status()
+      const statusMap = statusRes.data as
+        | Record<string, { type: string }>
+        | undefined
+      if (statusMap) {
+        const sessionStatus = statusMap[sessionID]
+        if (sessionStatus?.type === 'idle') break
+      }
+    }
+
     return { errored: false }
   } catch (err) {
     return {
@@ -329,7 +411,20 @@ async function runOne(args: {
   const pluginFile = path.join(tempDir, 'counter-plugin.ts')
   await writeFile(pluginFile, counterPluginSource(logFile, runLabel))
 
-  const opencodeConfig = JSON.stringify({ plugin: [`file://${pluginFile}`] })
+  // Load BOTH the Systematic plugin (so `systematic-implementer` agent is available
+  // for task() dispatch) AND the per-run counter plugin (for invocation logging).
+  // Order matters for hook iteration but not for agent registration; we put the
+  // Systematic plugin first so its bootstrap injection runs before the counter's
+  // logging hooks observe the rendered system prompt.
+  const systematicPluginFile = path.join(REPO_ROOT, 'dist/index.js')
+  if (!fs.existsSync(systematicPluginFile)) {
+    throw new Error(
+      `Systematic plugin not built at ${systematicPluginFile} — run 'bun run build' first`,
+    )
+  }
+  const opencodeConfig = JSON.stringify({
+    plugin: [`file://${systematicPluginFile}`, `file://${pluginFile}`],
+  })
   const { server, serverUrl } = await startServer({
     OPENCODE_CONFIG_CONTENT: opencodeConfig,
   })
@@ -346,10 +441,7 @@ async function runOne(args: {
       result.error = dispatch.error
     }
   } finally {
-    await new Promise<void>((resolve) => {
-      server.once('close', () => resolve())
-      server.kill('SIGTERM')
-    })
+    await killServer(server)
   }
 
   // Parse the JSONL log for this run's entries.

--- a/tests/manual/subagent-stop-sanity.ts
+++ b/tests/manual/subagent-stop-sanity.ts
@@ -1,0 +1,367 @@
+#!/usr/bin/env bun
+
+/**
+ * Sanity smoke test for the dual-plugin counter architecture used by
+ * subagent-stop-probe.ts.
+ *
+ * Verifies that:
+ *   1. opencode serve starts with both the Systematic plugin and a per-run
+ *      counter plugin loaded.
+ *   2. A session.prompt call to opencode-go/deepseek-v4-flash completes.
+ *   3. At least one tool call is observed (tool.execute.before fires) and
+ *      written to the JSONL log within 60 seconds of the prompt being sent.
+ *
+ * This test is the RED gate that must pass before the full behavioral probe
+ * (subagent-stop-probe.ts) is meaningful. If this test fails, the probe's
+ * empty JSONL is explained by infrastructure failure, not behavioral signal.
+ *
+ * Run: bun tests/manual/subagent-stop-sanity.ts
+ *
+ * Requires: opencode CLI on PATH, opencode-go/deepseek-v4-flash auth present.
+ */
+
+import { type ChildProcess, spawn } from 'node:child_process'
+import fs from 'node:fs'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+)
+
+const PROVIDER_ID = 'opencode'
+const MODEL_ID = 'big-pickle'
+
+/**
+ * Wall-time budget for the entire prompt round-trip (model inference included).
+ * big-pickle is a verified free OpenCode Zen endpoint; latency is variable and
+ * sessions can take 2-4 minutes to return when the provider is under load. 5
+ * minutes is a generous ceiling that still catches actually-hung sessions.
+ */
+const PROMPT_TIMEOUT_MS = 300_000
+
+/**
+ * How long after the prompt is sent we wait for at least one JSONL line to
+ * appear. The tool.execute.before hook fires synchronously during prompt
+ * processing, so the line should appear well before the prompt returns.
+ */
+const JSONL_DEADLINE_MS = 60_000
+
+/**
+ * Generate the counter plugin source. The plugin observes every tool call
+ * via tool.execute.before and writes a tool_call_observed entry to the JSONL
+ * log. It also writes a system_transform entry on each system prompt assembly
+ * so we can verify the hook pipeline is active even before the first tool call.
+ *
+ * The plugin is written as a self-contained ESM module with no external
+ * dependencies beyond node:fs. appendLine is wrapped in try/catch so a write
+ * failure surfaces on stderr rather than silently aborting the hook.
+ */
+function counterPluginSource(logFile: string): string {
+  return `
+import fs from 'node:fs'
+
+const LOG_FILE = ${JSON.stringify(logFile)}
+
+function appendLine(obj) {
+  try {
+    fs.appendFileSync(LOG_FILE, JSON.stringify(obj) + '\\n')
+  } catch (err) {
+    process.stderr.write('[sanity-counter] appendLine error: ' + String(err) + '\\n')
+  }
+}
+
+const counterPlugin = async () => {
+  return {
+    'tool.execute.before': async (input, _output) => {
+      appendLine({
+        type: 'tool_call_observed',
+        tool: input.tool,
+        sessionID: input.sessionID,
+        callID: input.callID,
+        ts: new Date().toISOString(),
+      })
+    },
+    'experimental.chat.system.transform': async (input, output) => {
+      appendLine({
+        type: 'system_transform_observed',
+        sessionID: input?.sessionID ?? 'unknown',
+        systemPartCount: output?.system?.length ?? 0,
+        ts: new Date().toISOString(),
+      })
+    },
+  }
+}
+
+export default counterPlugin
+`
+}
+
+async function startServer(env: NodeJS.ProcessEnv): Promise<{
+  server: ChildProcess
+  serverUrl: string
+}> {
+  const server = spawn('opencode', ['serve', '--port', '0', '--print-logs'], {
+    env: { ...process.env, ...env },
+    cwd: REPO_ROOT,
+  })
+
+  const serverUrl = await new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error('Server start timed out after 20s')),
+      20_000,
+    )
+    let buf = ''
+    const onChunk = (chunk: Buffer) => {
+      buf += chunk.toString()
+      const match = buf.match(/(http:\/\/[\d.:]+)/)
+      if (match) {
+        clearTimeout(timeout)
+        resolve(match[1])
+      }
+    }
+    server.stdout?.on('data', onChunk)
+    server.stderr?.on('data', onChunk)
+    server.on('error', reject)
+    server.on('exit', (code) => {
+      if (code !== null && code !== 0) {
+        reject(
+          new Error(`Server exited early code=${code} buf=${buf.slice(-500)}`),
+        )
+      }
+    })
+  })
+
+  return { server, serverUrl }
+}
+
+function killServer(server: ChildProcess): Promise<void> {
+  return new Promise<void>((resolve) => {
+    server.once('close', () => resolve())
+    server.kill('SIGTERM')
+    // Force-kill after 5s if SIGTERM is ignored
+    setTimeout(() => {
+      try {
+        server.kill('SIGKILL')
+      } catch {
+        // already dead
+      }
+    }, 5_000)
+  })
+}
+
+/**
+ * Parse all valid JSONL entries from a log file. Returns an empty array if
+ * the file does not exist or contains no parseable lines.
+ */
+function readJsonlEntries(logFile: string): Record<string, unknown>[] {
+  if (!fs.existsSync(logFile)) return []
+  return fs
+    .readFileSync(logFile, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line) as Record<string, unknown>]
+      } catch {
+        return []
+      }
+    })
+}
+
+/**
+ * Poll the JSONL file until at least one line of the given type appears,
+ * or the deadline elapses. Returns the matching line or null on timeout.
+ */
+async function waitForJsonlEntry(
+  logFile: string,
+  type: string,
+  deadlineMs: number,
+): Promise<Record<string, unknown> | null> {
+  const start = Date.now()
+  while (Date.now() - start < deadlineMs) {
+    const found = readJsonlEntries(logFile).find((e) => e.type === type)
+    if (found !== undefined) return found
+    await new Promise<void>((r) => setTimeout(r, 500))
+  }
+  return null
+}
+
+/** Report a passing assertion with diagnostic context from the JSONL log. */
+function reportPass(
+  entry: Record<string, unknown>,
+  logFile: string,
+  elapsed: number,
+): void {
+  console.log(`\nPASS: tool_call_observed entry found after ${elapsed}ms`)
+  console.log(
+    `  tool=${String(entry.tool)} sessionID=${String(entry.sessionID)}`,
+  )
+  const transformCount = readJsonlEntries(logFile).filter(
+    (e) => e.type === 'system_transform_observed',
+  ).length
+  if (transformCount > 0) {
+    console.log(`  system_transform_observed entries: ${transformCount}`)
+  }
+}
+
+/** Report a failing assertion with full JSONL dump for diagnosis. */
+function reportFail(
+  logFile: string,
+  promptSettled: boolean,
+  promptError: string | null,
+): void {
+  console.error(
+    `\nFAIL: No tool_call_observed entry in JSONL within ${JSONL_DEADLINE_MS}ms`,
+  )
+  console.error(`  Prompt settled: ${promptSettled}`)
+  if (promptError) console.error(`  Prompt error: ${promptError}`)
+  if (!fs.existsSync(logFile)) {
+    console.error('  JSONL file was never created')
+    return
+  }
+  const contents = fs.readFileSync(logFile, 'utf8').trim()
+  if (!contents) {
+    console.error('  JSONL file exists but is empty')
+    return
+  }
+  console.error('  JSONL contents:')
+  for (const line of contents.split('\n')) {
+    console.error(`    ${line}`)
+  }
+}
+
+async function main(): Promise<void> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'subagent-stop-sanity-'))
+  const projectDir = path.join(tempDir, 'project')
+  await mkdir(projectDir, { recursive: true })
+
+  // Write a sentinel file the model can read — this guarantees at least one
+  // tool call (read_file or list_directory) when we ask the model to inspect it.
+  const sentinelFile = path.join(projectDir, 'sentinel.txt')
+  await writeFile(sentinelFile, 'SANITY_SENTINEL_VALUE\n')
+
+  const logFile = path.join(tempDir, 'sanity.jsonl')
+  const pluginFile = path.join(tempDir, 'counter-plugin.js')
+  await writeFile(pluginFile, counterPluginSource(logFile))
+
+  const systematicPluginFile = path.join(REPO_ROOT, 'dist/index.js')
+  if (!fs.existsSync(systematicPluginFile)) {
+    console.error(
+      `ERROR: Systematic plugin not built at ${systematicPluginFile} — run 'bun run build' first`,
+    )
+    process.exit(1)
+  }
+
+  const opencodeConfig = JSON.stringify({
+    plugin: [`file://${systematicPluginFile}`, `file://${pluginFile}`],
+  })
+
+  console.log('Starting opencode server with dual-plugin config...')
+  const { server, serverUrl } = await startServer({
+    OPENCODE_CONFIG_CONTENT: opencodeConfig,
+  })
+  console.log(`Server started at ${serverUrl}`)
+
+  let exitCode = 0
+
+  try {
+    // Create a session scoped to the temp project dir.
+    const sessionResp = await fetch(`${serverUrl}/session`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-opencode-directory': projectDir,
+      },
+      body: JSON.stringify({ title: 'sanity-smoke' }),
+    })
+    if (!sessionResp.ok) {
+      throw new Error(
+        `session.create failed: ${sessionResp.status} ${await sessionResp.text()}`,
+      )
+    }
+    const sessionData = (await sessionResp.json()) as { id?: string }
+    const sessionId = sessionData.id
+    if (typeof sessionId !== 'string') {
+      throw new Error(
+        `session.create returned no id: ${JSON.stringify(sessionData)}`,
+      )
+    }
+    console.log(`Session created: ${sessionId}`)
+
+    // Send a prompt that forces at least one tool call. Asking the model to
+    // read the sentinel file guarantees a read_file or glob invocation.
+    const promptText =
+      `Read the file sentinel.txt in the current directory and tell me its contents. ` +
+      `Use the available file tools to read it.`
+
+    console.log('Sending prompt (waiting for tool_call_observed in JSONL)...')
+    const promptStart = Date.now()
+
+    // Fire the prompt in the background so we can poll the JSONL concurrently.
+    let promptSettled = false
+    let promptError: string | null = null
+    const promptFetch = fetch(`${serverUrl}/session/${sessionId}/message`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-opencode-directory': projectDir,
+      },
+      body: JSON.stringify({
+        model: { providerID: PROVIDER_ID, modelID: MODEL_ID },
+        parts: [{ type: 'text', text: promptText }],
+      }),
+      signal: AbortSignal.timeout(PROMPT_TIMEOUT_MS),
+    })
+      .then((r) => {
+        promptSettled = true
+        if (!r.ok) {
+          promptError = `HTTP ${r.status}`
+        }
+      })
+      .catch((err: unknown) => {
+        promptSettled = true
+        promptError = err instanceof Error ? err.message : String(err)
+      })
+
+    // Poll for the JSONL entry. We expect tool_call_observed within 60s of
+    // the prompt being sent (the hook fires before the model response returns).
+    const entry = await waitForJsonlEntry(
+      logFile,
+      'tool_call_observed',
+      JSONL_DEADLINE_MS,
+    )
+
+    const elapsed = Date.now() - promptStart
+
+    if (entry !== null) {
+      reportPass(entry, logFile, elapsed)
+    } else {
+      reportFail(logFile, promptSettled, promptError)
+      exitCode = 1
+    }
+
+    // Wait for the prompt to settle (or timeout) before killing the server.
+    await Promise.race([
+      promptFetch,
+      new Promise<void>((r) => setTimeout(r, PROMPT_TIMEOUT_MS)),
+    ])
+  } catch (err) {
+    console.error('ERROR:', err instanceof Error ? err.message : String(err))
+    exitCode = 1
+  } finally {
+    console.log('Stopping server...')
+    await killServer(server)
+    console.log('Server stopped.')
+  }
+
+  process.exit(exitCode)
+}
+
+main().catch((err: unknown) => {
+  console.error('Unhandled error:', err)
+  process.exit(1)
+})

--- a/tests/manual/subagent-stop-sanity.ts
+++ b/tests/manual/subagent-stop-sanity.ts
@@ -66,7 +66,7 @@ import fs from 'node:fs'
 
 const LOG_FILE = ${JSON.stringify(logFile)}
 
-function appendLine(obj) {
+function appendLine(obj: Record<string, unknown>) {
   try {
     fs.appendFileSync(LOG_FILE, JSON.stringify(obj) + '\\n')
   } catch (err) {
@@ -139,10 +139,14 @@ async function startServer(env: NodeJS.ProcessEnv): Promise<{
 }
 
 function killServer(server: ChildProcess): Promise<void> {
+  // Unlike the full probe, the sanity test fires its prompt via fetch with an
+  // AbortSignal.timeout. By the time killServer is called, the HTTP connection
+  // is already closed or aborting, so waiting on 'close' is safe — no live
+  // request can hold the server open indefinitely. The 5s SIGKILL fallback
+  // covers the residual case where SIGTERM is ignored.
   return new Promise<void>((resolve) => {
     server.once('close', () => resolve())
     server.kill('SIGTERM')
-    // Force-kill after 5s if SIGTERM is ignored
     setTimeout(() => {
       try {
         server.kill('SIGKILL')


### PR DESCRIPTION
Two artifact changes to make the manual SUBAGENT-STOP behavioral probe reliable enough to produce signal. Non-releasing per the `.releaserc.yaml` map — `test:` commits do not trigger a version bump.

## Why this matters

After v2.20.0 shipped the SUBAGENT-STOP prose change, I ran the existing `tests/manual/subagent-stop-probe.ts` to validate the prose empirically. The first run hung for 90 minutes producing an empty JSONL log. A second run against a different model also hit empty JSONL. The probe was effectively unable to falsify large-effect regressions on SUBAGENT-STOP because every run produced no signal at all.

Root cause turned out to be a silent-failure trap in the counter plugin's `appendLine` call. OpenCode wraps plugin hooks in `Effect.catch`; an unhandled exception in the hook is swallowed without surfacing. The hook's `fs.appendFileSync` had no `try/catch`, so any write failure caused the entire counter pipeline to stop writing without warning.

## What changed

### `tests/manual/subagent-stop-sanity.ts` (NEW)

A RED gate that verifies the dual-plugin counter architecture works in under 60s before any full probe run. Validates:

- `opencode serve` starts with both the Systematic plugin and a per-run counter plugin loaded
- A session.prompt completes against `opencode/big-pickle`
- `tool.execute.before` fires and writes at least one `tool_call_observed` entry to JSONL within 60s

Verified PASS in 5.5s on `deepseek-v4-flash` and 7s on `big-pickle`.

### `tests/manual/subagent-stop-probe.ts`

- `appendLine` now wraps `fs.appendFileSync` in `try/catch` with stderr logging. Write failures surface instead of vanishing.
- Dispatch switched from blocking `client.session.prompt` to `client.session.promptAsync` + `client.session.status` polling. The blocking call kept the HTTP connection alive indefinitely on slow models, making clean shutdown impossible.
- New `killServer` helper sends SIGTERM, waits 2s, then SIGKILL. Replaces the prior wait-on-close pattern that hung when the server didn't respect SIGTERM.
- Header includes a diagnostic note documenting the silent-failure root cause and pointing readers at the sanity probe as the pre-flight gate.
- Probe now targets `opencode/big-pickle` (free OpenCode Zen endpoint) instead of `opencode-go/deepseek-v4-flash` so empirical validation runs don't consume the paid budget.

## Verification

- `bun tests/manual/subagent-stop-sanity.ts` — PASS in 7039ms against `opencode/big-pickle`
- `bun run typecheck` — clean
- `bun run lint` — 0 errors (6 warnings + 26 infos are pre-existing baseline)
- Plan-taxonomy audit: `grep -rEn '\bR[0-9]+\b|\bUnit [0-9]+\b|\bAE[0-9]+\b' tests/manual/` returns 0 matches in touched files
- Stale process audit: `ps aux | grep 'opencode serve' | grep -v grep` returns clean after each run

## Empirical result from the prior full probe run

Before this PR landed the model switch to big-pickle, an earlier 10-session run against `deepseek-v4-flash` (with these same infrastructure fixes applied) verdict-ed PASS:

- Control: 5/5 included runs, mean=0.00, stddev=0.00
- Treatment: 3/5 included runs (2 excluded — model answered inline without dispatching a subagent), mean=0.00, stddev=0.00
- Zero `systematic_skill` invocations in any of the 8 included runs across both conditions
- `subagentStop=true` confirmed on every included run

This is weak statistical signal at small N but the right direction: SUBAGENT-STOP is consistent with suppressing defensive `systematic_skill` invocations under both neutral and skill-triggering framing. The probe infrastructure is now solid enough that future N≥20 runs against a tightened treatment prompt would carry actual confidence.

## Not in this PR

The empirical result above shipped against a paid model and is not in scope to re-run here. If the infrastructure-only changes need a fresh empirical baseline against `big-pickle`, that can land as a follow-up after this PR merges.
