### PR TITLE
feat(scripts): add docs:verify for local CI-parity pre-checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ bun test --filter "pattern"  # Filter tests
 bun run docs:dev         # Local docs site
 bun run docs:build       # Build docs (generates reference + builds Starlight)
 bun run docs:generate    # Sync reference content from bundled assets
+bun run docs:verify      # Run docs build the same way CI does (use before approving docs-framework dep bumps)
 bun run registry:build   # Build OCX registry
 bun run registry:drift   # Check registry source drift vs generated assets
 bun run registry:validate  # Validate registry without building

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "docs:dev": "bun run --cwd docs dev",
     "docs:build": "bun run docs:generate && bun run --cwd docs build",
     "docs:preview": "bun run --cwd docs preview",
+    "docs:verify": "bun install --frozen-lockfile && bun run --cwd docs playwright install --with-deps chromium && bun run docs:build",
     "docs:generate": "bun docs/scripts/transform-content.ts && bun scripts/generate-config-schema.ts && bun docs/scripts/generate-config-reference.ts",
     "schema:generate": "bun scripts/generate-config-schema.ts",
     "schema:drift": "bun scripts/generate-config-schema.ts --check",


### PR DESCRIPTION
## Summary

Adds a `docs:verify` npm script that runs the exact same command sequence as the CI **Docs Build** job, so a docs-framework Renovate PR (Starlight, Astro, expressive-code, etc.) can be locally pre-verified before approval rather than discovering config-shape incompatibilities only after CI fails.

## Why now

PR #444 (Renovate's Starlight 0.38→0.39 bump) failed CI on Docs Build because Starlight 0.39 removed the `{ label, autogenerate }` sidebar shorthand. The break only surfaces when Starlight's `astro:config:setup` hook runs under a real Astro build — typecheck, lint, content-integrity, registry-drift, and the bundled unit tests all stayed green. The fix was straightforward (wrap each `autogenerate` in `items: [...]`), but the lost time came from CI catching it instead of local pre-approval.

This is the second time in two weeks a Renovate docs-framework bump cleared every local gate and only failed at CI's docs build (the earlier one was a Playwright Chromium version mismatch that exposed a stale local browser cache).

## What `docs:verify` does

A single chained command equivalent to CI's Docs Build job:

```sh
bun install --frozen-lockfile && \
  bun run --cwd docs playwright install --with-deps chromium && \
  bun run docs:build
```

The three steps in order:

1. `bun install --frozen-lockfile` — ensures the lockfile in the working tree exactly matches `node_modules` (catches "lockfile bumped but node_modules stale" drift like the one observed during the Starlight 0.39 fix).
2. `bun run --cwd docs playwright install --with-deps chromium` — pre-warms the workspace-pinned Playwright Chromium that `rehype-mermaid` needs at build time.
3. `bun run docs:build` — runs `docs:generate` then `astro build`, which is what actually exercises the Starlight config schema.

On a hot cache the whole thing runs in ~5 seconds; on a cold cache the Playwright install dominates (~30-60s for the Chromium download).

## Verification

Local run on `feat/docs-verify-local-parity`:

```
22:32:21 [starlight:pagefind] Finished building search index in 555ms.
22:32:21 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
22:32:21 [build] 110 page(s) built in 4.41s
22:32:21 [build] Complete!
```

No lint regression. `bun.lock` untouched.

## Release impact

`feat(scripts):` is in the minor-bump scope set under `.releaserc.yaml`'s conventionalcommits preset (the `scripts` scope is a build-affecting scope but minor-vs-patch depends on the `feat:` subject). The script itself is dev-only and is not exported from the published package; it only affects local development. The v2 release-notes-narrative automation will pick up the next bump on merge — second consecutive opportunity for unattended verification since v2.23.5/v2.23.6.

## Workflow change

The new triage rule (memory #3944, codified in this session): when reviewing a docs-framework Renovate PR with a 0.x minor or any major bump, run `bun run docs:verify` against the Renovate branch before approval. If it fails locally, apply the fix on Renovate's branch before merging. This was the workflow I used to land #444 cleanly; making it a one-liner script removes the "what was that command sequence again" friction.
