### PR TITLE
refactor(docs): align interior page CSS with homepage design language

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -123,23 +123,6 @@
   text-decoration-color: var(--sl-color-accent);
 }
 
-/* Card Polish - Refined Motion */
-.card,
-.link-card {
-  border: 1px solid var(--sl-color-gray-5);
-  background-color: var(--sl-color-gray-6);
-  border-radius: 0.25rem;
-  transition:
-    transform 0.25s var(--ease-out-expo),
-    border-color 0.25s var(--ease-out-expo);
-}
-
-.card:hover,
-.link-card:hover {
-  border-color: var(--sl-color-accent);
-  transform: translateY(-2px);
-}
-
 /* Code Block Polish */
 .expressive-code .ec-line {
   line-height: 1.5;
@@ -147,10 +130,10 @@
 
 /* Blockquote Polish */
 .sl-markdown-content blockquote {
-  border-left-color: var(--sl-color-accent);
+  border-inline-start: none;
   background-color: var(--sl-color-gray-6);
   padding: var(--space-4) var(--space-6);
-  border-radius: 0; /* Boxy editorial feel */
+  border-radius: 0;
   font-family: var(--sl-font-heading);
   font-style: italic;
   font-size: 1.1rem;
@@ -160,18 +143,16 @@
 .sl-markdown-content table {
   border-collapse: collapse;
   width: 100%;
-  border: 1px solid var(--sl-color-gray-5);
-  border-radius: 0;
   margin-bottom: var(--space-6);
 }
 
 .sl-markdown-content th {
-  background-color: var(--sl-color-gray-6);
-  border-bottom: 1px solid var(--sl-color-gray-5);
+  border-bottom: 1px solid var(--sl-color-gray-4);
   padding: var(--space-3) var(--space-4);
   text-align: left;
-  font-weight: 500;
+  font-weight: 600;
   font-family: var(--sl-font-system);
+  color: var(--sl-color-white);
 }
 
 .sl-markdown-content td {


### PR DESCRIPTION
Aligns the interior documentation pages with the restrained list-and-spacing design language introduced on the homepage. Three CSS refinements in `docs/src/styles/custom.css`, scoped to shared Starlight element styles — no per-page or component changes.

## What changed

- **Tables** — removed the heavy full outer border and the solid header-cell background fill. Tables now read as clean row dividers (`border-bottom` only) with a brighter header label and a slightly stronger header underline, matching the homepage feature list. Affects the configuration reference and any guide with tables (the with/without comparison, the main-loop guide).
- **Blockquotes** — removed the accent-colored left side-stripe. The tinted, italic editorial treatment stays; only the stripe is gone, so prose blocks no longer compete with the page accent.
- **Dead CSS removal** — deleted a `.card`/`.link-card` rule that no rendered markup uses. Starlight's `<CardGrid>`/`<LinkCard>` emit `sl-link-card`/`card-grid`, never bare `.card`, so the rule applied to nothing. Removing it has zero visual effect and trims the stylesheet.

The reference-page header styles (`.definition-*`, live on every skill and agent page) are intentionally left untouched.

## Verification

- `bun run --cwd docs build` — 111 pages, clean.
- Verified on a static preview server via DOM computed-style checks: tables `border-top: 0`, blockquotes `border-inline-start: 0`, reference pages still render 51 `sl-link-card` elements unchanged.

## Screenshots

_Tables — configuration reference:_
<img width="1280" height="577" alt="image" src="https://github.com/user-attachments/assets/ce6da8eb-e898-429f-b760-e4a734c7b89a" />

_Tables — with/without comparison:_
<img width="1280" height="577" alt="image" src="https://github.com/user-attachments/assets/de0f4a05-a463-4099-9b66-a441f30d179e" />

_Blockquote — philosophy guide:_
<img width="1280" height="577" alt="image" src="https://github.com/user-attachments/assets/0d36db36-0aa6-4a92-9e6a-2a0f08bdf399" />