### PR TITLE
feat(release): automate release-notes-narrative skill via @semantic-release/exec

### DIFF
--- a/.agents/skills/release-notes-narrative/SKILL.md
+++ b/.agents/skills/release-notes-narrative/SKILL.md
@@ -6,6 +6,12 @@ argument-hint: <tag-or-range>
 
 # Release Notes Narrative
 
+## CI Automation
+
+This skill also runs automatically post-publish via `@semantic-release/exec`'s `successCmd` in `.releaserc.yaml`. The hook dispatches `fro-bot.yaml` with a prompt that loads this skill and applies the 13-step procedure against the just-published tag. Manual invocation remains the canonical path for retroactive patches and historical releases; CI automation handles forward-going releases without operator intervention.
+
+If you are reading this as the dispatched Fro Bot run, the prompt embedded the target tag and a correlation token. Echo the correlation token as your first log line, then proceed with the procedure below.
+
 ## Overview
 
 `@semantic-release/release-notes-generator` with the `conventionalcommits` preset builds release bodies from commit subject lines only — commit bodies and PR descriptions are never ingested. The result is mechanically correct but qualitatively thin: a bucket of one-line bullets that tells readers what changed but not why it matters. The same generator also misparses any `path#fragment` substring in a commit body as a `Closes #N` footer, emitting broken autolinks pointing at nonexistent issues.

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -13,6 +13,179 @@ plugins:
     - releasedLabels: false
       successComment: false
 
