### PR TITLE
ci(fro-bot): document fork-guard asymmetry across PR-adjacent event types

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -510,6 +510,24 @@ jobs:
         )
       )
     steps:
+      # Fork-guard asymmetry across the four PR-adjacent event types:
+      #
+      #   pull_request                  github.event.pull_request populated →
+      #                                 top-level if: gate catches forks.
+      #   pull_request_review_comment   github.event.pull_request populated →
+      #                                 top-level if: gate catches forks.
+      #   issue_comment                 github.event.pull_request is NULL even
+      #                                 when the issue IS a PR (GitHub uses
+      #                                 github.event.issue.pull_request instead).
+      #                                 Top-level gate cannot see the fork bit,
+      #                                 so this explicit API-query step is the
+      #                                 only line of defense for this path.
+      #   discussion_comment            No PR association possible → fork check
+      #                                 is N/A; OWNER/MEMBER/COLLABORATOR
+      #                                 association gate alone is sufficient.
+      #
+      # This step exists ONLY for the issue_comment case. Verified against
+      # GitHub webhook docs for each event type's payload shape.
       - name: Refuse fork PR heads from comment triggers
         if: github.event_name == 'issue_comment' && github.event.issue.pull_request
         env:


### PR DESCRIPTION
## Summary

Inline 18-line comment block above the "Refuse fork PR heads from comment triggers" step in `.github/workflows/fro-bot.yaml` documenting why the explicit guard exists only for `issue_comment` events. Closes #448.

## Why

Fro Bot's self-review of PR #446 flagged that the explicit fork-guard step covered `issue_comment` only — `pull_request_review_comment` events were not in its `if:` filter. This raised the question of whether the asymmetry was a real gap or a documentation gap.

Verified against GitHub webhook docs (`docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads`) for each event type:

| Event | `github.event.pull_request` populated? | Fork detection path |
|---|---|---|
| `pull_request` | ✅ Yes | Top-level `if:` gate (line 478-482) |
| `pull_request_review_comment` | ✅ Yes | Top-level `if:` gate (line 478-482) |
| `issue_comment` | ❌ No (uses `github.event.issue.pull_request` instead) | **This explicit step** |
| `discussion_comment` | ❌ No | N/A — discussions have no PR association |

The asymmetry was correct but opaque. A future maintainer reading just the `if:` condition could reasonably wonder why two of the three comment event types weren't included. The inline comment now explains why each comment event type takes the path it does.

## Verification

- `actionlint .github/workflows/fro-bot.yaml` — 0 errors.
- YAML parse — clean, 1 job preserved.
- Single-file diff: `+18 / -0` (pure comment addition).
- Functional behavior unchanged — comment-only change.

## Source

External verification done via @librarian, confirming GitHub webhook payload shapes for each of the four PR-adjacent event types and confirming the `fro-bot/agent@v0.45.0` action delegates all fork-safety enforcement to the workflow's `if:` gate and explicit checkout-ref handling.

## Release impact

`ci(fro-bot):` — internal CI/automation tooling, no published-package surface change, no version bump.