### PR TITLE
fix(ci): add OpenCode group name to Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,6 +25,7 @@
     },
     {
       matchPackageNames: ['@opencode-ai/{/,}**'],
+      groupName: 'OpenCode',
       semanticCommitType: 'build',
     },
   ],


### PR DESCRIPTION
Adds `groupName: 'OpenCode'` to the `@opencode-ai` package rule so Renovate PRs say "update OpenCode to vX.Y.Z" instead of "update all non-major dependencies".