### PR TITLE
build(design): align design-iterator and docs site with Impeccable design laws

### DIFF
--- a/agents/design/design-iterator.md
+++ b/agents/design/design-iterator.md
@@ -59,46 +59,20 @@ For focused screenshots:
 
 **Keep screenshots focused** - capture only the element/area you're working on to reduce noise.
 
-## Design Principles to Apply
+## Design Principles
 
-When analyzing components, look for opportunities in these areas:
+**Load `systematic:frontend-design` before starting iterations.** The skill contains the authoritative Design Laws (OKLCH color, theme forcing function, layout rhythm, absolute bans, AI slop test). Apply those laws to every iteration decision.
 
-### Visual Hierarchy
+When the skill is loaded, use its Design Laws as the evaluation criteria for each screenshot-analyze-improve cycle. When analyzing, check the current state against:
 
-- Headline sizing and weight progression
-- Color contrast and emphasis
-- Whitespace and breathing room
-- Section separation and groupings
+- **Color**: OKLCH color space, chroma-at-extremes rule, tinted neutrals (no `#000`/`#fff`), four-step strategy axis (Restrained → Committed → Full palette → Drenched)
+- **Theme**: Scene-sentence forcing function for light/dark choice
+- **Typography**: 65–75ch measure, ≥1.25 type-scale contrast between hierarchy levels
+- **Layout**: Spacing rhythm from a single base unit, cards only when content has genuine independent identity, no nested cards
+- **Motion**: Exponential ease-out only, no bounce/elastic, never animate layout properties (width, height, top, left)
+- **Absolute bans**: Side-stripe accent borders, gradient text on backgrounds, glassmorphism-as-default, hero-metric dashboard template, identical card grids, modal-as-first-thought
 
-### Modern Design Patterns
-
-- Gradient backgrounds and subtle patterns
-- Micro-interactions and hover states
-- Badge and tag styling
-- Icon treatments (size, color, backgrounds)
-- Border radius consistency
-
-### Typography
-
-- Font pairing (serif headlines, sans-serif body)
-- Line height and letter spacing
-- Text color variations (slate-900, slate-600, slate-400)
-- Italic emphasis for key phrases
-
-### Layout Improvements
-
-- Hero card patterns (featured item larger)
-- Grid arrangements (asymmetric can be more interesting)
-- Alternating patterns for visual rhythm
-- Proper responsive breakpoints
-
-### Polish Details
-
-- Shadow depth and color (blue shadows for blue buttons)
-- Animated elements (subtle pulses, transitions)
-- Social proof badges
-- Trust indicators
-- Numbered or labeled items
+If the skill is not available, these principles are the minimum bar. The skill provides deeper guidance including the two-tier AI slop test (first-order category-reflex + second-order escape check).
 
 ## Competitor Research (When Requested)
 
@@ -184,13 +158,11 @@ Avoid over-engineering. Only make changes that are directly requested or clearly
 
 ALWAYS read and understand relevant files before proposing code edits. Do not speculate about code you have not inspected. If the user references a specific file/path, you MUST open and inspect it before explaining or proposing fixes. Be rigorous and persistent in searching code for key facts. Thoroughly review the style, conventions, and abstractions of the codebase before implementing new features or abstractions.
 
-<frontend_aesthetics> You tend to converge toward generic, "on distribution" outputs. In frontend design,this creates what users call the "AI slop" aesthetic. Avoid this: make creative,distinctive frontends that surprise and delight. Focus on:
+<frontend_aesthetics> You tend to converge toward generic, "on distribution" outputs. In frontend design, this creates what users call the "AI slop" aesthetic. The Design Laws in `systematic:frontend-design` are the authoritative guard against this — load the skill and apply its two-tier AI slop test (first-order category-reflex + second-order escape check) to every design decision. Key anti-slop rules:
 
