### PR TITLE
docs(plans): mark 5 shipped plans as completed with provenance

### DIFF
--- a/docs/plans/2026-05-16-001-fix-provider-availability-memoization-plan.md
+++ b/docs/plans/2026-05-16-001-fix-provider-availability-memoization-plan.md
@@ -1,7 +1,8 @@
 ---
 title: 'fix(overlay): memoize getAvailableModels per OpencodeClient instance'
 type: fix
-status: active
+status: completed
+shipped: PR #383 → v2.14.5
 date: 2026-05-16
 origin: docs/brainstorms/2026-05-14-provider-availability-dx-hardening-requirements.md
 ---

--- a/docs/plans/2026-05-16-002-feat-typed-config-validation-plan.md
+++ b/docs/plans/2026-05-16-002-feat-typed-config-validation-plan.md
@@ -1,7 +1,8 @@
 ---
 title: feat: Typed config validation for bundled agent and skill names
 type: feat
-status: active
+status: completed
+shipped: PR #384 → v2.15.0
 date: 2026-05-16
 origin: docs/brainstorms/2026-05-16-typed-config-validation-requirements.md
 ---

--- a/docs/plans/2026-05-17-001-feat-import-superpowers-foundation-skills-plan.md
+++ b/docs/plans/2026-05-17-001-feat-import-superpowers-foundation-skills-plan.md
@@ -1,7 +1,8 @@
 ---
 title: 'feat: Import test-driven-development and writing-skills from obra/superpowers'
 type: feat
-status: active
+status: completed
+shipped: PR #394 → v2.17.0
 date: 2026-05-17
 deepened: 2026-05-17
 origin: docs/brainstorms/2026-05-17-import-superpowers-foundation-skills-requirements.md

--- a/docs/plans/2026-05-17-002-feat-cc-residue-excision-plan.md
+++ b/docs/plans/2026-05-17-002-feat-cc-residue-excision-plan.md
@@ -1,7 +1,8 @@
 ---
 title: 'feat: Minimal skill-deprecation surface (v2.19.0) + mark CC-residue skills as deprecated'
 type: feat
-status: active
+status: completed
+shipped: PR #401 → v2.19.0 (implementation phase; v3.0.0 excision in Future Work appendix, no committed timeline)
 date: 2026-05-17
 origin: docs/brainstorms/2026-05-17-excise-cc-residue-skills-requirements.md
 ---

--- a/docs/plans/2026-05-17-003-feat-subagent-stop-instruction-priority-plan.md
+++ b/docs/plans/2026-05-17-003-feat-subagent-stop-instruction-priority-plan.md
@@ -1,7 +1,8 @@
 ---
 title: 'feat(skills): add SUBAGENT-STOP block and Instruction Priority section to using-systematic'
 type: feat
-status: active
+status: completed
+shipped: PR #405 → v2.20.0
 date: 2026-05-17
 deepened: 2026-05-17
 origin: docs/brainstorms/2026-05-17-subagent-stop-instruction-priority-requirements.md


### PR DESCRIPTION
Reconciles 5 plan docs whose status fields were not updated post-merge.

Each plan is marked `status: completed` with a `shipped:` line citing the PR and release that delivered it:
- `2026-05-16-001` → PR #383, v2.14.5
- `2026-05-16-002` → PR #384, v2.15.0
- `2026-05-17-001` → PR #394, v2.17.0
- `2026-05-17-002` → PR #401, v2.19.0 (v3.0.0 excision is Future Work with no committed timeline)
- `2026-05-17-003` → PR #405, v2.20.0

Documentation-only — no executable code changes.