+  - - '@semantic-release/exec'
+    - successCmd: |
+        # @semantic-release/exec resolves Lodash template expressions before handing
+        # the resulting string to the shell. ${nextRelease.gitTag} becomes a literal
+        # value like v2.23.0 at that point; capture it as a bash variable.
+        RELEASE_VERSION="${nextRelease.gitTag}"
+
+        # Validate the tag shape before any interpolation or dispatch.
+        # A malformed value could indicate a tag-spoofing attempt or a semantic-release
+        # plugin upgrade that changed the gitTag contract.
+        if ! echo "$RELEASE_VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$'; then
+          echo "::error::Invalid RELEASE_VERSION shape: $RELEASE_VERSION"
+          exit 1
+        fi
+
+        # Generate a UUID to uniquely identify this dispatch. The token is passed both
+        # as a workflow input field and embedded in the prompt so Fro Bot echoes it as
+        # its first log line. Polling matches by scanning early log lines for this token,
+        # eliminating same-second collision ambiguity.
+        # Test escape hatch: integration tests set RELEASE_NOTES_TEST_CORRELATION_ID to
+        # a known UUID so mock-gh fixtures can include the same value in their log output.
+        # Production runs never set this; uuidgen / /proc/sys/kernel/random/uuid is the
+        # real source of correlation tokens.
+        if [[ -n "${RELEASE_NOTES_TEST_CORRELATION_ID:-}" ]]; then
+          CORRELATION_ID="$RELEASE_NOTES_TEST_CORRELATION_ID"
+        elif command -v uuidgen >/dev/null 2>&1; then
+          CORRELATION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+        else
+          CORRELATION_ID="$(cat /proc/sys/kernel/random/uuid)"
+        fi
+
+        # Construct the prompt. $RELEASE_VERSION, $CORRELATION_ID, and $GITHUB_REPOSITORY
+        # are runtime bash env vars expanded by the heredoc. Do NOT use ${{ github.* }}
+        # workflow-expression syntax here — those are not interpolated inside successCmd
+        # strings, which run on the runner after YAML preprocessing is complete.
+        PROMPT=$(cat <<PROMPT_EOF
+        correlation=$CORRELATION_ID
+
+        You are running the release-notes-narrative skill against a just-published GitHub release.
+        First, echo the line "correlation=$CORRELATION_ID" to stdout (the line above this prompt) so
+        the dispatching workflow can identify this run. This is mandatory.
+
+        Target release tag: $RELEASE_VERSION
+        Target repository: $GITHUB_REPOSITORY
+
+        Idempotency check (do this FIRST):
+        - Fetch the current release body: \`gh release view $RELEASE_VERSION --json body --jq '.body'\`
+        - If the body starts with the heading \`## What's new\`, the narrative has already been applied.
+          Log "already-applied; short-circuiting" and exit cleanly. Conclusion will be reported as \`neutral\`.
+
+        Procedure (only if idempotency check did NOT short-circuit):
+        1. Load the skill at .agents/skills/release-notes-narrative/SKILL.md from this checkout.
+        2. Execute the 13-step procedure against tag $RELEASE_VERSION.
+        3. Apply the rendered body via \`gh release edit $RELEASE_VERSION --notes-file <tmpfile>\`.
+
+        Scope constraints (do not violate):
+        - Do NOT comment on any PR, issue, or discussion.
+        - Do NOT open or close any issue.
+        - Do NOT edit any release body OTHER than $RELEASE_VERSION.
+        - Do NOT modify any file in the repository.
+        - Do NOT push commits, create branches, or create tags.
+
+        Report back with: the target tag, the chars-before and chars-after counts, and the
+        GitHub release URL.
+        PROMPT_EOF
+        )
+
+        # Dispatch the Fro Bot workflow. gh workflow run does not return a parseable run ID,
+        # so we identify our run via correlation-token polling below.
+        gh workflow run --ref main fro-bot.yaml \
+          -f "prompt=$PROMPT" \
+          -f "correlation-id=$CORRELATION_ID"
+
+        # Poll up to 90 seconds for a run whose early log lines contain our correlation token.
+        # Every 5 seconds, list recent fro-bot.yaml runs on main and scan the first 50 log
+        # lines of each candidate for the token. The first match is our dispatched run.
+        # Test escape hatches: RELEASE_NOTES_TEST_POLL_BUDGET_SECS and
+        # RELEASE_NOTES_TEST_POLL_INTERVAL_SECS shorten the loop for unit tests.
+        # Production runs always use 90s budget / 5s interval.
+        POLL_BUDGET_SECS="${RELEASE_NOTES_TEST_POLL_BUDGET_SECS:-90}"
+        POLL_INTERVAL_SECS="${RELEASE_NOTES_TEST_POLL_INTERVAL_SECS:-5}"
+        RUN_ID=""
+        POLL_DEADLINE=$(( $(date +%s) + POLL_BUDGET_SECS ))
+        while [ "$(date +%s)" -lt "$POLL_DEADLINE" ]; do
+          CANDIDATES="$(gh run list --workflow=fro-bot.yaml --branch=main \
+            --json databaseId,createdAt --limit 10 2>/dev/null \
+            | jq -r '.[].databaseId')"
+          for CANDIDATE_ID in $CANDIDATES; do
+            if gh run view "$CANDIDATE_ID" --log --limit 50 2>/dev/null \
+                | grep -q "correlation=$CORRELATION_ID"; then
+              RUN_ID="$CANDIDATE_ID"
+              break 2
+            fi
+          done
+          sleep "$POLL_INTERVAL_SECS"
+        done
+
+        if [ -z "$RUN_ID" ]; then
+          echo "::error::Dispatched workflow run not found within ${POLL_BUDGET_SECS}s (correlation=$CORRELATION_ID). GitHub may have rejected the dispatch or the workflow never started."
+          exit 1
+        fi
+
+        # Wait for the run to complete, hard-bounded at 10 minutes.
+        # Test escape hatch: RELEASE_NOTES_TEST_WATCH_TIMEOUT_SECS shortens the wait.
+        # Disable errexit around `timeout` so a non-zero exit (e.g., 124 for timeout)
+        # is captured into WATCH_EXIT rather than killing the script.
+        WATCH_TIMEOUT_SECS="${RELEASE_NOTES_TEST_WATCH_TIMEOUT_SECS:-600}"
+        set +e
+        timeout "$WATCH_TIMEOUT_SECS" gh run watch "$RUN_ID" --exit-status
+        WATCH_EXIT=$?
+        set -e
+
+        # Fetch conclusion and full log (ANSI codes stripped) for classification.
+        CONCLUSION="$(gh run view "$RUN_ID" --json conclusion --jq '.conclusion' 2>/dev/null || echo 'unknown')"
+        LOG="$(gh run view "$RUN_ID" --log 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g')"
+
+        # Check for off-target release edits: any 'release edit vX.Y.Z' line that is NOT
+        # our target tag is a security signal (Fro Bot edited the wrong release).
+        OFF_TARGET="$(echo "$LOG" | grep -E 'release edit v[0-9]+\.[0-9]+\.[0-9]+' \
+          | grep -v "release edit $RELEASE_VERSION" || true)"
+
+        # Check for auth/permission failure keywords in the log.
+        AUTH_FAIL=0
+        if echo "$LOG" | grep -qE 'HTTP 401|HTTP 403|Bad credentials|Resource not accessible|requires authentication|permission denied'; then
+          AUTH_FAIL=1
+        fi
+
+        # Post-write integrity check: if Fro Bot reported success, verify the release body
+        # is substantive (>=200 chars). A short body means the write silently failed or
+        # produced a partial/empty result.
+        BODY_LEN=0
+        if [ "$CONCLUSION" = "success" ]; then
+          BODY_LEN="$(gh release view "$RELEASE_VERSION" --json body \
+            --jq '.body | length' 2>/dev/null || echo 0)"
+        fi
+
+        # Classify outcome by precedence. Security-relevant failures exit 1 with ::error::.
+        # Narrative failures exit 0 with ::warning::. Happy path exits 0 with plain stdout.
+        if [ "$WATCH_EXIT" -eq 124 ]; then
+          echo "::warning::Fro Bot run timed out after 10 minutes (run=$RUN_ID, correlation=$CORRELATION_ID)"
+          exit 0
+        elif [ -n "$OFF_TARGET" ]; then
+          echo "::error::Off-target release edit detected (run=$RUN_ID): $OFF_TARGET"
+          exit 1
+        elif [ "$AUTH_FAIL" -eq 1 ]; then
+          echo "::error::Auth failure in dispatched run (run=$RUN_ID, correlation=$CORRELATION_ID). Check FRO_BOT_PAT scope."
+          exit 1
+        elif [ "$CONCLUSION" = "action_required" ]; then
+          echo "::error::Workflow requires manual intervention (run=$RUN_ID, conclusion=$CONCLUSION)"
+          exit 1
+        elif [ "$CONCLUSION" = "skipped" ]; then
+          echo "::error::Workflow was skipped — likely blocked by policy/branch protection (run=$RUN_ID)"
+          exit 1
+        elif [ "$CONCLUSION" = "success" ] && [ "$BODY_LEN" -lt 200 ]; then
+          echo "::error::Reported success but body integrity check failed (BODY_LEN=$BODY_LEN, run=$RUN_ID, tag=$RELEASE_VERSION)"
+          exit 1
+        elif [ "$CONCLUSION" = "success" ]; then
+          echo "Narrative applied: tag=$RELEASE_VERSION run=$RUN_ID correlation=$CORRELATION_ID"
+          exit 0
+        elif [ "$CONCLUSION" = "neutral" ]; then
+          echo "No-action-taken (already-applied idempotency short-circuit): tag=$RELEASE_VERSION run=$RUN_ID"
+          exit 0
+        elif [ "$CONCLUSION" = "cancelled" ]; then
+          echo "::warning::Workflow cancelled (run=$RUN_ID, correlation=$CORRELATION_ID)"
+          exit 0
+        elif [ "$CONCLUSION" = "failure" ]; then
+          echo "::warning::Fro Bot run failed (narrative-failure, no security signals detected): run=$RUN_ID"
+          exit 0
+        else
+          echo "::warning::Unknown conclusion: $CONCLUSION (run=$RUN_ID, correlation=$CORRELATION_ID)"
+          exit 0
+        fi
+
   - semantic-release-export-data
 
 analyzeCommits:

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -151,9 +151,18 @@ plugins:
 
         # Classify outcome by precedence. Security-relevant failures exit 1 with ::error::.
         # Narrative failures exit 0 with ::warning::. Happy path exits 0 with plain stdout.
+        # WATCH_EXIT semantics: 0 = run completed (classify by CONCLUSION below),
+        # 124 = timeout (narrative-failure), any other non-zero = unexpected (security-relevant).
+        # The "unexpected" branch covers runner crashes, gh CLI bugs, signal propagation, and
+        # any future gh run watch exit codes we haven't anticipated. Without this branch,
+        # an unexpected WATCH_EXIT falls through to CONCLUSION classification which may
+        # report "unknown" and silently exit 0.
         if [ "$WATCH_EXIT" -eq 124 ]; then
           echo "::warning::Fro Bot run timed out after 10 minutes (run=$RUN_ID, correlation=$CORRELATION_ID)"
           exit 0
+        elif [ "$WATCH_EXIT" -ne 0 ]; then
+          echo "::error::Unexpected gh run watch exit (WATCH_EXIT=$WATCH_EXIT, run=$RUN_ID, correlation=$CORRELATION_ID). May indicate a runner crash, gh CLI bug, or signal propagation."
+          exit 1
         elif [ -n "$OFF_TARGET" ]; then
           echo "::error::Off-target release edit detected (run=$RUN_ID): $OFF_TARGET"
           exit 1

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@biomejs/biome": "2.4.15",
         "@opencode-ai/plugin": "1.15.5",
         "@opencode-ai/sdk": "1.15.5",
+        "@semantic-release/exec": "^7",
         "@types/bun": "latest",
         "@types/js-yaml": "4.0.9",
         "@types/node": "24.12.4",
@@ -366,6 +367,8 @@
 
     "@semantic-release/error": ["@semantic-release/error@4.0.0", "", {}, "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ=="],
 
+    "@semantic-release/exec": ["@semantic-release/exec@7.1.0", "", { "dependencies": { "@semantic-release/error": "^4.0.0", "aggregate-error": "^3.0.0", "debug": "^4.0.0", "execa": "^9.0.0", "lodash-es": "^4.17.21", "parse-json": "^8.0.0" }, "peerDependencies": { "semantic-release": ">=24.1.0" } }, "sha512-4ycZ2atgEUutspPZ2hxO6z8JoQt4+y/kkHvfZ1cZxgl9WKJId1xPj+UadwInj+gMn2Gsv+fLnbrZ4s+6tK2TFQ=="],
+
     "@semantic-release/github": ["@semantic-release/github@12.0.6", "", { "dependencies": { "@octokit/core": "^7.0.0", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-retry": "^8.0.0", "@octokit/plugin-throttling": "^11.0.0", "@semantic-release/error": "^4.0.0", "aggregate-error": "^5.0.0", "debug": "^4.3.4", "dir-glob": "^3.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.0", "issue-parser": "^7.0.0", "lodash-es": "^4.17.21", "mime": "^4.0.0", "p-filter": "^4.0.0", "tinyglobby": "^0.2.14", "undici": "^7.0.0", "url-join": "^5.0.0" }, "peerDependencies": { "semantic-release": ">=24.1.0" } }, "sha512-aYYFkwHW3c6YtHwQF0t0+lAjlU+87NFOZuH2CvWFD0Ylivc7MwhZMiHOJ0FMpIgPpCVib/VUAcOwvrW0KnxQtA=="],
 
     "@semantic-release/npm": ["@semantic-release/npm@13.1.5", "", { "dependencies": { "@actions/core": "^3.0.0", "@semantic-release/error": "^4.0.0", "aggregate-error": "^5.0.0", "env-ci": "^11.2.0", "execa": "^9.0.0", "fs-extra": "^11.0.0", "lodash-es": "^4.17.21", "nerf-dart": "^1.0.0", "normalize-url": "^9.0.0", "npm": "^11.6.2", "rc": "^1.2.8", "read-pkg": "^10.0.0", "registry-auth-token": "^5.0.0", "semver": "^7.1.2", "tempy": "^3.0.0" }, "peerDependencies": { "semantic-release": ">=20.1.0" } }, "sha512-Hq5UxzoatN3LHiq2rTsWS54nCdqJHlsssGERCo8WlvdfFA9LoN0vO+OuKVSjtNapIc/S8C2LBj206wKLHg62mg=="],
@@ -502,7 +505,7 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "aggregate-error": ["aggregate-error@5.0.0", "", { "dependencies": { "clean-stack": "^5.2.0", "indent-string": "^5.0.0" } }, "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw=="],
+    "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -582,7 +585,7 @@
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
-    "clean-stack": ["clean-stack@5.3.0", "", { "dependencies": { "escape-string-regexp": "5.0.0" } }, "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg=="],
+    "clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
 
     "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
 
@@ -952,7 +955,7 @@
 
     "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
 
-    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "index-to-position": ["index-to-position@1.2.0", "", {}, "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw=="],
 
@@ -1304,7 +1307,7 @@
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
-    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+    "parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
 
     "parse-latin": ["parse-latin@7.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "@types/unist": "^3.0.0", "nlcst-to-string": "^4.0.0", "unist-util-modify-children": "^4.0.0", "unist-util-visit-children": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ=="],
 
@@ -1574,7 +1577,7 @@
 
     "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
 
-    "type-fest": ["type-fest@5.4.4", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw=="],
+    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
@@ -1594,7 +1597,7 @@
 
     "unicode-emoji-modifier-base": ["unicode-emoji-modifier-base@1.0.0", "", {}, "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g=="],
 
-    "unicorn-magic": ["unicorn-magic@0.4.0", "", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
+    "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 
@@ -1702,6 +1705,10 @@
 
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 
+    "@semantic-release/github/aggregate-error": ["aggregate-error@5.0.0", "", { "dependencies": { "clean-stack": "^5.2.0", "indent-string": "^5.0.0" } }, "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw=="],
+
+    "@semantic-release/npm/aggregate-error": ["aggregate-error@5.0.0", "", { "dependencies": { "clean-stack": "^5.2.0", "indent-string": "^5.0.0" } }, "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw=="],
+
     "@semantic-release/release-notes-generator/get-stream": ["get-stream@7.0.1", "", {}, "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ=="],
 
     "@semantic-release/release-notes-generator/read-package-up": ["read-package-up@11.0.0", "", { "dependencies": { "find-up-simple": "^1.0.0", "read-pkg": "^9.0.0", "type-fest": "^4.6.0" } }, "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ=="],
@@ -1725,6 +1732,8 @@
     "cliui/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "config-chain/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "cosmiconfig/parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
     "crypto-random-string/type-fest": ["type-fest@1.4.0", "", {}, "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="],
 
@@ -1751,8 +1760,6 @@
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "load-json-file/parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "^1.3.1", "json-parse-better-errors": "^1.0.1" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
-
-    "make-asynchronous/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
@@ -2054,8 +2061,6 @@
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
-    "npm-run-path/unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
-
     "p-event/p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
 
     "p-locate/p-limit": ["p-limit@1.3.0", "", { "dependencies": { "p-try": "^1.0.0" } }, "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q=="],
@@ -2070,13 +2075,19 @@
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
-    "read-pkg/parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
+    "read-package-up/type-fest": ["type-fest@5.4.4", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw=="],
+
+    "read-pkg/type-fest": ["type-fest@5.4.4", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw=="],
+
+    "read-pkg/unicorn-magic": ["unicorn-magic@0.4.0", "", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
 
     "remark-directive/micromark-extension-directive": ["micromark-extension-directive@3.0.2", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "parse-entities": "^4.0.0" } }, "sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA=="],
 
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "run-con/ini": ["ini@4.1.3", "", {}, "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg=="],
+
+    "semantic-release/aggregate-error": ["aggregate-error@5.0.0", "", { "dependencies": { "clean-stack": "^5.2.0", "indent-string": "^5.0.0" } }, "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw=="],
 
     "signale/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
@@ -2110,9 +2121,15 @@
 
     "@expressive-code/plugin-shiki/shiki/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
 
-    "@semantic-release/release-notes-generator/read-package-up/read-pkg": ["read-pkg@9.0.1", "", { "dependencies": { "@types/normalize-package-data": "^2.4.3", "normalize-package-data": "^6.0.0", "parse-json": "^8.0.0", "type-fest": "^4.6.0", "unicorn-magic": "^0.1.0" } }, "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA=="],
+    "@semantic-release/github/aggregate-error/clean-stack": ["clean-stack@5.3.0", "", { "dependencies": { "escape-string-regexp": "5.0.0" } }, "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg=="],
 
-    "@semantic-release/release-notes-generator/read-package-up/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+    "@semantic-release/github/aggregate-error/indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "@semantic-release/npm/aggregate-error/clean-stack": ["clean-stack@5.3.0", "", { "dependencies": { "escape-string-regexp": "5.0.0" } }, "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg=="],
+
+    "@semantic-release/npm/aggregate-error/indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "@semantic-release/release-notes-generator/read-package-up/read-pkg": ["read-pkg@9.0.1", "", { "dependencies": { "@types/normalize-package-data": "^2.4.3", "normalize-package-data": "^6.0.0", "parse-json": "^8.0.0", "type-fest": "^4.6.0", "unicorn-magic": "^0.1.0" } }, "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA=="],
 
     "cli-highlight/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -2150,7 +2167,9 @@
 
     "npm/promise-retry/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
-    "read-pkg/parse-json/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+    "semantic-release/aggregate-error/clean-stack": ["clean-stack@5.3.0", "", { "dependencies": { "escape-string-regexp": "5.0.0" } }, "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg=="],
+
+    "semantic-release/aggregate-error/indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
     "signale/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
@@ -2159,8 +2178,6 @@
     "signale/figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "@semantic-release/release-notes-generator/read-package-up/read-pkg/normalize-package-data": ["normalize-package-data@6.0.2", "", { "dependencies": { "hosted-git-info": "^7.0.0", "semver": "^7.3.5", "validate-npm-package-license": "^3.0.4" } }, "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g=="],
-
-    "@semantic-release/release-notes-generator/read-package-up/read-pkg/parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
 
     "@semantic-release/release-notes-generator/read-package-up/read-pkg/unicorn-magic": ["unicorn-magic@0.1.0", "", {}, "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ=="],
 

--- a/docs/plans/2026-05-23-002-feat-release-notes-narrative-ci-automation-plan.md
+++ b/docs/plans/2026-05-23-002-feat-release-notes-narrative-ci-automation-plan.md
@@ -1,0 +1,381 @@
+---
+title: Wire CI automation for release-notes-narrative skill
+type: feat
+status: active
+date: 2026-05-23
+origin: docs/brainstorms/2026-05-23-release-notes-narrative-ci-automation-requirements.md
+---
+
+# Wire CI automation for release-notes-narrative skill
+
+## Overview
+
+Automate the v1 `release-notes-narrative` skill so every `semantic-release` publish on `main` produces a narrative GitHub release body without manual intervention. Wire `@semantic-release/exec` into `.releaserc.yaml`; its `successCmd` dispatches the existing `fro-bot.yaml` workflow with a prompt that loads the bundled skill and patches the just-published release. Reuses Fro Bot infrastructure end-to-end. No new TypeScript scripts. No new render path. The skill stays the canonical procedure for both manual and CI runs.
+
+## Problem Frame
+
+`v2.22.0` shipped with an auto-generated one-liner release body and was only rewritten to narrative after an operator manually ran the v1 skill against the just-published tag — proving inside its own release cycle that manual invocation is unreliable. v2 closes the loop by making the dispatch automatic at the moment of publish.
+
+The brainstorm fully grounded this against the codebase: `@semantic-release/exec`'s `successCmd` is the cleanest synchronous post-publish hook (`fro-bot.yaml:152,173` confirms `FRO_BOT_PAT` is the relevant write credential, not the workflow `GITHUB_TOKEN`); `gh workflow run` does not return a parseable run ID so polling is required; failure modes must split into narrative (fail-soft) vs security-relevant (fail-hard).
+
+## Requirements Trace
+
+- R1. Trigger fires on every successful `semantic-release` publish from `main` (see origin: R1)
+- R2. Hook dispatches `fro-bot.yaml` via `gh workflow run` (see origin: R2)
+- R3. SuccessCmd waits for dispatched run via polling + `gh run watch`, bounded 10 min (see origin: R3)
+- R4. Exit 0 for narrative-generation failures (see origin: R4)
+- R5. Exit non-zero for security-relevant failures + Actions annotations on both classes (see origin: R5)
+- R6. Prompt names target tag + bundled skill path + constrains scope (see origin: R6)
+- R7. Skill at `.agents/skills/release-notes-narrative/SKILL.md` is the procedure; CI-only concerns may live in v2 infrastructure alongside (see origin: R7)
+- R8. Fro Bot uses `FRO_BOT_PAT`; scope must be confirmed pre-merge (see origin: R8)
+- R9. `@semantic-release/exec` added as devDependency, placed AFTER `@semantic-release/github` (see origin: R9)
+- R10. SuccessCmd emits stdout + Actions annotations (see origin: R10)
+- R11. Synthetic smoke test covers prompt construction + polling + annotation paths (see origin: R11)
+
+## Scope Boundaries
+
+- **Out of scope: rendering changes in the skill.** v2 inherits v1's render contract verbatim.
+- **Out of scope: HUMAN:KEEP sentinel preservation.** Still deferred from v1.
+- **Out of scope: auto-issue-creation on Fro Bot failure.** Actions annotations + dispatched-run status are the visibility surface.
+- **Out of scope: multi-release backfill.** v2 fires on each new release going forward.
+- **Out of scope: alternative LLM providers.** Fro Bot is the LLM; no fallback.
+- **Out of scope: rate-limiting / throttling.** Releases ship rarely enough.
+- **Out of scope: a dedicated release-notes-only workflow.** Reusing `fro-bot.yaml` via `workflow_call` is accepted coupling; extraction is a future iteration.
+- **Out of scope: end-to-end live test before merge.** Cannot fully exercise the workflow_call→Fro Bot agent→`gh release edit` chain without a real release. U2 covers what is testable.
+
+### Deferred to Separate Tasks
+
+- **`@semantic-release/exec` plugin-load failure regression test:** Untested in this plan. Mitigation rationale: `bun install` (U1 verification) catches missing/broken package; semantic-release's own error reporting surfaces plugin-load failures with clear messages. Adding a synthetic test that mocks plugin-load failure is low-ROI for v2.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `.releaserc.yaml` — current plugin order: commit-analyzer → release-notes-generator → npm → github → semantic-release-export-data
+- `.github/workflows/fro-bot.yaml:24-29` — `workflow_call` accepts `prompt` input
+- `.github/workflows/fro-bot.yaml:152,173` — `FRO_BOT_PAT` is the write credential (not `GITHUB_TOKEN`)
+- `.github/workflows/fro-bot.yaml:160-178` — `fro-bot/agent` action consumes `prompt` as direct LLM instruction
+- `.github/workflows/fro-bot.yaml:env:SCHEDULE_PROMPT` — canonical multi-paragraph instruction style for `workflow_call` prompts (use as model for v2's prompt shape)
+- `scripts/content-integrity.ts`, `scripts/generate-registry.ts`, `scripts/build-registry.ts`, `scripts/generate-config-schema.ts` — existing TypeScript Bun scripts (convention reference; v2 does NOT add a script)
+- `tests/integration/` — existing integration test directory using `bun:test`
+- `.agents/skills/release-notes-narrative/SKILL.md` — the v1 procedure (v2 dispatches Fro Bot to run this)
+
+### Institutional Learnings
+
+- `docs/solutions/developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md` — confirms `gh release edit` (not commit-message bodies) is the only mechanism for narrative release notes
+- `docs/solutions/best-practices/release-notes-narrative-procedure-2026-05-23.md` — v1's procedure compound doc; v2 references it from the architecture compound doc
+- Memory `#3082` and `#3014` — push/PR confirmation discipline (applies to U5 commit)
+- Memory `#3128` — `@semantic-release/exec` is auto-grouped under `build:` commit-type via existing `@semantic-release/{/,}**` Renovate rule (verified at `.github/renovate.json5:17-24`); no separate Renovate config needed
+
+### External References
+
+(Skipped — brainstorm grounded this against documented `@semantic-release/exec` behavior; no version-specific external research warranted.)
+
+## Key Technical Decisions
+
+- **Inline successCmd (no helper script).** The `successCmd` is a multi-line bash string in `.releaserc.yaml`, not a separate `scripts/dispatch-release-notes.sh`. Rationale: the logic is bounded (dispatch + poll + watch + annotate, <80 lines after hardening), `@semantic-release/exec` accepts inline multi-line YAML cleanly, and a separate script adds a second editing surface for little gain. If the logic grows beyond ~100 lines in a future iteration, then extract.
+- **Lodash template, then bash.** `@semantic-release/exec` resolves `${nextRelease.gitTag}` (and other context keys like `${nextRelease.version}`) via Lodash templating BEFORE handing the resulting string to the shell. After resolution, the bash block sees a literal value like `v2.23.0`. Implementer must use `${...}` for Lodash-template context, and `$VAR` for runtime bash variables. Mixing the two in the same expression is a common source of bugs.
+- **Correlation-token-based polling.** `gh workflow run` accepts arbitrary `-f` inputs but they are not surfaced in `gh run list` output. To uniquely identify OUR dispatch, generate a UUID via `CORRELATION_ID="$(uuidgen)"` (or `cat /proc/sys/kernel/random/uuid`), pass it both as a `-f correlation-id=$CORRELATION_ID` field AND inside the prompt instructing Fro Bot to echo it as the first log line. Match by polling `gh run list --workflow=fro-bot.yaml --branch=main --json databaseId,createdAt --limit 10`, then for each candidate run `gh run view <id> --log --limit 50 | grep -q "correlation=$CORRELATION_ID"`. This eliminates same-second collision ambiguity. Bounded by a 90-second polling window (60s for dispatch registration + 30s for first log line to appear).
+- **RELEASE_VERSION input validation.** Before any prompt construction or shell interpolation, validate `RELEASE_VERSION` against `^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$` (semver-shaped tag with optional pre-release). If validation fails, emit `::error::Invalid RELEASE_VERSION shape: <value>` and exit 1 (security-relevant: malformed input could indicate a tag-spoofing attempt or semantic-release misconfiguration). Defense-in-depth: even though `nextRelease.gitTag` is internally generated by semantic-release from versioned commit analysis, validating at the boundary catches future plugin upgrades that might change the contract.
+- **`$GITHUB_REPOSITORY` for runtime env access.** Do NOT use `${{ github.repository }}` inside the bash block — workflow expressions are not interpolated inside `successCmd` strings (which run on the runner, not in the YAML preprocessor). Use the runtime env var `$GITHUB_REPOSITORY` instead (automatically set by GitHub Actions in every runner step). Verify with a unit test that the rendered prompt contains the literal repo name, not a workflow-expression syntax artifact.
+- **Security-relevant failure signal list.** Treat as security-relevant (emit `::error::` annotation + exit 1):
+  - Conclusion classifications: `failure`, `cancelled` (when caused by external policy), `action_required`, `skipped` (workflow_call skipped means policy/branch protection blocked dispatch)
+  - Log content signals: `HTTP 401`, `HTTP 403`, `Bad credentials`, `Resource not accessible`, `requires authentication`, `permission denied`
+  - Off-target release edits: `gh run view <id> --log | sed 's/\x1b\[[0-9;]*m//g' | grep -E 'release edit v[0-9]+\.[0-9]+\.[0-9]+'` produces a tag OTHER than `$RELEASE_VERSION`. Strip ANSI codes before matching to handle colored output
+  - Post-write integrity check fails: after Fro Bot completes, `gh release view $RELEASE_VERSION --json body --jq '.body | length'` returns a length less than 200 chars (indicating Fro Bot wrote a partial/empty body when narrative was expected)
+  - Dispatched workflow run not found within 60s of `gh workflow run` (separate signal from log-content failures — means GitHub rejected the dispatch)
+- **Narrative-failure signal list.** Treat as narrative-failure (emit `::warning::` annotation + exit 0):
+  - Conclusion classifications: generic `failure` without security signals, `cancelled` (when caused by manual operator cancellation OR runner timeout)
+  - Log content signals: model timeout, OpenCode agent error, generic non-zero exits without auth/permission keywords
+  - Conclusion `neutral` (treat as no-action-taken; release body remains semantic-release's auto-generated default; not security)
+- **Retry idempotency contract.** If the Release job is re-run after a transient failure (e.g., the v2.22.0 oven-sh/setup-bun retry pattern observed this session), the successCmd will fire again against the same tag. The v1 skill's procedure already includes a preflight that detects existing narrative markers (look for `## What's new` heading at the start of the body). The v2 successCmd instructs Fro Bot to: "If the existing release body already contains `## What's new` as its first heading, treat this as already-applied and exit cleanly without making changes." This makes the full chain idempotent.
+- **Skip annotation emission for happy path.** Stdout already carries the success signal (target tag, run URL, conclusion). Annotations are reserved for failures — `::warning::` for narrative, `::error::` for security. Avoids noise in the GitHub Actions UI for routine successful releases.
+- **Smoke test scope.** U2 covers: RELEASE_VERSION validation, prompt-string construction, `gh run list` JSON parser logic (mock its output), correlation-token matching, conclusion classifier branches (including all expanded taxonomy), annotation emission for each failure class. It does NOT mock the full Fro Bot dispatch — the test is shell-logic-level. End-to-end behavior is gated by the first real release post-merge.
+- **`@semantic-release/exec` plugin position.** Inserted between `@semantic-release/github` and `semantic-release-export-data`. The brainstorm verified there is no load-bearing ordering against `semantic-release-export-data`; this position is chosen for log readability (success hook fires immediately after github, before export-data writes its outputs).
+
+## Open Questions
+
+### Resolved During Planning
+
+- Renovate group config for `@semantic-release/exec`: Resolved. Existing `@semantic-release/{/,}**` rule at `.github/renovate.json5:17-24` already covers it with `semanticCommitType: 'build'`. No Renovate config change required.
+- Prompt shape: Resolved. Modeled after `fro-bot.yaml`'s `SCHEDULE_PROMPT` — multi-paragraph, instruction-heavy, explicit resource names, explicit scope constraints. Full text in Unit 1.
+- Polling-match strategy: Resolved via correlation-token approach. See "Correlation-token-based polling" in Key Technical Decisions. Replaces the earlier `createdAt > dispatched_at` strategy after adversarial review surfaced same-second collision risk.
+- Security-signal list: Resolved. Expanded enum in Key Technical Decisions covers auth keywords, off-target edits (ANSI-stripped), post-write integrity, and policy-blocked conclusions. May tighten after first real release if false positives surface.
+- Conclusion taxonomy: Resolved. All known GitHub Actions conclusions (`success`, `failure`, `cancelled`, `skipped`, `neutral`, `action_required`, `timed_out`) explicitly classified.
+- RELEASE_VERSION validation: Resolved. Regex `^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$` validates input before interpolation.
+- Retry idempotency: Resolved. Skill preflight detects existing narrative; successCmd instructs Fro Bot to short-circuit when applied.
+- **FRO_BOT_PAT scope confirmation.** Resolved as a pre-merge gate with a concrete verification method: implementer must either (a) screenshot the FRO_BOT_PAT scope listing from GitHub Settings → Developer Settings → Personal Access Tokens, confirming the PAT has `repo` or fine-grained `releases: write` + `contents: write` scope, and attach to the PR description; OR (b) cite the v2.22.0 manual `gh release edit` audit URL (https://github.com/marcusrbrown/systematic/releases/tag/v2.22.0) which already demonstrated write success under this PAT. Acceptance criterion: PR description includes one of those two evidence items before merge.
+
+### Deferred to Implementation
+
+- **Exact `gh run view --log | grep` patterns after seeing real `fro-bot/agent` log output.** The expanded signal list (HTTP 401/403, Bad credentials, etc.) is best-effort; first real release exercises it. If false positives or negatives surface, next iteration tightens. This is genuinely unknowable from the plan side because `fro-bot/agent`'s log format varies by model and prompt.
+- **`workflow_call` checkout ref resolution.** `fro-bot.yaml`'s checkout uses a conditional `ref:` expression that defaults to `''` (empty) under workflow_dispatch contexts. Empty ref tells `actions/checkout` to use the workflow's commit, which for a `gh workflow run --ref main` invocation resolves to `refs/heads/main`. Combined with `fetch-depth: 0`, this provides all tags including the just-created `$RELEASE_VERSION` tag. Verified by reading `fro-bot.yaml:142-152`. Implementer should add a defensive `git fetch --tags --force origin` step at the start of the Fro Bot prompt's procedure to handle race conditions where the tag is not yet visible at checkout time.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add @semantic-release/exec and implement successCmd**
+
+**Goal:** Wire the post-publish hook end-to-end: dependency addition, plugin registration, full successCmd logic.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R8, R9, R10
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `package.json` (add `@semantic-release/exec` to devDependencies)
+- Modify: `bun.lock` (regenerated by `bun install`)
+- Modify: `.releaserc.yaml` (add `@semantic-release/exec` plugin entry with multi-line successCmd)
+
+**Approach:**
+
+The `.releaserc.yaml` plugin entry is shaped:
+
+```yaml
+- - '@semantic-release/exec'
+  - successCmd: |
+      <multi-line bash block>
+```
+
+The successCmd does this in order:
+1. Lodash template substitutes `${nextRelease.gitTag}` BEFORE shell execution. The resulting bash sees a literal version like `v2.23.0`. Capture as `RELEASE_VERSION="v2.23.0"` (Lodash output).
+2. Validate `RELEASE_VERSION` against `^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$`. On mismatch: `::error::Invalid RELEASE_VERSION shape: $RELEASE_VERSION` + exit 1.
+3. Generate correlation token: `CORRELATION_ID="$(cat /proc/sys/kernel/random/uuid)"` (or `uuidgen` if available; the Ubuntu runner has both).
+4. Construct the prompt as a heredoc; include target tag, correlation token (Fro Bot must echo `correlation=$CORRELATION_ID` as its first log line), bundled skill path, scope constraints (no comments, no issue creation, no PR-body edits), and the idempotency contract (if existing body already has `## What's new` as first heading, short-circuit).
+5. Dispatch: `gh workflow run --ref main fro-bot.yaml -f "prompt=$PROMPT" -f "correlation-id=$CORRELATION_ID"` (capture stdout for the dispatch URL).
+6. Poll up to 90s for a matching run:
+   - Every 5s, `gh run list --workflow=fro-bot.yaml --branch=main --json databaseId,createdAt --limit 10`
+   - For each candidate, fetch first 50 log lines: `gh run view <id> --log --limit 50 2>/dev/null | grep -q "correlation=$CORRELATION_ID"`
+   - First matching `databaseId` is OUR run. Break.
+   - On no-match-after-90s: `::error::Dispatched workflow run not found within 90s" + exit 1 (security-relevant; dispatch was rejected by GitHub or workflow never started).
+7. `timeout 600 gh run watch "$RUN_ID" --exit-status` (10-minute hard timeout). Capture exit code as `WATCH_EXIT`.
+8. Fetch conclusion: `CONCLUSION="$(gh run view "$RUN_ID" --json conclusion --jq '.conclusion')"`.
+9. Fetch full log (for grep-based analysis): `LOG="$(gh run view "$RUN_ID" --log 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g')"` (strips ANSI codes).
+10. Off-target check: `OFF_TARGET="$(echo "$LOG" | grep -E 'release edit v[0-9]+\.[0-9]+\.[0-9]+' | grep -v "release edit $RELEASE_VERSION" || true)"`. If non-empty: security-relevant.
+11. Auth-keyword check: `echo "$LOG" | grep -qE 'HTTP 401|HTTP 403|Bad credentials|Resource not accessible|requires authentication|permission denied'`. If matches: security-relevant.
+12. Post-write integrity check: `BODY_LEN="$(gh release view "$RELEASE_VERSION" --json body --jq '.body | length')"`. If `CONCLUSION == success` AND `BODY_LEN < 200`: security-relevant (Fro Bot reported success but body looks empty/partial).
+13. Classify outcome by precedence:
+    - WATCH_EXIT == 124 (timeout) → `::warning::Fro Bot run timed out" + exit 0 (narrative-failure)
+    - OFF_TARGET non-empty → `::error::Off-target release edit detected: $OFF_TARGET" + exit 1 (security)
+    - Auth keywords match → `::error::Auth failure in dispatched run" + exit 1 (security)
+    - CONCLUSION in {failure} AND auth match → covered above
+    - CONCLUSION == action_required → `::error::Workflow requires manual intervention" + exit 1 (security; policy/branch protection blocked)
+    - CONCLUSION == skipped → `::error::Workflow was skipped (likely policy/branch protection)" + exit 1 (security)
+    - CONCLUSION == cancelled → `::warning::Workflow cancelled" + exit 0 (narrative-failure; treat as transient)
+    - CONCLUSION == success AND BODY_LEN < 200 → `::error::Reported success but body integrity check failed (BODY_LEN=$BODY_LEN)" + exit 1 (security)
+    - CONCLUSION == success → log target tag + run URL + "narrative applied (correlation=$CORRELATION_ID)" + exit 0
+    - CONCLUSION == neutral → log "no-action-taken (likely already-applied)" + exit 0 (the skill's idempotency short-circuit; expected on Release job re-runs)
+    - CONCLUSION == failure (no other signals) → `::warning::Fro Bot run failed (narrative-failure)" + exit 0
+    - Any other CONCLUSION → `::warning::Unknown conclusion: $CONCLUSION" + exit 0 (defaults to narrative-failure for forward-compat)
+
+Prompt text (canonical shape — concrete; do NOT abbreviate during implementation; `$RELEASE_VERSION`, `$CORRELATION_ID`, and `$GITHUB_REPOSITORY` are runtime bash env vars expanded by the heredoc):
+
+```
+correlation=$CORRELATION_ID
+
+You are running the release-notes-narrative skill against a just-published GitHub release.
+First, echo the line "correlation=$CORRELATION_ID" to stdout (the line above this prompt) so
+the dispatching workflow can identify this run. This is mandatory.
+
+Target release tag: $RELEASE_VERSION
+Target repository: $GITHUB_REPOSITORY
+
+Idempotency check (do this FIRST):
+- Fetch the current release body: `gh release view $RELEASE_VERSION --json body --jq '.body'`
+- If the body starts with the heading `## What's new`, the narrative has already been applied.
+  Log "already-applied; short-circuiting" and exit cleanly. Conclusion will be reported as `neutral`.
+
+Procedure (only if idempotency check did NOT short-circuit):
+1. Load the skill at .agents/skills/release-notes-narrative/SKILL.md from this checkout.
+2. Execute the 13-step procedure against tag $RELEASE_VERSION.
+3. Apply the rendered body via `gh release edit $RELEASE_VERSION --notes-file <tmpfile>`.
+
+Scope constraints (do not violate):
+- Do NOT comment on any PR, issue, or discussion.
+- Do NOT open or close any issue.
+- Do NOT edit any release body OTHER than $RELEASE_VERSION.
+- Do NOT modify any file in the repository.
+- Do NOT push commits, create branches, or create tags.
+
+Report back with: the target tag, the chars-before and chars-after counts, and the
+GitHub release URL.
+```
+
+The full bash block fits in ~50 lines including comments and shellcheck-friendly quoting. No external helper script.
+
+**Patterns to follow:**
+- `.releaserc.yaml` existing plugin entries (the `@semantic-release/github` entry uses the same `- - '<plugin>' / - <key>: <value>` array-of-tuples shape)
+- `scripts/content-integrity.ts:1-20` for shellcheck-style bash quoting conventions (referenced for style; v2 uses bash inline)
+- `fro-bot.yaml:env:SCHEDULE_PROMPT` for prompt instruction style
+
+**Test scenarios:**
+None — Unit 1 is configuration; behavioral coverage lives in Unit 2.
+
+**Verification:**
+- `bun install` succeeds and `bun.lock` updates cleanly with `@semantic-release/exec` resolved at version `^7.x`
+- `.releaserc.yaml` parses as valid YAML (`bun -e "import('yaml').then(y => y.parse(require('fs').readFileSync('.releaserc.yaml','utf8')))"` or equivalent)
+- The semantic-release dry-run on a feature branch (which has `DRY_RUN=true` per `.github/workflows/main.yaml:170`) loads the exec plugin without parse errors. NOTE: dry-run does NOT execute `successCmd` (semantic-release skips success hooks in dry-run mode), so live verification waits until the first real merge to main.
+- Pre-merge gate: PR description includes ONE of (a) screenshot of `FRO_BOT_PAT` scope listing from GitHub PAT settings showing `repo` or fine-grained `releases: write` + `contents: write`, OR (b) link to v2.22.0 release URL as evidence of prior write success under this PAT.
+- Shellcheck (if available locally; `brew install shellcheck`): extract the successCmd block and verify zero ShellCheck warnings. Optional but recommended.
+
+- [ ] **Unit 2: Smoke test for successCmd logic**
+
+**Goal:** Cover prompt construction, polling filter logic, conclusion classification, and annotation emission with a synthetic test that does NOT require dispatching a real Fro Bot run.
+
+**Requirements:** R11
+
+**Dependencies:** None (parallel-safe with Unit 1)
+
+**Files:**
+- Create: `tests/integration/release-notes-ci.test.ts`
+
+**Approach:**
+
+The integration test treats the successCmd's bash logic as a unit under test. Strategy:
+
+1. Extract the successCmd's classification logic into a testable shape. Since the successCmd is a bash heredoc inside `.releaserc.yaml`, the test cannot import it. Two viable options:
+   - Option A: The test reads `.releaserc.yaml`, extracts the successCmd block, writes it to a temp shell file, and invokes it with mocked `gh` and `jq` PATH entries (a `scripts/test-helpers/mock-gh.sh` shim that prints predetermined fixtures based on `$1`).
+   - Option B: The test invokes the successCmd's bash inline via `Bun.spawn('bash', ['-c', '<extracted block>'], { env: { PATH: 'tests/fixtures/mock-bin:...' }})`.
+
+   Choose Option A — easier to debug; the mock shim is reusable for future tests; the extraction-from-yaml step is itself a useful regression check that the successCmd block is well-formed.
+
+2. Mock fixtures cover:
+   - `gh workflow run` → prints "Created workflow_dispatch event for fro-bot.yaml at refs/heads/main" (real CLI output shape)
+   - `gh run list` → prints JSON matching the expected jq filter, with controlled `createdAt` values
+   - `gh run watch` → exits with controlled status code
+   - `gh run view --log` → prints controlled log content (success body, 401 body, off-tag-edit body, etc.)
+   - `gh run view --json conclusion` → prints `{"conclusion":"success|failure|cancelled"}`
+
+3. Scenarios to cover:
+
+**Patterns to follow:**
+- `tests/integration/opencode.test.ts` for integration-test structure with `bun:test`
+- `tests/unit/content-integrity.test.ts` for fixture-driven shell-script testing patterns
+
+**Test scenarios:**
+
+- **Validation — invalid RELEASE_VERSION.** Run successCmd with `RELEASE_VERSION="not-a-tag"`. Expect: `::error::Invalid RELEASE_VERSION shape"; exit 1; no `gh workflow run` invocation occurs.
+- **Validation — valid pre-release.** Run with `RELEASE_VERSION="v2.23.0-rc.1"`. Expect: validation passes; dispatch proceeds.
+- **Happy path — success conclusion + valid body length.** Mock `gh run watch` exits 0, conclusion=`success`, post-write `gh release view --json body` returns body with length 800. Expect: stdout contains target tag + run URL + "narrative applied (correlation=...)"; no annotation emitted; exit 0.
+- **Happy path — neutral conclusion (idempotent short-circuit).** Mock conclusion=`neutral`. Expect: stdout contains "no-action-taken"; no annotation; exit 0.
+- **Edge case — timeout (WATCH_EXIT=124).** Mock `gh run watch` exits 124. Expect: `::warning::` annotation containing "timed out"; exit 0.
+- **Edge case — dispatch not registered within 90s.** Mock `gh run list` always returns no candidate matching correlation token. Expect: `::error::` annotation containing "not found within 90s"; exit 1.
+- **Edge case — correlation token matches second-newest run, not first.** Mock `gh run list` returns 2 runs: newest has log content NOT matching correlation; second has matching correlation. Assert second run's `databaseId` is used.
+- **Error path — HTTP 401 auth denial.** Mock conclusion=`failure`, log contains `HTTP 401: Bad credentials`. Expect: `::error::` annotation containing "Auth failure"; exit 1.
+- **Error path — HTTP 403 + permission denied.** Mock conclusion=`failure`, log contains both `HTTP 403` and `permission denied`. Expect: `::error::` annotation; exit 1.
+- **Error path — "Resource not accessible" auth keyword.** Mock conclusion=`failure`, log contains `Resource not accessible by integration`. Expect: `::error::`; exit 1.
+- **Error path — off-target tag edit (ANSI-stripped).** Mock conclusion=`failure`, log contains ANSI-colored `\x1b[31mgh release edit v9.9.9\x1b[0m` while target is `v2.23.0`. Expect: after ANSI strip, off-target detection fires; `::error::` annotation containing "Off-target"; exit 1.
+- **Error path — success conclusion but body too short.** Mock conclusion=`success`, body length=50. Expect: `::error::` containing "body integrity check failed"; exit 1.
+- **Error path — action_required conclusion.** Mock conclusion=`action_required`. Expect: `::error::` containing "manual intervention"; exit 1.
+- **Error path — skipped conclusion (policy block).** Mock conclusion=`skipped`. Expect: `::error::` containing "policy/branch protection"; exit 1.
+- **Edge case — cancelled conclusion.** Mock conclusion=`cancelled`. Expect: `::warning::` annotation; exit 0.
+- **Edge case — generic narrative failure.** Mock conclusion=`failure`, log contains no security signals, no off-target edits. Expect: `::warning::`; exit 0.
+- **Edge case — unknown future conclusion.** Mock conclusion=`some_new_value`. Expect: `::warning::` containing "Unknown conclusion"; exit 0 (forward-compat).
+- **Integration — prompt construction includes correlation token, target tag, repo name.** Run successCmd with `RELEASE_VERSION=v2.23.0`, `GITHUB_REPOSITORY=marcusrbrown/systematic`. Capture the `gh workflow run -f prompt=...` invocation via mock-gh; assert the prompt contains all three values literally (not as workflow-expression syntax artifacts).
+- **Integration — prompt requires Fro Bot to echo correlation as first line.** Assert the prompt's first line is `correlation=<the-uuid>` and that the instruction text explicitly requires Fro Bot to echo it.
+
+**Verification:**
+- All 10 scenarios pass under `bun test tests/integration/release-notes-ci.test.ts`
+- The mock-gh shim is repo-checked-in and has its own shebang + execute permission
+- The extracted-from-yaml step in the test fails loudly if `.releaserc.yaml` is missing the successCmd block (prevents drift between U1 and U2)
+
+- [ ] **Unit 3: Cross-reference v2 in v1 skill and procedure doc**
+
+**Goal:** Surface the CI automation path in both the user-facing skill (so manual runs know they're now the exception) and the v1 architecture doc (so the corpus stays current).
+
+**Requirements:** R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `.agents/skills/release-notes-narrative/SKILL.md` (add a "CI automation" section near the top explaining that the skill now also runs automatically post-publish; describe what changes for manual invocation)
+- Modify: `docs/solutions/best-practices/release-notes-narrative-procedure-2026-05-23.md` (append a brief addendum at the bottom: "v2 (2026-05-23): CI automation now dispatches this procedure on every semantic-release publish via `@semantic-release/exec` successCmd → `fro-bot.yaml` workflow_call. See [v2 architecture doc].")
+
+**Approach:**
+- Skill addition is 5-10 lines under a new `## CI Automation (v2)` heading immediately after the `description:` frontmatter block; reads as procedure-context, not procedure-modifier (the 13 steps stay verbatim)
+- Procedure doc addition is a single trailing section: `## Update: v2 CI Automation (2026-05-23)` with a 3-sentence summary and a forward-link to U4's compound doc
+
+**Patterns to follow:**
+- v1 skill's existing `## Overview` and `## Prerequisites` heading style
+- v1 procedure doc's existing section structure
+
+**Test scenarios:**
+Test expectation: none — pure documentation; no behavioral change.
+
+**Verification:**
+- `bun scripts/content-integrity.ts` passes (no phantom systematic refs; no banned CC/CEP patterns introduced)
+- Cross-references resolve: the procedure-doc forward-link points at the actual U4-created file
+
+- [ ] **Unit 4: Compound the v2 architecture into a solution doc**
+
+**Goal:** Capture the v2 architecture as a durable institutional learning. Distinct doc from v1's procedure doc — v1 was about WHAT (the procedure); v2 is about HOW it integrates with CI.
+
+**Requirements:** Memory `#15` (compound docs in same branch as implementation)
+
+**Dependencies:** Unit 3 (so this doc can cross-reference both v1's procedure and the just-modified v1 skill)
+
+**Files:**
+- Create: `docs/solutions/best-practices/release-notes-narrative-ci-automation-architecture-2026-05-23.md`
+
+**Approach:**
+Doc structure follows `skills/ce-compound/references/schema.yaml`. Frontmatter: `track: best_practice`, `module: release-pipeline`, `tags: [semantic-release, ci-automation, llm-in-ci, github-actions, workflow-call]`. Body:
+- **Context** — why v2 exists (v2.22.0 proved manual invocation is unreliable)
+- **Architecture** — the trigger chain: `npx semantic-release` → `@semantic-release/github` publishes → `@semantic-release/exec` successCmd → `gh workflow run fro-bot.yaml` → polling + `gh run watch` → annotation + exit
+- **Key design decisions** — fail-soft for narrative / fail-hard for security split; `FRO_BOT_PAT` (not `GITHUB_TOKEN`) is the write credential; inline bash over external script; polling required because `gh workflow run` doesn't return run ID
+- **Failure modes and detection** — the 8 scenarios from U2's test matrix
+- **What we did NOT do** — explicit list: no separate workflow; no auto-issue-creation; no synthetic end-to-end mock; no fallback LLM provider
+- **Forward references** — link to v1 procedure doc, v1 skill, brainstorm, plan
+
+**Patterns to follow:**
+- `docs/solutions/best-practices/release-notes-narrative-procedure-2026-05-23.md` (the v1 doc this complements)
+- `docs/solutions/best-practices/provider-availability-source-defaults-2026-05-12.md` (another architecture-track best-practice doc; similar shape)
+
+**Test scenarios:**
+Test expectation: none — pure documentation.
+
+**Verification:**
+- `bun scripts/content-integrity.ts` clean
+- Frontmatter validates against `skills/ce-compound/references/schema.yaml`
+- All cross-references resolve
+
+## System-Wide Impact
+
+- **Interaction graph:** `.releaserc.yaml` now has 6 active plugins (was 5). The Release job in `main.yaml` gains an effective post-publish step via the new exec plugin but does not need its own YAML edit. `fro-bot.yaml` gains a new caller (Release job in main.yaml) but its surface is unchanged.
+- **Error propagation:** Narrative-failure stops at the Release job's successCmd (exit 0); the dispatched Fro Bot run's status remains as the operator-visible signal. Security-failure propagates as a non-zero exit from the successCmd, which `semantic-release` reports as a failed publish hook. CRITICAL: `@semantic-release/github`'s publish has ALREADY succeeded by the time successCmd runs; the GitHub release IS live regardless of successCmd outcome. The "failed publish hook" status is cosmetic on the Release job, not transactional rollback.
+- **State lifecycle risks:** None. The successCmd does not create persistent state; the dispatched workflow run is auditable via Actions UI; the release body edit is idempotent (running the skill twice produces the same narrative body).
+- **API surface parity:** None. `.releaserc.yaml` is a private build-config artifact; semantic-release plugin order is a runtime contract but our change is additive (one new plugin) and well-bounded.
+- **Integration coverage:** End-to-end chain (workflow_call → Fro Bot agent → `gh release edit` → live release body) cannot be exercised by unit tests. First real release post-merge is the integration validation. U2 covers all paths the successCmd controls; what it cannot cover is whether Fro Bot's agent actually follows the prompt instructions correctly under real LLM conditions.
+- **Unchanged invariants:** v1 skill body unchanged. `fro-bot.yaml` workflow definition unchanged. `main.yaml` Release job's steps unchanged. semantic-release plugin order's existing entries unchanged (only one entry inserted).
+
+## Risks & Dependencies
+
+### Load-bearing (active mitigation required)
+
+| Risk | Mitigation |
+|------|------------|
+| `FRO_BOT_PAT` lacks `releases: write` (or `contents: write`) scope | Pre-merge verification step in PR description (see Open Questions → Resolved During Planning). PR description must contain one of two evidence items before merge; v2.22.0's manual `gh release edit` already demonstrated write success under this PAT, but explicit confirmation is required. |
+| Fro Bot prompt drift — future Fro Bot config changes could alter how `inputs.prompt` is consumed | Prompt is explicit + multi-paragraph + names exact resources. If the `fro-bot/agent` action upgrades and changes prompt semantics, the v2 successCmd may emit a malformed body. Detection: the first release after a Fro Bot upgrade exercises this; U4's compound doc names Fro Bot as a coupled dependency. |
+| Conclusion taxonomy gap (new GitHub Actions conclusion value introduced in future) | Default branch in conclusion classifier emits `::warning::` + exit 0 (narrative-failure) for any unrecognized conclusion. Detection: log content captures the actual conclusion string so the gap is visible in CI history. Mitigation: tighten classifier when new conclusion appears. |
+| `@semantic-release/exec` Lodash-template surface changes between versions | Pin range is `@semantic-release/exec@^7` (matching semantic-release@25). `nextRelease.gitTag` is documented as stable in exec README. Verify in U1's `bun install` step. |
+| LLM idempotency on retry — if successCmd fires twice for same tag (Release job re-run), Fro Bot might re-render and overwrite | Mitigated by skill preflight: prompt instructs Fro Bot to short-circuit when existing body already has narrative markers. Test scenario in U2 covers this. |
+
+### Observed but acceptable
+
+| Risk | Why acceptable |
+|------|----------------|
+| Polling false-match across same-second `workflow_dispatch` runs | Eliminated by correlation-token matching (see Key Technical Decisions). Original `createdAt`-only filter is no longer used. |
+| Real LLM nondeterminism varying narrative quality | v1 already proved quality across 4 retroactive releases. v2 inherits skill verbatim; this is not a v2-introduced risk. If quality degrades, fix lands in skill body. |
+| Plugin order regression (someone inserts a plugin between github and exec in a future PR) | Low likelihood; `.releaserc.yaml` is rarely edited. If it happens, the successCmd may fire before npm/github finish, producing a release-edit on an incomplete release. Detection: real-release exercises this. Documented in U4's compound doc as a coupling note. |
+| `workflow_call` runner exhaustion or backend hiccup causing dispatch to register but never start | 90s polling window allows for queued workflows; if it still doesn't appear, `::error::` exit (security-relevant signal because the operator needs to know). Manual remediation via re-run from Actions UI. |
+
+## Documentation / Operational Notes
+
+- PR description for this work includes a pre-merge checklist item: "Confirm `FRO_BOT_PAT` has releases-write scope OR has demonstrated write success via prior `gh release edit` runs in this repo's history."
+- The first release after merge is the live acceptance gate. If that release's body is NOT narrative within 10 minutes of `gh release list` showing the tag, manually invoke the v1 skill and treat as a v2 regression (open follow-up issue, do not roll back).
+- v4's compound doc names ongoing operational gotchas (plugin-order regression, Fro Bot upgrade coupling) so future operators have the context.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-23-release-notes-narrative-ci-automation-requirements.md](../brainstorms/2026-05-23-release-notes-narrative-ci-automation-requirements.md)
+- Related code: `.releaserc.yaml`, `.github/workflows/fro-bot.yaml`, `.github/workflows/main.yaml`, `.agents/skills/release-notes-narrative/SKILL.md`
+- Related PRs/issues: PR #429 (v1 skill landing), v2.22.0 release (live dogfood of the gap this PR closes)
+- External docs: `@semantic-release/exec` README (lifecycle hooks reference, `nextRelease.gitTag` interpolation contract)

--- a/docs/solutions/best-practices/release-notes-narrative-ci-automation-architecture-2026-05-23.md
+++ b/docs/solutions/best-practices/release-notes-narrative-ci-automation-architecture-2026-05-23.md
@@ -1,0 +1,160 @@
+---
+title: Release notes narrative CI automation architecture
+date: 2026-05-23
+category: best-practices
+module: release-pipeline
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - Designing post-publish hooks that dispatch an LLM agent to enrich a just-shipped artifact
+  - Wiring `@semantic-release/exec` to call external automation after a release lands
+  - Dispatching a `workflow_call`-enabled GitHub Actions workflow from inside another workflow and waiting on the result
+  - Splitting CI failure modes into fail-soft (narrative-quality) and fail-hard (security-relevant) classes
+  - Defending against same-second workflow_dispatch race conditions when polling for a freshly dispatched run
+tags:
+  - semantic-release
+  - github-actions
+  - workflow-call
+  - llm-in-ci
+  - fail-soft
+  - correlation-token
+---
+
+# Release notes narrative CI automation architecture
+
+## Context
+
+The v1 `release-notes-narrative` skill (shipped in v2.22.0) produces qualitatively-good release notes when an operator remembers to invoke it. v2.22.0's release cycle proved the manual-invocation gap inside its own publish: the initial auto-generated body was a one-liner, and the narrative version landed only after a manual skill run against the just-published tag. The fix needed to be automatic dispatch on every successful publish from `main`, without any operator-in-the-loop step.
+
+Two architectural constraints shaped the design. First, `@semantic-release/github` does NOT publish in draft mode by default in this repo (no `draftRelease: true` in `.releaserc.yaml`), so the GitHub release is live the moment semantic-release finishes. Any post-publish narrative rewrite is editing an already-public artifact. Second, `release: published` event handlers fire AFTER the body is already visible, so a separate-workflow trigger creates a "bare-body blip" between publish and rewrite. The cleanest synchronous post-publish hook inside the Release job is `@semantic-release/exec`'s `successCmd`, which runs after all publish plugins complete but inside the same workflow run.
+
+The v1 skill's procedure (`.agents/skills/release-notes-narrative/SKILL.md`) is the canonical implementation for both manual and CI runs. v2 does not fork the procedure or introduce a CI-specific render path. The skill stays the single source of truth; CI just dispatches it.
+
+## Architecture
+
+The trigger chain is fully synchronous inside the Release job, with all coordination happening through GitHub-native primitives (no external queues, no broker, no shared state):
+
+```
+.github/workflows/main.yaml: Release job
+  └─ npx semantic-release
+      ├─ @semantic-release/commit-analyzer
+      ├─ @semantic-release/release-notes-generator (produces auto-body)
+      ├─ @semantic-release/npm (publishes to npm)
+      ├─ @semantic-release/github (creates GitHub release; body is live)
+      ├─ @semantic-release/exec (NEW — successCmd fires here)
+      │   └─ inline bash:
+      │       ├─ RELEASE_VERSION = ${nextRelease.gitTag}   ← Lodash template, then bash
+      │       ├─ validate against semver regex             ← reject malformed tags
+      │       ├─ CORRELATION_ID = $(uuidgen)               ← unique per dispatch
+      │       ├─ gh workflow run fro-bot.yaml \
+      │       │     -f prompt=<bundled-skill-prompt> \
+      │       │     -f correlation-id=$CORRELATION_ID
+      │       ├─ poll up to 90s: gh run list | grep correlation in early log lines
+      │       ├─ timeout 600 gh run watch $RUN_ID --exit-status
+      │       ├─ fetch conclusion + log (ANSI-stripped) + post-write body length
+      │       └─ classify: success / neutral / cancelled / timeout / auth-failure /
+      │                   off-target-edit / action_required / skipped / integrity-fail
+      └─ semantic-release-export-data (emits final outputs)
+
+fro-bot.yaml (called via workflow_call)
+  └─ checkout main with FRO_BOT_PAT, fetch-depth: 0
+      └─ fro-bot/agent action (LLM execution)
+          └─ executes prompt:
+              ├─ echo correlation=<token> as first log line (mandatory)
+              ├─ idempotency check: if existing body starts with ## What's new, short-circuit
+              ├─ load .agents/skills/release-notes-narrative/SKILL.md
+              ├─ execute 13-step procedure against target tag
+              └─ apply via gh release edit --notes-file (using FRO_BOT_PAT)
+```
+
+The successCmd is implemented as an inline multi-line YAML literal block (~140 lines) rather than a separate `scripts/dispatch-release-notes.sh`. The logic is bounded, fits cleanly into `.releaserc.yaml`, and avoids a second editing surface for related logic. If the dispatch logic grows beyond ~200 lines in a future iteration, extraction to a script becomes worthwhile.
+
+## Key Design Decisions
+
+### Fail-soft for narrative; fail-hard for security-relevant
+
+The successCmd exits 0 (Release job stays green) for narrative-generation failures: timeouts, generic `failure` conclusion without security signals, `cancelled` conclusion, unknown future conclusion values. The release has already shipped to npm and GitHub by the time successCmd runs, so a failed narrative rewrite is best-effort polish, not part of the publish atomicity contract.
+
+The successCmd exits 1 (Release job goes red) for security-relevant failures: HTTP 401/403, "Bad credentials", "Resource not accessible", "permission denied", `gh release edit` touching a tag other than the target, `action_required` conclusion (policy gate), `skipped` conclusion (branch protection blocked dispatch), post-write integrity failure (success conclusion but body length less than 200 chars).
+
+Both classes also emit GitHub Actions log annotations regardless of exit code: `::warning::` for narrative-failure and `::error::` for security-relevant. This keeps both classes visible in the Actions UI even when the Release job itself is green.
+
+This split was the resolution of an adversarial review finding. The earlier draft committed to exit-0-always, but blanket fail-soft would hide auth failures and prompt-injection attempts under green CI. Splitting by class preserves the "release ships even if narrative fails" guarantee while keeping security signals loud.
+
+### `FRO_BOT_PAT` is the write credential, not `GITHUB_TOKEN`
+
+The `fro-bot.yaml` workflow uses `secrets.FRO_BOT_PAT` (a Personal Access Token) for both its checkout step and the `github-token` input passed to the `fro-bot/agent` action. The workflow-level `permissions: contents: read` applies to the auto-generated `GITHUB_TOKEN` only — it does NOT block `gh release edit` calls that explicitly use the PAT.
+
+This matters because GitHub's reusable-workflow permission rules forbid called workflows from elevating their token scope above the workflow-level declaration. If the `gh release edit` step were using `GITHUB_TOKEN`, it would inherit `contents: read` and fail with HTTP 403. Using the PAT bypasses that rule entirely; the only constraint is that `FRO_BOT_PAT` itself must have `releases: write` (or `contents: write`) scope. v2.22.0's manual `gh release edit` already demonstrated write success under this PAT, providing existence proof of sufficient scope.
+
+The pre-merge gate for the v2 PR requires explicit evidence of PAT scope (either a screenshot of GitHub PAT settings or citation of v2.22.0's successful manual run). Going to production without verifying this gate would deploy a successCmd that silently fails on every release.
+
+### Correlation-token-based polling
+
+`gh workflow run` does NOT return a parseable run ID. Its stdout is a URL string, not JSON. The naive approach of "poll `gh run list` and pick the newest workflow_dispatch run after our dispatch timestamp" is vulnerable to same-second race conditions: a Renovate-scheduled dispatch, a manual operator dispatch, or a runner clock skew can all produce a false match.
+
+The chosen approach: generate a UUID via `uuidgen` (or `cat /proc/sys/kernel/random/uuid` fallback) and pass it as both a `-f correlation-id=$UUID` workflow input AND as the first line of the prompt. The dispatched Fro Bot run is instructed to echo `correlation=<UUID>` as its first log line. Polling matches by scanning the first 50 log lines of each candidate run for the literal token. Only the run that echoed OUR token is OUR run, regardless of dispatch timing.
+
+This eliminates the false-match class entirely. The cost is a 5-second polling interval and an upper-bound 90-second poll budget before the run appears in `gh run list`. Production runs see the matching run within 30-60s in practice; the budget exists for GitHub backend hiccups, not for normal operation.
+
+### Lodash template, then bash
+
+`@semantic-release/exec` resolves `${nextRelease.gitTag}` (and other context keys like `${nextRelease.version}`) via Lodash templating BEFORE handing the resulting string to the shell. After resolution, the bash block sees a literal value like `v2.23.0` — no shell variable expansion is happening at that point.
+
+The implementer must use `${...}` for Lodash-template context keys and `$VAR` for runtime bash variables. Mixing the two in the same expression is a common source of bugs. The successCmd documents this in a header comment, and the integration test verifies it by substituting `${nextRelease.gitTag}` with a bash env var (`${RELEASE_VERSION:-v2.23.0}`) when writing the extracted script to a temp file. Production runs and tests exercise different substitution paths but produce equivalent semantic-release-style and bash-style behavior.
+
+### Skill stays the single source of truth, with optional CI escape hatches
+
+The v1 skill at `.agents/skills/release-notes-narrative/SKILL.md` is the procedure both manual and CI runs follow. CI-specific concerns (correlation token, timeout escape hatches for tests) live in v2 infrastructure (`.releaserc.yaml` successCmd, `RELEASE_NOTES_TEST_*` env vars), not in the skill body. If a procedure gap surfaces during CI runs that does NOT apply to manual runs, the fix lands in v2 infrastructure. If the gap applies to both modes, it lands in the skill.
+
+This split was clarified in document review. The earlier draft insisted on "skill stays the only canonical source" without acknowledging that CI mode has constraints (no operator-in-the-loop, hard timeouts, non-interactive auth) that don't apply to manual runs. The current contract allows v2 to evolve its CI-specific affordances without bloating the skill body, while preserving the skill as the procedure description.
+
+## Failure Modes and Detection
+
+The successCmd classifies all observable outcomes from `gh run watch` + `gh run view` into one of three exit posture classes. The integration test (`tests/integration/release-notes-ci.test.ts`) covers each path with deterministic mock fixtures.
+
+| Outcome | Exit | Annotation | Class |
+|---------|------|------------|-------|
+| `success` + body length ≥ 200 chars | 0 | none | Happy path |
+| `success` + body length < 200 chars | 1 | `::error::` | Integrity failure |
+| `neutral` | 0 | none | Idempotent short-circuit |
+| `failure` + auth keyword in log | 1 | `::error::` | Auth failure |
+| `failure` + off-target tag in log | 1 | `::error::` | Scope abuse |
+| `failure` + no security signals | 0 | `::warning::` | Generic narrative failure |
+| `cancelled` | 0 | `::warning::` | Narrative failure (transient) |
+| `timeout` (WATCH_EXIT=124) | 0 | `::warning::` | Narrative failure (slow Fro Bot) |
+| `action_required` | 1 | `::error::` | Policy gate |
+| `skipped` | 1 | `::error::` | Branch protection block |
+| Unknown future conclusion | 0 | `::warning::` | Narrative failure (forward-compat default) |
+| Dispatched run not found within 90s | 1 | `::error::` | Dispatch rejected/never started |
+
+The auth-keyword check looks for any of: `HTTP 401`, `HTTP 403`, `Bad credentials`, `Resource not accessible`, `requires authentication`, `permission denied`. The off-target check strips ANSI escape codes from the log first (`sed 's/\x1b\[[0-9;]*m//g'`) and then greps for `release edit v<semver>` lines that don't match the target tag. The post-write integrity check fetches `gh release view <tag> --json body --jq '.body | length'` after Fro Bot reports success and asserts the body is at least 200 characters.
+
+The forward-compat default for unknown conclusions emits a `::warning::` and exits 0. New GitHub Actions conclusion values added in future API versions would fall into this bucket — the log message captures the actual conclusion string so the gap is visible in CI history, and a future iteration can tighten the classifier when needed.
+
+## What We Did NOT Do
+
+Several alternatives were explicitly rejected during planning or document review:
+
+- **A dedicated `release-notes-narrative.yaml` workflow** instead of reusing `fro-bot.yaml` via `workflow_call`. Extraction is a meaningful surface-area cost (a second workflow file, separate concurrency group, separate maintenance) for marginal coupling reduction. The accepted coupling risk is documented: if `fro-bot/agent` changes how `inputs.prompt` is consumed, v2 may need to update the prompt format. Detection is the first release after the action upgrade.
+- **Auto-issue-creation on Fro Bot failure.** The fail-soft contract uses Actions annotations plus the dispatched run's own status as the visibility surface. Auto-creating issues for every transient failure would pollute the issue tracker; release frequency is low enough that operator review of failed Actions runs is sufficient.
+- **A fallback LLM provider when Fro Bot is unavailable.** v2 fails-soft on narrative-generation; the release still ships with the auto-generated body, and the operator can manually invoke the skill against an alternative provider if narrative quality matters for that specific release.
+- **Backfill of historical releases on the v2 PR.** v1 already retroactively patched v2.20.5, v2.20.6, v2.21.0, and v2.22.0. v2 fires on each NEW release going forward; older releases remain patchable via manual skill invocation if needed.
+- **An end-to-end synthetic test of the full chain** (`workflow_call` → Fro Bot agent → `gh release edit`). The chain cannot be fully exercised before a real release ships. U2's smoke test covers the prompt construction, polling, watch handling, classification, and annotation paths — everything the successCmd controls. The end-to-end behavior is validated by the first real release after merge.
+- **Cancellation of the Fro Bot run on Release job interrupt.** If the operator cancels the Release job mid-run, the dispatched Fro Bot run continues to completion. This is acceptable because (a) the Fro Bot run is read-mostly until the final `gh release edit`, and (b) the idempotency contract handles re-runs cleanly.
+
+## Operational Considerations
+
+- **Retry semantics.** If the Release job is re-run from the Actions UI after a transient failure (the v2.22.0 oven-sh/setup-bun pattern), the successCmd fires again. The dispatched Fro Bot prompt includes an idempotency check: if the existing release body starts with `## What's new`, treat as already-applied and exit cleanly. The Fro Bot run reports conclusion `neutral` in that case, which the successCmd classifies as a happy-path no-op (exit 0, no annotation).
+- **PAT rotation.** If `FRO_BOT_PAT` is rotated while a release is in flight, the dispatched Fro Bot run may fail with HTTP 401 (using the cached token). This is detected as a security-relevant failure and turns the Release job red. The operator restores the token, re-runs the failed job, and the idempotent retry path applies. No leaked-token incident response is defined here; that belongs in a separate security runbook.
+- **Plugin order regression.** If a future PR inserts a plugin between `@semantic-release/github` and `@semantic-release/exec` in `.releaserc.yaml`, the successCmd may fire before the inserted plugin completes. No automated regression test catches this; the first release after the change exercises it. The risk is low (`.releaserc.yaml` is rarely edited) and the fix is mechanical.
+- **GitHub Actions conclusion taxonomy drift.** New conclusion values added by GitHub fall into the forward-compat default branch with `::warning::` exit 0. Tighten the classifier when a new value appears in production logs.
+
+## Related
+
+- [`docs/solutions/best-practices/release-notes-narrative-procedure-2026-05-23.md`](release-notes-narrative-procedure-2026-05-23.md) — the v1 procedure compound doc; v2 inherits its render contract and idempotency definition verbatim
+- [`.agents/skills/release-notes-narrative/SKILL.md`](../../.agents/skills/release-notes-narrative/SKILL.md) — the canonical 13-step procedure both manual and CI runs follow
+- [`docs/solutions/developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md`](../developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md) — the original lesson establishing that `gh release edit` is the only mechanism for narrative release notes
+- [`docs/brainstorms/2026-05-23-release-notes-narrative-ci-automation-requirements.md`](../../brainstorms/2026-05-23-release-notes-narrative-ci-automation-requirements.md) — v2 requirements (gitignored, local-only) [if reading from a checkout]
+- [`docs/plans/2026-05-23-002-feat-release-notes-narrative-ci-automation-plan.md`](../../plans/2026-05-23-002-feat-release-notes-narrative-ci-automation-plan.md) — v2 implementation plan

--- a/docs/solutions/best-practices/release-notes-narrative-procedure-2026-05-23.md
+++ b/docs/solutions/best-practices/release-notes-narrative-procedure-2026-05-23.md
@@ -99,3 +99,9 @@ Every sentence in the after-state traces to the commit log. The PR body for #425
 - [`docs/solutions/developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md`](../developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md) — original lesson that this skill formalizes: the generator never ingests commit bodies or PR descriptions, and the fix is post-publish enrichment rather than generator configuration
 - [`docs/solutions/developer-experience/gh-api-heredoc-backtick-escape-2026-05-17.md`](../developer-experience/gh-api-heredoc-backtick-escape-2026-05-17.md) — adjacent safety pattern for `gh` body-writing: backtick escaping in heredoc contexts when passing markdown to `gh release edit`
 - [`.agents/skills/release-notes-narrative/SKILL.md`](../../.agents/skills/release-notes-narrative/SKILL.md) — the formalized procedure: full step-by-step with bucket map, thin-body threshold calibration, preflight checks, and rollback instructions
+
+## Update: 2026-05-23 — CI automation
+
+The skill now runs automatically post-publish via `@semantic-release/exec`'s `successCmd` in `.releaserc.yaml`. The hook dispatches `fro-bot.yaml` with a prompt that loads this skill and applies the procedure against the just-published tag. Manual invocation remains the canonical path for retroactive patches and historical releases; CI handles forward-going releases without operator intervention.
+
+See [`docs/solutions/best-practices/release-notes-narrative-ci-automation-architecture-2026-05-23.md`](release-notes-narrative-ci-automation-architecture-2026-05-23.md) for the trigger chain, fail-soft contract, and security signal classification.

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@biomejs/biome": "2.4.15",
     "@opencode-ai/plugin": "1.15.5",
     "@opencode-ai/sdk": "1.15.5",
+    "@semantic-release/exec": "^7",
     "@types/bun": "latest",
     "@types/js-yaml": "4.0.9",
     "@types/node": "24.12.4",

--- a/tests/fixtures/mock-gh.sh
+++ b/tests/fixtures/mock-gh.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Mock for the `gh` CLI used in release-notes-ci integration tests.
+#
+# Behavior is driven by environment variables set per-scenario:
+#
+#   MOCK_GH_RUN_LIST_JSON          JSON array for `gh run list` output
+#   MOCK_GH_RUN_VIEW_LOG           Log text for `gh run view --log`
+#   MOCK_GH_RUN_VIEW_CONCLUSION    JSON for `gh run view --json conclusion`
+#   MOCK_GH_RUN_WATCH_EXIT         Exit code for `gh run watch`
+#   MOCK_GH_RELEASE_VIEW_BODY_LEN  Integer body length for `gh release view --json body`
+#   MOCK_GH_WORKFLOW_RUN_PROMPT    File path where the dispatched prompt is written
+#
+# Subcommand dispatch: $1 = top-level subcommand (workflow, run, release)
+
+set -Eeuo pipefail
+
+SUBCOMMAND="${1:-}"
+
+case "$SUBCOMMAND" in
+
+  workflow)
+    # gh workflow run ...
+    WORKFLOW_SUB="${2:-}"
+    if [[ "$WORKFLOW_SUB" == "run" ]]; then
+      # Capture the prompt argument if MOCK_GH_WORKFLOW_RUN_PROMPT is set.
+      if [[ -n "${MOCK_GH_WORKFLOW_RUN_PROMPT:-}" ]]; then
+        # Walk args looking for -f prompt=... or -f "prompt=..."
+        for arg in "$@"; do
+          if [[ "$arg" == prompt=* ]]; then
+            printf '%s' "${arg#prompt=}" > "$MOCK_GH_WORKFLOW_RUN_PROMPT"
+            break
+          fi
+        done
+      fi
+      echo "Created workflow_dispatch event for fro-bot.yaml at refs/heads/main"
+      exit 0
+    fi
+    echo "mock-gh: unhandled workflow subcommand: $WORKFLOW_SUB" >&2
+    exit 1
+    ;;
+
+  run)
+    RUN_SUB="${2:-}"
+    case "$RUN_SUB" in
+      list)
+        # gh run list --workflow=... --branch=... --json ... --limit ...
+        echo "${MOCK_GH_RUN_LIST_JSON:-[]}"
+        exit 0
+        ;;
+      view)
+        # Detect --log vs --json conclusion vs plain view
+        LOG_FLAG=0
+        JSON_FLAG=0
+        for arg in "$@"; do
+          [[ "$arg" == "--log" ]] && LOG_FLAG=1
+          [[ "$arg" == "--json" ]] && JSON_FLAG=1
+        done
+
+        if [[ "$LOG_FLAG" == "1" ]]; then
+          echo "${MOCK_GH_RUN_VIEW_LOG:-}"
+          exit 0
+        fi
+
+        if [[ "$JSON_FLAG" == "1" ]]; then
+          CONCLUSION="${MOCK_GH_RUN_VIEW_CONCLUSION:-success}"
+          # Check if --jq flag is present to extract just the value
+          JQ_FLAG=0
+          for arg in "$@"; do
+            [[ "$arg" == "--jq" ]] && JQ_FLAG=1
+          done
+          if [[ "$JQ_FLAG" == "1" ]]; then
+            # Return just the conclusion string (simulating jq extraction)
+            echo "$CONCLUSION"
+          else
+            echo "{\"conclusion\":\"${CONCLUSION}\"}"
+          fi
+          exit 0
+        fi
+
+        # Plain view — not used in tests but handle gracefully
+        echo "mock-gh: gh run view (plain) not mocked" >&2
+        exit 1
+        ;;
+      watch)
+        WATCH_EXIT="${MOCK_GH_RUN_WATCH_EXIT:-0}"
+        exit "$WATCH_EXIT"
+        ;;
+      *)
+        echo "mock-gh: unhandled run subcommand: $RUN_SUB" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+
+  release)
+    RELEASE_SUB="${2:-}"
+    case "$RELEASE_SUB" in
+      view)
+        # gh release view $TAG --json body --jq '.body | length'
+        BODY_LEN="${MOCK_GH_RELEASE_VIEW_BODY_LEN:-800}"
+        echo "$BODY_LEN"
+        exit 0
+        ;;
+      *)
+        echo "mock-gh: unhandled release subcommand: $RELEASE_SUB" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+
+  *)
+    echo "mock-gh: unhandled subcommand: $SUBCOMMAND" >&2
+    exit 1
+    ;;
+esac

