### PR TITLE
fix(release): switch run identification from log-scan to timestamp

### DIFF
--- a/scripts/dispatch-release-notes.sh
+++ b/scripts/dispatch-release-notes.sh
@@ -21,12 +21,14 @@ if ! echo "$RELEASE_VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]
   exit 1
 fi
 
-# Generate a UUID to uniquely identify this dispatch. The token is passed both
-# as a workflow input field and embedded in the prompt so Fro Bot echoes it as
-# its first log line. Polling matches by scanning early log lines for this token,
-# eliminating same-second collision ambiguity.
+# Generate a UUID to uniquely identify this dispatch. The token is passed as a
+# workflow input field (correlation-id, declared on fro-bot.yaml) and remains
+# visible in the dispatched run's inputs metadata for auditing. Primary run
+# identification is timestamp-based via DISPATCH_EPOCH below — the correlation
+# token is a secondary audit anchor, not the polling matcher.
 # Test escape hatch: integration tests set RELEASE_NOTES_TEST_CORRELATION_ID to
-# a known UUID so mock-gh fixtures can include the same value in their log output.
+# a known UUID so mock-gh fixtures can assert it is forwarded verbatim through
+# the -f correlation-id=... argument to gh workflow run.
 # Production runs never set this; uuidgen / /proc/sys/kernel/random/uuid is the
 # real source of correlation tokens.
 if [[ -n "${RELEASE_NOTES_TEST_CORRELATION_ID:-}" ]]; then
@@ -45,8 +47,8 @@ PROMPT=$(cat <<PROMPT_EOF
 correlation=$CORRELATION_ID
 
 You are running the release-notes-narrative skill against a just-published GitHub release.
-First, echo the line "correlation=$CORRELATION_ID" to stdout (the line above this prompt) so
-the dispatching workflow can identify this run. This is mandatory.
+The dispatching workflow identifies this run by timestamp via gh run list, so no
+specific echo is required of you — the correlation value above is for audit only.
 
 Target release tag: $RELEASE_VERSION
 Target repository: $GITHUB_REPOSITORY

--- a/scripts/dispatch-release-notes.sh
+++ b/scripts/dispatch-release-notes.sh
@@ -73,15 +73,28 @@ GitHub release URL.
 PROMPT_EOF
 )
 
-# Dispatch the Fro Bot workflow. gh workflow run does not return a parseable run ID,
-# so we identify our run via correlation-token polling below.
+# Capture dispatch timestamp BEFORE issuing the workflow_run call.
+# We identify our dispatched run by selecting the newest workflow_dispatch run on
+# fro-bot.yaml created strictly after this timestamp. The correlation-id input
+# is also passed (and declared on fro-bot.yaml as an optional input) so that the
+# value is visible in the run's inputs metadata for auditing, but the primary
+# identification mechanism is timestamp-based.
+#
+# Previous strategy (log-scanning for correlation token echo) did not work in
+# production: Fro Bot's agent takes several minutes to bootstrap (bun install,
+# model download, MCP server startup) before it emits any prompt-derived log
+# content, so a 90-second log scan budget completed before the correlation
+# token ever appeared in the logs. Timestamp-based identification is robust
+# against arbitrary agent boot times since gh run list reflects run creation
+# time, not first-log time.
+DISPATCH_EPOCH=$(date +%s)
 gh workflow run --ref main fro-bot.yaml \
   -f "prompt=$PROMPT" \
   -f "correlation-id=$CORRELATION_ID"
 
-# Poll up to 90 seconds for a run whose early log lines contain our correlation token.
-# Every 5 seconds, list recent fro-bot.yaml runs on main and scan the first 50 log
-# lines of each candidate for the token. The first match is our dispatched run.
+# Poll up to 90 seconds for a workflow_dispatch run on fro-bot.yaml that was
+# created strictly after DISPATCH_EPOCH. Once found, this is our dispatched run
+# (no other dispatchers race against this from main.yaml's Release job).
 # Test escape hatches: RELEASE_NOTES_TEST_POLL_BUDGET_SECS and
 # RELEASE_NOTES_TEST_POLL_INTERVAL_SECS shorten the loop for unit tests.
 # Production runs always use 90s budget / 5s interval.
