### PR TITLE
ci(docs): activate docs-site analytics wiring + privacy facts

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -78,6 +78,10 @@ jobs:
           fi
 
       - name: Build docs
+        env:
+          # Public website id (ships in the client HTML), so a repo variable, not a
+          # secret. When unset, astro.config.mjs omits the analytics script entirely.
+          UMAMI_WEBSITE_ID: ${{ vars.UMAMI_WEBSITE_ID }}
         run: bun run --cwd docs build
 
       - name: Copy registry to docs output

--- a/docs/src/content/docs/privacy.mdx
+++ b/docs/src/content/docs/privacy.mdx
@@ -37,11 +37,9 @@ The tracker is configured with `data-do-not-track="true"`. Umami honors the brow
 
 All analytics data stays on infrastructure controlled by this project. No data is shared with, sold to, or processed by any third party.
 
-### Retention and IP handling
+### IP addresses and identifiers
 
-Retention period and IP address handling depend on the specific Umami instance configuration.
-
-> **Note:** Specific retention and IP-handling details are pending review of the live instance configuration and will be added here before the public launch.
+No raw IP addresses or personal identifiers are stored. Visitors are counted using a one-way hash that rotates monthly, so the same visitor cannot be tracked across months and the original IP cannot be recovered. Approximate location (country, region, city) is derived locally from the IP address at collection time, with no third-party calls. Visitors with Do Not Track enabled are not recorded at all.
 
 ## Plugin runtime
 


### PR DESCRIPTION
## Summary

Wires up the final launch unit: makes the docs-site analytics actually activatable, and fills the privacy page with the real data-handling facts. This is the mechanism behind the public launch — it does not itself turn analytics on.

## What's included

- **`ci(docs)`: thread `UMAMI_WEBSITE_ID` into the docs build.** `astro.config.mjs` only injects the Umami script when `UMAMI_WEBSITE_ID` is set at build time, but the "Build docs" step had no `env:` block — GitHub Actions doesn't auto-expose repo variables to `run:` steps, so the script never shipped even if the variable existed. Now the build passes `vars.UMAMI_WEBSITE_ID` through. Unset (dev, forks, or before the variable is configured) → no script at all.
- **`docs`: privacy page IP/identifier facts.** Replaces the pre-launch placeholder with the live `metrics.fro.bot` posture: no raw IPs or personal identifiers stored, monthly-rotating one-way hash for visitor counting, approximate location derived locally with no third-party calls, Do-Not-Track visitors not recorded.

## Verified

The env gating was tested both ways against a real build:

| Build | Umami script in homepage |
|-------|--------------------------|
| `UMAMI_WEBSITE_ID` unset | absent (0 tags) |
| `UMAMI_WEBSITE_ID` set | present, with `data-website-id` |

Workflow YAML parses clean. `docs:build` produces 112 pages in both modes.

## Activation is a separate, manual step (not in this PR)

Merging this PR does **not** start collecting analytics. After merge, the launch is:

1. Set the repo variable `UMAMI_WEBSITE_ID` (the website id is public — it ships in client HTML — so a variable, not a secret).
2. Trigger the `Docs` workflow via `workflow_dispatch` to build + deploy with the variable set.
3. Verify the live site loads the tracker and `metrics.fro.bot` receives a pageview.

## Release impact

`ci(docs)` / `docs` — no published-package surface change, so no version bump. The docs site deploys on the next release or a manual dispatch.