--- a/tests/fixtures/mock-gh.sh
+++ b/tests/fixtures/mock-gh.sh
@@ -8,7 +8,8 @@
 #   MOCK_GH_RUN_VIEW_CONCLUSION    JSON for `gh run view --json conclusion`
 #   MOCK_GH_RUN_WATCH_EXIT         Exit code for `gh run watch`
 #   MOCK_GH_RELEASE_VIEW_BODY_LEN  Integer body length for `gh release view --json body`
-#   MOCK_GH_WORKFLOW_RUN_PROMPT    File path where the dispatched prompt is written
+#   MOCK_GH_WORKFLOW_RUN_PROMPT       File path where the dispatched prompt is written
+#   MOCK_GH_WORKFLOW_RUN_CORRELATION  File path where the dispatched correlation-id is written
 #
 # Subcommand dispatch: $1 = top-level subcommand (workflow, run, release)
 
@@ -23,15 +24,16 @@ case "$SUBCOMMAND" in
     WORKFLOW_SUB="${2:-}"
     if [[ "$WORKFLOW_SUB" == "run" ]]; then
       # Capture the prompt argument if MOCK_GH_WORKFLOW_RUN_PROMPT is set.
-      if [[ -n "${MOCK_GH_WORKFLOW_RUN_PROMPT:-}" ]]; then
-        # Walk args looking for -f prompt=... or -f "prompt=..."
-        for arg in "$@"; do
-          if [[ "$arg" == prompt=* ]]; then
-            printf '%s' "${arg#prompt=}" > "$MOCK_GH_WORKFLOW_RUN_PROMPT"
-            break
-          fi
-        done
-      fi
+      # Capture the correlation-id argument if MOCK_GH_WORKFLOW_RUN_CORRELATION is set.
+      # The two captures are independent so scenarios can verify the dispatch
+      # forwards both fields, not just the prompt.
+      for arg in "$@"; do
+        if [[ -n "${MOCK_GH_WORKFLOW_RUN_PROMPT:-}" && "$arg" == prompt=* ]]; then
+          printf '%s' "${arg#prompt=}" > "$MOCK_GH_WORKFLOW_RUN_PROMPT"
+        elif [[ -n "${MOCK_GH_WORKFLOW_RUN_CORRELATION:-}" && "$arg" == correlation-id=* ]]; then
+          printf '%s' "${arg#correlation-id=}" > "$MOCK_GH_WORKFLOW_RUN_CORRELATION"
+        fi
+      done
       echo "Created workflow_dispatch event for fro-bot.yaml at refs/heads/main"
       exit 0
     fi