@@ -90,24 +103,24 @@ POLL_INTERVAL_SECS="${RELEASE_NOTES_TEST_POLL_INTERVAL_SECS:-5}"
 RUN_ID=""
 POLL_DEADLINE=$(( $(date +%s) + POLL_BUDGET_SECS ))
 while [ "$(date +%s)" -lt "$POLL_DEADLINE" ]; do
-  CANDIDATES="$(gh run list --workflow=fro-bot.yaml --branch=main \
+  # Find the newest workflow_dispatch run on main whose createdAt is strictly
+  # after DISPATCH_EPOCH. gh run list returns ISO-8601 timestamps; convert each
+  # to epoch via `date -d` and compare numerically.
+  CANDIDATE_ID="$(gh run list --workflow=fro-bot.yaml --branch=main --event=workflow_dispatch \
     --json databaseId,createdAt --limit 10 2>/dev/null \
-    | jq -r '.[].databaseId')"
-  for CANDIDATE_ID in $CANDIDATES; do
-    # `gh run view --log` has no --limit flag (it belongs to `gh run list`).
-    # Pipe through head -n 50 to bound the scan to early log lines where the
-    # correlation token is echoed by Fro Bot.
-    if gh run view "$CANDIDATE_ID" --log 2>/dev/null | head -n 50 \
-        | grep -q "correlation=$CORRELATION_ID"; then
-      RUN_ID="$CANDIDATE_ID"
-      break 2
-    fi
-  done
+    | jq -r --argjson cutoff "$DISPATCH_EPOCH" \
+      '[.[] | . + {epoch: (.createdAt | fromdateiso8601)}]
+       | map(select(.epoch > $cutoff))
+       | sort_by(.epoch) | reverse | .[0].databaseId // empty')"
+  if [ -n "$CANDIDATE_ID" ] && [ "$CANDIDATE_ID" != "null" ]; then
+    RUN_ID="$CANDIDATE_ID"
+    break
+  fi
   sleep "$POLL_INTERVAL_SECS"
 done
 
 if [ -z "$RUN_ID" ]; then
-  echo "::error::Dispatched workflow run not found within ${POLL_BUDGET_SECS}s (correlation=$CORRELATION_ID). GitHub may have rejected the dispatch or the workflow never started."
+  echo "::error::Dispatched workflow run not found within ${POLL_BUDGET_SECS}s (correlation=$CORRELATION_ID, dispatched_at_epoch=$DISPATCH_EPOCH). GitHub may have rejected the dispatch or the workflow never started."
   exit 1
 fi
 

