### PR TITLE
chore(docs): polish homepage with square brand mark and list layouts

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -37,6 +37,7 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'Systematic',
+      favicon: '/favicon.svg',
       description:
         'Systematic is an OpenCode plugin that brings structure to AI-assisted development — brainstorm, plan, implement, and review with bundled skills and agents that encode proven engineering workflows.',
       head: [

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-86 -70 172 172">
+  <defs>
+    <linearGradient id="fav-line" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4FD1C5" />
+      <stop offset="100%" stop-color="#E91E8C" />
+    </linearGradient>
+    <linearGradient id="fav-accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#4FD1C5" />
+      <stop offset="50%" stop-color="#E91E8C" />
+      <stop offset="100%" stop-color="#F5A623" />
+    </linearGradient>
+    <filter id="fav-glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="3" result="coloredBlur" />
+      <feMerge>
+        <feMergeNode in="coloredBlur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <g filter="url(#fav-glow)">
+    <line x1="0" y1="0" x2="-70" y2="40" stroke="url(#fav-line)" stroke-width="3.5" opacity="0.8" />
+    <line x1="0" y1="0" x2="70" y2="40" stroke="url(#fav-line)" stroke-width="3.5" opacity="0.8" />
+    <line x1="-70" y1="40" x2="70" y2="40" stroke="url(#fav-accent)" stroke-width="3.5" opacity="0.8" />
+    <circle cx="0" cy="0" r="24" fill="#4FD1C5" />
+    <circle cx="-70" cy="40" r="16" fill="#E91E8C" />
+    <circle cx="70" cy="40" r="16" fill="#F5A623" />
+  </g>
+</svg>

--- a/docs/src/components/FeatureCard.astro
+++ b/docs/src/components/FeatureCard.astro
@@ -9,71 +9,84 @@ interface Props {
 const { icon, title } = Astro.props
 ---
 
-<article class="not-content feature-card">
-  <div class="head">
+<article class="not-content feature-item">
+  <div class="feature-head">
     {icon && (
-      <span class="icon-wrap" aria-hidden="true">
+      <div class="icon-wrap" aria-hidden="true">
         <Icon name={icon as any} size="1.25rem" class="card-icon" />
-      </span>
+      </div>
     )}
-    <h3 class="title" set:html={title} />
+    <div class="title" set:html={title} />
   </div>
-  <p class="description"><slot /></p>
+  <div class="description"><slot /></div>
 </article>
 
 <style>
-  .feature-card {
-    position: relative;
+  .feature-item {
     display: flex;
     flex-direction: column;
-    gap: var(--space-3);
-    padding: var(--space-5) var(--space-5) var(--space-6);
-    background: var(--sl-color-gray-6);
-    border: 1px solid var(--sl-color-gray-5);
-    border-radius: 0.25rem;
-    transition: border-color 180ms cubic-bezier(0.16, 1, 0.3, 1),
-                background-color 180ms cubic-bezier(0.16, 1, 0.3, 1);
+    gap: var(--space-2);
+    padding: var(--space-5);
+    background-color: transparent;
+    border-bottom: 1px solid var(--sl-color-gray-5);
+    transition: background-color 180ms cubic-bezier(0.16, 1, 0.3, 1);
   }
 
-  .feature-card:hover {
-    border-color: var(--sl-color-accent);
+  .feature-item:last-child {
+    border-bottom: none;
+  }
+
+  .feature-item:hover {
     background-color: color-mix(in oklab, var(--sl-color-accent) 6%, var(--sl-color-gray-6));
   }
 
-  .head {
+  .feature-head {
     display: flex;
     align-items: center;
     gap: var(--space-3);
-    margin-bottom: var(--space-2);
   }
 
   .icon-wrap {
     flex-shrink: 0;
-    display: inline-flex;
+    display: flex;
     align-items: center;
     justify-content: center;
     width: 2.25rem;
     height: 2.25rem;
-    border-radius: 0.2rem;
+    border-radius: 0.375rem;
     background-color: color-mix(in oklab, var(--sl-color-accent) 15%, transparent);
     color: var(--sl-color-accent);
   }
 
   .title {
-    font-family: var(--sl-font-system); /* Keeping it simple and readable */
+    margin: 0 !important;
+    font-family: var(--sl-font-system);
     font-weight: 600;
-    font-size: 1.125rem;
-    line-height: 1.2;
+    font-size: 1.0625rem;
+    line-height: 1.25;
     letter-spacing: -0.01em;
     color: var(--sl-color-white);
-    margin: 0;
   }
 
   .description {
-    flex: 1;
-    font-size: 0.9375rem;
-    line-height: 1.55;
-    color: var(--sl-color-gray-2);
     margin: 0;
+    padding-left: calc(2.25rem + var(--space-3));
+  }
+
+  .description :global(p) {
+    margin: 0 !important;
+    font-size: 0.9375rem;
+    line-height: 1.6;
+    color: var(--sl-color-gray-2);
+  }
+
+  @media (max-width: 640px) {
+    .feature-item {
+      padding: var(--space-5) var(--space-4);
+    }
+
+    .description {
+      padding-left: 0;
+    }
   }
 </style>

--- a/docs/src/components/FeatureCard.astro
+++ b/docs/src/components/FeatureCard.astro
@@ -1,8 +1,11 @@
 ---
+import type { ComponentProps } from 'astro/types'
 import { Icon } from '@astrojs/starlight/components'
 
+type IconName = ComponentProps<typeof Icon>['name']
+
 interface Props {
-  icon?: string
+  icon?: IconName
   title: string
 }
 
@@ -13,7 +16,7 @@ const { icon, title } = Astro.props
   <div class="feature-head">
     {icon && (
       <div class="icon-wrap" aria-hidden="true">
-        <Icon name={icon as any} size="1.25rem" class="card-icon" />
+        <Icon name={icon} size="1.25rem" class="card-icon" />
       </div>
     )}
     <div class="title" set:html={title} />

--- a/docs/src/components/Logo.astro
+++ b/docs/src/components/Logo.astro
@@ -1,0 +1,39 @@
+---
+---
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-86 -70 172 172" class="systematic-logo" aria-hidden="true">
+  <defs>
+    <linearGradient id="sysmark-line" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4FD1C5" />
+      <stop offset="100%" stop-color="#E91E8C" />
+    </linearGradient>
+    <linearGradient id="sysmark-accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#4FD1C5" />
+      <stop offset="50%" stop-color="#E91E8C" />
+      <stop offset="100%" stop-color="#F5A623" />
+    </linearGradient>
+    <filter id="sysmark-glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="3" result="coloredBlur" />
+      <feMerge>
+        <feMergeNode in="coloredBlur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <!-- Three interconnected nodes, copied faithfully from assets/banner.svg -->
+  <g filter="url(#sysmark-glow)">
+    <line x1="0" y1="0" x2="-70" y2="40" stroke="url(#sysmark-line)" stroke-width="3.5" opacity="0.8" />
+    <line x1="0" y1="0" x2="70" y2="40" stroke="url(#sysmark-line)" stroke-width="3.5" opacity="0.8" />
+    <line x1="-70" y1="40" x2="70" y2="40" stroke="url(#sysmark-accent)" stroke-width="3.5" opacity="0.8" />
+    <circle cx="0" cy="0" r="24" fill="#4FD1C5" />
+    <circle cx="-70" cy="40" r="16" fill="#E91E8C" />
+    <circle cx="70" cy="40" r="16" fill="#F5A623" />
+  </g>
+</svg>
+
+<style>
+  .systematic-logo {
+    height: calc(var(--sl-nav-height) - 1.5 * var(--sl-nav-pad-y));
+    width: auto;
+    flex-shrink: 0;
+  }
+</style>

--- a/docs/src/components/SiteTitle.astro
+++ b/docs/src/components/SiteTitle.astro
@@ -1,33 +1,11 @@
 ---
-import { logos } from 'virtual:starlight/user-images';
+import Logo from './Logo.astro';
 import config from 'virtual:starlight/user-config';
 const { siteTitle, siteTitleHref } = Astro.locals.starlightRoute;
 ---
 
 <a href={siteTitleHref} class="site-title sl-flex">
-	{
-		config.logo && logos.dark && (
-			<>
-				<img
-					class:list={{ 'light:sl-hidden print:hidden': !('src' in config.logo) }}
-					alt={config.logo.alt}
-					src={logos.dark.src}
-					width={logos.dark.width}
-					height={logos.dark.height}
-				/>
-				{/* Show light alternate if a user configure both light and dark logos. */}
-				{!('src' in config.logo) && (
-					<img
-						class="dark:sl-hidden print:block"
-						alt={config.logo.alt}
-						src={logos.light?.src}
-						width={logos.light?.width}
-						height={logos.light?.height}
-					/>
-				)}
-			</>
-		)
-	}
+	<Logo />
 	<span class:list={["title-wrapper", { 'sr-only': config.logo?.replacesTitle }]} translate="no">
 		<span class="title-text">{siteTitle}</span>
 		<span class="tagline">Structured Engineering Workflows for OpenCode</span>
@@ -65,13 +43,6 @@ const { siteTitle, siteTitleHref } = Astro.locals.starlightRoute;
 			.tagline {
 				display: block;
 			}
-		}
-		img {
-			height: calc(var(--sl-nav-height) - 2 * var(--sl-nav-pad-y));
-			width: auto;
-			max-width: 100%;
-			object-fit: contain;
-			object-position: 0 50%;
 		}
 	}
 </style>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -41,7 +41,7 @@ import StatsBanner from '../../components/StatsBanner.astro'
 
 <h2 class="section-heading">What You Get</h2>
 
-<div class="feature-grid">
+<div class="feature-list">
   <FeatureCard
     icon="open-book"
     title="Bundled Skills"
@@ -112,20 +112,20 @@ import StatsBanner from '../../components/StatsBanner.astro'
 
 <h2 class="section-heading">What Systematic Is Not</h2>
 
-<div class="not-list">
-  <div class="not-item">
+<ul class="not-list">
+  <li class="not-item">
     <strong>Not a model wrapper or prompt pack.</strong> Systematic doesn't touch your model selection or inject hidden system prompts into every message. It registers structured skills you invoke explicitly.
-  </div>
-  <div class="not-item">
+  </li>
+  <li class="not-item">
     <strong>Not another chat UI.</strong> It runs inside OpenCode. You keep your existing setup.
-  </div>
-  <div class="not-item">
+  </li>
+  <li class="not-item">
     <strong>Not SaaS or telemetry.</strong> Everything is local-first markdown assets bundled with the npm package. Nothing phones home.
-  </div>
-  <div class="not-item">
+  </li>
+  <li class="not-item">
     <strong>Not magic autopilot.</strong> The AI still does the work. Systematic gives it a process to follow, the same process a disciplined engineer would use. You stay in the loop.
-  </div>
-</div>
+  </li>
+</ul>
 
 <p class="ocx-note">
   Also supported: install individual components via the OCX registry if you don't want the full bundle.
@@ -289,25 +289,14 @@ import StatsBanner from '../../components/StatsBanner.astro'
     padding-bottom: var(--space-3);
   }
 
-  .feature-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(min(100%, 300px), 1fr));
-    grid-auto-rows: 1fr;
-    gap: 1.5rem;
-    align-items: stretch;
+  .feature-list {
+    display: flex;
+    flex-direction: column;
     margin-bottom: var(--space-8);
-  }
-
-  /* Make sure children stretch */
-  /* Make sure children stretch */
-  .feature-grid > article {
-    height: 100%;
-  }
-
-  @media (min-width: 900px) {
-    .feature-grid {
-      grid-template-columns: repeat(3, 1fr);
-    }
+    background: var(--sl-color-gray-6);
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.5rem;
+    overflow: hidden;
   }
 
   .value-prop {
@@ -358,19 +347,25 @@ import StatsBanner from '../../components/StatsBanner.astro'
   }
 
   .not-list {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-4);
+    margin: 0 0 var(--space-8);
+    padding-left: var(--space-6);
     max-width: 56rem;
+    list-style: disc;
+    color: var(--sl-color-gray-2);
   }
 
   .not-item {
-    background: var(--sl-color-gray-6);
-    border: 1px solid var(--sl-color-gray-5);
-    border-radius: 0.25rem;
-    padding: var(--space-4) var(--space-5);
-    color: var(--sl-color-gray-2);
-    line-height: 1.5;
+    margin-bottom: var(--space-3);
+    padding-left: var(--space-2);
+    line-height: 1.55;
+  }
+
+  .not-item::marker {
+    color: var(--sl-color-accent);
+  }
+
+  .not-item:last-child {
+    margin-bottom: 0;
   }
 
   .not-item strong {


### PR DESCRIPTION
Visual polish pass on the docs homepage and brand mark, building on the redesign in #457.

## Changes

**Brand mark (header logo + favicon)**
- Square geometric mark: cyan apex node, magenta and gold base nodes, gradient connectors, soft glow.
- Square viewBox sized so the outer nodes sit flush to the left and right edges (no side gaps, no letterboxing in the square favicon slot).
- Header logo and favicon share the same mark; the header title renders through a small custom `SiteTitle` component.

**Homepage section layouts**
- "What You Get" — replaced the three-column feature grid (which left an orphaned 3+2 gap) with a single aligned vertical list: icon and title share one centered row, the description sits below with even spacing, and rows highlight on hover without movement.
- "What Systematic Is Not" — converted the boxed cards to a plain bulleted list, removing the redundant boxing and excess padding.

## Screenshots

_Home page — header logo + feature list:_
<img width="2880" height="3200" alt="image" src="https://github.com/user-attachments/assets/cce7d38c-201f-41cd-a6a1-8b98485c0c1a" />

_"What Systematic Is Not" bulleted list:_
<img width="2880" height="3200" alt="image" src="https://github.com/user-attachments/assets/93a8f460-fa3a-4f23-aaa2-7fa9b8b4a13f" />

## Verification
- Header logo and favicon render as a square mark with nodes flush to the edges (measured in-browser).
- Feature list: icon/title vertically centered, even row spacing, hover highlight with no movement.
- typecheck, lint, content-integrity, and docs build all clean (111 pages). Docs-only; non-releasing.