### PR TITLE
feat: add ce:review validation pass and solution-doc frontmatter check

### DIFF
--- a/docs/plans/2026-06-04-001-feat-cep-verification-layers-plan.md
+++ b/docs/plans/2026-06-04-001-feat-cep-verification-layers-plan.md
@@ -1,0 +1,353 @@
+---
+title: "feat: CEP verification-layer ports (ce-review Stage 5b + frontmatter parse-safety)"
+type: feat
+status: active
+date: 2026-06-04
+origin: docs/brainstorms/2026-06-04-cep-verification-layers-requirements.md
+---
+
+# feat: CEP Verification-Layer Ports
+
+## Overview
+
+Port two independent-verification capabilities surfaced by the CEP `ce:*` delta analysis, both
+right-sized after grounding against our actual code:
+
+1. **ce-review Stage 5b validation pass** — an independent per-finding validator that re-checks
+   merged findings before synthesis, annotating each `validated: true|false` with a reason.
+   **Validate-only: never deletes a finding** — rejected findings are surfaced in a "Filtered (not
+   validated)" section, neutralizing the false-negative risk. This is the primary, higher-value item.
+2. **content-integrity frontmatter parse-safety** — extend the CI gate to detect the silent
+   `#`-truncation YAML class and to scan `docs/solutions/` (currently unscanned), plus adopt
+   upstream's narrower category enums. Prevents silent loss of compounded knowledge.
+
+The two units are **independent** and may ship in separate PRs **in either order** — neither
+depends on the other, and each leaves a self-consistent state if it ships alone (Unit 1 is
+self-contained `ce:review` behavior + its template; Unit 2 is a self-contained gate + schema
+change). There is no shared release expectation and no compatibility coupling between them.
+ce-ideate's basis-as-required-field refinement is **deferred** (mostly already ours; below YAGNI)
+and is not planned here.
+
+## Problem Frame
+
+Upstream `EveryInc/compound-engineering-plugin`'s recent valuable work is in independent-
+verification / quality-floor layers. Two map to real gaps in Systematic (see origin:
+`docs/brainstorms/2026-06-04-cep-verification-layers-requirements.md`):
+
+- Our multi-persona `ce:review` trusts every surfaced finding. False positives (persona missed an
+  existing guard, flagged pre-existing code, misread types) reach the user/fixer unfiltered. We
+  have no false-positive filter.
+- Our `content-integrity` gate's `checkFrontmatter` only scans skill entry files, and our
+  `parseFrontmatter` silently truncates `#`-bearing unquoted values (`parseError: false`, data
+  lost) — verified empirically. `docs/solutions/`, the project's institutional memory, is scanned
+  by nothing, so silent knowledge loss there is undetected.
+
+## Requirements Trace
+
+- R1. ce-review gains an independent validation pass over merged findings before synthesis.
+- R2. The validator never deletes a finding; rejected findings are surfaced in the "Filtered (not
+  validated)" group with reason (validate-only).
+- R3. The validation pass is bounded by a default gating threshold (cost is linear in validated
+  count).
+- R4. content-integrity detects the `#`-truncation parse-safety class that `parseFrontmatter`
+  silently drops.
+- R5. content-integrity scans `docs/solutions/` markdown frontmatter (currently unscanned).
+- R6. Adopt upstream's narrower category enums + "prefer narrowest" guidance in
+  `skills/ce-compound/references/schema.yaml`.
+- R7. Anti-coupling: port discrete capabilities only — no upstream `mode:agent` apply model,
+  action-class rubric, or CEP-internal skill dependency.
+
+## Scope Boundaries
+
+- No CONCEPTS.md / vocabulary lifecycle, no `ce-sessions` dependency.
+- No action-class rubric adoption (apply-philosophy mismatch).
+- No ce-ideate scope expansion (elsewhere-modes, web research, caching).
+- No regression of our existing autofix/report-only/headless mode system.
+- No bundled Python scripts — gate logic stays TypeScript.
+- The gate **detects** truncation risk in CI; it does not prevent write-time data loss.
+
+### Deferred to Separate Tasks
+
+- ce-ideate `basis`-as-required-field refinement: deferred maybe-not; revisit only with an
+  explicit user-value case (see origin: Resolved Decisions).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `skills/ce-review/SKILL.md` — Stages 1–6. Stage 5 (Merge findings, ~line 451) produces the
+  merged finding set with `autofix_class`/`requires_verification`/`confidence`/`pre_existing`;
+  Stage 6 (Synthesize and present, ~line 480) renders the finding tables. The validation pass
+  inserts as **Stage 5b** between them.
+- `skills/ce-review/references/subagent-template.md` — existing pattern for a persona subagent
+  prompt; the new `validator-template.md` mirrors its structure (read-only, JSON-only return).
+- `skills/document-review/references/findings-schema.json` and the document-review validator are
+  prior art for an independent re-verification subagent returning `{validated, reason}` JSON.
+- `scripts/content-integrity.ts` — `collectScanTargets` (~line 430) iterates only
+  `['skills', 'agents']`; `checkFrontmatter`/`scanSkillFrontmatter` (~line 616) gate on
+  `isSkillEntryFile` and rely on `parseFrontmatter.parseError`. The design-rationale comment
+  (~line 30) explicitly states the gate "does not scan `docs/`" — must be updated.
+- `src/lib/frontmatter.ts` — `parseFrontmatter`; verified: `# ` in an unquoted value →
+  `parseError: false` with truncated value; `: ` in an unquoted value → `parseError: true`.
+- `skills/ce-compound/references/schema.yaml` — current category enums (broad `best_practice`
+  catch-all); upstream adds `architecture_pattern`/`design_pattern`/`tooling_decision`/
+  `convention` + "prefer narrowest".
+
+### Institutional Learnings
+
+- The zsh/YAML silent-truncation solution-doc lesson (`docs/solutions/`) is the documented prior
+  occurrence of this exact silent-data-loss class — the value case for R4/R5.
+- `docs/solutions/` best-practice docs on independent-verification passes and discovery contracts
+  inform the validate-only design.
+
+### External References
+
+- Upstream `EveryInc/compound-engineering-plugin` `plugins/compound-engineering/skills/
+  ce-code-review/references/validator-template.md` (89 lines) — the validator prompt logic to
+  adapt (not vendor verbatim; convert CC/CEP wording, drop `mode:agent` coupling).
+- Upstream `ce-compound/scripts/validate-frontmatter.py` — the *logic* for parse-safety
+  (re-implemented in TypeScript), not the file.
+
+## Key Technical Decisions
+
+- **Stage 5b placement:** between Merge (Stage 5) and Synthesize (Stage 6), operating on the
+  merged finding set so it sees final severity/routing before presentation.
+- **Validate-only:** annotate `validated`/`reason`; rejected findings move to the canonical
+  "Filtered (not validated)" presentation group in Stage 6, never deleted. Resolves the
+  false-negative risk. (Use this exact label in all template/skill edits.)
+- **Default gating threshold (decided):** validate findings that are **P0/P1 OR
+  `requires_verification: true`** by default. This resolves the reviewer concern that pure
+  severity-gating would skip wrong-P2 noise: `requires_verification` catches lower-severity
+  findings the personas themselves flagged as needing confirmation, which is precisely the
+  uncertain class most worth validating. Cost stays bounded (it's a subset, not all findings).
+  Findings outside this band pass through unvalidated and unfiltered.
+- **Frontmatter check is TypeScript in the gate:** a new parse-safety scan distinct from
+  `parseFrontmatter` (since that silently succeeds on the `#` class). Detect unquoted scalar
+  values containing ` #` (comment-truncation) regardless of `parseError`.
+- **Scan breadth:** add `docs/solutions/` to `collectScanTargets` markdown; apply the parse-safety
+  check to those files (frontmatter present/structure only — not the skill required-field rules,
+  which are skill-specific). Keep existing skill/agent scanning unchanged.
+- **Severity:** the parse-safety violation **fails** CI (consistent with existing gate behavior;
+  it's a deterministic structural check, not a fuzzy heuristic). Carried as a confirmable decision.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Where does the validator slot? → Stage 5b, between Merge and Synthesize.
+- Does the validator delete findings? → No, validate-only with filtered surfacing.
+- Python vs TS for parse-safety? → TypeScript in the gate (no bundle runtime dep).
+- Which schema enums? → upstream's `architecture_pattern`/`design_pattern`/`tooling_decision`/
+  `convention` + "prefer narrowest".
+
+### Deferred to Implementation
+
+- **default-on vs flag:** whether Stage 5b runs by default or behind a mode/flag. Working
+  assumption: on by default for the gated band (P0/P1 OR `requires_verification`), since
+  validate-only adds no deletion risk and the band bounds cost. Confirm during implementation if
+  latency proves material.
+- **Scan breadth final call:** `docs/solutions/` only vs broader `docs/**/*.md`. Plan scopes to
+  `docs/solutions/` (the knowledge store); widening is a one-line change to the `solutionMarkdown`
+  collection if wanted later.
+
+## Implementation Units
+
+- [ ] **Unit 1: ce-review Stage 5b validation pass (prose + validator template)**
+
+**Goal:** Add an independent, validate-only finding-validation pass to `ce:review` between Stage 5
+and Stage 6, with a reusable validator subagent template.
+
+**Requirements:** R1, R2, R3, R7
+
+**Dependencies:** None
+
+**Files:**
+- Create: `skills/ce-review/references/validator-template.md`
+- Modify: `skills/ce-review/SKILL.md`
+- Modify: `skills/ce-review/references/review-output-template.md` (add canonical "Filtered (not
+  validated)" presentation group)
+- Test: `tests/unit/content-integrity.test.ts` (structural assertions, see below) + manual dogfood
+
+**Automated structural coverage (not prose behavior, but catches regressions):** add lightweight
+checks that the new sub-file is reference-integrity-resolvable and that `SKILL.md` retains required
+structure. Prefer asserting via the existing content-integrity sub-file reference check (already
+fails on dangling `references/*` paths) plus, if cheap, a test that `SKILL.md` contains the Stage
+5b heading and references `validator-template.md`. Manual dogfood remains the behavioral check; the
+structural test guards against accidental reference/heading breakage in our highest-traffic skill.
+
+**Approach:**
+- Adapt upstream `validator-template.md` into `skills/ce-review/references/validator-template.md`:
+  one independent validator per gated finding, three questions (real in code as written? introduced
+  by THIS diff? not handled elsewhere?), returns JSON `{validated, reason}`, read-only,
+  conservative-confidence labeling. Convert all CC/CEP wording to Systematic/OpenCode; remove any
+  `mode:agent`/action-class coupling (R7).
+- Insert a new **Stage 5b: Validation pass** section in `SKILL.md` after Stage 5, before Stage 6:
+  - Gate: validate only findings that are P0/P1 OR `requires_verification: true` by default (state
+    the band + that it bounds cost).
+  - Dispatch one validator subagent per gated finding in parallel, passing finding fields + diff +
+    scope context (mirror the Stage 4 context bundle shape).
+  - Collect `{validated, reason}`; attach to each finding. **Never drop a finding.**
+  - Findings with `validated: false` are routed to a "Filtered (not validated)" group for Stage 6,
+    not removed from the report.
+- Update Stage 6 presentation in **both modes**:
+  - **Interactive:** add a "Filtered (not validated)" subsection (canonical label — use this exact
+    string everywhere) rendering rejected findings with their validator reason, appended AFTER the
+    existing severity tables; validated findings flow through existing tables unchanged.
+  - **Headless:** the headless envelope (Stage 6 / Mode Detection) has its own fixed structure —
+    add the filtered findings to it too (e.g., a `filtered` array preserving the same per-finding
+    fields + validator reason), so the validator state is not invisible in headless/autofix flows.
+- **Output-contract compatibility note:** the change is additive — existing severity tables keep
+  their structure, headings, and order; the Filtered group is appended. Document this so any reader
+  or consumer relying on existing section order is unaffected (new content only ever appears after
+  existing sections).
+- Update `review-output-template.md` to include the canonical "Filtered (not validated)" group.
+
+**Execution note:** This is skill-prose work; dogfood by running `ce:review` mentally/manually
+against a known false-positive to confirm the flow reads correctly. No code is added.
+
+**Patterns to follow:**
+- `skills/ce-review/references/subagent-template.md` (subagent prompt shape, read-only contract).
+- `skills/document-review` validator/independent-reviewer prior art for `{validated, reason}` JSON.
+
+**Test scenarios:**
+- Happy path (dogfood): a P1 finding that is genuinely guarded upstream → validator returns
+  `validated: false`, finding appears in the Filtered group with reason, NOT in the actioned set.
+- Happy path (dogfood): a real P0 finding new in the diff → `validated: true`, flows through normal
+  P0 table unchanged.
+- Edge case (prose): a P2 finding below the threshold → passes through unvalidated, no Filtered
+  treatment, no validator dispatched.
+- Anti-coupling check: `validator-template.md` contains no `mode:agent`, action-class, or
+  CEP-internal skill references (grep).
+
+**Verification:**
+- `bun scripts/content-integrity.ts` clean (no phantom refs; new `references/validator-template.md`
+  resolves from `SKILL.md`).
+- The new sub-file is referenced in `SKILL.md` so the sub-file reference-integrity check passes.
+- Registry drift check passes after regeneration (new reference file under a registered skill).
+- Manual read-through confirms the validate-only flow never deletes findings.
+
+---
+
+- [ ] **Unit 2: content-integrity frontmatter parse-safety + docs/solutions scan + schema enums**
+
+**Goal:** Extend the CI gate to detect the silent `#`-truncation frontmatter class and to scan
+`docs/solutions/`, and tighten the ce-compound schema enums.
+
+**Requirements:** R4, R5, R6
+
+**Dependencies:** None (independent of Unit 1; can ship as a separate PR)
+
+**Files:**
+- Modify: `scripts/content-integrity.ts` (add parse-safety check; extend `collectScanTargets`;
+  update the design-rationale comment)
+- Modify: `tests/unit/content-integrity.test.ts` (parse-safety + docs/solutions scan coverage)
+- Modify: `skills/ce-compound/references/schema.yaml` (narrower enums + "prefer narrowest")
+- Test: `tests/unit/content-integrity.test.ts`
+
+**Approach:**
+- Add a `checkFrontmatterParseSafety` function that detects the comment-truncation class. **It
+  must not be an ad-hoc regex** — reviewers correctly flagged that distinguishing a truncating
+  ` #` from a quoted value, a URL, a `#` inside a string, or a full-line comment is exactly what a
+  YAML parser disambiguates. Use a **constrained, frontmatter-aware line scan** with explicit
+  grammar rules, operating per top-level `key: value` line in the frontmatter block:
+  - Only flat `key: scalar` lines are in scope (skip full-line comments `^\s*#`, list items `- `,
+    block-scalar indicators `|`/`>`, and continuation/indented lines).
+  - For an in-scope line, isolate the value portion after the first `: `. If the value is wrapped
+    in matching quotes (`"..."` or `'...'`), it is SAFE (a `#` inside is literal) — skip it.
+  - For an unquoted value, flag it if it contains ` #` (space-hash, the comment trigger). A `#`
+    with no preceding space, or `#` at the start of an otherwise-quoted/structural value, is not a
+    comment trigger.
+  - Cross-check the verdict against `parseFrontmatter`: if the parsed value differs from the raw
+    value (truncation actually occurred), that is the high-confidence signal; the line scan is the
+    detector and the parse-diff is corroboration.
+  - Emit a `FrontmatterViolation` with remediation (quote the value).
+- **Adversarial fixtures are mandatory** (test-first): truncating `# ` (flag), quoted value with
+  `#` (no flag), full-line comment (no flag), URL with `#fragment` in a quoted value (no flag),
+  `#` at value start (no flag), list-item value with `#` (decide + cover). The check ships only
+  when these all pass.
+- Extend `collectScanTargets` to collect markdown under `docs/solutions/` into a **dedicated
+  `solutionMarkdown` target set — NOT merged into `targets.markdown`/`allScannedFiles`.** This is
+  critical: `allScannedFiles` feeds `checkBannedPatterns` and allowlist warnings, so adding
+  solution docs to the general set would subject historical docs to CC/CEP banned-pattern
+  enforcement they were never meant to have and fail CI. The parse-safety check is the ONLY check
+  that consumes `solutionMarkdown`; skill/agent required-field checks and banned-pattern scanning
+  keep their existing skills+agents+src scope unchanged.
+- Update the design-rationale comment block (~line 30) that currently states the gate "does not
+  scan `docs/`" to reflect the new `docs/solutions/` parse-safety scope.
+- Update `schema.yaml`: add `architecture_pattern`, `design_pattern`, `tooling_decision`,
+  `convention` to the category enum, and add the "prefer the narrowest applicable value;
+  best_practice is the fallback" guidance + the YAML-reserved-indicator quoting rule.
+
+**Execution note:** Test-first — add a failing fixture proving `# `-truncation is currently
+undetected and `docs/solutions/` is unscanned, then implement until green.
+
+**Patterns to follow:**
+- `scanSkillFrontmatter` / `checkFrontmatter` structure in `scripts/content-integrity.ts`
+  (violation objects + remediation strings).
+- Existing `collectScanTargets` directory-walk pattern.
+
+**Test scenarios:**
+- Happy path: a solution-doc fixture with `problem: cache miss # under load` → parse-safety
+  violation flagged citing the `#`-truncation risk.
+- Happy path: a correctly-quoted value `problem: "cache miss # under load"` → no violation.
+- Edge case: `#` inside an already-quoted value → no false positive.
+- Edge case: a `#` at line start (full-line YAML comment) → no false positive (it's a real comment,
+  not a truncated value).
+- Scan coverage: a malformed `docs/solutions/` fixture is now picked up (proves the file is
+  scanned, where before it was skipped).
+- Regression: existing skill/agent frontmatter checks still pass unchanged.
+- Schema: `schema.yaml` parses and contains the four new enum values + "prefer narrowest" guidance.
+
+**Verification:**
+- `bun test tests/unit/content-integrity.test.ts` green including new cases.
+- `bun scripts/content-integrity.ts` runs clean on the real repo (no new violations introduced by
+  the scan extension — i.e., existing solution docs are already safe, or are fixed in this unit).
+- `bun run typecheck` + `bun run lint` clean.
+
+## System-Wide Impact
+
+- **Interaction graph:** Unit 1 touches only `ce:review` skill prose + a new reference file; no
+  source code. Unit 2 touches the CI gate (`scripts/content-integrity.ts`) which runs in the build
+  job — a new failing class could block releases (intended; deterministic check).
+- **Error propagation:** Unit 2's new violation type flows through the existing
+  `FrontmatterViolation` aggregation + exit-code path; no new error channel.
+- **State lifecycle risks:** None — both units are additive checks/prose.
+- **API surface parity:** `collectScanTargets` return shape gains `docs/solutions/` coverage;
+  confirm callers (`checkFrontmatter` and the new parse-safety check) consume the right target set
+  and existing callers are unaffected.
+- **Integration coverage:** Unit 2's "file is now scanned" scenario is the key integration proof
+  (unit-level function tests alone won't prove `collectScanTargets` actually reaches solution docs).
+- **Unchanged invariants:** existing skill/agent required-field frontmatter checks, phantom-ref
+  checks, banned-pattern checks, and agent-color checks are unchanged. ce-review Stages 1–5 and the
+  existing mode system are unchanged; Stage 5b is purely additive and validate-only.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Validator subagent rejects real findings (false negatives) | Validate-only design: findings are never deleted, only surfaced in the "Filtered (not validated)" group with reason — human/fixer always sees them. |
+| Per-finding validator cost scales with finding count | Default band (P0/P1 OR `requires_verification`) bounds the validated set; findings outside it skip the pass. |
+| New parse-safety check is noisy / flags existing safe docs | Test-first with precise ` #`-on-unquoted-value detection; full-line comments and quoted values excluded; run against real repo before merge. |
+| Extending the CI gate blocks releases on a new class | Intended for a deterministic structural check; fix any real existing violations in Unit 2 so the gate is green on merge. |
+| Porting from upstream re-couples to CEP | Anti-coupling boundary (R7): adapt the discrete validator prompt only; strip `mode:agent`/action-class; convert all CC/CEP wording. |
+
+## Documentation / Operational Notes
+
+- Unit 1 changes are user-facing `ce:review` behavior — `docs/` reference for the review skill may
+  need a note about the validation pass (check `docs:generate` output; counts unaffected).
+- Unit 2 changes CI gate behavior; the design-rationale comment + any AGENTS.md/`docs/AGENTS.md`
+  mention of the gate's scan scope should be checked for accuracy.
+- Both units require registry regeneration only if reference-file inventories change (Unit 1 adds
+  `validator-template.md` under the `ce-review` skill — regenerate + drift check).
+- Commit prefixes: Unit 1 (`ce:review` skill behavior) and Unit 2 (gate + schema) are both
+  user-visible-quality changes; classify per the conventional-commit map (likely `feat(review):`
+  for Unit 1 since it adds review functionality, `fix(integrity):` or `feat(integrity):` for Unit 2
+  depending on framing — confirm at PR time).
+
+## Sources & References
+
+- **Origin document:** docs/brainstorms/2026-06-04-cep-verification-layers-requirements.md
+- Related code: `skills/ce-review/SKILL.md`, `scripts/content-integrity.ts`,
+  `src/lib/frontmatter.ts`, `skills/ce-compound/references/schema.yaml`
+- Upstream prior art: `EveryInc/compound-engineering-plugin` ce-code-review `validator-template.md`,
+  ce-compound `validate-frontmatter.py` + `schema.yaml`

--- a/registry/registry.jsonc
+++ b/registry/registry.jsonc
@@ -443,7 +443,8 @@
         "skills/ce-review/references/persona-catalog.md",
         "skills/ce-review/references/resolve-base.sh",
         "skills/ce-review/references/review-output-template.md",
-        "skills/ce-review/references/subagent-template.md"
+        "skills/ce-review/references/subagent-template.md",
+        "skills/ce-review/references/validator-template.md"
       ]
     },
     {

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -55,7 +55,10 @@ import {
   isValidAgentColor,
   OPENCODE_AGENT_COLOR_TOKENS,
 } from '../src/lib/agent-colors.js'
-import { parseFrontmatter } from '../src/lib/frontmatter.js'
+import {
+  extractFrontmatterBlock,
+  parseFrontmatter,
+} from '../src/lib/frontmatter.js'
 import { SKILL_FRONTMATTER_FIELDS } from '../src/lib/skills.js'
 import { walkDir } from '../src/lib/walk-dir.js'
 
@@ -797,6 +800,10 @@ function checkDeprecatedBlockForBundled(
 /**
  * Ban unquoted inline comments in docs/solutions/ frontmatter.
  *
+ * Scope: flat top-level `key: value` lines only. Nested/indented mapping
+ * values (lines that start with whitespace) are intentionally not scanned —
+ * see `extractFlatKeyValue`.
+ *
  * A top-level flat `key: value` line is flagged when ALL of:
  * - It is a flat key-value line (not a full-line comment, list item, indented
  *   continuation, or block-scalar indicator).
@@ -832,11 +839,9 @@ function scanFrontmatterParseSafety(
   content: string,
   violations: FrontmatterViolation[],
 ): void {
-  // Extract the raw frontmatter block (between the first --- delimiters).
-  const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n?---/)
-  if (!frontmatterMatch) return
+  const rawBlock = extractFrontmatterBlock(content)
+  if (rawBlock === null) return
 
-  const rawBlock = frontmatterMatch[1] ?? ''
   const lines = rawBlock.split('\n')
   for (const line of lines) {
     const violation = checkParseSafetyLine(relPath, line)
@@ -878,6 +883,11 @@ function checkParseSafetyLine(
  * Extract the key and raw value from a flat `key: value` frontmatter line.
  * Returns null for lines that are not flat key-value pairs (comments, list
  * items, indented lines, block-scalar indicators).
+ *
+ * Scope boundary: indented lines (lines starting with whitespace) are skipped
+ * unconditionally. A `#` inside a nested mapping value such as
+ * `  note: cache miss # under load` is therefore out of scope by design —
+ * only flat top-level key-value lines are inspected.
  */
 function extractFlatKeyValue(
   line: string,

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -27,9 +27,14 @@
  *    model instead of hardcoding provider-specific model IDs.
  *
  * Scope is narrow by design: `skills/**\/*.md`, `agents/**\/*.md`, and
- * `src/**\/*.ts`. The gate does not scan `docs/`, `.opencode/`, `.github/`,
+ * `src/**\/*.ts` for the full invariant suite. Additionally, `docs/solutions/**\/*.md`
+ * is scanned for frontmatter parse-safety only (flags any unquoted inline comment —
+ * whitespace-before-`#` or value-start `#` — in frontmatter; remediation is to quote
+ * the value or remove the comment). The gate does not scan `.opencode/`, `.github/`,
  * `dist/`, `node_modules/`, `registry/`, or markdown files under `src/` —
  * those intentionally contain historical or documented CC/CEP references.
+ * Solution docs are intentionally excluded from banned-pattern enforcement
+ * because historical docs may legitimately reference CC/CEP terms.
  *
  * Agent categories are discovered at runtime from `agents/` subdirectories so
  * adding a new category auto-extends coverage without a regex update.
@@ -151,6 +156,7 @@ export interface FrontmatterViolation {
     | 'missing-frontmatter'
     | 'deprecated-reason-missing'
     | 'deprecated-missing-required-fields'
+    | 'parse-safety'
   field?: string
   message: string
   remediation: string
@@ -181,6 +187,7 @@ export interface CheckResult {
   brokenSubfileRefs: BrokenSubfileRef[]
   bannedPatterns: BannedPatternHit[]
   frontmatterViolations: FrontmatterViolation[]
+  parseSafetyViolations: FrontmatterViolation[]
   agentModelViolations: AgentModelViolation[]
   agentColorViolations: AgentColorViolation[]
   agentStemViolations: AgentStemViolation[]
@@ -188,6 +195,7 @@ export interface CheckResult {
   scanStats: {
     markdownFiles: number
     typescriptFiles: number
+    solutionMarkdownFiles: number
   }
 }
 
@@ -421,11 +429,19 @@ export function discoverCategories(rootDir: string): string[] {
 export interface ScanTargets {
   markdown: string[] // repo-relative paths under skills/ and agents/
   typescript: string[] // repo-relative paths under src/ (excluding markdown)
+  solutionMarkdown: string[] // repo-relative paths under docs/solutions/ (parse-safety only)
 }
 
 /**
  * Collect the files the gate scans. Paths are repo-relative for consistent
  * allowlist matching.
+ *
+ * - `markdown`: skills/ and agents/ markdown — full invariant suite.
+ * - `typescript`: src/ TypeScript — banned-pattern scan.
+ * - `solutionMarkdown`: docs/solutions/ markdown — parse-safety check ONLY.
+ *   Deliberately NOT merged into `markdown` to keep banned-pattern enforcement
+ *   scoped to skills+agents+src; historical solution docs may legitimately
+ *   reference CC/CEP terms.
  */
 export function collectScanTargets(rootDir: string): ScanTargets {
   const markdown: string[] = []
@@ -454,9 +470,22 @@ export function collectScanTargets(rootDir: string): ScanTargets {
     }
   }
 
+  const solutionMarkdown: string[] = []
+  const solutionsDir = path.join(rootDir, 'docs', 'solutions')
+  if (fs.existsSync(solutionsDir)) {
+    const entries = walkDir(solutionsDir, {
+      maxDepth: 10,
+      filter: (e) => !e.isDirectory && e.name.endsWith('.md'),
+    })
+    for (const e of entries) {
+      solutionMarkdown.push(path.relative(rootDir, e.path))
+    }
+  }
+
   markdown.sort()
   typescript.sort()
-  return { markdown, typescript }
+  solutionMarkdown.sort()
+  return { markdown, typescript, solutionMarkdown }
 }
 
 // ---------------------------------------------------------------------------
@@ -761,6 +790,130 @@ function checkDeprecatedBlockForBundled(
   })
 }
 
+// ---------------------------------------------------------------------------
+// Frontmatter parse-safety check
+// ---------------------------------------------------------------------------
+
+/**
+ * Ban unquoted inline comments in docs/solutions/ frontmatter.
+ *
+ * A top-level flat `key: value` line is flagged when ALL of:
+ * - It is a flat key-value line (not a full-line comment, list item, indented
+ *   continuation, or block-scalar indicator).
+ * - The value is NOT wrapped in matching quotes (quoted values are safe; a `#`
+ *   inside quotes is literal).
+ * - The unquoted value contains a comment trigger: whitespace-before-`#`
+ *   (`/\s#/`) OR the value's first non-space char is `#` (`/^\s*#/`).
+ *
+ * The decision is purely lexical — no parse-diff corroboration. Policy: inline
+ * YAML comments in solution-doc frontmatter are banned regardless of whether
+ * the YAML parser happens to preserve the value, because the distinction is
+ * undecidable from the raw text alone.
+ *
+ * Emits a `FrontmatterViolation` with `rule: 'parse-safety'`.
+ */
+export function checkFrontmatterParseSafety(
+  rootDir: string,
+  markdownFiles: readonly string[],
+): FrontmatterViolation[] {
+  const violations: FrontmatterViolation[] = []
+
+  for (const relPath of markdownFiles) {
+    const content = readFileSafe(path.join(rootDir, relPath))
+    if (content === null) continue
+    scanFrontmatterParseSafety(relPath, content, violations)
+  }
+
+  return violations
+}
+
+function scanFrontmatterParseSafety(
+  relPath: string,
+  content: string,
+  violations: FrontmatterViolation[],
+): void {
+  // Extract the raw frontmatter block (between the first --- delimiters).
+  const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n?---/)
+  if (!frontmatterMatch) return
+
+  const rawBlock = frontmatterMatch[1] ?? ''
+  const lines = rawBlock.split('\n')
+  for (const line of lines) {
+    const violation = checkParseSafetyLine(relPath, line)
+    if (violation) violations.push(violation)
+  }
+}
+
+/**
+ * Inspect a single frontmatter line for an unquoted inline comment.
+ * Returns a violation if the line is a flat `key: value` with an unquoted
+ * value containing a comment trigger, or null if the line is safe or out of
+ * scope.
+ */
+function checkParseSafetyLine(
+  relPath: string,
+  line: string,
+): FrontmatterViolation | null {
+  const kv = extractFlatKeyValue(line)
+  if (!kv) return null
+
+  const { key, rawValue } = kv
+  if (isQuotedValue(rawValue)) return null
+  if (!isCommentCandidate(rawValue)) return null
+
+  return {
+    file: relPath,
+    rule: 'parse-safety',
+    field: key,
+    message:
+      `Frontmatter field \`${key}\` contains an unquoted inline comment (whitespace before \`#\` or value starting with \`#\`). ` +
+      `Inline YAML comments in solution-doc frontmatter are silently stripped and risk data loss. ` +
+      `Raw value: ${JSON.stringify(rawValue)}`,
+    remediation:
+      'Quote the value or remove the inline comment — inline YAML comments in solution-doc frontmatter are silently stripped and risk data loss.',
+  }
+}
+
+/**
+ * Extract the key and raw value from a flat `key: value` frontmatter line.
+ * Returns null for lines that are not flat key-value pairs (comments, list
+ * items, indented lines, block-scalar indicators).
+ */
+function extractFlatKeyValue(
+  line: string,
+): { key: string; rawValue: string } | null {
+  if (/^\s*#/.test(line)) return null
+  if (/^\s*- /.test(line)) return null
+  if (/^\s/.test(line)) return null
+  if (/^([^:]+):\s*[|>]/.test(line)) return null
+
+  const kvMatch = line.match(/^([^:]+):\s(.*)$/)
+  if (!kvMatch) return null
+
+  return { key: (kvMatch[1] ?? '').trim(), rawValue: kvMatch[2] ?? '' }
+}
+
+/**
+ * True when `rawValue` is a candidate for comment-truncation: it contains
+ * whitespace-before-hash (`\s#`) or starts with `#` (both cause YAML to treat
+ * the text as a comment, silently dropping content).
+ */
+function isCommentCandidate(rawValue: string): boolean {
+  return /\s#/.test(rawValue) || /^\s*#/.test(rawValue)
+}
+
+/**
+ * True when `value` is wrapped in matching double or single quotes.
+ * A `#` inside a quoted value is literal, not a comment trigger.
+ */
+function isQuotedValue(value: string): boolean {
+  const trimmed = value.trim()
+  return (
+    (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'") && trimmed.length >= 2)
+  )
+}
+
 export function checkAgentColors(
   rootDir: string,
   markdownFiles: readonly string[],
@@ -937,6 +1090,9 @@ function findExemption(
 export function checkContentIntegrity(rootDir: string): CheckResult {
   const categories = discoverCategories(rootDir)
   const targets = collectScanTargets(rootDir)
+  // allScannedFiles feeds banned-pattern enforcement and allowlist warnings.
+  // solutionMarkdown is intentionally excluded: historical solution docs may
+  // legitimately reference CC/CEP terms and must not trigger banned-pattern hits.
   const allScannedFiles = [...targets.markdown, ...targets.typescript]
 
   const { allowlist, warnings: allowlistWarnings } = loadAllowlist(
@@ -951,6 +1107,10 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
   )
   const brokenSubfileRefs = checkSubfileReferences(rootDir, targets.markdown)
   const frontmatterViolations = checkFrontmatter(rootDir, targets.markdown)
+  const parseSafetyViolations = checkFrontmatterParseSafety(
+    rootDir,
+    targets.solutionMarkdown,
+  )
   const agentModelViolations = checkAgentModel(rootDir, targets.markdown)
   const agentColorViolations = checkAgentColors(rootDir, targets.markdown)
   const agentStemViolations = checkAgentStemUniqueness(
@@ -971,6 +1131,7 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     brokenSubfileRefs,
     bannedPatterns,
     frontmatterViolations,
+    parseSafetyViolations,
     agentModelViolations,
     agentColorViolations,
     agentStemViolations,
@@ -978,6 +1139,7 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     scanStats: {
       markdownFiles: targets.markdown.length,
       typescriptFiles: targets.typescript.length,
+      solutionMarkdownFiles: targets.solutionMarkdown.length,
     },
   }
 }
@@ -1012,6 +1174,10 @@ function printResult(result: CheckResult, verbose: boolean): void {
   printBrokenSubfileRefs(result.brokenSubfileRefs)
   printBannedPatterns(result.bannedPatterns)
   printFrontmatterViolations(result.frontmatterViolations)
+  printFrontmatterViolations(
+    result.parseSafetyViolations,
+    'Parse-safety violations',
+  )
   printAgentModelViolations(result.agentModelViolations)
   printAgentColorViolations(result.agentColorViolations)
   printAgentStemViolations(result.agentStemViolations)
@@ -1019,7 +1185,8 @@ function printResult(result: CheckResult, verbose: boolean): void {
   if (totalViolations(result) === 0) {
     process.stdout.write(
       `content-integrity: clean (${result.scanStats.markdownFiles} md + ` +
-        `${result.scanStats.typescriptFiles} ts scanned, ` +
+        `${result.scanStats.typescriptFiles} ts + ` +
+        `${result.scanStats.solutionMarkdownFiles} solution-md scanned, ` +
         `${result.exemptHits.length} exempt hits, ` +
         `${result.allowlistWarnings.length} warnings)\n`,
     )
@@ -1028,8 +1195,9 @@ function printResult(result: CheckResult, verbose: boolean): void {
   if (verbose) {
     process.stdout.write(
       `\ncategories: ${result.categories.join(', ')}\n` +
-        `scanStats: ${result.scanStats.markdownFiles} md + ${result.scanStats.typescriptFiles} ts\n` +
+        `scanStats: ${result.scanStats.markdownFiles} md + ${result.scanStats.typescriptFiles} ts + ${result.scanStats.solutionMarkdownFiles} solution-md\n` +
         `frontmatterViolations: ${result.frontmatterViolations.length}\n` +
+        `parseSafetyViolations: ${result.parseSafetyViolations.length}\n` +
         `agentModelViolations: ${result.agentModelViolations.length}\n` +
         `agentColorViolations: ${result.agentColorViolations.length}\n` +
         `agentStemViolations: ${result.agentStemViolations.length}\n` +
@@ -1072,9 +1240,10 @@ function printBannedPatterns(hits: readonly BannedPatternHit[]): void {
 
 function printFrontmatterViolations(
   violations: readonly FrontmatterViolation[],
+  label = 'Frontmatter violations',
 ): void {
   if (violations.length === 0) return
-  process.stderr.write(`\nFrontmatter violations (${violations.length}):\n`)
+  process.stderr.write(`\n${label} (${violations.length}):\n`)
   for (const v of violations) {
     const field = v.field ? ` (${v.field})` : ''
     process.stderr.write(`  ${v.file}  ${v.rule}${field}: ${v.message}\n`)
@@ -1123,6 +1292,7 @@ function totalViolations(result: CheckResult): number {
     result.brokenSubfileRefs.length +
     result.bannedPatterns.length +
     result.frontmatterViolations.length +
+    result.parseSafetyViolations.length +
     result.agentModelViolations.length +
     result.agentColorViolations.length +
     result.agentStemViolations.length

--- a/skills/ce-compound/references/schema.yaml
+++ b/skills/ce-compound/references/schema.yaml
@@ -235,13 +235,13 @@ validation_rules:
   - "date must match YYYY-MM-DD format"
   - "rails_version, if provided, must match X.Y.Z format and only applies to bug-track docs"
   - "tags should be lowercase and hyphen-separated"
-  - >-
+  - |-
     YAML quoting: scalar values that contain ' #' (space-hash) must be
     double-quoted to prevent silent YAML comment truncation (the YAML parser
     treats ' #' as an inline comment, silently dropping the rest of the value
-    with parseError: false). Example: problem: \"cache miss # under load\".
-  - >-
+    with parseError: false). Example: problem: "cache miss # under load".
+  - |-
     YAML quoting: array-of-strings frontmatter items must be double-quoted when
     the value starts with a YAML reserved indicator (e.g., '{', '[', '|', '>',
     '!', '&', '*', '?', ':', '-') or contains ': ' (colon-space). Example:
-    symptoms: - \"[mdx-js/rollup] Could not parse expression\"
+    symptoms: - "[mdx-js/rollup] Could not parse expression"

--- a/skills/ce-compound/references/schema.yaml
+++ b/skills/ce-compound/references/schema.yaml
@@ -23,12 +23,16 @@ tracks:
       - integration_issue
       - logic_error
   knowledge:
-    description: "Best practices, workflow improvements, patterns, and documentation"
+    description: "Best practices, workflow improvements, patterns, conventions, and documentation"
     problem_types:
       - best_practice
       - documentation_gap
       - workflow_issue
       - developer_experience
+      - architecture_pattern
+      - design_pattern
+      - tooling_decision
+      - convention
 
 # --- Fields required by BOTH tracks -----------------------------------------
 required_fields:
@@ -57,7 +61,18 @@ required_fields:
       - workflow_issue
       - best_practice
       - documentation_gap
-    description: "Primary category — determines track (bug vs knowledge)"
+      - architecture_pattern
+      - design_pattern
+      - tooling_decision
+      - convention
+    description: >-
+      Primary category — determines track (bug vs knowledge).
+      Prefer the narrowest applicable value; best_practice is the fallback
+      when no narrower knowledge-track value fits.
+      architecture_pattern: structural decisions about how components relate.
+      design_pattern: reusable solutions to recurring design problems.
+      tooling_decision: choices about tools, libraries, or build infrastructure.
+      convention: agreed-upon naming, formatting, or style rules.
 
   component:
     type: enum
@@ -220,3 +235,13 @@ validation_rules:
   - "date must match YYYY-MM-DD format"
   - "rails_version, if provided, must match X.Y.Z format and only applies to bug-track docs"
   - "tags should be lowercase and hyphen-separated"
+  - >-
+    YAML quoting: scalar values that contain ' #' (space-hash) must be
+    double-quoted to prevent silent YAML comment truncation (the YAML parser
+    treats ' #' as an inline comment, silently dropping the rest of the value
+    with parseError: false). Example: problem: \"cache miss # under load\".
+  - >-
+    YAML quoting: array-of-strings frontmatter items must be double-quoted when
+    the value starts with a YAML reserved indicator (e.g., '{', '[', '|', '>',
+    '!', '&', '*', '?', ':', '-') or contains ': ' (colon-space). Example:
+    symptoms: - \"[mdx-js/rollup] Could not parse expression\"

--- a/skills/ce-review/SKILL.md
+++ b/skills/ce-review/SKILL.md
@@ -477,12 +477,31 @@ Convert multiple reviewer compact JSON returns into one deduplicated, confidence
 10. **Collect coverage data.** Union residual_risks and testing_gaps across reviewers.
 11. **Preserve CE agent artifacts.** Keep the learnings, agent-native, schema-drift, and deployment-verification outputs alongside the merged finding set. Do not drop unstructured agent output just because it does not match the persona JSON schema.
 
+### Stage 5b: Validation pass
+
+Run an independent validation pass over the merged finding set before synthesis. This pass annotates each gated finding `validated: true` or `validated: false` with a one-sentence reason. It never deletes a finding — findings with `validated: false` are surfaced in the "Filtered (not validated)" group in Stage 6, not removed from the report.
+
+**Gating band (default):** Validate only findings that are **P0 or P1 severity**, or that have `requires_verification: true`. Findings outside this band pass through to Stage 6 unvalidated and unfiltered — no validator is dispatched for them. This bounds cost: one validator subagent per gated finding.
+
+**Dispatch:**
+
+1. Identify all gated findings from the Stage 5 merged set.
+2. For each gated finding, spawn one validator subagent in parallel using the validator template at `references/validator-template.md`. Pass the finding fields, the intent summary, the file list, and the full diff.
+3. Collect `{validated, reason}` from each validator. Attach both fields to the finding.
+4. **Never drop a finding.** A finding with `validated: false` is routed to the "Filtered (not validated)" group for Stage 6 presentation. It is not removed from the report, not suppressed, and not excluded from the Coverage count.
+5. Findings with `validated: true` flow through to Stage 6 unchanged — they appear in the normal severity tables.
+6. Findings outside the gating band carry no `validated` annotation and appear in Stage 6 severity tables unchanged.
+
+**Failure handling:** If a validator subagent fails or times out, treat the finding as `validated: true` (conservative fallback — keep it in the actioned set) and note the validator failure in the Coverage section.
+
+**Output-contract compatibility:** This pass is additive. Existing severity tables in Stage 6 keep their structure, headings, and order. The "Filtered (not validated)" group is appended after the existing severity tables. Consumers relying on existing section order are unaffected — new content only ever appears after existing sections.
+
 ### Stage 6: Synthesize and present
 
 Assemble the final report using **pipe-delimited markdown tables for findings** from the review output template included below. The table format is mandatory for finding rows in interactive mode — do not render findings as freeform text blocks or horizontal-rule-separated prose. Other report sections (Applied Fixes, Learnings, Coverage, etc.) use bullet lists and the `---` separator before the verdict, as shown in the template.
 
 1. **Header.** Scope, intent, mode, reviewer team with per-conditional justifications.
-2. **Findings.** Rendered as pipe-delimited tables grouped by severity (`### P0 -- Critical`, `### P1 -- High`, `### P2 -- Moderate`, `### P3 -- Low`). Each finding row shows `#`, file, issue, reviewer(s), confidence, and synthesized route. Omit empty severity levels. Never render findings as freeform text blocks or numbered lists.
+2. **Findings.** Rendered as pipe-delimited tables grouped by severity (`### P0 -- Critical`, `### P1 -- High`, `### P2 -- Moderate`, `### P3 -- Low`). Each finding row shows `#`, file, issue, reviewer(s), confidence, and synthesized route. Omit empty severity levels. Never render findings as freeform text blocks or numbered lists. Only findings with `validated: true` (or no `validated` annotation) appear in these tables.
 3. **Requirements Completeness.** Include only when a plan was found in Stage 2b. For each requirement (R1, R2, etc.) and implementation unit in the plan, report whether corresponding work appears in the diff. Use a simple checklist: met / not addressed / partially addressed. Routing depends on `plan_source`:
    - **`explicit`** (caller-provided or PR body): Flag unaddressed requirements as P1 findings with `autofix_class: manual`, `owner: downstream-resolver`. These enter the residual actionable queue and can become todos.
    - **`inferred`** (auto-discovered): Flag unaddressed requirements as P3 findings with `autofix_class: advisory`, `owner: human`. These stay in the report only — no todos, no autonomous follow-up. An inferred plan match is a hint, not a contract.
@@ -490,12 +509,13 @@ Assemble the final report using **pipe-delimited markdown tables for findings** 
 4. **Applied Fixes.** Include only if a fix phase ran in this invocation.
 5. **Residual Actionable Work.** Include when unresolved actionable findings were handed off or should be handed off.
 6. **Pre-existing.** Separate section, does not count toward verdict.
-7. **Learnings & Past Solutions.** Surface learnings-researcher results: if past solutions are relevant, flag them as "Known Pattern" with links to docs/solutions/ files.
-8. **Agent-Native Gaps.** Surface agent-native-reviewer results. Omit section if no gaps found.
-9. **Schema Drift Check.** If schema-drift-detector ran, summarize whether drift was found. If drift exists, list the unrelated schema objects and the required cleanup command. If clean, say so briefly.
-10. **Deployment Notes.** If deployment-verification-agent ran, surface the key Go/No-Go items: blocking pre-deploy checks, the most important verification queries, rollback caveats, and monitoring focus areas. Keep the checklist actionable rather than dropping it into Coverage.
-11. **Coverage.** Suppressed count, residual risks, testing gaps, failed/timed-out reviewers, and any intent uncertainty carried by non-interactive modes.
-12. **Verdict.** Ready to merge / Ready with fixes / Not ready. Fix order if applicable. When an `explicit` plan has unaddressed requirements, the verdict must reflect it — a PR that's code-clean but missing planned requirements is "Not ready" unless the omission is intentional. When an `inferred` plan has unaddressed requirements, note it in the verdict reasoning but do not block on it alone.
+7. **Filtered (not validated).** Include when Stage 5b produced any findings with `validated: false`. Render as a pipe-delimited table with columns `#`, `File`, `Issue`, `Reviewer`, `Confidence`, `Validator reason`. These findings are surfaced for human review — they are not removed from the report. The validator found evidence that the issue may not be real in the code as written, was not introduced by this diff, or is already handled elsewhere; the human reviewer makes the final call. Omit this section when no findings were filtered.
+8. **Learnings & Past Solutions.** Surface learnings-researcher results: if past solutions are relevant, flag them as "Known Pattern" with links to docs/solutions/ files.
+9. **Agent-Native Gaps.** Surface agent-native-reviewer results. Omit section if no gaps found.
+10. **Schema Drift Check.** If schema-drift-detector ran, summarize whether drift was found. If drift exists, list the unrelated schema objects and the required cleanup command. If clean, say so briefly.
+11. **Deployment Notes.** If deployment-verification-agent ran, surface the key Go/No-Go items: blocking pre-deploy checks, the most important verification queries, rollback caveats, and monitoring focus areas. Keep the checklist actionable rather than dropping it into Coverage.
+12. **Coverage.** Suppressed count, residual risks, testing gaps, failed/timed-out reviewers, validator failures, and any intent uncertainty carried by non-interactive modes.
+13. **Verdict.** Ready to merge / Ready with fixes / Not ready. Fix order if applicable. When an `explicit` plan has unaddressed requirements, the verdict must reflect it — a PR that's code-clean but missing planned requirements is "Not ready" unless the omission is intentional. When an `inferred` plan has unaddressed requirements, note it in the verdict reasoning but do not block on it alone.
 
 Do not include time estimates.
 
@@ -539,6 +559,10 @@ Pre-existing issues:
 [P2][gated_auto -> downstream-resolver] File: <file:line> -- <title> (<reviewer>, confidence <N>)
   Why: <why_it_matters>
 
+Filtered (not validated):
+[P1][gated_auto -> downstream-resolver] File: <file:line> -- <title> (<reviewer>, confidence <N>)
+  Validator reason: <one-sentence reason from the validator>
+
 Residual risks:
 - <risk>
 
@@ -559,6 +583,7 @@ Testing gaps:
 
 Coverage:
 - Suppressed: <N> findings below 0.60 confidence (P0 at 0.50+ retained)
+- Filtered (not validated): <N> findings surfaced for human review
 - Untracked files excluded: <file1>, <file2>
 - Failed reviewers: <reviewer>
 
@@ -576,6 +601,7 @@ Review complete
 - The `Artifact:` line gives callers the path to the full run artifact for machine-readable access to the complete findings schema. The text envelope is the primary handoff; the artifact is for debugging and full-fidelity access.
 - Findings with `owner: release` appear in the Advisory section (they are operational/rollout items, not code fixes).
 - Findings with `pre_existing: true` appear in the Pre-existing section regardless of autofix_class.
+- Findings with `validated: false` from Stage 5b appear in the "Filtered (not validated)" section. They are surfaced for human review — not removed. Include the validator reason on the indented `Validator reason:` line.
 - The Verdict appears in the metadata header (deliberately reordered from the interactive format where it appears at the bottom) so programmatic callers get the verdict first.
 - Omit any section with zero items.
 - If all reviewers fail or time out, emit `Code review degraded (headless mode). Reason: 0 of N reviewers returned results.` followed by "Review complete".

--- a/skills/ce-review/references/review-output-template.md
+++ b/skills/ce-review/references/review-output-template.md
@@ -59,6 +59,12 @@ Use this **exact format** when presenting synthesized review findings. Findings 
 |---|------|-------|----------|
 | 1 | `orders_controller.rb:12` | Broad rescue masking failed permission check | correctness |
 
+### Filtered (not validated)
+
+| # | File | Issue | Reviewer | Confidence | Validator reason |
+|---|------|-------|----------|------------|-----------------|
+| 1 | `orders_controller.rb:55` | Rate limit bypass via header spoofing | security | 0.72 | The `X-Forwarded-For` header is already stripped by the load balancer before reaching the application, so the cited bypass path does not exist in this deployment. |
+
 ### Learnings & Past Solutions
 
 - [Known Pattern] `docs/solutions/export-pagination.md` -- previous export pagination fix applies to this endpoint
@@ -126,6 +132,7 @@ This fails because: no pipe-delimited tables, no severity-grouped `###` headers,
 - **Applied Fixes section** -- include only when a fix phase ran in this review invocation
 - **Residual Actionable Work section** -- include only when unresolved actionable findings were handed off for later work
 - **Pre-existing section** -- separate table, no confidence column (these are informational)
+- **Filtered (not validated) section** -- findings where Stage 5b returned `validated: false`. Rendered as a pipe-delimited table with columns `#`, `File`, `Issue`, `Reviewer`, `Confidence`, `Validator reason`. These findings are surfaced for human review, not removed. Omit this section when Stage 5b produced no filtered findings.
 - **Learnings & Past Solutions section** -- results from learnings-researcher, with links to docs/solutions/ files
 - **Agent-Native Gaps section** -- results from agent-native-reviewer. Omit if no gaps found.
 - **Schema Drift Check section** -- results from schema-drift-detector. Omit if the agent did not run.
@@ -145,4 +152,5 @@ In `mode:headless`, replace the interactive pipe-delimited table report with a s
 - **`Artifact:` line** in metadata header gives callers the path to the full run artifact.
 - **`[needs-verification]` marker** on findings where `requires_verification: true`.
 - **Evidence lines** included per finding.
+- **"Filtered (not validated)" section** included when Stage 5b produced findings with `validated: false`. Uses `[severity][autofix_class -> owner] File: <file:line> -- <title>` format with an indented `Validator reason:` line. These findings are surfaced for human review, not removed.
 - **Completion signal:** "Review complete" as the final line.

--- a/skills/ce-review/references/validator-template.md
+++ b/skills/ce-review/references/validator-template.md
@@ -1,0 +1,96 @@
+# Validator Subagent Prompt Template
+
+This template is used by the Stage 5b orchestrator to spawn one independent validator per gated finding. Variable substitution slots are filled at dispatch time.
+
+A finding is **gated** (eligible for validation) when it is P0 or P1 severity, or when `requires_verification: true`. Findings outside this band pass through to Stage 6 unvalidated and unfiltered — no validator is dispatched for them.
+
+---
+
+## Template
+
+```
+You are an independent finding validator for a code review.
+
+Your sole job is to answer three questions about one specific finding and return a JSON verdict. You do NOT add new findings, suggest fixes, or produce any output other than the JSON object below.
+
+<output-contract>
+Return ONLY valid JSON matching this schema. No prose, no markdown, no explanation outside the JSON object.
+
+{
+  "validated": <boolean>,
+  "reason": "<one sentence explaining why the finding is validated or not>"
+}
+
+Rules:
+- You are a leaf validator inside an already-running review workflow. Do not invoke systematic skills or agents. Perform your analysis directly and return the JSON verdict only.
+- You are operationally read-only. You may use non-mutating inspection tools (file reads, glob, grep, git log, git diff, git show, git blame, gh pr view) to examine the code. Do not edit project files, change branches, commit, push, create PRs, or otherwise mutate the checkout or repository state.
+- Answer the three validation questions below. Set `validated: true` only when all three answers are YES. Set `validated: false` when any answer is NO.
+- The `reason` field must be one sentence. State the specific code evidence that drove your verdict (file name, function name, or line reference when relevant). Do not repeat the finding title verbatim.
+- Be conservative: when evidence is ambiguous, prefer `validated: true` (keep the finding in the actioned set). A false negative that lets a real bug through is worse than a false positive that the human reviewer can dismiss.
+- Do not validate based on general coding principles alone. Ground your verdict in the actual code as written in this diff and the surrounding context.
+</output-contract>
+
+<validation-questions>
+Answer each question YES or NO based on the code evidence you find.
+
+1. **Is the issue real in the code as written?**
+   Read the cited file and line. Does the problem the finding describes actually exist in the current code? A finding is not real if the code already handles the case, the cited line does not contain the described issue, or the issue is in a comment or dead code path.
+
+2. **Was this issue introduced by THIS diff?**
+   Check whether the cited code is new or changed in this diff, or whether it existed before. A finding is not introduced by this diff if the code is unchanged (pre-existing). Exception: if the diff makes a pre-existing issue newly reachable or newly relevant (e.g., a new call site, a removed guard), the finding is still valid — mark it as introduced by this diff.
+
+3. **Is the issue already handled elsewhere?**
+   Check whether the problem is already mitigated by a guard, middleware, framework behavior, type constraint, or other mechanism not visible at the cited line. A finding is not valid if the issue is fully handled at a higher or lower layer that the reviewer missed.
+
+Set `validated: true` only when: the issue is real (Q1 YES), introduced by this diff or newly relevant (Q2 YES), and not already handled elsewhere (Q3 YES).
+Set `validated: false` when any question is NO, and state which question failed and why in `reason`.
+</validation-questions>
+
+<finding>
+Title: {finding_title}
+Severity: {finding_severity}
+File: {finding_file}
+Line: {finding_line}
+Reviewer(s): {finding_reviewers}
+Confidence: {finding_confidence}
+requires_verification: {finding_requires_verification}
+Suggested fix: {finding_suggested_fix}
+</finding>
+
+<review-context>
+Intent: {intent_summary}
+
+Changed files: {file_list}
+
+Diff:
+{diff}
+</review-context>
+```
+
+---
+
+## Variable Reference
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| `{finding_title}` | Stage 5 merged finding | The finding's title field |
+| `{finding_severity}` | Stage 5 merged finding | P0, P1, P2, or P3 |
+| `{finding_file}` | Stage 5 merged finding | File path cited by the finding |
+| `{finding_line}` | Stage 5 merged finding | Line number cited by the finding |
+| `{finding_reviewers}` | Stage 5 merged finding | Reviewer(s) that flagged this finding |
+| `{finding_confidence}` | Stage 5 merged finding | Confidence score (0.0–1.0) |
+| `{finding_requires_verification}` | Stage 5 merged finding | Boolean from the merged finding |
+| `{finding_suggested_fix}` | Stage 5 merged finding | Suggested fix text, or "none" |
+| `{intent_summary}` | Stage 2 output | 2–3 line description of what the change is trying to accomplish |
+| `{file_list}` | Stage 1 output | List of changed files from the scope step |
+| `{diff}` | Stage 1 output | The actual diff content to review |
+
+---
+
+## Dispatch Notes
+
+- Dispatch one validator subagent per gated finding **in parallel** to keep latency bounded.
+- Pass the full diff and file list so the validator can inspect surrounding context, not just the cited line.
+- The validator returns `{validated, reason}`. Attach both fields to the finding before Stage 6.
+- **Never drop a finding based on the validator verdict.** A finding with `validated: false` moves to the "Filtered (not validated)" presentation group in Stage 6. It is never removed from the report.
+- If a validator subagent fails or times out, treat the finding as `validated: true` (conservative fallback — keep it in the actioned set) and note the validator failure in the Coverage section.

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -8,6 +8,22 @@ export interface FrontmatterResult<T = Record<string, unknown>> {
 }
 
 /**
+ * Returns the raw YAML text between the opening and closing `---` delimiters,
+ * or `null` when the content has no frontmatter block.
+ *
+ * Scope: flat top-level frontmatter only. Nested/indented mapping values are
+ * returned verbatim as part of the block — callers that scan individual lines
+ * (e.g. parse-safety checks) must skip indented lines themselves.
+ *
+ * Handles LF and CRLF line endings. The closing `---` does not need a trailing
+ * newline (handles files that end immediately after the delimiter).
+ */
+export function extractFrontmatterBlock(content: string): string | null {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n?---/)
+  return match ? (match[1] ?? '') : null
+}
+
+/**
  * Parses YAML frontmatter from Markdown content.
  *
  * Uses js-yaml with JSON_SCHEMA for security (prevents code execution via YAML tags).

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -1849,6 +1849,33 @@ describe('checkFrontmatterParseSafety', () => {
       fs.rmSync(root, { recursive: true, force: true })
     }
   })
+
+  test('does NOT flag a space-hash inside a nested (indented) mapping value', () => {
+    // Indented lines are out of scope by design — the check covers flat
+    // top-level `key: value` lines only. A `#` inside a nested mapping value
+    // such as `  note: cache miss # under load` is not scanned.
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        [
+          '---',
+          'meta:',
+          '  note: cache miss # under load',
+          'date: 2026-01-01',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -12,6 +12,7 @@ import {
   checkBannedPatterns,
   checkContentIntegrity,
   checkFrontmatter,
+  checkFrontmatterParseSafety,
   checkReferenceIntegrity,
   checkSubfileReferences,
   collectScanTargets,
@@ -1360,6 +1361,711 @@ describe('checkContentIntegrity (top-level)', () => {
 })
 
 // ---------------------------------------------------------------------------
+// checkFrontmatterParseSafety — adversarial fixture suite
+// ---------------------------------------------------------------------------
+
+describe('checkFrontmatterParseSafety', () => {
+  test('flags unquoted value containing space-hash (truncation trigger)', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        [
+          '---',
+          'problem: cache miss # under load',
+          'date: 2026-01-01',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({
+        file: 'docs/solutions/test-doc.md',
+        rule: 'parse-safety',
+        field: 'problem',
+      })
+      expect(violations[0]?.message).toContain('#')
+      expect(violations[0]?.remediation).toContain('Quote')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('does NOT flag a double-quoted value containing hash (safe)', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        [
+          '---',
+          'problem: "cache miss # under load"',
+          'date: 2026-01-01',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('does NOT flag a single-quoted value containing hash (safe)', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        [
+          '---',
+          "problem: 'cache miss # under load'",
+          'date: 2026-01-01',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('does NOT flag a full-line YAML comment (not a value)', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        [
+          '---',
+          '# this is a real YAML comment',
+          'problem: cache miss',
+          'date: 2026-01-01',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('does NOT flag a URL with #fragment inside a quoted value', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        [
+          '---',
+          'url: "https://example.com/page#section"',
+          'date: 2026-01-01',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags a hash at the start of an unquoted value (value-start # is a comment trigger)', () => {
+    // `tag: #important` — the ban rule applies: value starts with #.
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        ['---', 'tag: #important', 'date: 2026-01-01', '---', 'body'].join(
+          '\n',
+        ),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({
+        file: 'docs/solutions/test-doc.md',
+        rule: 'parse-safety',
+        field: 'tag',
+      })
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('does NOT flag a list item line (not a flat key: scalar)', () => {
+    // List items like `  - cache miss # under load` are not flat key: scalar lines.
+    // The check skips them to avoid false positives on YAML arrays.
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        [
+          '---',
+          'symptoms:',
+          '  - cache miss # under load',
+          'date: 2026-01-01',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('does NOT flag a hash inside a value when no space precedes it', () => {
+    // e.g. `title: MDX {#anchor} syntax` — {# has no space before #
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        [
+          '---',
+          'title: MDX heading anchor syntax `{#anchor}` crashes the build',
+          'date: 2026-01-01',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('returns empty for a file with no frontmatter', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(root, 'docs/solutions/test-doc.md', '# Just a heading\n\nbody')
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('returns empty for a file with clean frontmatter (no space-hash in values)', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        [
+          '---',
+          'problem: cache miss under load',
+          'date: 2026-01-01',
+          'severity: high',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags multiple truncating fields in the same file', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        [
+          '---',
+          'problem: cache miss # under load',
+          'solution: add index # on column',
+          'date: 2026-01-01',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toHaveLength(2)
+      const fields = violations.map((v) => v.field).sort()
+      expect(fields).toEqual(['problem', 'solution'])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags tab-before-hash (tab is whitespace, same comment trigger as space)', () => {
+    // `problem: cache miss\t# under load` — tab counts as whitespace; the ban
+    // rule applies: unquoted value with whitespace-before-#.
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        [
+          '---',
+          'problem: cache miss\t# under load',
+          'date: 2026-01-01',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({
+        file: 'docs/solutions/test-doc.md',
+        rule: 'parse-safety',
+        field: 'problem',
+      })
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags hash-at-value-start (value-start # is a comment trigger)', () => {
+    // `tag: #important` — the ban rule applies: value starts with #.
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        ['---', 'tag: #important', 'date: 2026-01-01', '---', 'body'].join(
+          '\n',
+        ),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({
+        file: 'docs/solutions/test-doc.md',
+        rule: 'parse-safety',
+        field: 'tag',
+      })
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags anchor-prefixed value with inline comment (whitespace-before-#)', () => {
+    // `problem: &p cache miss # under load` — unquoted value with whitespace-before-#;
+    // the anchor prefix does not exempt the line from the ban.
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        [
+          '---',
+          'problem: &p cache miss # under load',
+          'date: 2026-01-01',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({
+        file: 'docs/solutions/test-doc.md',
+        rule: 'parse-safety',
+        field: 'problem',
+      })
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('does NOT flag anchor-prefixed value with no inline comment', () => {
+    // `key: &anchor value` — has no `#`, so the ban rule does not apply.
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        ['---', 'key: &anchor value', 'date: 2026-01-01', '---', 'body'].join(
+          '\n',
+        ),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags trailing comment on boolean scalar (unquoted value with whitespace-#)', () => {
+    // `draft: false # intentionally published` — the ban rule applies to all
+    // unquoted values with whitespace-before-#, including booleans. Policy:
+    // inline comments in solution-doc frontmatter are banned regardless of
+    // whether the YAML parser happens to preserve the value.
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        [
+          '---',
+          'draft: false # intentionally published',
+          'date: 2026-01-01',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({
+        file: 'docs/solutions/test-doc.md',
+        rule: 'parse-safety',
+        field: 'draft',
+      })
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags trailing comment on date string scalar (unquoted value with whitespace-#)', () => {
+    // `date: 2026-01-01 # created` — the ban rule applies: unquoted value with
+    // whitespace-before-#. Authors should quote: date: "2026-01-01".
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        [
+          '---',
+          'problem: cache miss',
+          'date: 2026-01-01 # created',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({
+        rule: 'parse-safety',
+        field: 'date',
+      })
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags string value with trailing inline comment (whitespace-before-#)', () => {
+    // `title: My Feature # draft` — unquoted value with whitespace-before-#; banned.
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        [
+          '---',
+          'title: My Feature # draft',
+          'date: 2026-01-01',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({
+        file: 'docs/solutions/test-doc.md',
+        rule: 'parse-safety',
+        field: 'title',
+      })
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags value with multiple spaces before hash (multi-space whitespace-before-#)', () => {
+    // `field: value  # comment` (2+ spaces) — whitespace-before-# still matches; banned.
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/test-doc.md',
+        [
+          '---',
+          'field: value  # comment',
+          'date: 2026-01-01',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const violations = checkFrontmatterParseSafety(root, [
+        'docs/solutions/test-doc.md',
+      ])
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({
+        file: 'docs/solutions/test-doc.md',
+        rule: 'parse-safety',
+        field: 'field',
+      })
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// collectScanTargets — docs/solutions/ isolation
+// ---------------------------------------------------------------------------
+
+describe('collectScanTargets — docs/solutions/ isolation', () => {
+  test('solutionMarkdown collects markdown under docs/solutions/', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(root, 'docs/solutions/best-practices/foo.md', '# foo')
+      writeFile(root, 'docs/solutions/workflow-issues/bar.md', '# bar')
+      writeFile(
+        root,
+        'skills/my-skill/SKILL.md',
+        '---\nname: x\ndescription: y\n---\nbody',
+      )
+
+      const targets = collectScanTargets(root)
+
+      // solutionMarkdown must contain the docs/solutions/ files
+      expect(targets.solutionMarkdown).toContain(
+        'docs/solutions/best-practices/foo.md',
+      )
+      expect(targets.solutionMarkdown).toContain(
+        'docs/solutions/workflow-issues/bar.md',
+      )
+
+      // docs/solutions/ files must NOT appear in targets.markdown (banned-pattern scope)
+      expect(targets.markdown).not.toContain(
+        'docs/solutions/best-practices/foo.md',
+      )
+      expect(targets.markdown).not.toContain(
+        'docs/solutions/workflow-issues/bar.md',
+      )
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('solutionMarkdown is empty when docs/solutions/ does not exist', () => {
+    const root = makeFixtureRepo()
+    try {
+      const targets = collectScanTargets(root)
+      expect(targets.solutionMarkdown).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('existing markdown and typescript targets are unaffected by docs/solutions/ addition', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'skills/foo/SKILL.md',
+        '---\nname: foo\ndescription: bar\n---\nbody',
+      )
+      writeFile(root, 'agents/research/a.md', '---\nname: a\n---\nagent')
+      writeFile(root, 'src/lib/foo.ts', '// ts')
+      writeFile(root, 'docs/solutions/best-practices/doc.md', '# doc')
+
+      const targets = collectScanTargets(root)
+
+      // Existing scopes unchanged
+      expect(targets.markdown).toContain('skills/foo/SKILL.md')
+      expect(targets.markdown).toContain('agents/research/a.md')
+      expect(targets.typescript).toContain('src/lib/foo.ts')
+
+      // docs/solutions/ isolated
+      expect(targets.solutionMarkdown).toContain(
+        'docs/solutions/best-practices/doc.md',
+      )
+      expect(targets.markdown).not.toContain(
+        'docs/solutions/best-practices/doc.md',
+      )
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// checkContentIntegrity — parse-safety integration
+// ---------------------------------------------------------------------------
+
+describe('checkContentIntegrity — parse-safety integration', () => {
+  test('a malformed docs/solutions/ fixture is now picked up by the gate', () => {
+    // This is the key integration proof: before this change, docs/solutions/
+    // was unscanned. Now a truncating value in a solution doc is detected.
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/best-practices/truncating.md',
+        [
+          '---',
+          'problem: cache miss # under load',
+          'date: 2026-01-01',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+
+      const result = checkContentIntegrity(root)
+      expect(result.parseSafetyViolations).toHaveLength(1)
+      expect(result.parseSafetyViolations[0]).toMatchObject({
+        file: 'docs/solutions/best-practices/truncating.md',
+        rule: 'parse-safety',
+        field: 'problem',
+      })
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('a clean docs/solutions/ fixture produces no parse-safety violations', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/best-practices/clean.md',
+        [
+          '---',
+          'problem: cache miss under load',
+          'date: 2026-01-01',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+
+      const result = checkContentIntegrity(root)
+      expect(result.parseSafetyViolations).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('regression: existing skill/agent frontmatter checks still pass unchanged', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeCompliantSkill(root, 'foo', 'body')
+      writeAgent(root, 'research', 'a')
+
+      const result = checkContentIntegrity(root)
+      expect(result.frontmatterViolations).toEqual([])
+      expect(result.agentModelViolations).toEqual([])
+      expect(result.parseSafetyViolations).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('docs/solutions/ files are NOT subject to banned-pattern enforcement', () => {
+    // Historical solution docs may legitimately reference CC/CEP terms in
+    // their problem descriptions. They must not be scanned for banned patterns.
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/workflow-issues/historical.md',
+        [
+          '---',
+          'problem: migrated from Claude Code',
+          'date: 2026-01-01',
+          '---',
+          'We used Claude Code before switching.',
+        ].join('\n'),
+      )
+
+      const result = checkContentIntegrity(root)
+      // No banned-pattern hits from the solution doc
+      expect(result.bannedPatterns).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('allowlist zero-match warning still fires when glob covers docs/solutions/ but solutionMarkdown is excluded from allScannedFiles', () => {
+    // solutionMarkdown must NOT leak into allScannedFiles (which feeds loadAllowlist).
+    // A docs/solutions/** allowlist entry should produce a zero-match warning
+    // because no scanned file (skills/agents/src) matches that glob.
+    // We include a skill so allScannedFiles is non-empty (zero-match check only
+    // runs when scannedFiles.length > 0).
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/best-practices/doc.md',
+        ['---', 'problem: cache miss', 'date: 2026-01-01', '---', 'body'].join(
+          '\n',
+        ),
+      )
+      // A skill gives allScannedFiles a non-empty entry so the zero-match check runs.
+      writeCompliantSkill(root, 'foo', 'body')
+      writeAllowlist(root, [
+        {
+          pathGlob: 'docs/solutions/**',
+          patterns: ['Claude Code'],
+          reason: 'Historical solution docs may reference Claude Code by name.',
+        },
+      ])
+
+      const result = checkContentIntegrity(root)
+      // The allowlist entry covers docs/solutions/** but no scanned file
+      // (skills/agents/src) matches it → zero-match warning must appear.
+      const zeroMatch = result.allowlistWarnings.filter(
+        (w) => w.kind === 'zero-match' && w.pathGlob === 'docs/solutions/**',
+      )
+      expect(zeroMatch).toHaveLength(1)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Integration smoke: run the gate against the real repo. This is the test
 // that catches both v2.4.0 cycle bugs if they reintroduce themselves, and the
 // one that actually fails CI when content drifts.
@@ -1643,12 +2349,20 @@ describe('integration: real repo', () => {
       throw new Error(`Duplicate bundled agent stems in repo:\n  ${details}`)
     }
 
+    if (result.parseSafetyViolations.length > 0) {
+      const details = result.parseSafetyViolations
+        .map((v) => `${v.file}  ${v.field ?? ''}  ${v.message}`)
+        .join('\n  ')
+      throw new Error(`Parse-safety violations in repo:\n  ${details}`)
+    }
+
     expect(result.phantomRefs).toEqual([])
     expect(result.brokenSubfileRefs).toEqual([])
     expect(result.bannedPatterns).toEqual([])
     expect(result.frontmatterViolations).toEqual([])
     expect(result.agentModelViolations).toEqual([])
     expect(result.agentStemViolations).toEqual([])
+    expect(result.parseSafetyViolations).toEqual([])
     expect(result.allowlistWarnings).toEqual([])
     expect(result.scanStats.markdownFiles).toBeGreaterThan(0)
     expect(result.scanStats.typescriptFiles).toBeGreaterThan(0)
@@ -1720,6 +2434,36 @@ describe('CLI', () => {
         'Banned patterns outside allowlist',
       )
       expect(result.stderr.toString()).toContain('TaskCreate')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('exits 1 when a parse-safety violation exists in docs/solutions/', () => {
+    // A docs/solutions/ file with a truncating frontmatter value must cause
+    // the CLI to exit 1 and report the violation path and rule.
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/solutions/truncating.md',
+        [
+          '---',
+          'problem: cache miss # under load',
+          'date: 2026-01-01',
+          '---',
+          'body',
+        ].join('\n'),
+      )
+      const result = Bun.spawnSync(['bun', SCRIPT_PATH, root], {
+        cwd: REPO_ROOT,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      expect(result.exitCode).toBe(1)
+      const stderr = result.stderr.toString()
+      expect(stderr).toContain('Parse-safety violations')
+      expect(stderr).toContain('truncating.md')
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }

--- a/tests/unit/frontmatter.test.ts
+++ b/tests/unit/frontmatter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import {
+  extractFrontmatterBlock,
   formatFrontmatter,
   parseFrontmatter,
   stripFrontmatter,
@@ -228,5 +229,48 @@ Content with leading newline`
       const result = stripFrontmatter(content)
       expect(result).toBe('Content with leading newline')
     })
+  })
+})
+
+describe('extractFrontmatterBlock', () => {
+  test('returns the raw YAML text between delimiters for well-formed frontmatter', () => {
+    const content = '---\nname: test\ndescription: A skill\n---\n# Body'
+    expect(extractFrontmatterBlock(content)).toBe(
+      'name: test\ndescription: A skill',
+    )
+  })
+
+  test('returns null when there is no frontmatter', () => {
+    expect(extractFrontmatterBlock('# Just a heading\nSome content')).toBeNull()
+  })
+
+  test('returns null when only the opening delimiter is present', () => {
+    expect(
+      extractFrontmatterBlock('---\nname: test\n# No closing delimiter'),
+    ).toBeNull()
+  })
+
+  test('handles Windows (CRLF) line endings', () => {
+    const content = '---\r\nname: test\r\n---\r\nBody'
+    expect(extractFrontmatterBlock(content)).toBe('name: test')
+  })
+
+  test('handles no trailing newline before the closing delimiter', () => {
+    // File ends immediately after closing --- with no trailing newline.
+    const content = '---\nname: test\n---'
+    expect(extractFrontmatterBlock(content)).toBe('name: test')
+  })
+
+  test('returns an empty string for empty frontmatter', () => {
+    const content = '---\n---\n# Body'
+    expect(extractFrontmatterBlock(content)).toBe('')
+  })
+
+  test('preserves nested/indented lines verbatim in the returned block', () => {
+    // The helper returns raw text; callers are responsible for skipping
+    // indented lines when scanning flat top-level key-value pairs.
+    const content = '---\nmeta:\n  note: cache miss # under load\n---\nbody'
+    const block = extractFrontmatterBlock(content)
+    expect(block).toBe('meta:\n  note: cache miss # under load')
   })
 })


### PR DESCRIPTION
## Summary

Two independent verification layers, distilled from a review of the upstream Compound Engineering plugin's `ce:*` workflows. Both are quality-floor passes that filter low-quality output before it propagates — the genuinely valuable pattern in upstream's recent work, ported without its surrounding complexity.

### `ce:review` — Stage 5b independent validation pass

A new validation stage runs between finding-merge and synthesis: each high-severity or verification-flagged finding is independently re-checked by a validator that asks whether the issue is real in the code as written, introduced by this diff, and not already handled elsewhere.

It is **validate-only** — it never deletes a finding. Rejected findings move to a "Filtered (not validated)" group with the validator's reason, so the human always sees what was filtered and why. This neutralizes the obvious failure mode (a validator wrongly dropping a real finding) by making the pass a re-prioritizer, not a gate. The pass is bounded to P0/P1 or verification-flagged findings to keep cost in check, and it surfaces in both interactive and headless output.

### `content-integrity` — solution-doc frontmatter comment check

The gate now scans `docs/solutions/` frontmatter and flags unquoted inline YAML comments (whitespace before `#`, or a value starting with `#`), which YAML silently strips — a real silent-data-loss vector for the knowledge store. Solution docs are scanned through a dedicated target set kept separate from banned-pattern enforcement, so historical docs aren't subject to checks they were never meant to have.

The rule is deliberately a flat "no unquoted inline comments" ban rather than an attempt to detect content loss: a truncating comment and a legitimate one are byte-identical to the YAML parser, so the honest, low-false-positive rule is to quote the value or drop the comment. Remediation says exactly that.

Also tightens the `ce-compound` category enums with narrower values (`architecture_pattern`, `design_pattern`, `tooling_decision`, `convention`) and a "prefer the narrowest" guideline.

## Notes

- The two changes are independent — neither depends on the other.
- Deliberately excluded from the upstream surface: the `mode:agent` apply model, the action-class rubric, vocabulary-lifecycle artifacts, and the ideation scope expansion. Discrete capabilities only.

## Verification

- 955 unit tests pass
- typecheck, lint, content-integrity, registry drift, schema drift, build, Node ESM smoke (default-only export), and docs build all green
- No existing solution doc flags under the new frontmatter rule
