### PR TITLE
fix(docs): iterate HTML-tag strip in cleanDescription to a fixed point

### DIFF
--- a/docs/scripts/transform-content.ts
+++ b/docs/scripts/transform-content.ts
@@ -56,7 +56,22 @@ function toTitleCase(name: string): string {
 }
 
 function cleanDescription(raw: string): string {
-  return raw.replace(/<[^>]+>/g, '').replace(/\\\\n/g, '\n')
+  // Trust boundary: `raw` is the description field of bundled SKILL.md / agent
+  // frontmatter we ship in this repo. It is not user-supplied at runtime — the
+  // docs build only ever runs against committed source. The HTML-tag strip is
+  // cosmetic (descriptions occasionally include `<br>` etc.), not a security
+  // control. The regex is still iterated to a fixed point so the static analyzer
+  // (CodeQL `js/incomplete-multi-character-sanitization`, alert #31) sees a
+  // sanitizer that cannot leave a stripped prefix behind on adversarial input
+  // like `<<tag>` — defense in depth in case this helper is ever reused on
+  // untrusted input by a future change.
+  let cleaned = raw
+  let previous: string
+  do {
+    previous = cleaned
+    cleaned = cleaned.replace(/<[^>]+>/g, '')
+  } while (cleaned !== previous)
+  return cleaned.replace(/\\\\n/g, '\n')
 }
 
 function transformFrontmatter(


### PR DESCRIPTION
## Summary

Closes CodeQL warning #31 (`js/incomplete-multi-character-sanitization`) by iterating the HTML-tag strip in `cleanDescription` to a fixed point. The alert has been stable in the Weekly Maintenance Report (issue #157) for 5+ consecutive weeks.

## Vulnerability shape

The flagged line was:

```ts
function cleanDescription(raw: string): string {
  return raw.replace(/<[^>]+>/g, '').replace(/\\n/g, '\n')
}
```

CodeQL flags this regex pattern because adversarial input like `<<tag>` survives a single-pass strip — the inner `<tag>` is removed, leaving the outer `<` behind. The fixed pattern iterates the strip until input no longer changes.

## Trust boundary

`cleanDescription` is invoked exclusively from `docs/scripts/transform-content.ts` at build time, against the `description` field of bundled `SKILL.md` and agent frontmatter we ship in this repo. It does not run against runtime user input. The single-pass strip was cosmetic (handling stray `<br>` in descriptions), not a security control.

This fix is therefore defense in depth: the alert is closed and the helper is hardened so a future change that reuses it against untrusted input doesn't silently re-introduce the gap. The trust boundary is documented in a comment block above the loop.

## Verification

| Check | Result |
|-------|--------|
| Typecheck | clean |
| Lint | clean |
| Unit tests | 918/0/0 |
| `bun scripts/content-integrity.ts` | clean (167 md + 21 ts scanned, 0 warnings) |
| `bun scripts/generate-registry.ts --check` | clean (103 components) |
| `cd docs && bun run build` | 110 pages built in 6.04s |
| Anti-pattern sweep on the diff | none |

## Release impact

`fix(docs):` is in the patch-bump scope set under `.releaserc.yaml`'s conventionalcommits preset, so this will publish as the next patch release after merge. The change has no runtime impact on the published plugin — `transform-content.ts` is a build-time docs script, not part of `dist/`.
