### PR TITLE
docs: remove OCX mention from homepage

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -127,10 +127,6 @@ import StatsBanner from '../../components/StatsBanner.astro'
   </li>
 </ul>
 
-<p class="ocx-note">
-  Also supported: install individual components via the OCX registry if you don't want the full bundle.
-</p>
-
 </div>
 
 <style>
@@ -373,13 +369,5 @@ import StatsBanner from '../../components/StatsBanner.astro'
     font-weight: 500;
   }
 
-  .ocx-note {
-    margin-top: var(--space-12);
-    padding-top: var(--space-6);
-    border-top: 1px solid var(--sl-color-gray-5);
-    color: var(--sl-color-gray-3);
-    font-size: 0.875rem;
-    text-align: center;
-  }
 `}
 </style>


### PR DESCRIPTION
Removes the OCX registry mention from the homepage so the landing page presents the npm plugin as the single install path.

## What

- Removed the "Also supported: install individual components via the OCX registry" note from the install section of the homepage.
- Removed the now-orphaned `.ocx-note` CSS rule.

## Why

OCX is a lightweight alternative, not a headline feature. The homepage should present one clear install path (the npm plugin); OCX remains documented in its own guide, which sits last in the Guides sidebar and frames the plugin as recommended.

## Verification

- `docs:build`: clean, 111 pages
- Homepage has zero remaining OCX/registry references
- OCX guide unchanged and still discoverable (Guides, last)