### PR TITLE
fix(ci): declare correlation-id input on fro-bot.yaml

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -20,11 +20,26 @@ on:
       prompt:
         description: Custom prompt for the Fro Bot agent
         required: true
+      correlation-id:
+        description: >-
+          Optional UUID for callers that need to identify their dispatched run by
+          scanning early log output. The release-notes-narrative automation uses
+          this to match its dispatch against gh run list output. Unused by all
+          other entry points; the value is informational only and Fro Bot does
+          not act on it directly.
+        required: false
   workflow_call:
     inputs:
       prompt:
         description: Prompt for the Fro Bot agent
         required: true
+        type: string
+      correlation-id:
+        description: >-
+          Optional UUID for callers that need to identify their dispatched run
+          by scanning early log output. See workflow_dispatch input of the
+          same name.
+        required: false
         type: string
 
 permissions:


### PR DESCRIPTION
## Summary

Third hotfix in the `release-notes-narrative` v2 automation chain. v2.23.2 (#432) shipped npm and GitHub release successfully, but the Release job failed at the dispatch step with:

```
HTTP 422: Unexpected inputs provided: ["correlation-id"]
```

GitHub validates `workflow_dispatch` and `workflow_call` inputs against the called workflow's declared inputs and rejects any unknown fields. `fro-bot.yaml` only declares `prompt`, so when `scripts/dispatch-release-notes.sh` passed `-f correlation-id=$UUID` alongside the prompt, the API rejected the entire dispatch.

## Why this is the right place

The dispatch script generates a UUID per release dispatch and passes it two ways:

1. As a structured `-f correlation-id=$UUID` workflow input field
2. Embedded in the prompt body so Fro Bot echoes it as its first log line

Polling then matches dispatched runs by scanning early log lines for the token, eliminating same-second collision ambiguity that pure timestamp-based filtering can't resolve.

The structured input field is informational only — Fro Bot does not act on the value. But GitHub still validates input names against the declared schema before allowing the dispatch through, regardless of whether the called workflow uses them.

## Changes

Declared `correlation-id` as an **optional** input on both `workflow_dispatch` and `workflow_call` entry points of `.github/workflows/fro-bot.yaml`. The field is unused by all existing entry points (PR comments, issue events, scheduled maintenance) and exists purely as a polling correlation primitive for callers that need to identify their dispatched run.

```yaml
workflow_dispatch:
  inputs:
    prompt:
      description: Custom prompt for the Fro Bot agent
      required: true
    correlation-id:
      description: >-
        Optional UUID for callers that need to identify their dispatched run
        by scanning early log output. ...
      required: false
workflow_call:
  inputs:
    prompt:
      description: Prompt for the Fro Bot agent
      required: true
      type: string
    correlation-id:
      description: >-
        Optional UUID ... See workflow_dispatch input of the same name.
      required: false
      type: string
```

## v2.23.2 narrative recovery

While this PR is in review, v2.23.2's release body has been manually rewritten using the v1 `release-notes-narrative` skill procedure (420 → 2,517 chars). The narrative explains the three-hotfix sequence (v2.23.0 → v2.23.1 → v2.23.2) and points to this PR as the fourth in the chain.

## End-to-end acceptance

The next release after this merges is the real acceptance gate for v2. With `correlation-id` declared as a valid input, the HTTP 422 path is closed. If that release's Release job goes green AND the live release body shows narrative within ~10 minutes of tag publication, the v2 automation works end-to-end.

If dispatch succeeds but the resulting Fro Bot run fails (timeout, auth, etc.), that's a separate test surface and the existing 19 integration tests cover it.

## Verification

- `bun test tests/integration/release-notes-ci.test.ts` — 19 pass (the integration tests don't validate against the live workflow schema; production caught what mocks could not)
- Manual workflow file syntax check via `yq` — clean
- The `correlation-id` field IS used in `scripts/dispatch-release-notes.sh:74-76` already; this PR just makes the called workflow accept it.

## Why not also fix the test gap

The 19-scenario integration test suite mocks `gh` entirely and doesn't validate against the real workflow's input schema. Adding a CI check that parses both files and asserts the dispatch script's `-f` fields all match declared inputs in `fro-bot.yaml` is a reasonable follow-up but adds complexity for a one-line declaration drift. Filing as a smart note rather than adding to this PR.
