### PR TITLE
ci(fro-bot): document PROMPT routing precedence inline

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -570,6 +570,22 @@ jobs:
           # Modernization Watch) is the only consumer and only ever runs from
           # the daily autoheal schedule or an autoheal-mode dispatch.
           IS_SUNDAY_UTC: ${{ env.IS_SUNDAY_UTC || 'false' }}
+          # PROMPT routing precedence — ORDER MATTERS.
+          #
+          # Both workflow_call AND workflow_dispatch can carry a non-empty
+          # `inputs.prompt`, and both branches MUST come BEFORE the mode-gated
+          # branches below. External callers (release-notes-narrative
+          # automation via scripts/dispatch-release-notes.sh, manual
+          # operators, sister workflows) commonly dispatch with prompt-only
+          # and let `mode` default to `autoheal`. If a mode-gated branch
+          # captured them first, the supplied prompt would be silently
+          # ignored and AUTOHEAL_PROMPT rendered instead — breaking the live
+          # release-notes automation contract verified across v2.23.4-v2.24.0.
+          #
+          # When editing this ternary, walk every event_name × mode × cron
+          # combination explicitly. The validate-review-mode-inputs step
+          # above only protects against `mode=review` with empty prompt;
+          # all other invalid combinations rely entirely on this ordering.
           PROMPT: >-
             ${{
               (github.event_name == 'workflow_call' && inputs.prompt != '' && inputs.prompt)


### PR DESCRIPTION
## Summary

Single 16-line comment block inserted above the PROMPT ternary in `.github/workflows/fro-bot.yaml` documenting the routing precedence rule that Oracle caught during PR #446 review.

## Why

The consolidated Fro Bot workflow has a PROMPT ternary with 9 branches. Oracle's review of PR #446 flagged a near-miss: an earlier draft of the ternary gated the dispatched `prompt` input behind `mode == 'review'`, which would have silently routed `scripts/dispatch-release-notes.sh` invocations (prompt-only, no mode) to `AUTOHEAL_PROMPT` instead of using the supplied release-notes prompt. The fix landed in PR #446 — this PR just documents the rule inline at its highest-leverage location.

## Capture mechanisms already in place

This rule is also captured durably in:

- A cross-session memory (rule documentation visible to any future session reasoning about this workflow).
- The PR #446 commit body and squash-merge log.

The inline comment adds defense-in-depth at the surface a maintainer is editing when the rule applies. Two surfaces are better than one for a rule that takes silently-misroutes-production-automation as its failure mode.

## Verification

- `actionlint .github/workflows/fro-bot.yaml` — 0 errors.
- YAML parse — clean, 1 job preserved.
- Single-file diff: `.github/workflows/fro-bot.yaml | 16 ++++++++++++++++`.
- Functional behavior of the workflow is unchanged — this is a comment-only addition.

## Release impact

`ci(fro-bot):` — no published-package surface change, no version bump.