--- a/tests/integration/release-notes-ci.test.ts
+++ b/tests/integration/release-notes-ci.test.ts
@@ -639,7 +639,8 @@ describe('release-notes-ci successCmd smoke tests', () => {
         testTempDir,
         'captured-correlation.txt',
       )
-      const knownCorrelationId = 'test-known-correlation-uuid-for-scenario-18'
+      const knownCorrelationId =
+        'test-known-correlation-uuid-for-forwarding-assertion'
 
       const result = run({
         RELEASE_VERSION: 'v2.23.0',

--- a/tests/integration/release-notes-ci.test.ts
+++ b/tests/integration/release-notes-ci.test.ts
@@ -5,26 +5,27 @@
  * with a mock `gh` binary on PATH. The mock binary's behavior is controlled
  * per-scenario via environment variables.
  *
- * All 22 scenarios are covered:
+ * All 19 scenarios are covered:
  *  1.  Validation — invalid RELEASE_VERSION
  *  2.  Validation — valid pre-release (v2.23.0-rc.1)
  *  3.  Happy path — success conclusion + valid body length
  *  4.  Happy path — neutral conclusion (idempotent short-circuit)
  *  5.  Edge case — timeout (WATCH_EXIT=124)
  *  5b. Edge case — unexpected non-zero WATCH_EXIT (e.g., 137)
- *  6.  Edge case — dispatch not registered within 90s
- *  7.  Edge case — correlation token matches second-newest run, not first
- *  8.  Error — HTTP 401 auth denial
- *  9.  Error — HTTP 403 + permission denied
- * 10.  Error — "Resource not accessible" auth keyword
- * 11.  Error — off-target tag edit (ANSI-stripped)
- * 12.  Error — success conclusion but body too short
- * 13.  Error — action_required conclusion
- * 14.  Error — skipped conclusion (policy block)
- * 15.  Edge case — cancelled conclusion
- * 16.  Edge case — generic narrative failure
- * 17.  Edge case — unknown future conclusion
- * 18.  Integration — prompt construction includes correlation token, target tag, repo name
+ *  6.  Edge case — dispatch not registered within 90s (empty run list)
+ *  7.  Edge case — no run created after dispatch epoch (all runs pre-date cutoff)
+ *  8.  Edge case — selects newest workflow_dispatch run created after dispatch epoch
+ *  9.  Error — HTTP 401 auth denial
+ * 10.  Error — HTTP 403 + permission denied
+ * 11.  Error — "Resource not accessible" auth keyword
+ * 12.  Error — off-target tag edit (ANSI-stripped)
+ * 13.  Error — success conclusion but body too short
+ * 14.  Error — action_required conclusion
+ * 15.  Error — skipped conclusion (policy block)
+ * 16.  Edge case — cancelled conclusion
+ * 17.  Edge case — generic narrative failure
+ * 18.  Edge case — unknown future conclusion
+ * 19.  Integration — prompt construction includes correlation token, target tag, repo name
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
@@ -71,26 +72,21 @@ interface ScenarioResult {
 }
 
 /**
- * Builds a run-list JSON array where each entry has a databaseId and a log
- * that either matches or does not match the correlation token.
+ * Builds a run-list JSON array where each entry has a databaseId and a
+ * createdAt timestamp. The script identifies the dispatched run by selecting
+ * the newest workflow_dispatch run whose createdAt is strictly after the
+ * DISPATCH_EPOCH captured immediately before `gh workflow run`.
  *
- * The successCmd polls `gh run list` and then calls `gh run view <id> --log`
- * for each candidate. The mock-gh.sh returns MOCK_GH_RUN_VIEW_LOG for ALL
- * `gh run view --log` calls. To simulate "second run matches", we need the
- * run-list to contain two entries and the log to contain the correlation token
- * (the script will find it on the second attempt after the first fails).
- *
- * For the "second matches" scenario we use a special env var
- * MOCK_GH_RUN_VIEW_LOG_BY_ID which the mock reads to return different logs
- * per run ID. Since our mock-gh.sh is simple (single MOCK_GH_RUN_VIEW_LOG),
- * we implement the "second matches" scenario by having the first run's ID
- * appear in a MOCK_GH_SKIP_IDS list that causes the mock to return empty log.
+ * Using a far-future fixed timestamp ensures the run is always selected
+ * regardless of when the test executes.
  */
-function makeRunListJson(entries: Array<{ databaseId: number }>): string {
+function makeRunListJson(
+  entries: Array<{ databaseId: number; createdAt?: string }>,
+): string {
   return JSON.stringify(
     entries.map((e) => ({
       databaseId: e.databaseId,
-      createdAt: new Date().toISOString(),
+      createdAt: e.createdAt ?? '2099-01-01T00:00:00Z',
     })),
   )
 }
@@ -131,22 +127,17 @@ function runSuccessCmd(
 
   const parentPath = process.env.PATH ?? '/usr/local/bin:/usr/bin:/bin'
 
-  // Default correlation ID — used to wire the polling loop end-to-end so most
-  // tests can focus on conclusion classification rather than re-mocking polling.
-  // Tests that explicitly want polling to FAIL set MOCK_GH_RUN_LIST_JSON: '[]'.
-  // The correlation line is auto-prepended to any provided MOCK_GH_RUN_VIEW_LOG
-  // so tests that override the log to inject auth/off-target signals still let
-  // the polling loop find their run.
+  // Default correlation ID — forwarded as RELEASE_NOTES_TEST_CORRELATION_ID so
+  // scenario 19 can assert the value is passed as a separate -f arg to gh workflow run.
   const defaultCorrelationId =
     env.RELEASE_NOTES_TEST_CORRELATION_ID ?? 'test-correlation-token-default'
-  const correlationLine = `correlation=${defaultCorrelationId}\n`
-  const providedLog = env.MOCK_GH_RUN_VIEW_LOG
+
+  // Default log provides a realistic success-path output for off-target detection
+  // and auth-failure scanning. Run identification is now timestamp-based, so the
+  // log is NOT scanned for the correlation token during polling.
   const effectiveLog =
-    providedLog === undefined
-      ? `${correlationLine}release edit ${env.RELEASE_VERSION ?? 'v2.23.0'} succeeded\n`
-      : providedLog === ''
-        ? '' // explicit empty — caller wants polling to fail
-        : `${correlationLine}${providedLog}`
+    env.MOCK_GH_RUN_VIEW_LOG ??
+    `release edit ${env.RELEASE_VERSION ?? 'v2.23.0'} succeeded\n`
 
   const releaseVersion = env.RELEASE_VERSION ?? 'v2.23.0'
 
@@ -154,7 +145,10 @@ function runSuccessCmd(
     PATH: `${mockBinDir}:${parentPath}`,
     GITHUB_REPOSITORY: env.GITHUB_REPOSITORY ?? 'marcusrbrown/systematic',
     MOCK_GH_RUN_LIST_JSON:
-      env.MOCK_GH_RUN_LIST_JSON ?? makeRunListJson([{ databaseId: 12345 }]),
+      env.MOCK_GH_RUN_LIST_JSON ??
+      makeRunListJson([
+        { databaseId: 12345, createdAt: '2099-01-01T00:00:00Z' },
+      ]),
     MOCK_GH_RUN_VIEW_LOG: effectiveLog,
     MOCK_GH_RUN_VIEW_CONCLUSION: env.MOCK_GH_RUN_VIEW_CONCLUSION ?? 'success',
     MOCK_GH_RUN_WATCH_EXIT: env.MOCK_GH_RUN_WATCH_EXIT ?? '0',
@@ -275,13 +269,12 @@ describe('release-notes-ci successCmd smoke tests', () => {
   it(
     'exits 0 with narrative-applied message on success conclusion and body length >= 200',
     () => {
-      const correlationId = 'test-correlation-happy-path'
       const result = run({
         RELEASE_VERSION: 'v2.23.0',
         MOCK_GH_RUN_VIEW_CONCLUSION: 'success',
         MOCK_GH_RELEASE_VIEW_BODY_LEN: '800',
-        // Log must contain the correlation token so polling finds the run
-        MOCK_GH_RUN_VIEW_LOG: `correlation=${correlationId}\nsome other log content`,
+        MOCK_GH_RUN_VIEW_LOG:
+          'release edit v2.23.0 succeeded\nsome other log content',
       })
 
       expect(result.exitCode).toBe(0)
@@ -380,107 +373,59 @@ describe('release-notes-ci successCmd smoke tests', () => {
   )
 
   // -------------------------------------------------------------------------
-  // 7. Edge case — correlation token matches second-newest run, not first
+  // 7. Edge case — no run created after dispatch epoch
   // -------------------------------------------------------------------------
   it(
-    'uses the second run when correlation token only appears in its log',
+    'exits 1 with ::error:: when all candidate runs pre-date the dispatch epoch',
     () => {
-      // Two runs: 99999 (newest, no correlation match) and 12345 (second, matches)
-      // The mock returns MOCK_GH_RUN_VIEW_LOG for ALL view --log calls.
-      // We need the first run (99999) to NOT match and the second (12345) to match.
-      //
-      // Since mock-gh.sh returns the same log for all run IDs, we use a
-      // special approach: set the log to contain the correlation token, but
-      // also write a wrapper that skips the first ID.
-      //
-      // Simpler: use a custom mock-gh wrapper that checks the run ID arg.
-      const customMockBin = path.join(testTempDir, 'custom-mock-bin')
-      fs.mkdirSync(customMockBin, { recursive: true })
+      // All runs have a createdAt in the past — before any real DISPATCH_EPOCH.
+      // The script's jq filter selects runs with epoch > DISPATCH_EPOCH, so none
+      // qualify and the polling loop times out.
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        MOCK_GH_RUN_LIST_JSON: makeRunListJson([
+          { databaseId: 12345, createdAt: '1999-01-01T00:00:00Z' },
+        ]),
+      })
 
-      const customGh = path.join(customMockBin, 'gh')
-      // The script returns empty log for run 99999, and a correlation-matching
-      // log for run 12345. The correlation token is embedded in the log.
-      fs.writeFileSync(
-        customGh,
-        `#!/usr/bin/env bash
-set -Eeuo pipefail
-SUBCOMMAND="\${1:-}"
-if [[ "$SUBCOMMAND" == "run" && "\${2:-}" == "list" ]]; then
-  echo "\${MOCK_GH_RUN_LIST_JSON:-[]}"
-  exit 0
-fi
-if [[ "$SUBCOMMAND" == "run" && "\${2:-}" == "view" ]]; then
-  RUN_ID="\${3:-}"
-  LOG_FLAG=0
-  JSON_FLAG=0
-  for arg in "$@"; do
-    [[ "$arg" == "--log" ]] && LOG_FLAG=1
-    [[ "$arg" == "--json" ]] && JSON_FLAG=1
-  done
-  if [[ "$LOG_FLAG" == "1" ]]; then
-    if [[ "$RUN_ID" == "99999" ]]; then
-      echo "no correlation here"
-    else
-      echo "\${MOCK_GH_RUN_VIEW_LOG:-}"
-    fi
-    exit 0
-  fi
-  if [[ "$JSON_FLAG" == "1" ]]; then
-    echo "{\\"conclusion\\":\\"\${MOCK_GH_RUN_VIEW_CONCLUSION:-success}\\"}"
-    exit 0
-  fi
-fi
-if [[ "$SUBCOMMAND" == "run" && "\${2:-}" == "watch" ]]; then
-  exit "\${MOCK_GH_RUN_WATCH_EXIT:-0}"
-fi
-if [[ "$SUBCOMMAND" == "workflow" && "\${2:-}" == "run" ]]; then
-  echo "Created workflow_dispatch event for fro-bot.yaml at refs/heads/main"
-  exit 0
-fi
-if [[ "$SUBCOMMAND" == "release" && "\${2:-}" == "view" ]]; then
-  echo "\${MOCK_GH_RELEASE_VIEW_BODY_LEN:-800}"
-  exit 0
-fi
-echo "custom-mock-gh: unhandled: $*" >&2
-exit 1
-`,
-      )
-      fs.chmodSync(customGh, 0o755)
-
-      const runListJson = makeRunListJson([
-        { databaseId: 99999 },
-        { databaseId: 12345 },
-      ])
-
-      // Use a specific correlation token so the script and the custom mock's
-      // run-12345 log agree on the exact match value. The custom mock returns
-      // "no correlation here" for run 99999, so only run 12345's log matches.
-      const knownCorrelation = 'second-run-correlation-token'
-      const result = runSuccessCmd(
-        scriptPath,
-        {
-          RELEASE_VERSION: 'v2.23.0',
-          RELEASE_NOTES_TEST_CORRELATION_ID: knownCorrelation,
-          MOCK_GH_RUN_LIST_JSON: runListJson,
-          MOCK_GH_RUN_VIEW_LOG: `correlation=${knownCorrelation}\nsome log`,
-          MOCK_GH_RUN_VIEW_CONCLUSION: 'success',
-          MOCK_GH_RELEASE_VIEW_BODY_LEN: '800',
-        },
-        customMockBin,
-      )
-
-      // The script should find run 12345 (second) and succeed
-      expect(result.exitCode).toBe(0)
+      expect(result.exitCode).toBe(1)
       const combined = result.stdout + result.stderr
-      expect(combined).not.toContain('::error::')
-      // Should contain the second run's ID in output
-      expect(combined).toContain('12345')
+      expect(combined).toContain('::error::')
+      expect(combined).toMatch(/not found within/i)
+      expect(combined).toContain('dispatched_at_epoch=')
     },
     SCENARIO_TIMEOUT_MS,
   )
 
   // -------------------------------------------------------------------------
-  // 8. Error — HTTP 401 auth denial
+  // 8. Edge case — selects newest workflow_dispatch run created after dispatch epoch
+  // -------------------------------------------------------------------------
+  it(
+    'selects newest workflow_dispatch run created after dispatch epoch when two candidates exist',
+    () => {
+      // Two runs both after the cutoff. Run 99999 has a later createdAt than 12345,
+      // so the script should select 99999 (newest-after-cutoff wins).
+      const result = run({
+        RELEASE_VERSION: 'v2.23.0',
+        MOCK_GH_RUN_LIST_JSON: JSON.stringify([
+          { databaseId: 99999, createdAt: '2099-06-01T00:00:00Z' },
+          { databaseId: 12345, createdAt: '2099-01-01T00:00:00Z' },
+        ]),
+        MOCK_GH_RUN_VIEW_CONCLUSION: 'success',
+        MOCK_GH_RELEASE_VIEW_BODY_LEN: '800',
+      })
+
+      expect(result.exitCode).toBe(0)
+      const combined = result.stdout + result.stderr
+      expect(combined).not.toContain('::error::')
+      // The newer run (99999) should be selected and appear in the output
+      expect(combined).toContain('99999')
+    },
+    SCENARIO_TIMEOUT_MS,
+  )
+
+  // -------------------------------------------------------------------------
+  // 9. Error — HTTP 401 auth denial
   // -------------------------------------------------------------------------
   it(
     'exits 1 with ::error:: Auth failure when log contains HTTP 401',
@@ -500,7 +445,7 @@ exit 1
   )
 
   // -------------------------------------------------------------------------
-  // 9. Error — HTTP 403 + permission denied
+  // 10. Error — HTTP 403 + permission denied
   // -------------------------------------------------------------------------
   it(
     'exits 1 with ::error:: Auth failure when log contains HTTP 403 and permission denied',
@@ -521,7 +466,7 @@ exit 1
   )
 
   // -------------------------------------------------------------------------
-  // 10. Error — "Resource not accessible" auth keyword
+  // 11. Error — "Resource not accessible" auth keyword
   // -------------------------------------------------------------------------
   it(
     'exits 1 with ::error:: Auth failure when log contains "Resource not accessible"',
@@ -542,7 +487,7 @@ exit 1
   )
 
   // -------------------------------------------------------------------------
-  // 11. Error — off-target tag edit (ANSI-stripped)
+  // 12. Error — off-target tag edit (ANSI-stripped)
   // -------------------------------------------------------------------------
   it(
     'exits 1 with ::error:: Off-target when log contains ANSI-colored edit of a different tag',
@@ -564,7 +509,7 @@ exit 1
   )
 
   // -------------------------------------------------------------------------
-  // 12. Error — success conclusion but body too short
+  // 13. Error — success conclusion but body too short
   // -------------------------------------------------------------------------
   it(
     'exits 1 with ::error:: body integrity check failed when conclusion=success but body length < 200',
@@ -584,7 +529,7 @@ exit 1
   )
 
   // -------------------------------------------------------------------------
-  // 13. Error — action_required conclusion
+  // 14. Error — action_required conclusion
   // -------------------------------------------------------------------------
   it(
     'exits 1 with ::error:: manual intervention when conclusion=action_required',
@@ -603,7 +548,7 @@ exit 1
   )
 
   // -------------------------------------------------------------------------
-  // 14. Error — skipped conclusion (policy block)
+  // 15. Error — skipped conclusion (policy block)
   // -------------------------------------------------------------------------
   it(
     'exits 1 with ::error:: policy/branch protection when conclusion=skipped',
@@ -622,7 +567,7 @@ exit 1
   )
 
   // -------------------------------------------------------------------------
-  // 15. Edge case — cancelled conclusion
+  // 16. Edge case — cancelled conclusion
   // -------------------------------------------------------------------------
   it(
     'exits 0 with ::warning:: when conclusion=cancelled',
@@ -641,7 +586,7 @@ exit 1
   )
 
   // -------------------------------------------------------------------------
-  // 16. Edge case — generic narrative failure
+  // 17. Edge case — generic narrative failure
   // -------------------------------------------------------------------------
   it(
     'exits 0 with ::warning:: for generic failure with no security signals',
@@ -664,7 +609,7 @@ exit 1
   )
 
   // -------------------------------------------------------------------------
-  // 17. Edge case — unknown future conclusion
+  // 18. Edge case — unknown future conclusion
   // -------------------------------------------------------------------------
   it(
     'exits 0 with ::warning:: Unknown conclusion for unrecognized conclusion values',
@@ -684,7 +629,7 @@ exit 1
   )
 
   // -------------------------------------------------------------------------
-  // 18. Integration — prompt construction includes correlation token, target tag, repo name
+  // 19. Integration — prompt construction includes correlation token, target tag, repo name
   // -------------------------------------------------------------------------
   it(
     'prompt and correlation-id are forwarded to gh workflow run as separate -f fields',


### PR DESCRIPTION
## Summary

Fourth hotfix in the `release-notes-narrative` v2 automation chain. v2.23.3 (#433) closed the HTTP 422 input-validation path, and Fro Bot's dispatch actually fired this time. But the script's polling loop still failed:

```
::error::Dispatched workflow run not found within 90s (correlation=099da1ed-681b-4ae5-b7ef-a9057a118244)
```

The dispatch succeeded — the Release job log shows the URL `actions/runs/26347038600` being printed by `gh workflow run`. The polling loop just couldn't match that run against the correlation token within 90 seconds.

## Root cause

The previous strategy scanned each candidate run's early log lines for the correlation token, expecting the Fro Bot agent to echo the token quickly per the prompt instruction. **The agent does eventually echo it, but not within 90 seconds.** Fro Bot's OpenCode agent has substantial bootstrap time:

1. Runner spin-up
2. Checkout (full history)
3. `bun install --frozen-lockfile`
4. Model/auth setup
5. MCP server startup
6. OpenCode CLI launches and reads the prompt

Only after all of that does any prompt-derived content appear in the run's logs. The 90-second budget was tight even before this; with real-world boot times it's the wrong primitive entirely.

## The fix

Switch to **timestamp-based identification**. Capture an epoch timestamp immediately before `gh workflow run`, then poll for the newest `workflow_dispatch` run on `fro-bot.yaml` whose `createdAt` is strictly greater than that epoch:

```bash
DISPATCH_EPOCH=$(date +%s)
gh workflow run --ref main fro-bot.yaml \
  -f "prompt=$PROMPT" \
  -f "correlation-id=$CORRELATION_ID"

while [ "$(date +%s)" -lt "$POLL_DEADLINE" ]; do
  CANDIDATE_ID="$(gh run list --workflow=fro-bot.yaml --branch=main --event=workflow_dispatch \
    --json databaseId,createdAt --limit 10 2>/dev/null \
    | jq -r --argjson cutoff "$DISPATCH_EPOCH" \
      '[.[] | . + {epoch: (.createdAt | fromdateiso8601)}]
       | map(select(.epoch > $cutoff))
       | sort_by(.epoch) | reverse | .[0].databaseId // empty')"
  ...
done
```

`gh run list` reflects run **creation time**, not first-log time. The run is visible to the API as soon as it's created (long before logs start streaming), so timestamp-based identification works regardless of agent boot time.

The correlation-id field is still passed (and `fro-bot.yaml` still declares it from PR #433). It remains visible in the dispatched run's `inputs` metadata for audit purposes, but it's no longer the primary identification mechanism. If a future debugging session needs to confirm which dispatch produced which run, the correlation-id is a second source of truth.

## Why this wasn't caught in tests

The 20-scenario integration suite mocks `gh` entirely. The mock returned canned `MOCK_GH_RUN_VIEW_LOG` content that contained the correlation token on demand, so log-scanning "worked" in tests. The mock did not simulate real-world agent boot delay. Production caught what mocks couldn't.

The new logic IS testable: `MOCK_GH_RUN_LIST_JSON` returns `createdAt` values, and the timestamp filter is deterministic. The updated tests use far-future timestamps (`2099-01-01T00:00:00Z`) so the default run is always selected, and a new scenario explicitly tests "no run created after dispatch epoch" by passing a 1999 timestamp.

## Test scaffold updates

- `makeRunListJson` now accepts optional `createdAt` per entry, defaults to far-future
- `runSuccessCmd` drops the correlation-token prepend on `MOCK_GH_RUN_VIEW_LOG`; default log is now realistic `release edit v2.23.0 succeeded\n` for off-target/auth scanning
- **Renamed scenario** (was: "correlation matches second-newest run via log scan"): now "no run created after dispatch epoch" — passes `createdAt: 1999-01-01`, asserts exit 1 with `dispatched_at_epoch=` in error message
- **New scenario**: "selects newest workflow_dispatch run created after dispatch epoch" — two runs with different future `createdAt` values; asserts the newer one wins

## Changes

| File | Change |
|------|--------|
| `scripts/dispatch-release-notes.sh` | Replaces log-scan polling with timestamp-filter polling. Adds `DISPATCH_EPOCH` capture before `gh workflow run`. Error message now includes `dispatched_at_epoch=` for diagnostics. |
| `tests/integration/release-notes-ci.test.ts` | Updates 19 scenarios + adds 1 new for newest-wins. `makeRunListJson` signature change. Drops correlation-prepend machinery. |

## Verification

| Check | Result |
|-------|--------|
| `bun test tests/integration/release-notes-ci.test.ts` | 20 pass, 0 fail (was 19) |
| `bun run typecheck` | clean |
| `bun run lint` | 0 errors |
| `bun scripts/content-integrity.ts` | clean (167 md + 21 ts scanned) |
| `bun scripts/generate-registry.ts --check` | up to date |
| Plan-taxonomy grep | empty (no leakage in shipped files) |

## End-to-end acceptance

The first release after this merges will be v2.23.4. Two things to watch:

1. **Release job exits 0** (or with a `::warning::` for narrative-failure modes — both are green for the workflow). The current Release job fails because the dispatcher never finds its run.
2. **Live release body shows narrative** within ~5–10 minutes of tag publication, once Fro Bot's agent finishes bootstrapping and runs the v1 skill against the just-published tag.

If both happen, v2 automation is verified end-to-end. The four-hotfix sequence is:

| PR | What it fixed | Tag |
|----|---------------|-----|
| #430 | Introduced the v2 automation (inline successCmd) | v2.23.0 |
| #431 | Tried backslash-escaping `${VAR}` for Lodash (didn't work) | v2.23.1 |
| #432 | Extracted bash to external script, eliminated Lodash collision | v2.23.2 |
| #433 | Declared `correlation-id` as workflow input | v2.23.3 |
| **#434 (this)** | Switch identification from log-scan to timestamp | v2.23.4 |
