### PR TITLE
fix(docs): modernize architecture guide

### DIFF
--- a/docs/src/content/docs/guides/architecture.mdx
+++ b/docs/src/content/docs/guides/architecture.mdx
@@ -10,8 +10,8 @@ Systematic is designed as a lightweight yet powerful extension for OpenCode. It 
 ## Overview
 
 The plugin is divided into two main parts:
-1.  **TypeScript Source (`src/`):** The core logic that handles plugin registration, asset discovery, and conversion.
-2.  **Bundled Assets (`skills/` and `agents/`):** Battle-tested engineering content that is automatically discovered and registered by the plugin.
+1.  **TypeScript Source (`src/`):** The core logic that handles plugin registration, asset discovery, config validation, and model availability resolution.
+2.  **Bundled Assets (`skills/` and `agents/`):** Structured engineering workflows and specialized agent definitions that are automatically discovered and registered by the plugin.
 
 ## How It Works
 
@@ -27,13 +27,13 @@ flowchart TB
     C --> F[Register systematic_skill tool]
     D --> G[Inject bootstrap prompt into every conversation]
 
-    style A fill:#1a1a2e,stroke:#4FD1C5,color:#fff
-    style B fill:#16213e,stroke:#4FD1C5,color:#4FD1C5
-    style C fill:#16213e,stroke:#E91E8C,color:#E91E8C
-    style D fill:#16213e,stroke:#F5A623,color:#F5A623
-    style E fill:#0f0f23,stroke:#4FD1C5,color:#B2F5EA
-    style F fill:#0f0f23,stroke:#E91E8C,color:#B2F5EA
-    style G fill:#0f0f23,stroke:#F5A623,color:#B2F5EA
+    style A fill:#1e2530,stroke:#33b1c4,color:#fff
+    style B fill:#1e2530,stroke:#33b1c4,color:#33b1c4
+    style C fill:#1e2530,stroke:#c74a8a,color:#c74a8a
+    style D fill:#1e2530,stroke:#c4a033,color:#c4a033
+    style E fill:#141a22,stroke:#33b1c4,color:#8fd9d0
+    style F fill:#141a22,stroke:#c74a8a,color:#8fd9d0
+    style G fill:#141a22,stroke:#c4a033,color:#8fd9d0
 ```
 
 ### 1. `config` Hook
@@ -58,14 +58,5 @@ For developers looking to contribute or understand the implementation, here are 
 | `createConfigHandler` | Implements the `config` hook logic | `src/lib/config-handler.ts` |
 | `createSkillTool` | Implements the `systematic_skill` tool | `src/lib/skill-tool.ts` |
 | `getBootstrapContent` | Handles system prompt injection | `src/lib/bootstrap.ts` |
-| `convertContent` | Handles CEP to OpenCode format conversion | `src/lib/converter.ts` |
+| `convertContent` | Claude Code-to-OpenCode format conversion (CLI) | `src/lib/converter.ts` |
 | `findSkillsInDir` | Discovers bundled skills | `src/lib/skills.ts` |
-
-## Technical Stack
-
-Systematic is built with modern web technologies:
-- **Runtime:** [Bun](https://bun.sh/) (Node.js API compatible)
-- **Language:** TypeScript 5.7+ in strict mode
-- **Modules:** ESM (`"type": "module"`)
-- **Linter:** [Biome](https://biomejs.dev/)
-- **Testing:** `bun:test`


### PR DESCRIPTION
Removes stale content from the architecture guide:

- Mermaid colors updated to OKLCH-derived hex palette
- `convertContent` description: "CEP to OpenCode" → "CC-to-OpenCode format conversion (CLI)"
- Overview: updated `src/` description (added config validation, model availability)
- Overview: updated bundled assets description (removed "battle-tested" marketing)
- Removed Technical Stack section (TS version, runtime, linter — clutter, already in AGENTS.md for contributors)

Docs build: 110 pages, zero errors.