-- Typography: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics.
-- Color & Theme: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes. Draw from IDE themes and cultural aesthetics for inspiration.
-- Motion: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions.
-- Backgrounds: Create atmosphere and depth rather than defaulting to solid colors. Layer CSS gradients, use geometric patterns, or add contextual effects that match the overall aesthetic. Avoid generic AI-generated aesthetics:
-- Overused font families (Inter, Roboto, Arial, system fonts)
-- Clichéd color schemes (particularly purple gradients on white backgrounds)
-- Predictable layouts and component patterns
-- Cookie-cutter design that lacks context-specific character Interpret creatively and make unexpected choices that feel genuinely designed for the context. Vary between light and dark themes, different fonts, different aesthetics. You still tend to converge on common choices (Space Grotesk, for example) across generations. Avoid this: it is critical that you think outside the box! </frontend_aesthetics>
+- Use OKLCH color space. No `#000`/`#fff` — use tinted neutrals. Choose a color strategy from the four-step axis (Restrained/Committed/Full palette/Drenched) and commit to it.
+- Write a physical-scene sentence to force the light/dark theme choice — no arbitrary switching.
+- Typography: 65–75ch measure, ≥1.25 type-scale contrast. Avoid generic system font stacks where a distinctive choice is warranted.
+- Motion: Exponential ease-out only. No bounce/elastic. Never animate layout properties.
+- Absolute bans: side-stripe accent borders, gradient text on backgrounds, glassmorphism-as-default, hero-metric dashboard template, identical card grids, modal-as-first-thought, em dashes in copy.
+- Run the category-reflex check: if you can describe the design with a single compound noun ("SaaS dashboard", "developer docs"), the first-draft aesthetic is wrong — find the second-order escape. </frontend_aesthetics>

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -17,8 +17,8 @@ export default defineConfig({
             themeVariables: {
               primaryColor: '#182225',
               primaryTextColor: '#f3f6f7',
-              primaryBorderColor: '#4fd1c5',
-              lineColor: '#4fd1c5',
+              primaryBorderColor: '#59d3c8',
+              lineColor: '#59d3c8',
               secondaryColor: '#243033',
               tertiaryColor: '#101719',
             },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -15,12 +15,12 @@ export default defineConfig({
           mermaidConfig: {
             theme: 'dark',
             themeVariables: {
-              primaryColor: '#1a1a2e',
-              primaryTextColor: '#fff',
-              primaryBorderColor: '#4FD1C5',
-              lineColor: '#4FD1C5',
-              secondaryColor: '#16213e',
-              tertiaryColor: '#0f0f23',
+              primaryColor: '#182225',
+              primaryTextColor: '#f3f6f7',
+              primaryBorderColor: '#4fd1c5',
+              lineColor: '#4fd1c5',
+              secondaryColor: '#243033',
+              tertiaryColor: '#101719',
             },
           },
         },

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -1,38 +1,62 @@
 :root {
-  --sl-color-accent-low: #0f403c;
-  --sl-color-accent: #4fd1c5;
-  --sl-color-accent-high: #b2f5ea;
-  --sl-color-white: #ffffff;
-  --sl-color-gray-1: #eceef2;
-  --sl-color-gray-2: #c0c8d1;
-  --sl-color-gray-3: #94a1b2;
-  --sl-color-gray-4: #485870;
-  --sl-color-gray-5: #252c38;
-  --sl-color-gray-6: #1a1a2e;
-  --sl-color-black: #0f0f23;
+  /* OKLCH Tinted Neutrals (Teal hue ~195) */
+  --sl-color-accent-low: oklch(0.3 0.05 195);
+  --sl-color-accent: oklch(0.8 0.1 195);
+  --sl-color-accent-high: oklch(0.95 0.05 195);
+  --sl-color-white: oklch(0.98 0.005 195);
+  --sl-color-gray-1: oklch(0.9 0.01 195);
+  --sl-color-gray-2: oklch(0.75 0.015 195);
+  --sl-color-gray-3: oklch(0.55 0.015 195);
+  --sl-color-gray-4: oklch(0.35 0.015 195);
+  --sl-color-gray-5: oklch(0.25 0.015 195);
+  --sl-color-gray-6: oklch(0.2 0.015 195);
+  --sl-color-black: oklch(0.15 0.015 195);
+
+  /* Typography - Editorial Reference Manual escape */
+  --sl-font-system:
+    ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, "Helvetica Neue", Arial, sans-serif;
+  --sl-font-heading:
+    ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+  --sl-font-mono:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
+
+  /* Spacing Scale Rhythm */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-12: 3rem;
+
+  --sl-line-height: 1.6;
+  --sl-nav-gap: var(--space-3);
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 [data-theme="light"] {
-  --sl-color-accent-low: #b2f5ea;
-  --sl-color-accent: #4fd1c5;
-  --sl-color-accent-high: #0f403c;
-  --sl-color-white: #0f0f23;
-  --sl-color-gray-1: #1a1a2e;
-  --sl-color-gray-2: #252c38;
-  --sl-color-gray-3: #485870;
-  --sl-color-gray-4: #94a1b2;
-  --sl-color-gray-5: #c0c8d1;
-  --sl-color-gray-6: #eceef2;
-  --sl-color-black: #ffffff;
+  --sl-color-accent-low: oklch(0.95 0.05 195);
+  --sl-color-accent: oklch(0.5 0.1 195);
+  --sl-color-accent-high: oklch(0.3 0.05 195);
+  --sl-color-white: oklch(0.15 0.015 195);
+  --sl-color-gray-1: oklch(0.2 0.015 195);
+  --sl-color-gray-2: oklch(0.25 0.015 195);
+  --sl-color-gray-3: oklch(0.35 0.015 195);
+  --sl-color-gray-4: oklch(0.55 0.015 195);
+  --sl-color-gray-5: oklch(0.75 0.015 195);
+  --sl-color-gray-6: oklch(0.9 0.01 195);
+  --sl-color-black: oklch(0.98 0.005 195);
 }
 
 /* Definition header for reference pages */
 .definition-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0;
-  margin-bottom: 1rem;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
+  margin-bottom: var(--space-4);
   border-bottom: 1px solid var(--sl-color-gray-5);
   font-size: var(--sl-text-sm);
 }
@@ -43,8 +67,8 @@
   letter-spacing: 0.05em;
   background: var(--sl-color-gray-5);
   color: var(--sl-color-white);
-  padding: 0.125rem 0.5rem;
-  border-radius: 0.25rem;
+  padding: var(--space-1) var(--space-2);
+  border-radius: 0.125rem;
 }
 
 .definition-source {
@@ -52,48 +76,37 @@
   color: var(--sl-color-gray-3);
   text-decoration: none;
   font-size: var(--sl-text-xs);
+  transition: color 0.4s var(--ease-out-expo);
 }
 
 .definition-source:hover {
   color: var(--sl-color-accent);
 }
 
-/* Typography & Spacing Polish - OpenCode Aligned */
-:root {
-  /* Refined Typography */
-  --sl-font-system:
-    ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    Roboto, "Helvetica Neue", Arial, sans-serif;
-  --sl-font-heading: var(--sl-font-system);
-  --sl-font-mono:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-    "Courier New", monospace;
-
-  /* Spacing & Layout */
-  --sl-line-height: 1.75;
-  --sl-nav-gap: 0.75rem;
-}
-
-/* Heading Polish */
+/* Heading Polish - Editorial */
 .sl-markdown-content h1,
 .sl-markdown-content h2,
 .sl-markdown-content h3,
 .sl-markdown-content h4 {
-  font-weight: 700;
-  letter-spacing: -0.025em;
-  margin-top: 2.5em;
-  margin-bottom: 0.75em;
+  font-family: var(--sl-font-heading);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  margin-top: var(--space-8);
+  margin-bottom: var(--space-3);
+  color: var(--sl-color-white);
 }
 
 .sl-markdown-content h1 {
-  font-size: 2.5rem;
-  line-height: 1.2;
+  font-size: 2.75rem;
+  line-height: 1.1;
+  margin-top: 0;
+  margin-bottom: var(--space-6);
 }
 
 .sl-markdown-content p {
-  margin-bottom: 1.5em;
-  line-height: 1.8;
-  color: var(--sl-color-gray-2);
+  margin-bottom: var(--space-6);
+  line-height: var(--sl-line-height);
+  color: var(--sl-color-gray-1);
 }
 
 /* Link Polish */
@@ -101,22 +114,23 @@
   text-decoration-thickness: 1px;
   text-underline-offset: 4px;
   transition:
-    color 0.2s ease,
-    text-decoration-color 0.2s ease;
+    color 0.4s var(--ease-out-expo),
+    text-decoration-color 0.4s var(--ease-out-expo);
 }
 
 .sl-markdown-content a:not(.not-content):hover {
   text-decoration-color: var(--sl-color-accent);
 }
 
-/* Card Polish */
+/* Card Polish - Refined Motion */
 .card,
 .link-card {
   border: 1px solid var(--sl-color-gray-5);
   background-color: var(--sl-color-gray-6);
+  border-radius: 0.25rem;
   transition:
-    transform 0.2s ease,
-    border-color 0.2s ease;
+    transform 0.4s var(--ease-out-expo),
+    border-color 0.4s var(--ease-out-expo);
 }
 
 .card:hover,
@@ -127,37 +141,41 @@
 
 /* Code Block Polish */
 .expressive-code .ec-line {
-  line-height: 1.6;
+  line-height: 1.5;
 }
 
 /* Blockquote Polish */
 .sl-markdown-content blockquote {
   border-left-color: var(--sl-color-accent);
   background-color: var(--sl-color-gray-6);
-  padding: 1rem 1.5rem;
-  border-radius: 0.25rem;
+  padding: var(--space-4) var(--space-6);
+  border-radius: 0; /* Boxy editorial feel */
+  font-family: var(--sl-font-heading);
+  font-style: italic;
+  font-size: 1.1rem;
 }
 
 /* Table Polish */
 .sl-markdown-content table {
-  border-collapse: separate;
-  border-spacing: 0;
+  border-collapse: collapse;
   width: 100%;
   border: 1px solid var(--sl-color-gray-5);
-  border-radius: 0.5rem;
+  border-radius: 0;
   overflow: hidden;
+  margin-bottom: var(--space-6);
 }
 
 .sl-markdown-content th {
   background-color: var(--sl-color-gray-6);
   border-bottom: 1px solid var(--sl-color-gray-5);
-  padding: 0.75rem 1rem;
+  padding: var(--space-3) var(--space-4);
   text-align: left;
-  font-weight: 600;
+  font-weight: 500;
+  font-family: var(--sl-font-system);
 }
 
 .sl-markdown-content td {
-  padding: 0.75rem 1rem;
+  padding: var(--space-3) var(--space-4);
   border-bottom: 1px solid var(--sl-color-gray-5);
 }
 

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -27,6 +27,7 @@
   --space-2: 0.5rem;
   --space-3: 0.75rem;
   --space-4: 1rem;
+  --space-5: 1.25rem;
   --space-6: 1.5rem;
   --space-8: 2rem;
   --space-12: 3rem;
@@ -76,7 +77,7 @@
   color: var(--sl-color-gray-3);
   text-decoration: none;
   font-size: var(--sl-text-xs);
-  transition: color 0.4s var(--ease-out-expo);
+  transition: color 0.25s var(--ease-out-expo);
 }
 
 .definition-source:hover {
@@ -114,8 +115,8 @@
   text-decoration-thickness: 1px;
   text-underline-offset: 4px;
   transition:
-    color 0.4s var(--ease-out-expo),
-    text-decoration-color 0.4s var(--ease-out-expo);
+    color 0.25s var(--ease-out-expo),
+    text-decoration-color 0.25s var(--ease-out-expo);
 }
 
 .sl-markdown-content a:not(.not-content):hover {
@@ -129,8 +130,8 @@
   background-color: var(--sl-color-gray-6);
   border-radius: 0.25rem;
   transition:
-    transform 0.4s var(--ease-out-expo),
-    border-color 0.4s var(--ease-out-expo);
+    transform 0.25s var(--ease-out-expo),
+    border-color 0.25s var(--ease-out-expo);
 }
 
 .card:hover,