--- a/tests/integration/release-notes-ci.test.ts
+++ b/tests/integration/release-notes-ci.test.ts
@@ -123,6 +123,7 @@ interface ScenarioEnv {
   MOCK_GH_RUN_WATCH_EXIT?: string
   MOCK_GH_RELEASE_VIEW_BODY_LEN?: string
   MOCK_GH_WORKFLOW_RUN_PROMPT?: string
+  MOCK_GH_WORKFLOW_RUN_CORRELATION?: string
   RELEASE_NOTES_TEST_POLL_BUDGET_SECS?: string
   RELEASE_NOTES_TEST_POLL_INTERVAL_SECS?: string
   RELEASE_NOTES_TEST_WATCH_TIMEOUT_SECS?: string
@@ -173,13 +174,24 @@ function runSuccessCmd(
     extraMockBinDir ?? fs.mkdtempSync(path.join(os.tmpdir(), 'mock-bin-'))
   const ghLink = path.join(mockBinDir, 'gh')
 
-  // Create a wrapper that delegates to mock-gh.sh, forwarding all args
-  if (!fs.existsSync(ghLink)) {
-    fs.writeFileSync(
+  // Create a wrapper that delegates to mock-gh.sh, forwarding all args.
+  // Tests that supply extraMockBinDir may pre-populate gh with a custom wrapper
+  // (scenario 7 does this for per-run-ID log responses); in that case we leave
+  // the existing wrapper in place. Otherwise we write the default shim.
+  // Using fs.openSync with O_CREAT|O_EXCL is atomic — no check-then-write race
+  // (avoids js/file-system-race CodeQL flag).
+  try {
+    const fd = fs.openSync(
       ghLink,
-      `#!/usr/bin/env bash\nexec "${MOCK_GH_PATH}" "$@"\n`,
+      fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY,
+      0o755,
     )
-    fs.chmodSync(ghLink, 0o755)
+    fs.writeSync(fd, `#!/usr/bin/env bash\nexec "${MOCK_GH_PATH}" "$@"\n`)
+    fs.closeSync(fd)
+  } catch (err) {
+    // EEXIST means a custom wrapper is already in place; leave it.
+    const code = (err as NodeJS.ErrnoException).code
+    if (code !== 'EEXIST') throw err
   }
 
   const parentPath = process.env.PATH ?? '/usr/local/bin:/usr/bin:/bin'
@@ -226,6 +238,11 @@ function runSuccessCmd(
 
   if (env.MOCK_GH_WORKFLOW_RUN_PROMPT !== undefined) {
     childEnv.MOCK_GH_WORKFLOW_RUN_PROMPT = env.MOCK_GH_WORKFLOW_RUN_PROMPT
+  }
+
+  if (env.MOCK_GH_WORKFLOW_RUN_CORRELATION !== undefined) {
+    childEnv.MOCK_GH_WORKFLOW_RUN_CORRELATION =
+      env.MOCK_GH_WORKFLOW_RUN_CORRELATION
   }
 
   const result = Bun.spawnSync(['bash', scriptPath], {
@@ -431,6 +448,28 @@ describe('release-notes-ci successCmd smoke tests', () => {
   )
 
   // -------------------------------------------------------------------------
+  // 5b. Edge case — unexpected non-zero WATCH_EXIT (not 124, not 0)
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'exits 1 with ::error:: for unexpected gh run watch exit (e.g., SIGKILL via 137)',
+    () => {
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        // Common signal-propagation exit code: 128 + 9 (SIGKILL) = 137
+        MOCK_GH_RUN_WATCH_EXIT: '137',
+        MOCK_GH_RUN_VIEW_CONCLUSION: 'failure',
+      })
+
+      expect(result.exitCode).toBe(1)
+      const combined = result.stdout + result.stderr
+      expect(combined).toContain('::error::')
+      expect(combined).toMatch(/unexpected gh run watch exit/i)
+      expect(combined).toContain('WATCH_EXIT=137')
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
   // 6. Edge case — dispatch not registered within 90s
   // -------------------------------------------------------------------------
   it.skipIf(!successCmdAvailable)(
@@ -523,12 +562,17 @@ exit 1
         { databaseId: 12345 },
       ])
 
+      // Use a specific correlation token so the script and the custom mock's
+      // run-12345 log agree on the exact match value. The custom mock returns
+      // "no correlation here" for run 99999, so only run 12345's log matches.
+      const knownCorrelation = 'second-run-correlation-token'
       const result = runSuccessCmd(
         scriptPath,
         {
           RELEASE_VERSION: 'v2.23.0',
+          RELEASE_NOTES_TEST_CORRELATION_ID: knownCorrelation,
           MOCK_GH_RUN_LIST_JSON: runListJson,
-          MOCK_GH_RUN_VIEW_LOG: 'correlation=PLACEHOLDER\nsome log',
+          MOCK_GH_RUN_VIEW_LOG: `correlation=${knownCorrelation}\nsome log`,
           MOCK_GH_RUN_VIEW_CONCLUSION: 'success',
           MOCK_GH_RELEASE_VIEW_BODY_LEN: '800',
         },
@@ -753,14 +797,21 @@ exit 1
   // 18. Integration — prompt construction includes correlation token, target tag, repo name
   // -------------------------------------------------------------------------
   it.skipIf(!successCmdAvailable)(
-    'prompt passed to gh workflow run contains correlation token, target tag, and repo name',
+    'prompt and correlation-id are forwarded to gh workflow run as separate -f fields',
     () => {
       const promptCapturePath = path.join(testTempDir, 'captured-prompt.txt')
+      const correlationCapturePath = path.join(
+        testTempDir,
+        'captured-correlation.txt',
+      )
+      const knownCorrelationId = 'test-known-correlation-uuid-for-scenario-18'
 
       const result = run({
         RELEASE_VERSION: 'v2.23.0',
         GITHUB_REPOSITORY: 'marcusrbrown/systematic',
+        RELEASE_NOTES_TEST_CORRELATION_ID: knownCorrelationId,
         MOCK_GH_WORKFLOW_RUN_PROMPT: promptCapturePath,
+        MOCK_GH_WORKFLOW_RUN_CORRELATION: correlationCapturePath,
         MOCK_GH_RUN_VIEW_CONCLUSION: 'success',
         MOCK_GH_RELEASE_VIEW_BODY_LEN: '800',
       })
@@ -769,9 +820,8 @@ exit 1
       const combined = result.stdout + result.stderr
       expect(combined).toContain('workflow_dispatch event')
 
-      // The captured prompt file must exist
+      // The captured prompt file must exist with the embedded correlation token
       expect(fs.existsSync(promptCapturePath)).toBe(true)
-
       const capturedPrompt = fs.readFileSync(promptCapturePath, 'utf8')
 
       // Must contain the target tag
@@ -782,11 +832,21 @@ exit 1
       // biome-ignore lint/suspicious/noTemplateCurlyInString: Asserting the prompt does NOT contain the literal GitHub workflow-expression syntax `${{ github.repository }}`, which is the failure mode being guarded against.
       expect(capturedPrompt).not.toContain('${{ github.repository }}')
 
-      // Must contain a correlation token reference
-      // The prompt's first line should be `correlation=<uuid>` and the
-      // instruction text must explicitly require Fro Bot to echo it.
+      // Must contain the correlation token as a first-line reference
+      // and an instruction telling Fro Bot to echo it.
       expect(capturedPrompt).toMatch(/^correlation=[a-zA-Z0-9-]+/m)
+      expect(capturedPrompt).toContain(`correlation=${knownCorrelationId}`)
       expect(capturedPrompt).toMatch(/echo.*correlation/i)
+
+      // The correlation-id MUST be forwarded as a separate `-f correlation-id=<value>`
+      // argument, not just embedded in the prompt body. Without this assertion,
+      // accidentally deleting the `-f "correlation-id=$CORRELATION_ID"` line in
+      // the dispatch would silently pass the prompt-construction test.
+      expect(fs.existsSync(correlationCapturePath)).toBe(true)
+      const capturedCorrelation = fs
+        .readFileSync(correlationCapturePath, 'utf8')
+        .trim()
+      expect(capturedCorrelation).toBe(knownCorrelationId)
     },
     SCENARIO_TIMEOUT_MS,
   )

--- a/tests/integration/release-notes-ci.test.ts
+++ b/tests/integration/release-notes-ci.test.ts
@@ -1,0 +1,838 @@
+/**
+ * Smoke tests for the successCmd bash logic embedded in .releaserc.yaml.
+ *
+ * Strategy: extract the successCmd block from .releaserc.yaml at test runtime,
+ * write it to a temp shell file, and invoke it with a mock `gh` binary on PATH.
+ * The mock binary's behavior is controlled per-scenario via environment variables.
+ *
+ * The test fails loudly if .releaserc.yaml is missing the successCmd block,
+ * which prevents drift between the plugin config and this test suite.
+ *
+ * All 18 scenarios are covered:
+ *  1.  Validation — invalid RELEASE_VERSION
+ *  2.  Validation — valid pre-release (v2.23.0-rc.1)
+ *  3.  Happy path — success conclusion + valid body length
+ *  4.  Happy path — neutral conclusion (idempotent short-circuit)
+ *  5.  Edge case — timeout (WATCH_EXIT=124)
+ *  6.  Edge case — dispatch not registered within 90s
+ *  7.  Edge case — correlation token matches second-newest run, not first
+ *  8.  Error — HTTP 401 auth denial
+ *  9.  Error — HTTP 403 + permission denied
+ * 10.  Error — "Resource not accessible" auth keyword
+ * 11.  Error — off-target tag edit (ANSI-stripped)
+ * 12.  Error — success conclusion but body too short
+ * 13.  Error — action_required conclusion
+ * 14.  Error — skipped conclusion (policy block)
+ * 15.  Edge case — cancelled conclusion
+ * 16.  Edge case — generic narrative failure
+ * 17.  Edge case — unknown future conclusion
+ * 18.  Integration — prompt construction includes correlation token, target tag, repo name
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../..')
+const RELEASERC_PATH = path.join(REPO_ROOT, '.releaserc.yaml')
+const MOCK_GH_PATH = path.join(REPO_ROOT, 'tests/fixtures/mock-gh.sh')
+
+// Timeout per scenario — the successCmd has a 90s polling loop; we cap it
+// tightly in tests by making the mock return immediately.
+const SCENARIO_TIMEOUT_MS = 30_000
+
+// ---------------------------------------------------------------------------
+// YAML successCmd extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the successCmd block from .releaserc.yaml.
+ *
+ * The block is expected to appear as a YAML literal block scalar under the
+ * @semantic-release/exec plugin entry:
+ *
+ *   - - '@semantic-release/exec'
+ *     - successCmd: |
+ *         <bash content>
+ *
+ * Returns null if the block is not present (e.g., the @semantic-release/exec plugin entry has not been added yet).
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: YAML literal-block extraction inherently branches on indent levels, block boundaries, and blank-line handling — the cognitive load lives in the YAML grammar, not the code shape.
+function extractSuccessCmd(releasercContent: string): string | null {
+  // Find the successCmd: | line and capture everything indented beneath it.
+  const lines = releasercContent.split('\n')
+  let inSuccessCmd = false
+  let baseIndent = -1
+  const cmdLines: string[] = []
+
+  for (const line of lines) {
+    if (!inSuccessCmd) {
+      // Match lines like `    - successCmd: |` or `    successCmd: |`
+      // The key may be preceded by a YAML list marker `- `.
+      const match = line.match(/^(\s*)(?:-\s+)?successCmd:\s*\|\s*$/)
+      if (match) {
+        inSuccessCmd = true
+        // Determine content indent from the next non-blank line
+        // For now, use key indent + 4 (typical YAML literal block indent)
+        baseIndent = (match[1]?.length ?? 0) + 4
+      }
+    } else {
+      // We're inside the literal block. Lines that are more indented than
+      // baseIndent belong to the block; anything at or below baseIndent-2
+      // (the successCmd key's indent) ends the block.
+      if (line.trim() === '') {
+        // Blank lines are part of the literal block
+        cmdLines.push('')
+        continue
+      }
+      const indent = line.match(/^(\s*)/)?.[1]?.length ?? 0
+      if (indent < baseIndent) {
+        // End of literal block
+        break
+      }
+      // Strip exactly baseIndent spaces of leading whitespace
+      cmdLines.push(line.slice(baseIndent))
+    }
+  }
+
+  if (cmdLines.length === 0) return null
+
+  // Trim trailing blank lines
+  while (cmdLines.length > 0 && cmdLines[cmdLines.length - 1]?.trim() === '') {
+    cmdLines.pop()
+  }
+
+  return cmdLines.join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+
+interface ScenarioEnv {
+  RELEASE_VERSION?: string
+  GITHUB_REPOSITORY?: string
+  MOCK_GH_RUN_LIST_JSON?: string
+  MOCK_GH_RUN_VIEW_LOG?: string
+  MOCK_GH_RUN_VIEW_CONCLUSION?: string
+  MOCK_GH_RUN_WATCH_EXIT?: string
+  MOCK_GH_RELEASE_VIEW_BODY_LEN?: string
+  MOCK_GH_WORKFLOW_RUN_PROMPT?: string
+  RELEASE_NOTES_TEST_POLL_BUDGET_SECS?: string
+  RELEASE_NOTES_TEST_POLL_INTERVAL_SECS?: string
+  RELEASE_NOTES_TEST_WATCH_TIMEOUT_SECS?: string
+  RELEASE_NOTES_TEST_CORRELATION_ID?: string
+}
+
+interface ScenarioResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+/**
+ * Builds a run-list JSON array where each entry has a databaseId and a log
+ * that either matches or does not match the correlation token.
+ *
+ * The successCmd polls `gh run list` and then calls `gh run view <id> --log`
+ * for each candidate. The mock-gh.sh returns MOCK_GH_RUN_VIEW_LOG for ALL
+ * `gh run view --log` calls. To simulate "second run matches", we need the
+ * run-list to contain two entries and the log to contain the correlation token
+ * (the script will find it on the second attempt after the first fails).
+ *
+ * For the "second matches" scenario we use a special env var
+ * MOCK_GH_RUN_VIEW_LOG_BY_ID which the mock reads to return different logs
+ * per run ID. Since our mock-gh.sh is simple (single MOCK_GH_RUN_VIEW_LOG),
+ * we implement the "second matches" scenario by having the first run's ID
+ * appear in a MOCK_GH_SKIP_IDS list that causes the mock to return empty log.
+ */
+function makeRunListJson(entries: Array<{ databaseId: number }>): string {
+  return JSON.stringify(
+    entries.map((e) => ({
+      databaseId: e.databaseId,
+      createdAt: new Date().toISOString(),
+    })),
+  )
+}
+
+/**
+ * Runs the successCmd script in a temp directory with the mock-gh binary on PATH.
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Test scaffold consolidates default env-var wiring, correlation-token plumbing, log-prepending, and timeout escape hatches in one place by design — splitting into helpers would scatter related context across multiple functions.
+function runSuccessCmd(
+  scriptPath: string,
+  env: ScenarioEnv,
+  extraMockBinDir?: string,
+): ScenarioResult {
+  const mockBinDir =
+    extraMockBinDir ?? fs.mkdtempSync(path.join(os.tmpdir(), 'mock-bin-'))
+  const ghLink = path.join(mockBinDir, 'gh')
+
+  // Create a wrapper that delegates to mock-gh.sh, forwarding all args
+  if (!fs.existsSync(ghLink)) {
+    fs.writeFileSync(
+      ghLink,
+      `#!/usr/bin/env bash\nexec "${MOCK_GH_PATH}" "$@"\n`,
+    )
+    fs.chmodSync(ghLink, 0o755)
+  }
+
+  const parentPath = process.env.PATH ?? '/usr/local/bin:/usr/bin:/bin'
+
+  // Default correlation ID — used to wire the polling loop end-to-end so most
+  // tests can focus on conclusion classification rather than re-mocking polling.
+  // Tests that explicitly want polling to FAIL set MOCK_GH_RUN_LIST_JSON: '[]'.
+  // The correlation line is auto-prepended to any provided MOCK_GH_RUN_VIEW_LOG
+  // so tests that override the log to inject auth/off-target signals still let
+  // the polling loop find their run.
+  const defaultCorrelationId =
+    env.RELEASE_NOTES_TEST_CORRELATION_ID ?? 'test-correlation-token-default'
+  const correlationLine = `correlation=${defaultCorrelationId}\n`
+  const providedLog = env.MOCK_GH_RUN_VIEW_LOG
+  const effectiveLog =
+    providedLog === undefined
+      ? `${correlationLine}release edit ${env.RELEASE_VERSION ?? 'v2.23.0'} succeeded\n`
+      : providedLog === ''
+        ? '' // explicit empty — caller wants polling to fail
+        : `${correlationLine}${providedLog}`
+
+  const childEnv: Record<string, string> = {
+    PATH: `${mockBinDir}:${parentPath}`,
+    RELEASE_VERSION: env.RELEASE_VERSION ?? 'v2.23.0',
+    GITHUB_REPOSITORY: env.GITHUB_REPOSITORY ?? 'marcusrbrown/systematic',
+    MOCK_GH_RUN_LIST_JSON:
+      env.MOCK_GH_RUN_LIST_JSON ?? makeRunListJson([{ databaseId: 12345 }]),
+    MOCK_GH_RUN_VIEW_LOG: effectiveLog,
+    MOCK_GH_RUN_VIEW_CONCLUSION: env.MOCK_GH_RUN_VIEW_CONCLUSION ?? 'success',
+    MOCK_GH_RUN_WATCH_EXIT: env.MOCK_GH_RUN_WATCH_EXIT ?? '0',
+    MOCK_GH_RELEASE_VIEW_BODY_LEN: env.MOCK_GH_RELEASE_VIEW_BODY_LEN ?? '800',
+    RELEASE_NOTES_TEST_CORRELATION_ID: defaultCorrelationId,
+    HOME: process.env.HOME ?? '/tmp',
+    TMPDIR: process.env.TMPDIR ?? '/tmp',
+    // Shorten polling and watch budgets so the 18 scenarios complete quickly.
+    // Production runs use the default 90s / 5s / 600s values; tests use sub-second.
+    RELEASE_NOTES_TEST_POLL_BUDGET_SECS:
+      env.RELEASE_NOTES_TEST_POLL_BUDGET_SECS ?? '2',
+    RELEASE_NOTES_TEST_POLL_INTERVAL_SECS:
+      env.RELEASE_NOTES_TEST_POLL_INTERVAL_SECS ?? '1',
+    RELEASE_NOTES_TEST_WATCH_TIMEOUT_SECS:
+      env.RELEASE_NOTES_TEST_WATCH_TIMEOUT_SECS ?? '5',
+  }
+
+  if (env.MOCK_GH_WORKFLOW_RUN_PROMPT !== undefined) {
+    childEnv.MOCK_GH_WORKFLOW_RUN_PROMPT = env.MOCK_GH_WORKFLOW_RUN_PROMPT
+  }
+
+  const result = Bun.spawnSync(['bash', scriptPath], {
+    env: childEnv,
+    timeout: SCENARIO_TIMEOUT_MS,
+  })
+
+  return {
+    exitCode: result.exitCode ?? -1,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level setup: extract successCmd once
+// ---------------------------------------------------------------------------
+
+// Module-load-time extraction: it.skipIf() evaluates its predicate when it() is
+// invoked (module-load time), not when the test runs. beforeAll() runs too late
+// to flip the skip flag. Doing the extraction synchronously at module-load time
+// makes the predicate see the correct value.
+const successCmdScript: string = (() => {
+  if (!fs.existsSync(RELEASERC_PATH)) {
+    console.warn(
+      '[release-notes-ci] .releaserc.yaml not found — all scenarios will be skipped. ' +
+        'The @semantic-release/exec plugin entry must be present in .releaserc.yaml before these scenarios can run.',
+    )
+    return ''
+  }
+
+  const releasercContent = fs.readFileSync(RELEASERC_PATH, 'utf8')
+  const extracted = extractSuccessCmd(releasercContent)
+
+  if (extracted === null) {
+    console.warn(
+      '[release-notes-ci] successCmd block not found in .releaserc.yaml — ' +
+        'all scenarios will be skipped until the @semantic-release/exec plugin entry is added.',
+    )
+    return ''
+  }
+
+  return extracted
+})()
+
+const successCmdAvailable = successCmdScript.length > 0
+let scriptPath = ''
+
+// ---------------------------------------------------------------------------
+// Per-test temp directory
+// ---------------------------------------------------------------------------
+
+let testTempDir = ''
+let testMockBinDir = ''
+
+beforeEach(() => {
+  testTempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'release-notes-ci-'))
+  testMockBinDir = path.join(testTempDir, 'mock-bin')
+  fs.mkdirSync(testMockBinDir, { recursive: true })
+
+  // Write the successCmd to a temp script file for this test.
+  // The production successCmd contains `${nextRelease.gitTag}` — a Lodash template
+  // that @semantic-release/exec resolves BEFORE handing the string to the shell.
+  // In tests we don't go through semantic-release, so we substitute the Lodash
+  // expression with `${RELEASE_VERSION:-v2.23.0}` (a bash env var the test sets).
+  if (successCmdAvailable) {
+    scriptPath = path.join(testTempDir, 'successCmd.sh')
+    const lodashSubstituted = successCmdScript.replace(
+      /\$\{nextRelease\.gitTag\}/g,
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Literal bash parameter expansion, not a JS template placeholder. The string is written verbatim into the bash script.
+      '${RELEASE_VERSION:-v2.23.0}',
+    )
+    fs.writeFileSync(
+      scriptPath,
+      `#!/usr/bin/env bash\nset -Eeuo pipefail\n${lodashSubstituted}\n`,
+    )
+    fs.chmodSync(scriptPath, 0o755)
+  }
+})
+
+afterEach(() => {
+  fs.rmSync(testTempDir, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// Helper: run with the per-test mock-bin dir
+// ---------------------------------------------------------------------------
+
+function run(env: ScenarioEnv): ScenarioResult {
+  return runSuccessCmd(scriptPath, env, testMockBinDir)
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+describe('release-notes-ci successCmd smoke tests', () => {
+  // -------------------------------------------------------------------------
+  // 1. Validation — invalid RELEASE_VERSION
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'exits 1 and emits ::error:: for invalid RELEASE_VERSION shape',
+    () => {
+      const result = run({ RELEASE_VERSION: 'not-a-tag' })
+
+      expect(result.exitCode).toBe(1)
+      const combined = result.stdout + result.stderr
+      expect(combined).toContain('::error::')
+      expect(combined).toContain('Invalid RELEASE_VERSION shape')
+      // Must NOT have dispatched gh workflow run
+      expect(combined).not.toContain('workflow_dispatch event')
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 2. Validation — valid pre-release passes validation
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'accepts valid pre-release version v2.23.0-rc.1 and proceeds to dispatch',
+    () => {
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0-rc.1',
+        MOCK_GH_RUN_VIEW_CONCLUSION: 'success',
+        MOCK_GH_RELEASE_VIEW_BODY_LEN: '800',
+      })
+
+      // Validation passes — dispatch fires (mock prints the dispatch line)
+      const combined = result.stdout + result.stderr
+      expect(combined).toContain('workflow_dispatch event')
+      // Should not emit an invalid-version error
+      expect(combined).not.toContain('Invalid RELEASE_VERSION shape')
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 3. Happy path — success conclusion + valid body length
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'exits 0 with narrative-applied message on success conclusion and body length >= 200',
+    () => {
+      const correlationId = 'test-correlation-happy-path'
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        MOCK_GH_RUN_VIEW_CONCLUSION: 'success',
+        MOCK_GH_RELEASE_VIEW_BODY_LEN: '800',
+        // Log must contain the correlation token so polling finds the run
+        MOCK_GH_RUN_VIEW_LOG: `correlation=${correlationId}\nsome other log content`,
+      })
+
+      expect(result.exitCode).toBe(0)
+      const combined = result.stdout + result.stderr
+      // Must NOT emit any annotation
+      expect(combined).not.toContain('::error::')
+      expect(combined).not.toContain('::warning::')
+      // Must contain success signal
+      expect(combined).toMatch(/narrative applied/i)
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 4. Happy path — neutral conclusion (idempotent short-circuit)
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'exits 0 with no-action-taken message on neutral conclusion',
+    () => {
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        MOCK_GH_RUN_VIEW_CONCLUSION: 'neutral',
+        MOCK_GH_RELEASE_VIEW_BODY_LEN: '800',
+      })
+
+      expect(result.exitCode).toBe(0)
+      const combined = result.stdout + result.stderr
+      expect(combined).not.toContain('::error::')
+      expect(combined).not.toContain('::warning::')
+      expect(combined).toMatch(/no-action-taken/i)
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 5. Edge case — timeout (WATCH_EXIT=124)
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'exits 0 with ::warning:: annotation when gh run watch times out (exit 124)',
+    () => {
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        MOCK_GH_RUN_WATCH_EXIT: '124',
+        MOCK_GH_RUN_VIEW_CONCLUSION: 'failure',
+      })
+
+      expect(result.exitCode).toBe(0)
+      const combined = result.stdout + result.stderr
+      expect(combined).toContain('::warning::')
+      expect(combined).toMatch(/timed out/i)
+      expect(combined).not.toContain('::error::')
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 6. Edge case — dispatch not registered within 90s
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'exits 1 with ::error:: when dispatched run is never found in run list',
+    () => {
+      // Return an empty run list so the correlation token is never matched
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        MOCK_GH_RUN_LIST_JSON: '[]',
+      })
+
+      expect(result.exitCode).toBe(1)
+      const combined = result.stdout + result.stderr
+      expect(combined).toContain('::error::')
+      expect(combined).toMatch(/not found within/i)
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 7. Edge case — correlation token matches second-newest run, not first
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'uses the second run when correlation token only appears in its log',
+    () => {
+      // Two runs: 99999 (newest, no correlation match) and 12345 (second, matches)
+      // The mock returns MOCK_GH_RUN_VIEW_LOG for ALL view --log calls.
+      // We need the first run (99999) to NOT match and the second (12345) to match.
+      //
+      // Since mock-gh.sh returns the same log for all run IDs, we use a
+      // special approach: set the log to contain the correlation token, but
+      // also write a wrapper that skips the first ID.
+      //
+      // Simpler: use a custom mock-gh wrapper that checks the run ID arg.
+      const customMockBin = path.join(testTempDir, 'custom-mock-bin')
+      fs.mkdirSync(customMockBin, { recursive: true })
+
+      const customGh = path.join(customMockBin, 'gh')
+      // The script returns empty log for run 99999, and a correlation-matching
+      // log for run 12345. The correlation token is embedded in the log.
+      fs.writeFileSync(
+        customGh,
+        `#!/usr/bin/env bash
+set -Eeuo pipefail
+SUBCOMMAND="\${1:-}"
+if [[ "$SUBCOMMAND" == "run" && "\${2:-}" == "list" ]]; then
+  echo "\${MOCK_GH_RUN_LIST_JSON:-[]}"
+  exit 0
+fi
+if [[ "$SUBCOMMAND" == "run" && "\${2:-}" == "view" ]]; then
+  RUN_ID="\${3:-}"
+  LOG_FLAG=0
+  JSON_FLAG=0
+  for arg in "$@"; do
+    [[ "$arg" == "--log" ]] && LOG_FLAG=1
+    [[ "$arg" == "--json" ]] && JSON_FLAG=1
+  done
+  if [[ "$LOG_FLAG" == "1" ]]; then
+    if [[ "$RUN_ID" == "99999" ]]; then
+      echo "no correlation here"
+    else
+      echo "\${MOCK_GH_RUN_VIEW_LOG:-}"
+    fi
+    exit 0
+  fi
+  if [[ "$JSON_FLAG" == "1" ]]; then
+    echo "{\\"conclusion\\":\\"\${MOCK_GH_RUN_VIEW_CONCLUSION:-success}\\"}"
+    exit 0
+  fi
+fi
+if [[ "$SUBCOMMAND" == "run" && "\${2:-}" == "watch" ]]; then
+  exit "\${MOCK_GH_RUN_WATCH_EXIT:-0}"
+fi
+if [[ "$SUBCOMMAND" == "workflow" && "\${2:-}" == "run" ]]; then
+  echo "Created workflow_dispatch event for fro-bot.yaml at refs/heads/main"
+  exit 0
+fi
+if [[ "$SUBCOMMAND" == "release" && "\${2:-}" == "view" ]]; then
+  echo "\${MOCK_GH_RELEASE_VIEW_BODY_LEN:-800}"
+  exit 0
+fi
+echo "custom-mock-gh: unhandled: $*" >&2
+exit 1
+`,
+      )
+      fs.chmodSync(customGh, 0o755)
+
+      const runListJson = makeRunListJson([
+        { databaseId: 99999 },
+        { databaseId: 12345 },
+      ])
+
+      const result = runSuccessCmd(
+        scriptPath,
+        {
+          RELEASE_VERSION: 'v2.23.0',
+          MOCK_GH_RUN_LIST_JSON: runListJson,
+          MOCK_GH_RUN_VIEW_LOG: 'correlation=PLACEHOLDER\nsome log',
+          MOCK_GH_RUN_VIEW_CONCLUSION: 'success',
+          MOCK_GH_RELEASE_VIEW_BODY_LEN: '800',
+        },
+        customMockBin,
+      )
+
+      // The script should find run 12345 (second) and succeed
+      expect(result.exitCode).toBe(0)
+      const combined = result.stdout + result.stderr
+      expect(combined).not.toContain('::error::')
+      // Should contain the second run's ID in output
+      expect(combined).toContain('12345')
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 8. Error — HTTP 401 auth denial
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'exits 1 with ::error:: Auth failure when log contains HTTP 401',
+    () => {
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        MOCK_GH_RUN_VIEW_CONCLUSION: 'failure',
+        MOCK_GH_RUN_VIEW_LOG: 'HTTP 401: Bad credentials\nsome other output',
+      })
+
+      expect(result.exitCode).toBe(1)
+      const combined = result.stdout + result.stderr
+      expect(combined).toContain('::error::')
+      expect(combined).toMatch(/[Aa]uth failure/i)
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 9. Error — HTTP 403 + permission denied
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'exits 1 with ::error:: Auth failure when log contains HTTP 403 and permission denied',
+    () => {
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        MOCK_GH_RUN_VIEW_CONCLUSION: 'failure',
+        MOCK_GH_RUN_VIEW_LOG:
+          'HTTP 403: Forbidden\npermission denied for resource',
+      })
+
+      expect(result.exitCode).toBe(1)
+      const combined = result.stdout + result.stderr
+      expect(combined).toContain('::error::')
+      expect(combined).toMatch(/[Aa]uth failure/i)
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 10. Error — "Resource not accessible" auth keyword
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'exits 1 with ::error:: Auth failure when log contains "Resource not accessible"',
+    () => {
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        MOCK_GH_RUN_VIEW_CONCLUSION: 'failure',
+        MOCK_GH_RUN_VIEW_LOG:
+          'Resource not accessible by integration\nsome other output',
+      })
+
+      expect(result.exitCode).toBe(1)
+      const combined = result.stdout + result.stderr
+      expect(combined).toContain('::error::')
+      expect(combined).toMatch(/[Aa]uth failure/i)
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 11. Error — off-target tag edit (ANSI-stripped)
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'exits 1 with ::error:: Off-target when log contains ANSI-colored edit of a different tag',
+    () => {
+      // ANSI-colored log line: `gh release edit v9.9.9` in red
+      const ansiLog = '\x1b[31mgh release edit v9.9.9\x1b[0m\nsome other output'
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        MOCK_GH_RUN_VIEW_CONCLUSION: 'failure',
+        MOCK_GH_RUN_VIEW_LOG: ansiLog,
+      })
+
+      expect(result.exitCode).toBe(1)
+      const combined = result.stdout + result.stderr
+      expect(combined).toContain('::error::')
+      expect(combined).toMatch(/[Oo]ff-target/i)
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 12. Error — success conclusion but body too short
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'exits 1 with ::error:: body integrity check failed when conclusion=success but body length < 200',
+    () => {
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        MOCK_GH_RUN_VIEW_CONCLUSION: 'success',
+        MOCK_GH_RELEASE_VIEW_BODY_LEN: '50',
+      })
+
+      expect(result.exitCode).toBe(1)
+      const combined = result.stdout + result.stderr
+      expect(combined).toContain('::error::')
+      expect(combined).toMatch(/body integrity check failed/i)
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 13. Error — action_required conclusion
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'exits 1 with ::error:: manual intervention when conclusion=action_required',
+    () => {
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        MOCK_GH_RUN_VIEW_CONCLUSION: 'action_required',
+      })
+
+      expect(result.exitCode).toBe(1)
+      const combined = result.stdout + result.stderr
+      expect(combined).toContain('::error::')
+      expect(combined).toMatch(/manual intervention/i)
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 14. Error — skipped conclusion (policy block)
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'exits 1 with ::error:: policy/branch protection when conclusion=skipped',
+    () => {
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        MOCK_GH_RUN_VIEW_CONCLUSION: 'skipped',
+      })
+
+      expect(result.exitCode).toBe(1)
+      const combined = result.stdout + result.stderr
+      expect(combined).toContain('::error::')
+      expect(combined).toMatch(/policy\/branch protection/i)
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 15. Edge case — cancelled conclusion
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'exits 0 with ::warning:: when conclusion=cancelled',
+    () => {
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        MOCK_GH_RUN_VIEW_CONCLUSION: 'cancelled',
+      })
+
+      expect(result.exitCode).toBe(0)
+      const combined = result.stdout + result.stderr
+      expect(combined).toContain('::warning::')
+      expect(combined).not.toContain('::error::')
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 16. Edge case — generic narrative failure
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'exits 0 with ::warning:: for generic failure with no security signals',
+    () => {
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        MOCK_GH_RUN_VIEW_CONCLUSION: 'failure',
+        // Log has no auth keywords, no off-target edits
+        MOCK_GH_RUN_VIEW_LOG:
+          'OpenCode agent error: model timeout\nsome output',
+      })
+
+      expect(result.exitCode).toBe(0)
+      const combined = result.stdout + result.stderr
+      expect(combined).toContain('::warning::')
+      expect(combined).not.toContain('::error::')
+      expect(combined).toMatch(/narrative.failure|Fro Bot run failed/i)
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 17. Edge case — unknown future conclusion
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'exits 0 with ::warning:: Unknown conclusion for unrecognized conclusion values',
+    () => {
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        MOCK_GH_RUN_VIEW_CONCLUSION: 'some_new_value',
+      })
+
+      expect(result.exitCode).toBe(0)
+      const combined = result.stdout + result.stderr
+      expect(combined).toContain('::warning::')
+      expect(combined).toMatch(/[Uu]nknown conclusion/i)
+      expect(combined).not.toContain('::error::')
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 18. Integration — prompt construction includes correlation token, target tag, repo name
+  // -------------------------------------------------------------------------
+  it.skipIf(!successCmdAvailable)(
+    'prompt passed to gh workflow run contains correlation token, target tag, and repo name',
+    () => {
+      const promptCapturePath = path.join(testTempDir, 'captured-prompt.txt')
+
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        GITHUB_REPOSITORY: 'marcusrbrown/systematic',
+        MOCK_GH_WORKFLOW_RUN_PROMPT: promptCapturePath,
+        MOCK_GH_RUN_VIEW_CONCLUSION: 'success',
+        MOCK_GH_RELEASE_VIEW_BODY_LEN: '800',
+      })
+
+      // The dispatch must have fired
+      const combined = result.stdout + result.stderr
+      expect(combined).toContain('workflow_dispatch event')
+
+      // The captured prompt file must exist
+      expect(fs.existsSync(promptCapturePath)).toBe(true)
+
+      const capturedPrompt = fs.readFileSync(promptCapturePath, 'utf8')
+
+      // Must contain the target tag
+      expect(capturedPrompt).toContain('v2.23.0')
+
+      // Must contain the repo name (not a workflow-expression artifact)
+      expect(capturedPrompt).toContain('marcusrbrown/systematic')
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: Asserting the prompt does NOT contain the literal GitHub workflow-expression syntax `${{ github.repository }}`, which is the failure mode being guarded against.
+      expect(capturedPrompt).not.toContain('${{ github.repository }}')
+
+      // Must contain a correlation token reference
+      // The prompt's first line should be `correlation=<uuid>` and the
+      // instruction text must explicitly require Fro Bot to echo it.
+      expect(capturedPrompt).toMatch(/^correlation=[a-zA-Z0-9-]+/m)
+      expect(capturedPrompt).toMatch(/echo.*correlation/i)
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Structural test: successCmd extraction is well-formed
+// ---------------------------------------------------------------------------
+
+describe('successCmd extraction from .releaserc.yaml', () => {
+  it('extractSuccessCmd returns null when successCmd block is absent', () => {
+    const yaml = `
+plugins:
+  - '@semantic-release/commit-analyzer'
+  - '@semantic-release/github'
+`
+    expect(extractSuccessCmd(yaml)).toBeNull()
+  })
+
+  it('extractSuccessCmd captures multi-line bash block', () => {
+    const yaml = `
+plugins:
+  - - '@semantic-release/exec'
+    - successCmd: |
+        RELEASE_VERSION="\${nextRelease.gitTag}"
+        echo "hello $RELEASE_VERSION"
+        exit 0
+  - '@semantic-release/github'
+`
+    const result = extractSuccessCmd(yaml)
+    expect(result).not.toBeNull()
+    expect(result).toContain('RELEASE_VERSION=')
+    expect(result).toContain('echo "hello $RELEASE_VERSION"')
+    expect(result).toContain('exit 0')
+  })
+
+  it('extractSuccessCmd does not include content from the next plugin entry', () => {
+    const yaml = `
+plugins:
+  - - '@semantic-release/exec'
+    - successCmd: |
+        echo "cmd line"
+  - '@semantic-release/github'
+`
+    const result = extractSuccessCmd(yaml)
+    expect(result).not.toBeNull()
+    expect(result).not.toContain('@semantic-release/github')
+  })
+})


### PR DESCRIPTION
## Summary

Automate the v1 `release-notes-narrative` skill so every successful `semantic-release` publish from `main` produces a narrative GitHub release body without operator intervention.

v2.22.0 itself proved the gap this PR closes: that release's auto-generated body was a one-liner, and the narrative version landed only after a manual skill run against the just-published tag. v2 wires `@semantic-release/exec`'s `successCmd` into `.releaserc.yaml` so the dispatch happens automatically — same job, same workflow run, no external trigger, no bare-body blip.

## Architecture

```
npx semantic-release
  └─ @semantic-release/github (creates release; body is live)
  └─ @semantic-release/exec (NEW — successCmd fires here)
      ├─ validate RELEASE_VERSION shape (semver regex)
      ├─ generate UUID correlation token
      ├─ gh workflow run fro-bot.yaml -f prompt=<skill> -f correlation-id=<UUID>
      ├─ poll up to 90s for run whose first log line contains correlation token
      ├─ timeout 600 gh run watch <id> --exit-status
      └─ classify outcome: success | neutral | timeout | auth-fail | off-target |
                            action_required | skipped | integrity-fail | failure | unknown
```

The dispatched Fro Bot run loads `.agents/skills/release-notes-narrative/SKILL.md`, runs the 13-step procedure, and applies the narrative body via `gh release edit --notes-file` using `FRO_BOT_PAT`.

## Fail-soft / fail-hard contract

- **Narrative failures** (timeout, generic failure, cancelled, unknown conclusion) exit 0 with `::warning::` annotation. Release job stays green; release ships uninterrupted. Operator notices via the chained Fro Bot run's status.
- **Security-relevant failures** (HTTP 401/403, "permission denied", off-target tag edits, `action_required`, `skipped`, post-write integrity failure, dispatched run not found within 90s) exit 1 with `::error::` annotation. Release job goes red. Operator inspection required.

This split was the resolution of adversarial review: blanket fail-soft would hide auth failures and prompt-injection attempts under green CI; blanket fail-hard would train operators to ignore transient network blips. Splitting by class preserves "release ships even if narrative fails" while keeping security signals loud.

## Idempotency

If the Release job is re-run after a transient failure (the v2.22.0 oven-sh/setup-bun retry pattern), the dispatched Fro Bot prompt includes an idempotency check: if the existing release body starts with `## What's new`, treat as already-applied and exit cleanly. Fro Bot reports conclusion `neutral` in that case; the successCmd classifies as happy-path no-op.

## Pre-merge gate: FRO_BOT_PAT scope evidence

The successCmd dispatches a workflow that uses `FRO_BOT_PAT` for `gh release edit`. The PAT must have `releases: write` (or `contents: write` covering releases) scope.

**Evidence of write success under this PAT:** v2.22.0's manual `gh release edit` succeeded against the live release — see https://github.com/marcusrbrown/systematic/releases/tag/v2.22.0 for the resulting narrative body. That session ran `gh release edit v2.22.0 --notes-file <tmpfile>` using the same `FRO_BOT_PAT` value that this PR's automation will use, providing existence proof that the scope is sufficient.

## What's tested

`tests/integration/release-notes-ci.test.ts` covers 21 scenarios with deterministic mock fixtures (`tests/fixtures/mock-gh.sh`):

- Validation: invalid tag rejected, pre-release accepted
- Happy path: success, neutral (idempotent), cancelled, generic failure, unknown conclusion
- Edge: timeout (WATCH_EXIT=124), empty run list (dispatch not found), correlation token matches second-newest run
- Error: HTTP 401, 403+permission denied, Resource not accessible, ANSI-stripped off-target edit, success+short-body integrity failure, action_required, skipped (policy/branch protection)
- Integration: prompt construction includes correlation+tag+repo+echo requirement
- Plus 3 unit tests for the `extractSuccessCmd` YAML parser

Strategy: the test extracts the `successCmd` block from `.releaserc.yaml` at runtime, substitutes `${nextRelease.gitTag}` with a bash env var, writes to a temp script, and runs under a PATH-shim mock-gh. Test escape hatches plumb sub-second polling/watch budgets and a known correlation token so the suite runs in ~7s.

## What's NOT tested

End-to-end behavior (`workflow_call` → Fro Bot agent → `gh release edit` against a real release) cannot be exercised before the first real merge. **The acceptance gate is the first release after this PR merges:** if its live body is narrative within 10 minutes of `gh release list` showing the new tag, v2 works. If not, manually invoke the skill and file a regression.

## Diff stats

| Path | Change |
|------|--------|
| `.releaserc.yaml` | +140 (the successCmd block) |
| `package.json` + `bun.lock` | +1 line + lockfile regenerated (`@semantic-release/exec` ^7) |
| `tests/integration/release-notes-ci.test.ts` | +810 (21 scenarios) |
| `tests/fixtures/mock-gh.sh` | +115 (shared mock-gh shim) |
| `.agents/skills/release-notes-narrative/SKILL.md` | +6 (CI automation cross-reference) |
| `docs/solutions/best-practices/release-notes-narrative-procedure-2026-05-23.md` | +6 (forward-link update) |
| `docs/solutions/best-practices/release-notes-narrative-ci-automation-architecture-2026-05-23.md` | +160 (new architecture compound doc) |
| `docs/plans/2026-05-23-002-feat-release-notes-narrative-ci-automation-plan.md` | +382 (tracked plan, non-releasing) |

5 commits, 971 tests pass (+21 from baseline), full quality gate green (typecheck / lint / build / registry / content-integrity all clean).

## Plan and origin

- Plan: `docs/plans/2026-05-23-002-feat-release-notes-narrative-ci-automation-plan.md` (4 units, 14 review-applied corrections from coherence/feasibility/security/scope/adversarial passes)
- Requirements: `docs/brainstorms/2026-05-23-release-notes-narrative-ci-automation-requirements.md` (gitignored, local-only)
