### PR TITLE
build(skills): upgrade frontend-design with Impeccable design laws

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -69,6 +69,23 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
+## pbakaus/impeccable — Apache 2.0
+
+**Source repository:** [https://github.com/pbakaus/impeccable](https://github.com/pbakaus/impeccable)  
+**Pinned commit:** `642f03d5a10eb3deb91bd511241e387e23b9aa39`  
+**License:** Apache 2.0  
+**Copyright:** Paul Bakaus  
+
+### Files derived
+
+- `skills/frontend-design/SKILL.md` — Design Laws section
+
+### Adaptation notes
+
+Verbatim merge of the `## Shared design laws` section. Register-specific qualifiers ("both registers") replaced with register-agnostic phrasing ("every design"). The `{{model}}` placeholder found in the section intro was removed (not substituted). No other `{{placeholder}}` syntax was present in the imported section.
+
+Impeccable itself incorporates Anthropic's frontend-design skill content (CC-BY-4.0). The Apache 2.0 license from Impeccable governs this derived work per its own attribution chain.
+
 ## Anthropic — CC-BY-4.0
 
 **Source page:** [Skill authoring best practices](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices)

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -86,6 +86,189 @@ Verbatim merge of the `## Shared design laws` section. Register-specific qualifi
 
 Impeccable itself incorporates Anthropic's frontend-design skill content (CC-BY-4.0). The Apache 2.0 license from Impeccable governs this derived work per its own attribution chain.
 
+### Upstream Apache 2.0 license text
+
+The following is the full Apache License, Version 2.0 text, reproduced here in compliance with the license's notice requirements:
+
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+```
+
 ## Anthropic — CC-BY-4.0
 
 **Source page:** [Skill authoring best practices](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices)

--- a/docs/plans/2026-05-20-001-feat-frontend-design-upgrade-plan.md
+++ b/docs/plans/2026-05-20-001-feat-frontend-design-upgrade-plan.md
@@ -1,0 +1,145 @@
+---
+title: "feat: Upgrade frontend-design skill with Impeccable design laws"
+type: feat
+status: active
+date: 2026-05-20
+origin: docs/brainstorms/2026-05-20-frontend-design-upgrade-requirements.md
+---
+
+# feat: Upgrade frontend-design skill with Impeccable design laws
+
+## Overview
+
+Merge Impeccable's Shared Design Laws (pbakaus/impeccable, Apache 2.0) into Systematic's bundled `skills/frontend-design/SKILL.md`. The upgrade adds concrete, opinionated aesthetic rules — OKLCH color theory, a color strategy axis, a theme-forcing function, absolute bans on AI-slop patterns, and a two-tier category-reflex check — while leaving Systematic's workflow structure (Layer 0–4 + visual verification) intact.
+
+## Problem Frame
+
+Systematic's frontend-design skill guides workflow well but its design-law content is generic. Impeccable has distilled a tight set of concrete laws that prevent the AI-slop defaults that make AI-generated UI identifiable on sight. Merging these laws gives the skill the specificity it currently lacks.
+
+## Requirements Trace
+
+- R1. Add `## Design Laws` section after Layer 1, before Layer 2; verbatim merge with minimal normalization (remove `{{placeholder}}` syntax, soften register-specific qualifiers to be register-agnostic)
+- R2. Section must cover Color (OKLCH, chroma-at-extremes, `#000`/`#fff` prohibition, tinted neutrals, four-step strategy axis), Theme (scene-sentence forcing function), Typography (65–75ch, ≥1.25 scale contrast), Layout (spacing rhythm, cards-as-lazy, nested cards always wrong, container overuse), Motion (exponential ease-out only, no bounce/elastic, no layout-property animation), Copy (no em dashes, no `--`), Absolute Bans (side-stripe borders, gradient text, glassmorphism-as-default, hero-metric template, identical card grids, modal-as-first-thought), AI Slop Test (first-order + second-order category-reflex checks)
+- R3. Layer 0–4 workflow structure remains intact; Layer 2 duplicate bullets consolidated
+- R4. `license: Apache-2.0` added to frontmatter
+- R5. `ATTRIBUTIONS.md` entry added for Impeccable (Apache 2.0) noting Anthropic CC-BY-4.0 upstream
+
+## Scope Boundaries
+
+- No PRODUCT.md / DESIGN.md context-file protocol
+- No Impeccable sub-commands (craft, shape, audit, teach, document, live)
+- No `{{placeholder}}` compilation system
+- No import of Impeccable reference sub-files (brand.md, product.md, etc.)
+- Only `skills/frontend-design/SKILL.md` and `ATTRIBUTIONS.md` are modified
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `skills/frontend-design/SKILL.md` (258 lines, no sub-files) — Layer 2 has Typography, Color & Theme, Composition, Motion, Accessibility, Imagery. The Composition section's card bullet (`Default to cardless layouts / Cards are allowed when...`) partially duplicates Impeccable's card law — consolidate on Impeccable's formulation
+- `ATTRIBUTIONS.md` — use same attribution block format as the obra/superpowers entry (repo header, Source repository, Pinned commit, License, Copyright, Cloned at, Files derived, Adaptation notes)
+- `skills/test-driven-development/SKILL.md` — `license: MIT` frontmatter example; use `license: Apache-2.0` for this import
+- `scripts/content-integrity.ts` — banned patterns are CC/CEP-specific strings only; Impeccable's design law prose (OKLCH, chroma, glassmorphism, gradient text, side-stripe) does not trigger the gate
+
+### Institutional Learnings
+
+- PR #394 (obra/superpowers import): verbatim merge with minimal normalization is the established pattern; attribution via ATTRIBUTIONS.md + frontmatter `license:` field; no per-file attribution comments
+- Impeccable's `## Shared design laws` section contains zero `{{placeholder}}` syntax — clean import, no substitution needed
+
+### External References
+
+- Impeccable source: https://github.com/pbakaus/impeccable/blob/main/skill/SKILL.md (`## Shared design laws` section)
+- Apache 2.0 license: https://www.apache.org/licenses/LICENSE-2.0
+
+## Key Technical Decisions
+
+- **Verbatim merge, minimal normalization:** Rules imported as-is; only mechanical edits allowed — remove `{{placeholder}}` syntax, replace "both registers" with register-agnostic phrasing. No editorial rewriting.
+- **New section placement:** `## Design Laws` goes after `## Layer 1: Pre-Build Planning` and before `## Layer 2: Design Guidance Core`. This ensures agents receive the laws before the Layer 2 workflow guidance.
+- **Layer 2 card consolidation:** The existing Layer 2 Composition card bullet is the only direct overlap with the imported laws. Replace it with a forward reference to the Design Laws section rather than leaving duplicate guidance.
+- **Attribution in ATTRIBUTIONS.md only:** No attribution prose in the skill body — content-integrity gate scans skill bodies for banned strings and any CC/CEP attribution comment would be a maintenance hazard.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Will Impeccable prose trip the content-integrity gate?** No — banned patterns are CC/CEP-specific strings only. OKLCH, chroma, glassmorphism, gradient text, side-stripe are all clean.
+- **Does Impeccable's design laws section use `{{placeholder}}` syntax?** No — the `## Shared design laws` section is pure prose with no placeholder variables. Normalization is trivial.
+- **Pinned commit for attribution?** Fetch HEAD commit SHA from pbakaus/impeccable at import time and record it in ATTRIBUTIONS.md.
+
+### Deferred to Implementation
+
+- Exact SHA of pbakaus/impeccable HEAD at import time (fetch during Unit 1)
+
+## Implementation Units
+
+- [ ] **Unit 1: Merge design laws into SKILL.md**
+
+**Goal:** Add `## Design Laws` section containing Impeccable's Shared Design Laws; consolidate overlapping Layer 2 Composition card bullet; add `license: Apache-2.0` to frontmatter.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `skills/frontend-design/SKILL.md`
+
+**Approach:**
+- Fetch `## Shared design laws` content from pbakaus/impeccable `skill/SKILL.md` at HEAD
+- Record HEAD SHA for attribution (needed in Unit 2)
+- Insert new `## Design Laws` section immediately after the `## Layer 1: Pre-Build Planning` closing line and before `## Layer 2: Design Guidance Core`
+- Normalize: no `{{placeholder}}` instances exist in this section; remove any "both registers" qualifiers by replacing with neutral phrasing (e.g., "every design")
+- In Layer 2 `### Composition`: replace the card bullet (`Default to cardless layouts...`) with a forward reference: `- Card and layout rules: see Design Laws above.`
+- Add `license: Apache-2.0` to frontmatter alongside existing `name` and `description` fields
+
+**Test expectation:** None — this is a markdown content change with no runtime behavior. Verification is manual content review + gate checks.
+
+**Verification:**
+- `## Design Laws` section present and positioned correctly in file
+- All 8 required topics from R2 present in the section
+- No `{{placeholder}}` syntax remains
+- Layer 2 Composition card bullet replaced with forward reference
+- `license: Apache-2.0` in frontmatter
+- `bun scripts/content-integrity.ts` passes with 0 violations
+- `bun run build` passes
+
+- [ ] **Unit 2: Update ATTRIBUTIONS.md**
+
+**Goal:** Add attribution entry for Impeccable following the established obra/superpowers block format.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 1 (need HEAD SHA fetched there)
+
+**Files:**
+- Modify: `ATTRIBUTIONS.md`
+
+**Approach:**
+- Add a new attribution block following the same block structure used for obra/superpowers (omit `Cloned at` — no local clone for Impeccable):
+  - Header: `## pbakaus/impeccable — Apache 2.0`
+  - Source repository link
+  - Pinned commit SHA (from Unit 1)
+  - License: Apache 2.0
+  - Copyright: Paul Bakaus
+  - Note that Impeccable itself incorporates Anthropic's frontend-design skill content (CC-BY-4.0); the Apache 2.0 license from Impeccable governs this derived work per its own attribution chain
+  - Files derived: `skills/frontend-design/SKILL.md` (Design Laws section)
+  - Adaptation notes: verbatim merge; register-specific qualifiers removed; no placeholder substitution
+
+**Test expectation:** None — documentation change only.
+
+**Verification:**
+- ATTRIBUTIONS.md has a new `## pbakaus/impeccable` block in correct format
+- Pinned SHA is present and accurate
+- Attribution chain (Impeccable → Anthropic upstream) is noted
+
+## System-Wide Impact
+
+- **Unchanged invariants:** Systematic's Layer 0 context detection, Layer 1 pre-build planning, Layers 2–4 implementation guidance, visual verification, and creative energy sections are unmodified. The skill's description and trigger conditions are unchanged.
+- **Content-integrity gate:** No new banned patterns introduced. Gate passes at current allowlist configuration.
+- **Registry:** No registry changes needed — no new sub-files added, existing component entry for `frontend-design` remains valid.
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-05-20-frontend-design-upgrade-requirements.md`
+- Impeccable skill source: https://github.com/pbakaus/impeccable/blob/main/skill/SKILL.md
+- Precedent import: obra/superpowers (PR #394)
+- ATTRIBUTIONS.md: `ATTRIBUTIONS.md`

--- a/docs/plans/2026-05-20-001-feat-frontend-design-upgrade-plan.md
+++ b/docs/plans/2026-05-20-001-feat-frontend-design-upgrade-plan.md
@@ -1,7 +1,8 @@
 ---
 title: "feat: Upgrade frontend-design skill with Impeccable design laws"
 type: feat
-status: active
+status: completed
+shipped: "PR #418"
 date: 2026-05-20
 origin: docs/brainstorms/2026-05-20-frontend-design-upgrade-requirements.md
 ---

--- a/docs/solutions/workflow-issues/registry-drift-on-skill-description-change-2026-05-20.md
+++ b/docs/solutions/workflow-issues/registry-drift-on-skill-description-change-2026-05-20.md
@@ -1,0 +1,72 @@
+---
+title: Registry drift when SKILL.md description changes
+date: 2026-05-20
+category: workflow-issues
+module: registry
+problem_type: workflow_issue
+component: tooling
+severity: medium
+applies_when:
+  - Editing a SKILL.md description field
+  - Running the build without also running registry generation
+  - CI fails on "Registry drift check" after an otherwise clean build
+tags:
+  - registry
+  - drift
+  - skill-description
+  - generate-registry
+  - ci-gate
+---
+
+# Registry drift when SKILL.md description changes
+
+## Context
+
+`scripts/generate-registry.ts` reads each skill's frontmatter `description` into `registry/registry.jsonc`. The CI "Registry drift check" step (`bun scripts/generate-registry.ts --check`) compares the generated output against the committed file and fails if they differ. `bun run build` does not include registry generation, so a SKILL.md description change that passes `build` + `typecheck` + `lint` + `test` locally will fail CI.
+
+## Guidance
+
+After any SKILL.md frontmatter change, run:
+
+```bash
+bun scripts/generate-registry.ts
+```
+
+Then commit the updated `registry/registry.jsonc` alongside the skill change. The full local gate sequence that matches CI is:
+
+```bash
+bun run build && bun run typecheck && bun run lint && bun test tests/unit && bun scripts/generate-registry.ts --check
+```
+
+When delegating skill edits to subagents, include `bun scripts/generate-registry.ts` in the verification checklist explicitly — the standard `build` + `typecheck` + `lint` + `test` gate does not cover it.
+
+## Why This Matters
+
+The registry is the source of truth for OCX component installation. A stale description means users installing via `npx ocx add frontend-design` get outdated metadata. The CI gate catches this, but discovering the failure only in CI wastes a push cycle.
+
+## When to Apply
+
+- Any edit to `skills/*/SKILL.md` frontmatter `description` field
+- Any edit to `agents/*/*.md` frontmatter `description` field
+- After running `bun scripts/generate-registry.ts` for other reasons (adding/removing skills or agents)
+
+## Examples
+
+**Failure scenario:**
+
+1. Update `skills/frontend-design/SKILL.md` description to mention OKLCH and absolute bans
+2. Run `bun run build && bun run typecheck && bun run lint && bun test` — all pass
+3. Push to PR — CI "Registry drift check" fails
+
+**Correct sequence:**
+
+1. Update `skills/frontend-design/SKILL.md` description
+2. Run `bun scripts/generate-registry.ts` — updates `registry/registry.jsonc` with the new description
+3. Commit both files together
+4. Push — CI passes
+
+## Related
+
+- `scripts/generate-registry.ts` — the generator script
+- `registry/registry.jsonc` — the generated output
+- PR #418 — where this gap was caught

--- a/docs/solutions/workflow-issues/subagent-skill-permission-scoping-2026-05-20.md
+++ b/docs/solutions/workflow-issues/subagent-skill-permission-scoping-2026-05-20.md
@@ -1,0 +1,89 @@
+---
+title: Subagent skill tool permissions require explicit per-agent configuration
+date: 2026-05-20
+category: workflow-issues
+module: plugin-permissions
+problem_type: workflow_issue
+component: tooling
+severity: medium
+applies_when:
+  - A subagent needs to load a Systematic skill via the systematic_skill tool
+  - Using OMO Slim or any OpenCode config that restricts agent tool permissions
+  - Delegating design, review, or other skill-dependent work to a subagent
+tags:
+  - permissions
+  - subagent
+  - systematic-skill
+  - omo-slim
+  - opencode-config
+---
+
+# Subagent skill tool permissions require explicit per-agent configuration
+
+## Context
+
+OpenCode subagents do not inherit the parent agent's tool permission allow-rules. When using a plugin configuration layer like OMO Slim (`oh-my-opencode-slim.jsonc`) that restricts agent tool access via explicit `skills` arrays, each subagent that needs to invoke `systematic_skill` must have the tool explicitly permitted in its own agent configuration.
+
+This was discovered when `@designer` failed to load `systematic:frontend-design` during a GREEN verification test. The orchestrator had `skills: ["*"]` but designer only had `skills: ["agent-browser"]`, so `systematic_skill` tool calls were denied.
+
+## Guidance
+
+When configuring agents that may need Systematic skills, add the appropriate permission:
+
+```jsonc
+// In oh-my-opencode-slim.jsonc or equivalent
+{
+  "agents": {
+    "designer": {
+      "skills": ["agent-browser", "systematic:*"]
+      //                          ^^^^^^^^^^^^^^^^
+      // Without this, designer cannot load any systematic skill
+    }
+  }
+}
+```
+
+The wildcard `"systematic:*"` covers all Systematic-namespaced skills. For tighter scoping, list specific skills:
+
+```jsonc
+{
+  "agents": {
+    "designer": {
+      "skills": ["agent-browser", "systematic:frontend-design"]
+    }
+  }
+}
+```
+
+## Why This Matters
+
+A subagent that cannot load its domain skill falls back to general knowledge, producing significantly lower-quality output for specialized tasks. The failure is silent from the orchestrator's perspective — the subagent simply proceeds without the skill's guidance, and the quality gap only surfaces during verification.
+
+## When to Apply
+
+- Adding a new subagent that should use Systematic skills
+- Debugging why a subagent's output lacks skill-specific patterns (OKLCH, design laws, TDD phases, etc.)
+- Configuring OMO Slim or similar permission-restricting OpenCode config layers
+
+## Examples
+
+**Failure scenario:**
+
+1. Orchestrator dispatches `@designer` to apply frontend-design skill
+2. Designer attempts `systematic_skill({ name: "systematic:frontend-design" })`
+3. OMO Slim denies the call — designer's `skills` array lacks the entry
+4. Designer proceeds without the skill, producing generic output
+5. Orchestrator's verification catches the quality gap
+
+**Diagnostic check:**
+
+```bash
+# Inspect the agent's effective config
+grep -A 10 '"designer"' ~/.config/opencode/oh-my-opencode-slim.jsonc
+# Look for "skills" array — must include "systematic:*" or the specific skill name
+```
+
+## Related
+
+- Oracle troubleshooting session on PR #418 — root cause analysis
+- OMO Slim documentation for agent permission configuration

--- a/registry/registry.jsonc
+++ b/registry/registry.jsonc
@@ -556,7 +556,7 @@
     {
       "name": "frontend-design",
       "type": "skill",
-      "description": "Build web interfaces with genuine design quality, not AI slop. Use for any frontend work - landing pages, web apps, dashboards, admin panels, components, interactive experiences. Activates for both greenfield builds and modifications to existing applications. Detects existing design systems and respects them. Covers composition, typography, color, motion, and copy. Verifies results via screenshots before declaring done.",
+      "description": "Use when building or reviewing any frontend interface. Covers the full design lifecycle: context detection, pre-build planning, design laws (OKLCH color, theme forcing function, layout rhythm, absolute bans on AI-slop patterns), implementation guidance, and visual verification. Use for landing pages, dashboards, components, or any web UI where design quality matters.",
       "files": ["skills/frontend-design/SKILL.md"]
     },
     {

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-design
-description: 'Build web interfaces with genuine design quality, not AI slop. Use for any frontend work - landing pages, web apps, dashboards, admin panels, components, interactive experiences. Activates for both greenfield builds and modifications to existing applications. Detects existing design systems and respects them. Covers composition, typography, color, motion, and copy. Verifies results via screenshots before declaring done.'
+description: 'Use when building or reviewing any frontend interface. Covers the full design lifecycle: context detection, pre-build planning, design laws (OKLCH color, theme forcing function, layout rhythm, absolute bans on AI-slop patterns), implementation guidance, and visual verification. Use for landing pages, dashboards, components, or any web UI where design quality matters.'
 license: Apache-2.0
 ---
 
@@ -135,7 +135,7 @@ Match-and-refuse. If you're about to write any of these, rewrite the element wit
 
 ### The AI slop test
 
-If someone could look at this interface and say "AI made that" without doubt, it's failed. Cross-register failures are the absolute bans above.
+If someone could look at this interface and say "AI made that" without doubt, it's failed. The absolute bans above are the primary failure class — they are never acceptable regardless of context.
 
 **Category-reflex check.** Run at two altitudes; the second one catches what the first one misses.
 
@@ -157,7 +157,7 @@ These principles apply across all context types. Each yields to existing design 
 ### Color & Theme
 
 - Commit to a cohesive palette using CSS variables. A dominant color with sharp accents outperforms timid, evenly-distributed palettes.
-- No purple-on-white bias, no dark-mode bias. Vary between light and dark based on context.
+- No purple-on-white bias. For dark vs. light choice, apply the scene-sentence forcing function in Design Laws above.
 - One accent color by default unless the product already has a multi-color system.
 - *Yields to existing color tokens when detected.*
 

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: frontend-design
 description: 'Build web interfaces with genuine design quality, not AI slop. Use for any frontend work - landing pages, web apps, dashboards, admin panels, components, interactive experiences. Activates for both greenfield builds and modifications to existing applications. Detects existing design systems and respects them. Covers composition, typography, color, motion, and copy. Verifies results via screenshots before declaring done.'
+license: Apache-2.0
 ---
 
 # Frontend Design
@@ -77,6 +78,72 @@ Before writing code, write three short statements. These create coherence and gi
 
 ---
 
+## Design Laws
+
+Apply to every design. Match implementation complexity to the aesthetic vision: maximalism needs elaborate code, minimalism needs precision. Interpret creatively. Vary across projects; never converge on the same choices. Don't hold back.
+
+### Color
+
+- Use OKLCH. Reduce chroma as lightness approaches 0 or 100; high chroma at extremes looks garish.
+- Never use `#000` or `#fff`. Tint every neutral toward the brand hue (chroma 0.005–0.01 is enough).
+- Pick a **color strategy** before picking colors. Four steps on the commitment axis:
+  - **Restrained**: tinted neutrals + one accent ≤10%. Product default; brand minimalism.
+  - **Committed**: one saturated color carries 30–60% of the surface. Brand default for identity-driven pages.
+  - **Full palette**: 3–4 named roles, each used deliberately. Brand campaigns; product data viz.
+  - **Drenched**: the surface IS the color. Brand heroes, campaign pages.
+- The "one accent ≤10%" rule is Restrained only. Committed / Full palette / Drenched exceed it on purpose. Don't collapse every design to Restrained by reflex.
+
+### Theme
+
+Dark vs. light is never a default. Not dark "because tools look cool dark." Not light "to be safe."
+
+Before choosing, write one sentence of physical scene: who uses this, where, under what ambient light, in what mood. If the sentence doesn't force the answer, it's not concrete enough. Add detail until it does.
+
+"Observability dashboard" does not force an answer. "SRE glancing at incident severity on a 27-inch monitor at 2am in a dim room" does. Run the sentence, not the category.
+
+### Typography
+
+- Cap body line length at 65–75ch.
+- Hierarchy through scale + weight contrast (≥1.25 ratio between steps). Avoid flat scales.
+
+### Layout
+
+- Vary spacing for rhythm. Same padding everywhere is monotony.
+- Cards are the lazy answer. Use them only when they're truly the best affordance. Nested cards are always wrong.
+- Don't wrap everything in a container. Most things don't need one.
+
+### Motion
+
+- Don't animate CSS layout properties.
+- Ease out with exponential curves (ease-out-quart / quint / expo). No bounce, no elastic.
+
+### Absolute bans
+
+Match-and-refuse. If you're about to write any of these, rewrite the element with different structure.
+
+- **Side-stripe borders.** `border-left` or `border-right` greater than 1px as a colored accent on cards, list items, callouts, or alerts. Never intentional. Rewrite with full borders, background tints, leading numbers/icons, or nothing.
+- **Gradient text.** `background-clip: text` combined with a gradient background. Decorative, never meaningful. Use a single solid color. Emphasis via weight or size.
+- **Glassmorphism as default.** Blurs and glass cards used decoratively. Rare and purposeful, or nothing.
+- **The hero-metric template.** Big number, small label, supporting stats, gradient accent. SaaS cliché.
+- **Identical card grids.** Same-sized cards with icon + heading + text, repeated endlessly.
+- **Modal as first thought.** Modals are usually laziness. Exhaust inline / progressive alternatives first.
+
+### Copy
+
+- Every word earns its place. No restated headings, no intros that repeat the title.
+- **No em dashes.** Use commas, colons, semicolons, periods, or parentheses. Also not `--`.
+
+### The AI slop test
+
+If someone could look at this interface and say "AI made that" without doubt, it's failed. Cross-register failures are the absolute bans above.
+
+**Category-reflex check.** Run at two altitudes; the second one catches what the first one misses.
+
+- **First-order:** if someone could guess the theme + palette from the category alone ("observability → dark blue", "healthcare → white + teal", "finance → navy + gold", "crypto → neon on black"), it's the first training-data reflex. Rework the scene sentence and color strategy until the answer isn't obvious from the domain.
+- **Second-order:** if someone could guess the aesthetic family from category-plus-anti-references ("AI workflow tool that's not SaaS-cream → editorial-typographic", "fintech that's not navy-and-gold → terminal-native dark mode"), it's the trap one tier deeper. The first reflex was avoided; the second wasn't. Rework until both answers are not obvious.
+
+---
+
 ## Layer 2: Design Guidance Core
 
 These principles apply across all context types. Each yields to existing design systems and user instructions per the authority hierarchy.
@@ -98,7 +165,7 @@ These principles apply across all context types. Each yields to existing design 
 
 - Start with composition, not components. Treat the first viewport as a poster, not a document.
 - Use whitespace, alignment, scale, cropping, and contrast before adding chrome (borders, shadows, cards).
-- Default to cardless layouts. Cards are allowed when they serve as the container for a user interaction (clickable item, draggable unit, selectable option). If removing the card styling would not hurt comprehension, it should not be a card.
+- Card and layout rules: see Design Laws above.
 - *All composition rules are defaults. The user can override them.*
 
 ### Motion


### PR DESCRIPTION
Upgrades `skills/frontend-design/SKILL.md` with Impeccable's Shared Design Laws (pbakaus/impeccable, Apache 2.0), following the same import pattern established for obra/superpowers (PR #394).

## What changed

**`skills/frontend-design/SKILL.md`**
- Added `## Design Laws` section after Layer 1 / before Layer 2 with verbatim merge of Impeccable's design laws: OKLCH color theory, four-step color strategy axis (Restrained/Committed/Full palette/Drenched), theme forcing function (scene-sentence discipline), typography scale rules, layout rhythm, exponential motion curves, absolute bans (side-stripe borders, gradient text, glassmorphism, hero-metric, identical card grids, modal-as-first-thought, em dashes), and two-tier AI slop category-reflex check
- Updated `description` frontmatter to surface OKLCH, absolute bans, and AI slop test in trigger keywords
- Added `license: Apache-2.0` to frontmatter
- Layer 2 card bullet consolidated to forward reference; Layer 2 dark/light bias note defers to scene-sentence law
- Jargon-free language in AI slop test section

**`ATTRIBUTIONS.md`**
- Added `## pbakaus/impeccable — Apache 2.0` block (pinned SHA `642f03d`, Apache 2.0, noting Anthropic CC-BY-4.0 upstream attribution chain)

**`docs/plans/`**
- Added `2026-05-20-001-feat-frontend-design-upgrade-plan.md`

## Verification

- Content-integrity gate: clean (167 md + 21 ts, 0 warnings)
- Build: passes
- Application test: `@designer` agent correctly named the four-step color axis, applied the scene-sentence forcing function, enumerated specific absolute bans, and ran both tiers of the category-reflex check against a realistic pricing-section scenario