@@ -161,7 +162,6 @@
   width: 100%;
   border: 1px solid var(--sl-color-gray-5);
   border-radius: 0;
-  overflow: hidden;
   margin-bottom: var(--space-6);
 }
 


### PR DESCRIPTION
Align the design-iterator agent and docs site CSS with the Impeccable Design Laws merged in PR #418.

## Changes

### design-iterator agent
- Replace generic "Design Principles to Apply" section (which recommended gradient backgrounds, hero card patterns, and generic font pairings — all contradicting the Design Laws) with authoritative `systematic:frontend-design` skill reference
- Update `<frontend_aesthetics>` block to use OKLCH, tinted neutrals, category-reflex check, and absolute bans vocabulary

### Docs site CSS
- Convert all 22 color values from hex to `oklch()` with tinted neutrals (hue 195 teal, no pure black/white)
- Apply editorial serif heading typography (`ui-serif, Georgia, Cambria`) as category-reflex escape from generic "developer docs" dark-teal aesthetic
- Standardize spacing on CSS variable scale (`--space-1` through `--space-12`) from single base unit
- Replace `ease`/`linear` transitions with exponential ease-out curve (`cubic-bezier(0.16, 1, 0.3, 1)`)
- Scene-sentence: "A meticulous engineer consulting a technical reference manual bound in soft teal leather, lying open under a warm desk lamp"

### Mermaid theme
- Update `astro.config.mjs` theme variables to hex approximations of the new OKLCH palette

## Verification
- Build, typecheck, lint all pass
- `docs:build` produces 112 pages cleanly
- Zero hex colors remain in `custom.css`
- Content-integrity gate clean
- Registry unchanged (agent description not modified)