### PR TITLE
docs(plans): reconcile completed plan statuses with shipped provenance

### DIFF
--- a/docs/plans/2026-05-22-001-feat-launch-surface-cleanup-plan.md
+++ b/docs/plans/2026-05-22-001-feat-launch-surface-cleanup-plan.md
@@ -1,10 +1,14 @@
 ---
 title: "feat: Launch surface cleanup — docs, README, and repo polish"
 type: feat
-status: active
+status: completed
 date: 2026-05-22
 deepened: 2026-05-22
 origin: docs/brainstorms/2026-05-22-launch-surface-requirements.md
+shipped:
+  pr: 428
+  release: v2.21.0
+  date: 2026-05-23
 ---
 
 # Launch Surface Cleanup

--- a/docs/plans/2026-05-23-001-feat-release-notes-narrative-skill-plan.md
+++ b/docs/plans/2026-05-23-001-feat-release-notes-narrative-skill-plan.md
@@ -1,9 +1,13 @@
 ---
 title: "feat: Add release-notes-narrative project-scoped skill"
 type: feat
-status: active
+status: completed
 date: 2026-05-23
 origin: docs/brainstorms/2026-05-23-release-notes-narrative-skill-requirements.md
+shipped:
+  pr: 429
+  release: v2.22.0
+  date: 2026-05-23
 ---
 
 # feat: Add release-notes-narrative project-scoped skill

--- a/docs/plans/2026-05-23-002-feat-release-notes-narrative-ci-automation-plan.md
+++ b/docs/plans/2026-05-23-002-feat-release-notes-narrative-ci-automation-plan.md
@@ -1,9 +1,15 @@
 ---
 title: Wire CI automation for release-notes-narrative skill
 type: feat
-status: active
+status: completed
 date: 2026-05-23
 origin: docs/brainstorms/2026-05-23-release-notes-narrative-ci-automation-requirements.md
+shipped:
+  pr: 430
+  hotfix_prs: [431, 432, 433, 434]
+  release: v2.23.4
+  date: 2026-05-23
+  note: "v2.23.0–v2.23.3 each surfaced a different production contract violation; v2.23.4 is the end-to-end-verified release with auto-narrative landing within seconds of tag publication. See docs/solutions/best-practices/release-notes-narrative-ci-automation-architecture-2026-05-23.md for the Production Verification table."
 ---
 
 # Wire CI automation for release-notes-narrative skill


### PR DESCRIPTION
## Summary

Three plan docs from the May 22–23 sprint still carried `status: active` in their frontmatter despite the work shipping in merged PRs and live releases. This PR flips each to `status: completed` and adds a `shipped:` block capturing the PR number, release version, and date.

## Affected plans

| Plan | Branch reference | Shipped via | Release |
|------|------------------|-------------|---------|
| `docs/plans/2026-05-22-001-feat-launch-surface-cleanup-plan.md` | Launch surface cleanup | PR #428 | v2.21.0 |
| `docs/plans/2026-05-23-001-feat-release-notes-narrative-skill-plan.md` | v1 manual skill | PR #429 | v2.22.0 |
| `docs/plans/2026-05-23-002-feat-release-notes-narrative-ci-automation-plan.md` | v2 CI automation | PR #430 (+ hotfixes #431–#434) | v2.23.4 |

## Why this matters

Stale `status: active` frontmatter creates two problems:

1. **Plan-tracker drift.** Audits of `docs/plans/` for in-flight work return false positives, hiding the real set of plans that still need execution.
2. **Lost institutional memory.** The shipped record is buried in git log and PR history rather than surfacing on the plan doc itself, which is what readers actually find first when searching for a topic.

The v2 CI automation plan in particular benefits from explicit shipped provenance — the `shipped:` block captures the four-PR hotfix sequence (#431–#434) inline, with a `note:` field pointing at the Production Verification table in the architecture compound doc for the full failure-mode-by-release breakdown.

## Frontmatter shape

```yaml
status: completed
shipped:
  pr: <merge PR number>
  release: <tag>
  date: <YYYY-MM-DD>
  # optional fields:
  hotfix_prs: [N, N+1, ...]
  note: "..."
```

This matches the pattern already in use elsewhere in the repo for closed plans.

## Verification

| Check | Result |
|-------|--------|
| `bun scripts/content-integrity.ts` | clean (167 md + 21 ts scanned, 0 warnings) |
| Frontmatter parses on all three files | ✅ |
| All shipped-PR numbers exist on `main` | ✅ — #428 (`400f36f`), #429 (`e203c8d`), #430 (`cbe4c33`) + hotfixes #431 (`d07b090`), #432 (`d0c6486`), #433 (`5dc7101`), #434 (`5568ffc`) |

## Release impact

`docs(plans):` does not trigger a semver bump under the conventionalcommits preset in `.releaserc.yaml`. This PR will merge non-releasing.
