### PR TITLE
feat(skills): merge upstream ce:brainstorm and ce:plan improvements

### DIFF
--- a/docs/plans/2026-06-04-002-feat-merge-upstream-brainstorm-plan-plan.md
+++ b/docs/plans/2026-06-04-002-feat-merge-upstream-brainstorm-plan-plan.md
@@ -1,0 +1,322 @@
+---
+title: "feat: Merge upstream ce-brainstorm + ce-plan improvements into ours"
+type: feat
+status: active
+date: 2026-06-04
+origin: docs/brainstorms/2026-06-04-merge-upstream-brainstorm-plan-requirements.md
+---
+
+# Merge Upstream ce-brainstorm + ce-plan Improvements
+
+## Overview
+
+Merge the improvements from upstream CEP `ce-brainstorm` and `ce-plan` into Systematic's versions —
+while preserving the Systematic-specific additions upstream lacks (Phase 3.5 Document Review,
+`requirements-capture.md`, `visual-communication.md`, our Core Plan Template). Upstream's
+improvements taken: Phase 2.5 Synthesis Summary, markdown rendering guidance, section contracts, and
+ce-plan's anti-expansion + scope-synthesis steps. **HTML output mode and the output-mode toggle are
+dropped** — Systematic renders markdown only, so the html-rendering machinery and Phase 0.0 output
+resolution add no value.
+
+## Problem Frame
+
+Our `ce-brainstorm` and `ce-plan` diverged from upstream and have fallen behind on genuinely useful
+improvements (see origin: docs/brainstorms/2026-06-04-merge-upstream-brainstorm-plan-requirements.md).
+The directive is to bring upstream's improvements into ours, not to lean-rewrite or cherry-pick.
+These are our two highest-traffic workflow skills, so the merge must read as one coherent skill each,
+not stitched-together halves.
+
+## Requirements Trace
+
+- R1. ce-brainstorm gains Phase 2.5 Synthesis Summary (+ `synthesis-summary.md`) as a scope
+  checkpoint before doc-write, coexisting with our Phase 3.5 Document Review (quality gate after).
+- R2. Both skills gain a per-skill `markdown-rendering.md` rendering-guidance reference (prose/bullets/
+  tables heuristics, ID-prefix format, bold-leader labels, section anatomy), wired into the skill.
+  **HTML rendering and any output-mode toggle are explicitly NOT included** — markdown only.
+- R3. Section description (`brainstorm-sections.md` / `plan-sections.md`) lands as a **rendering/
+  ordering layer only**; our `requirements-capture.md` / Core Plan Template remain the canonical
+  content authority. (No html-rendering sub-file.)
+- R4. ce-plan gains 0.7 Solo-Mode Scoping Synthesis + 5.1.5 Brainstorm-Sourced Scoping Synthesis
+  (mutually exclusive: no-origin-doc vs with-origin-doc) + 3.7 Anti-Expansion.
+- R5. All Systematic-specific additions preserved and reconciled (no drop, no duplication).
+- R6. All CEP-internal converted to Systematic conventions; content-integrity clean
+  (no `.compound-engineering`, `CLAUDE.md`, `compound-engineering:`; all sub-file refs resolve;
+  no dangling html-rendering ref); registry regenerated; full gate green; additions dogfood
+  `writing-skills`.
+
+## Scope Boundaries
+
+- No CONCEPTS.md creation; no `ce-sessions` dependency.
+- No regression of Phase 3.5 Document Review or the Core Plan Template.
+- **No HTML rendering** (`html-rendering.md` not imported) and **no output-mode toggle** (no Phase 0.0,
+  no `output:` token, no config field) — Systematic renders markdown only.
+
+### Deferred to Separate Tasks
+
+- **Vocabulary Capture** (both skills): OMIT — depends on CONCEPTS.md we don't have. Reintroduce
+  as its own task if CONCEPTS.md ever lands. (origin decision)
+- **ce-plan 0.1a Approach-Altitude**: DEFER — planning-time grounding found `approach-altitude.md`
+  introduces an `execution: knowledge-work` carve-out coupled to `ce-work` routing changes
+  (`plan-sections.md` markers + ce-work carve-out path) that are outside this merge's scope and were
+  rejected in the ce-work delta analysis. Porting 0.1a faithfully would pull in that out-of-scope
+  carve-out. Track separately if the knowledge-work carve-out is ever adopted across ce-plan+ce-work.
+- ce-work / ce-compound-refresh merges: separate skills, separate effort.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `skills/ce-brainstorm/SKILL.md` (198 lines) — our skill; Phase 0/0.1b/2/3/3.5 structure; `$ARGUMENTS`
+  at line 42; `argument-hint` frontmatter. Phase 3.5 Document Review is ours (upstream lacks).
+- `skills/ce-brainstorm/references/{handoff,requirements-capture,universal-brainstorming}.md` — ours.
+  `requirements-capture.md` (243 lines) is the canonical content contract — preserve.
+- `skills/ce-plan/SKILL.md` (737 lines) — our skill; Core Plan Template under Phase 4 is canonical.
+- `skills/ce-plan/references/{deepening-workflow,plan-handoff,universal-planning,visual-communication}.md`
+  — ours; `visual-communication.md` (31 lines) upstream lacks — preserve.
+- `scripts/content-integrity.ts` — `checkSubfileReferences` requires referenced sub-files to resolve;
+  banned-pattern scan catches CC/CEP residue. New sub-files must be referenced + convertible.
+- `src/lib/config-schema.ts` — strict Zod schema; confirms output-mode must NOT use config (R2).
+
+### Upstream Source (EveryInc/compound-engineering-plugin, plugins/compound-engineering/skills/)
+
+- `ce-brainstorm/SKILL.md` (285 lines): Phase 2.5 Synthesis Summary (take); Phase 0.0 Output Mode +
+  Vocabulary Capture (omit).
+- `ce-brainstorm/references/`: `synthesis-summary.md` (271, take), `brainstorm-sections.md` (301,
+  take), `markdown-rendering.md` (207, take, strip html cross-refs); `html-rendering.md` (538, omit).
+- `ce-plan/SKILL.md` (791 lines): 0.7 Solo-Mode Scoping, 3.7 Anti-Expansion, 5.1.5 Brainstorm-Sourced
+  Scoping, section-contract wiring (take); Phase 0.0 Output Mode + 0.1a Approach-Altitude (omit/defer).
+- `ce-plan/references/`: `plan-sections.md` (286, take), `synthesis-summary.md` (take),
+  `markdown-rendering.md` (take, strip html cross-refs); `approach-altitude.md` + `html-rendering.md` (omit).
+
+### Institutional Learnings
+
+- `docs/solutions/` CEP-conversion lessons: grep changed files for CC/CEP residue + over-conversions
+  after any sed pass; zsh word-splitting silent-failure class — use `find | while read` not `for f in $X`.
+- Imported sub-files carry no per-file attribution comment (the skills are adaptations, not vendored).
+
+## Key Technical Decisions
+
+- **Drop HTML + output-mode entirely** (R2): Systematic renders markdown only. No `html-rendering.md`
+  import, no Phase 0.0 Output Mode, no `output:` token, no config field. Upstream's own
+  `markdown-rendering.md` states "No HTML mixed in... defer to HTML rendering" — confirming markdown
+  is a clean standalone target. This removes the config-vs-token question and ~1076 lines of html
+  machinery.
+- **Per-skill `markdown-rendering.md`** (R2): each skill gets its own adapted copy (matches upstream
+  layout; self-contained skills). ~200 lines/skill — the useful rendering guidance (prose/bullets/
+  tables heuristics, ID-prefix format, bold-leader labels, section anatomy).
+- **Section authority = single owner, hard rule** (R3 — tightened per review): our
+  `requirements-capture.md` / Core Plan Template are the SOLE owner of section *inventory, ordering,
+  and meaning*. The imported `*-sections.md` must be reduced to a strictly mechanical presentation
+  reference — any normative section *names/order* in upstream's copy are STRIPPED on import and, if
+  genuinely missing, folded into our canonical contract instead. `*-sections.md` may only describe
+  *how* a section renders, never *which* sections exist. This is a hard single-owner rule, not a
+  soft split — if a sentence in `*-sections.md` defines section existence, it's a bug to fix during
+  import.
+- **2.5 / 3.5 checkpoint contract**: 2.5 = scope gate before doc (only scope gate); 3.5 = quality/
+  format review after doc (not a second scope negotiation).
+- **One shared synthesis artifact, three consumers** (reframed per review — not "one model"):
+  `synthesis-summary.md` is a shared summary artifact consumed by brainstorm Phase 2.5 (from
+  dialogue), ce-plan 0.7 (solo, no origin doc), and ce-plan 5.1.5 (with origin doc). The three are
+  distinct control flows over different input states — they share the artifact's keep-tests/shape
+  budgets, not one flow. **Verified against upstream** (ce-plan SKILL.md lines 234, 638): 0.7 fires
+  only in solo invocation (4 explicit guards); 5.1.5 fires only when an origin `*-requirements.md`
+  exists; each explicitly skips when the other's condition holds. Mutual exclusivity is upstream's
+  actual wiring, not an inference.
+- **0.7 is safe to take without 0.1a** (verified — review concern resolved): upstream SKILL.md line
+  125 states approach-altitude (0.1a) operates *before* deliverable-commitment while 0.7/5.1.5
+  "operate on a deliverable already committed to" — disjoint surfaces. 0.7 depends only on
+  `synthesis-summary.md` (zero outbound refs), NOT on the knowledge-work carve-out. Defer 0.1a only.
+- **Preserve headless-mode routing**: `synthesis-summary.md` carries headless-mode routing (internal
+  draft, skip chat-time stage, route inferred bets to `## Assumptions`). Our skills have pipeline/
+  `disable-model-invocation` paths — preserve this routing on import so automated callers behave.
+- **Defer 0.1a Approach-Altitude**: coupled to out-of-scope ce-work knowledge-work carve-out.
+
+## Open Questions
+
+### Resolved During Planning
+
+- HTML + output-mode: dropped entirely (markdown-only target).
+- Rendering layout: per-skill `markdown-rendering.md` copy.
+- Section authority (split-brain risk): ours canonical, upstream rendering-only.
+- Vocabulary Capture: omit (CONCEPTS.md dependency).
+- Approach-Altitude coupling: defer (ce-work carve-out dependency).
+- 2.5/3.5 and triple-synthesis coherence: explicit contracts above.
+
+### Deferred to Implementation
+
+- Exact merged phase numbering in each SKILL.md (preserve our existing numbers; insert upstream
+  phases at the grounded insertion points — brainstorm 2.5 between our Phase 2 and Phase 3; plan
+  3.7 after our 3.6, 0.7/5.1.5 at their phases) — final numbering settled when editing the live files.
+- Whether any upstream section in `*-sections.md` names a section our canonical contract is missing
+  (fold in if so) — determined when reconciling the two during Unit edits.
+**Transitive sub-file reference audit (verified against upstream — these MUST be cleaned on import,
+because content-integrity only scans SKILL.md entry files, NOT nested reference docs):**
+- `brainstorm-sections.md` → references `html-rendering.md` + `markdown-rendering.md`: STRIP the
+  html-rendering ref (not imported); keep markdown-rendering ref.
+- `plan-sections.md` → references `approach-altitude.md` + `html-rendering.md` + `deepening-workflow.md`
+  + `markdown-rendering.md`: STRIP approach-altitude + html-rendering refs (neither imported); keep
+  `deepening-workflow.md` (we already have it) + markdown-rendering.
+- `synthesis-summary.md` (brainstorm) → references `brainstorm-sections.md` (imported ✓);
+  `synthesis-summary.md` (ce-plan) → zero outbound refs ✓; both `markdown-rendering.md` → zero refs ✓.
+- After import, grep every NEW sub-file for `html-rendering`, `approach-altitude`, `.compound-engineering`,
+  `CONCEPTS.md`, `ce-sessions` — all must be absent (manual audit, since the gate won't catch nested refs).
+
+## Implementation Units
+
+- [ ] **Unit 1: ce-brainstorm merge — Phase 2.5 Synthesis Summary + markdown rendering + sections**
+
+**Goal:** Merge upstream's improvements into `skills/ce-brainstorm/`, preserving Phase 3.5 Document
+Review + `requirements-capture.md`. No html, no output-mode.
+
+**Requirements:** R1, R2, R3, R5, R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `skills/ce-brainstorm/SKILL.md` (add Phase 2.5 Synthesis Summary between our Phase 2 and
+  Phase 3; wire the markdown-rendering + sections references; keep Phase 3.5; NO Phase 0.0)
+- Create: `skills/ce-brainstorm/references/synthesis-summary.md` (converted from upstream)
+- Create: `skills/ce-brainstorm/references/brainstorm-sections.md` (rendering/ordering layer)
+- Create: `skills/ce-brainstorm/references/markdown-rendering.md` (converted; html cross-refs stripped)
+- Preserve: `skills/ce-brainstorm/references/requirements-capture.md` (canonical content authority)
+
+**Approach:**
+- Fetch upstream sub-files; apply CEP→Systematic conversion (`compound-engineering:`→`systematic:`,
+  `.compound-engineering/`→drop, `CLAUDE.md`→`AGENTS.md`, CC tool names). Do NOT import
+  `html-rendering.md`; strip any html-rendering cross-references inside `markdown-rendering.md` and
+  the section files (html is not a Systematic output).
+- Phase 2.5: insert the synthesis-summary scope checkpoint before doc-write; explicitly note it is
+  the scope gate and Phase 3.5 remains the post-doc quality review.
+- `brainstorm-sections.md` + `markdown-rendering.md` describe section ordering/rendering only;
+  `requirements-capture.md` stays the content authority — if upstream names a missing section, fold
+  it into requirements-capture.
+- Omit Vocabulary Capture entirely. No Phase 0.0 / output token.
+
+**Execution note:** Dogfood `writing-skills` — edited skills must be tested (apply the skill mentally
+to confirm the merged flow is coherent end-to-end before claiming done).
+
+**Patterns to follow:** existing Systematic skill prose style; our Phase 3.5 wording; converted-import
+hygiene from prior CEP imports.
+
+**Test scenarios:**
+- Happy path: a Standard brainstorm surfaces Phase 2.5 scope synthesis (confirm-gated) before the doc,
+  then runs Phase 3.5 Document Review after — both fire, no redundancy.
+- Error path / hygiene: content-integrity finds zero CC/CEP residue, no html-rendering reference, and
+  all 3 new sub-file refs resolve.
+- Integration: merged SKILL.md reads coherently end-to-end (no orphaned phase numbers, no dangling
+  refs, no stray output-mode mention).
+
+**Verification:** content-integrity clean; merged skill reads as one coherent workflow; Phase 3.5 +
+requirements-capture.md intact; no html/output-mode residue.
+
+- [ ] **Unit 2: ce-plan merge — 3.7 Anti-Expansion + 0.7/5.1.5 scope synthesis + markdown rendering + sections**
+
+**Goal:** Merge upstream's improvements into `skills/ce-plan/`, preserving the Core Plan Template +
+`visual-communication.md`; defer 0.1a Approach-Altitude; no html, no output-mode.
+
+**Requirements:** R2, R3, R4, R5, R6
+
+**Dependencies:** Unit 1 (shared conversion approach + synthesis-summary concept established first;
+ship in order)
+
+**Files:**
+- Modify: `skills/ce-plan/SKILL.md` (3.7 Anti-Expansion after our 3.6; 0.7 Solo-Mode Scoping;
+  5.1.5 Brainstorm-Sourced Scoping; section-contract wiring to plan-sections; keep Core Plan
+  Template; NO Phase 0.0; do NOT add 0.1a)
+- Create: `skills/ce-plan/references/synthesis-summary.md` (converted)
+- Create: `skills/ce-plan/references/plan-sections.md` (rendering/ordering layer)
+- Create: `skills/ce-plan/references/markdown-rendering.md` (converted; html cross-refs stripped)
+- Preserve: `skills/ce-plan/references/visual-communication.md`
+
+**Approach:**
+- Same conversion approach as Unit 1 (no html import; strip html cross-refs; no output token).
+- 3.7 Anti-Expansion: route tangential "while we're here" work to our existing `### Deferred to
+  Separate Tasks` section under Scope Boundaries (reference our section name, not upstream's).
+- 0.7 Solo-Mode Scoping (no origin doc) and 5.1.5 Brainstorm-Sourced Scoping (with origin doc) are
+  mutually exclusive — wire both to reference `synthesis-summary.md`; ensure exactly one fires.
+- Section-contract wiring references `plan-sections.md` for rendering only; Core Plan Template stays
+  the content authority.
+- Do NOT port 0.1a Approach-Altitude (deferred — ce-work carve-out coupling).
+
+**Execution note:** Dogfood `writing-skills`; verify the merged plan flow end-to-end.
+
+**Patterns to follow:** our Core Plan Template; our Scope Boundaries / Deferred sub-heading; Unit 1's
+conversion hygiene.
+
+**Test scenarios:**
+- Happy path: `ce:plan` from an origin requirements doc fires 5.1.5 (not 0.7); from a bare request via
+  bootstrap fires 0.7 (not 5.1.5) — never both.
+- Edge case: a tangential refactor request routes to Deferred (3.7) unless explicitly asked.
+- Error path / hygiene: content-integrity clean; all 3 new sub-file refs resolve; 0.1a absent;
+  no `approach-altitude.md` or `html-rendering.md` reference dangling.
+- Integration: merged SKILL.md coherent end-to-end; Core Plan Template + visual-communication.md intact.
+
+**Verification:** content-integrity clean; one-synthesis-model holds (0.7 xor 5.1.5); 3.7 routes to our
+Deferred section; Core Plan Template preserved; 0.1a + html/output-mode not present.
+
+- [ ] **Unit 3: Regenerate registry + full gate + dogfood verification**
+
+**Goal:** Reconcile generated artifacts and prove the full quality gate.
+
+**Requirements:** R6
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `registry/registry.jsonc` (regenerated via `bun scripts/generate-registry.ts`)
+
+**Approach:**
+- Regenerate registry (new sub-files may change registry output).
+- Run the full pre-PR gate.
+
+**Test scenarios:** Test expectation: none — generated-artifact reconciliation + gate run, no new
+behavioral code.
+
+**Verification (concrete assertions, not "reads coherently"):**
+- **Phase-sequence assertion:** extract the merged phase headings from each SKILL.md; confirm the
+  expected ordered sequence (brainstorm: ...Phase 2 → Phase 2.5 → Phase 3 → Phase 3.5...; plan:
+  ...0.7 present, 3.7 after 3.6, 5.1.5 at its phase, NO Phase 0.0, NO 0.1a). No orphaned/duplicate
+  phase numbers.
+- **Reference-resolution assertion:** every `references/*.md` mentioned in each SKILL.md resolves on
+  disk (content-integrity covers this); PLUS the manual nested-ref audit from Unit 1/2 confirms no
+  `html-rendering`/`approach-altitude` strings survive in any new sub-file.
+- **Gate:** typecheck, lint, content-integrity, registry drift, schema drift, build, Node ESM smoke
+  (default-only), full unit suite, docs build — all green.
+- **Taxonomy leak:** `grep -rEn '\bR[0-9]+\b|\bUnit [0-9]+\b' skills/ce-brainstorm skills/ce-plan`
+  returns only legitimate illustrative content, not leaked taxonomy from THIS plan.
+- **Preservation assertion:** Phase 3.5 Document Review, requirements-capture.md, Core Plan Template,
+  visual-communication.md all present and unmodified in behavior.
+
+## System-Wide Impact
+
+- **Interaction graph:** ce-brainstorm and ce-plan are loaded by users + by other workflows
+  (`ce:work` reads plans; LFG/SLFG pipelines invoke them with `disable-model-invocation`). No output
+  mode means no behavioral change for automated callers — they keep getting markdown.
+- **API surface parity:** both skills get the same `markdown-rendering.md` guidance — keep the
+  rendering conventions consistent across the two so docs look uniform.
+- **Unchanged invariants:** Phase 3.5 Document Review, requirements-capture.md, Core Plan Template,
+  visual-communication.md — explicitly preserved, not modified in behavior. The skill registration
+  mechanism (`collectSkillsAsCommands`) is unchanged; this is content-only.
+- **Integration coverage:** content-integrity's sub-file-reference + banned-pattern checks are the
+  automated proof that the merge introduced no dangling refs or CEP residue.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Half-converted CEP residue slips through (history of missed `CLAUDE.md`/`.compound-engineering`) | Post-conversion grep on changed files for CC/CEP refs AND over-conversions; content-integrity gate as backstop |
+| Merged SKILL.md becomes stitched-together halves (incoherent flow) | Dogfood `writing-skills`; read end-to-end; user-flow-coherence success criterion (one scope model, one section authority, one output path) |
+| Split-brain section authority (two normative section sources) | Decided: ours canonical, upstream rendering-only; fold missing sections into ours rather than keep parallel normative file |
+| 0.7 / 5.1.5 both fire (redundant synthesis) | Mutually exclusive by origin-doc presence; verify exactly one path in test scenarios |
+| Imported `markdown-rendering.md` retains html cross-references (upstream treats html as a sibling) | Strip html-rendering cross-refs during conversion; content-integrity confirms no dangling html-rendering reference |
+
+## Documentation / Operational Notes
+
+- No docs-site changes expected (skills are bundled content; registry regen covers OCX).
+- No `argument-hint` changes needed (no output mode). Skill argument shapes are unchanged.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-04-merge-upstream-brainstorm-plan-requirements.md](docs/brainstorms/2026-06-04-merge-upstream-brainstorm-plan-requirements.md)
+- Upstream: `EveryInc/compound-engineering-plugin` @ `plugins/compound-engineering/skills/{ce-brainstorm,ce-plan}/`
+- Related code: `scripts/content-integrity.ts`, `src/lib/config-schema.ts`, `skills/ce-brainstorm/`, `skills/ce-plan/`

--- a/docs/plans/2026-06-04-002-feat-merge-upstream-brainstorm-plan-plan.md
+++ b/docs/plans/2026-06-04-002-feat-merge-upstream-brainstorm-plan-plan.md
@@ -163,7 +163,7 @@ because content-integrity only scans SKILL.md entry files, NOT nested reference 
 
 ## Implementation Units
 
-- [ ] **Unit 1: ce-brainstorm merge — Phase 2.5 Synthesis Summary + markdown rendering + sections**
+- [x] **Unit 1: ce-brainstorm merge — Phase 2.5 Synthesis Summary + markdown rendering + sections**
 
 **Goal:** Merge upstream's improvements into `skills/ce-brainstorm/`, preserving Phase 3.5 Document
 Review + `requirements-capture.md`. No html, no output-mode.
@@ -209,7 +209,7 @@ hygiene from prior CEP imports.
 **Verification:** content-integrity clean; merged skill reads as one coherent workflow; Phase 3.5 +
 requirements-capture.md intact; no html/output-mode residue.
 
-- [ ] **Unit 2: ce-plan merge — 3.7 Anti-Expansion + 0.7/5.1.5 scope synthesis + markdown rendering + sections**
+- [x] **Unit 2: ce-plan merge — 3.7 Anti-Expansion + 0.7/5.1.5 scope synthesis + markdown rendering + sections**
 
 **Goal:** Merge upstream's improvements into `skills/ce-plan/`, preserving the Core Plan Template +
 `visual-communication.md`; defer 0.1a Approach-Altitude; no html, no output-mode.
@@ -254,7 +254,7 @@ conversion hygiene.
 **Verification:** content-integrity clean; one-synthesis-model holds (0.7 xor 5.1.5); 3.7 routes to our
 Deferred section; Core Plan Template preserved; 0.1a + html/output-mode not present.
 
-- [ ] **Unit 3: Regenerate registry + full gate + dogfood verification**
+- [x] **Unit 3: Regenerate registry + full gate + dogfood verification**
 
 **Goal:** Reconcile generated artifacts and prove the full quality gate.
 

--- a/registry/registry.jsonc
+++ b/registry/registry.jsonc
@@ -389,7 +389,8 @@
         "skills/ce-brainstorm/references/markdown-rendering.md",
         "skills/ce-brainstorm/references/requirements-capture.md",
         "skills/ce-brainstorm/references/synthesis-summary.md",
-        "skills/ce-brainstorm/references/universal-brainstorming.md"
+        "skills/ce-brainstorm/references/universal-brainstorming.md",
+        "skills/ce-brainstorm/references/visual-communication.md"
       ]
     },
     {

--- a/registry/registry.jsonc
+++ b/registry/registry.jsonc
@@ -384,8 +384,11 @@
       "description": "Explore requirements and approaches through collaborative dialogue before writing a right-sized requirements document and planning implementation. Use for feature ideas, problem framing, when the user says 'let's brainstorm', or when they want to think through options before deciding what to build. Also use when a user describes a vague or ambitious feature request, asks 'what should we build', 'help me think through X', presents a problem with multiple valid solutions, or seems unsure about scope or direction — even if they don't explicitly ask to brainstorm.",
       "files": [
         "skills/ce-brainstorm/SKILL.md",
+        "skills/ce-brainstorm/references/brainstorm-sections.md",
         "skills/ce-brainstorm/references/handoff.md",
+        "skills/ce-brainstorm/references/markdown-rendering.md",
         "skills/ce-brainstorm/references/requirements-capture.md",
+        "skills/ce-brainstorm/references/synthesis-summary.md",
         "skills/ce-brainstorm/references/universal-brainstorming.md"
       ]
     },
@@ -427,7 +430,10 @@
       "files": [
         "skills/ce-plan/SKILL.md",
         "skills/ce-plan/references/deepening-workflow.md",
+        "skills/ce-plan/references/markdown-rendering.md",
         "skills/ce-plan/references/plan-handoff.md",
+        "skills/ce-plan/references/plan-sections.md",
+        "skills/ce-plan/references/synthesis-summary.md",
         "skills/ce-plan/references/universal-planning.md",
         "skills/ce-plan/references/visual-communication.md"
       ]

--- a/skills/ce-brainstorm/SKILL.md
+++ b/skills/ce-brainstorm/SKILL.md
@@ -179,13 +179,30 @@ If relevant, call out whether the choice is:
 - Extend an existing capability
 - Build something net new
 
+### Phase 2.5: Synthesis Summary
+
+**STOP. Before composing the synthesis, read `references/synthesis-summary.md`.** The two-stage shape (internal three-bucket draft → chat-time scoping synthesis), the Path A / Path B gate, the four scoping synthesis sections with their keep tests, the tier-aware bullet budget with re-cut rule, anti-pattern guidance, soft-cut behavior, self-redirect support, and headless-mode routing all live there. Composing a synthesis without these rules loaded reliably produces malformed output — pasting the full internal three-bucket draft verbatim into chat, implementation-detail leakage into the scoping synthesis, the proposal-pitch anti-pattern. **Each scoping synthesis bullet must pass the affirmability test (can the user evaluate this without reading code?) AND the detail test (1–2 lines max, conversational not documentary); over-share and over-detail are the failure modes to avoid.** This is not optional supplementary reading; it is the source of truth for how the phase behaves.
+
+Surface a scoping synthesis to the user before Phase 3 writes the requirements doc — the user's last opportunity to correct scope before the artifact lands. **Phase 2.5 is the only scope gate in this workflow.** The scoping synthesis is shaped like what two product collaborators would confirm before writing a PRD, not like a comprehensive audit or a one-line preview.
+
+Fires for **all tiers** including Lightweight. Skip Phase 2.5 entirely on the Phase 0.1b non-software (universal-brainstorming) route.
+
+**Path A vs Path B:** the scoping synthesis shape depends on TWO signals — whether any blocking question fired AND what tier Phase 0.3 classified the scope as.
+
+- **Path A — no blocking questions fired AND tier is Lightweight**: announce-mode. Emit "What we're building" prose only (1–3 sentences), then proceed to Phase 3 doc-write in the same turn. No other sections, no confirmation question. Do NOT end the turn waiting for acknowledgment. The user can revise after the doc lands if the shape is wrong — Lightweight Path A docs are short, post-hoc revision is cheap.
+- **Path B — at least one blocking question fired, OR tier is Standard / Deep-feature / Deep-product**: full tier-aware scoping synthesis with confirmation gate. Two scenarios fire Path B: (a) the user invested answer-time during dialogue, or (b) the user pre-loaded substantive scope content (Phase 0.2 fast-path with a richly-specified opening prompt). Either way, the substance earns a real checkpoint. Confirmation is unconditional even when zero call-outs survive the keep test.
+
+**Why the tier guard on Path A**: Phase 0.2's fast path serves two very different cases — a tight one-liner that needs no dialogue ("fix the typo on line 47") and a richly pre-loaded brainstorm context that ALSO needs no dialogue because the user pre-stated everything. Without the tier guard, both route to Path A and the pre-loaded case gets a 1-sentence checkpoint for what may be 20+ items worth of scope. Tier-classifying Phase 0.3 distinguishes the two — pre-loaded substance makes the tier Standard or Deep, which then routes to Path B.
+
 ### Phase 3: Capture the Requirements
 
-Write or update a requirements document only when the conversation produced durable decisions worth preserving. Read `references/requirements-capture.md` for the document template, formatting rules, visual aid guidance, and completeness checks.
+Write or update a requirements document only when the conversation produced durable decisions worth preserving. Read `references/requirements-capture.md` for the document template, formatting rules, visual aid guidance, and completeness checks. Read `references/brainstorm-sections.md` for metadata field contracts and ID conventions. Read `references/markdown-rendering.md` for markdown presentation principles.
 
 For **Lightweight** brainstorms, keep the document compact. Skip document creation when the user only needs brief alignment and no durable decisions need to be preserved.
 
 ### Phase 3.5: Document Review
+
+**This is a quality and format review of the written artifact — not a second scope negotiation.** Scope was confirmed at Phase 2.5; Phase 3.5 checks that the written doc faithfully reflects that confirmed scope and meets quality standards. Do not re-open scope decisions here.
 
 When a requirements document was created or updated, run the `document-review` skill on it before presenting handoff options. Pass the document path as the argument.
 

--- a/skills/ce-brainstorm/references/brainstorm-sections.md
+++ b/skills/ce-brainstorm/references/brainstorm-sections.md
@@ -38,40 +38,7 @@ or repurpose its semantics. Agents composing new brainstorms MUST use these
 exact names; adding new fields is fine, but renaming `topic` to `subject`
 or `date` to `created` breaks filename construction and resume detection.
 
-## ID and content rules
-
-- **Stable IDs.** R-IDs (Requirements), A-IDs (if Actors fire), F-IDs (if
-  Flows fire), AE-IDs (if Acceptance Examples fire). No other ID namespaces.
-- **Plain prefix.** `R1.`, `A1.`, `F1.`, `AE1.` as bullet prefixes. Do not
-  bold; the prefix is visually distinctive on its own.
-- **Bold leader labels** inside Flows and Acceptance Examples
-  (`**Trigger:**`, `**Covers R4, R8.**`) provide structure without deeper
-  heading levels.
-- **Repo-relative paths.** Always. Never absolute paths.
-- **No process exhaust.** No "captured at Phase X" notes, no `## Next Steps`
-  pointing to ce-plan, no italic provenance lines. Engineering process
-  metadata belongs in commit messages and tool output, not the artifact.
-- **No implementation details by default.** Libraries, schemas, endpoints,
-  file layouts, code structure stay out unless the brainstorm itself is
-  inherently about a technical or architectural change and those details are
-  the subject of the decision.
-
-## Discipline: Summary vs Problem Frame
-
-When both sections are present, they earn separate sections only by holding
-to different purposes:
-
-| Section | Question it answers | Time direction | Length |
-|---|---|---|---|
-| `## Summary` | What is this doc proposing? | Forward-looking | 1-3 lines |
-| `## Problem Frame` | Why does this proposal exist? | Backward-looking / situational | Paragraphs |
-
-- **Summary doesn't need problem context.** A reader scanning Summary gets
-  the proposal at a glance.
-- **Problem Frame doesn't restate the proposal.** It establishes the
-  situation, the specific moment of pain, and the cost shape — then stops.
-  The remedy lives in Summary; restating it in Problem Frame is the
-  duplication that makes the two sections feel redundant.
+> **Section inventory, content rules, and the Summary vs Problem Frame discipline are owned by `references/requirements-capture.md`; this file covers rendering conventions and metadata contracts only.**
 
 ## Rendering
 

--- a/skills/ce-brainstorm/references/brainstorm-sections.md
+++ b/skills/ce-brainstorm/references/brainstorm-sections.md
@@ -1,0 +1,83 @@
+# Brainstorm Sections
+
+This reference describes the rendering and ordering conventions for brainstorm
+requirements documents. It does NOT prescribe which sections exist or what they
+must contain — section inventory, content rules, and the document template live
+in `references/requirements-capture.md`.
+
+Rendering is handled by `references/markdown-rendering.md`.
+
+## Brainstorm metadata fields
+
+Every brainstorm carries a small set of stable metadata fields that
+downstream tooling depends on. The contract is format-independent: these
+fields appear as YAML frontmatter at the top of the file. Field names and
+semantics are stable so consumers can locate them without knowing which
+session produced the brainstorm.
+
+### Required
+
+- **`date`** — creation date in ISO 8601 (`YYYY-MM-DD`), ASCII digits only.
+  Used in the filename (`docs/brainstorms/YYYY-MM-DD-<topic>-requirements.md`).
+- **`topic`** — kebab-case slug identifying the brainstorm subject (e.g.,
+  `surface-scope-earlier`, `demo-reel-local-save`). Used in the filename
+  alongside `date` and as the resume-detection key when `ce-brainstorm`'s
+  Phase 0.1 scans `docs/brainstorms/` for an existing artifact to continue.
+
+### Status flip does not apply to brainstorm
+
+Unlike plans, brainstorm artifacts have no `status` field — there is no
+`active → completed` lifecycle. A brainstorm is a one-time output that
+downstream consumers (`ce-plan`, `document-review`) reference via the plan's
+`origin:` field.
+
+### Field-name stability
+
+Field names are stable across brainstorm revisions — never rename a field
+or repurpose its semantics. Agents composing new brainstorms MUST use these
+exact names; adding new fields is fine, but renaming `topic` to `subject`
+or `date` to `created` breaks filename construction and resume detection.
+
+## ID and content rules
+
+- **Stable IDs.** R-IDs (Requirements), A-IDs (if Actors fire), F-IDs (if
+  Flows fire), AE-IDs (if Acceptance Examples fire). No other ID namespaces.
+- **Plain prefix.** `R1.`, `A1.`, `F1.`, `AE1.` as bullet prefixes. Do not
+  bold; the prefix is visually distinctive on its own.
+- **Bold leader labels** inside Flows and Acceptance Examples
+  (`**Trigger:**`, `**Covers R4, R8.**`) provide structure without deeper
+  heading levels.
+- **Repo-relative paths.** Always. Never absolute paths.
+- **No process exhaust.** No "captured at Phase X" notes, no `## Next Steps`
+  pointing to ce-plan, no italic provenance lines. Engineering process
+  metadata belongs in commit messages and tool output, not the artifact.
+- **No implementation details by default.** Libraries, schemas, endpoints,
+  file layouts, code structure stay out unless the brainstorm itself is
+  inherently about a technical or architectural change and those details are
+  the subject of the decision.
+
+## Discipline: Summary vs Problem Frame
+
+When both sections are present, they earn separate sections only by holding
+to different purposes:
+
+| Section | Question it answers | Time direction | Length |
+|---|---|---|---|
+| `## Summary` | What is this doc proposing? | Forward-looking | 1-3 lines |
+| `## Problem Frame` | Why does this proposal exist? | Backward-looking / situational | Paragraphs |
+
+- **Summary doesn't need problem context.** A reader scanning Summary gets
+  the proposal at a glance.
+- **Problem Frame doesn't restate the proposal.** It establishes the
+  situation, the specific moment of pain, and the cost shape — then stops.
+  The remedy lives in Summary; restating it in Problem Frame is the
+  duplication that makes the two sections feel redundant.
+
+## Rendering
+
+The format-specific reference describes how to render these sections:
+
+- **Markdown rendering:** `references/markdown-rendering.md`
+
+This reference (`brainstorm-sections.md`) is about rendering conventions and
+metadata contracts; section content rules live in `references/requirements-capture.md`.

--- a/skills/ce-brainstorm/references/markdown-rendering.md
+++ b/skills/ce-brainstorm/references/markdown-rendering.md
@@ -1,0 +1,202 @@
+# Markdown Rendering
+
+This is a format-rendering reference — it describes how to render any
+artifact in markdown, independent of which skill is producing it.
+
+It is paired with a section contract (`references/brainstorm-sections.md`)
+that describes *what* the artifact contains. This reference describes *how*
+markdown specifically presents it.
+
+## Hard invariants
+
+These hold regardless of which skill produced the artifact.
+
+- **YAML frontmatter at the top of the file.** Standard `---` delimited block
+  containing the artifact's stable metadata (title, status, date, type, etc.
+  — exact fields are per-skill, defined in the section contract). Editable
+  in place; tools and agents that do status flips (`active → completed`)
+  update the YAML directly.
+- **ASCII identifiers in anchors.** Markdown headings auto-generate anchors
+  from the heading text. Keep headings ASCII so anchors are predictable
+  (`#implementation-units`, not `#implementación-units`).
+- **Repo-relative paths for file references.** Always. Never absolute paths
+  — they break portability across machines, worktrees, teammates.
+- **No HTML mixed in.** Keep the markdown pure. No `<div>`, no `<details>`,
+  no inline `<style>`. Markdown stays markdown.
+
+## Format principles
+
+These shape what "good" markdown looks like; the agent applies them per
+artifact based on content shape.
+
+### ID prefix format
+
+Stable IDs (R, U, A, F, AE, KTD) appear as plain prefixes at the start of
+the bullet or heading — do NOT bold the prefix. The prefix is visually
+distinctive on its own; bolding it inflates visual noise.
+
+```markdown
+- R1. The plan returns paginated sessions.   ← right
+- **R1.** The plan returns paginated sessions.   ← wrong (bolded prefix)
+```
+
+Same applies to unit headings: `### U1. Cloak detection in preflight contract`.
+
+### Content shape: prose vs bullets vs tables
+
+The same content can be rendered three ways; the agent picks per content
+shape, not by template default.
+
+- **Prose** when the content has narrative flow (motivation, decision
+  rationale, problem framing). Bullets fragment narrative into
+  disconnected pieces.
+- **Bullets** when items share a parallel shape but each carries enough
+  prose to not fit a table cell.
+- **Tables** when 5+ items share uniform structure (`ID + body`,
+  `name + value`, `decision + rationale`, `risk + mitigation`). Tables
+  scan faster at that scale and unlock additional columns (status,
+  traceability, severity) that bullets can't accommodate cleanly.
+
+The test: which shape would a reader scan fastest for this content? If
+items have parallel structure and 5+ instances, table. If items are 3-5
+and each has a few lines of prose, bullets. If the content is a single
+narrative thought, prose.
+
+### Bold leader labels within bullets
+
+When a bullet has substructure that benefits from named fields (Key Flows
+with Trigger / Actors / Steps / Outcome, Acceptance Examples with Covers
+/ Given / When / Then), use bold leader labels at the start of nested
+bullets — not deeper heading levels.
+
+```markdown
+- F1. Anonymous capture
+  - **Trigger:** Agent enters Step 2a with no session.
+  - **Actors:** A1, A2
+  - **Steps:** Preflight detects cloak; agent launches; capture proceeds.
+  - **Covered by:** R1, R2, R5
+```
+
+This gives the bullet structure without needing H4/H5 headings that would
+clutter the doc and break TOC generation.
+
+### Section separators
+
+For substantial artifacts, use horizontal rules (`---`) between top-level
+H2 sections. Omit for short docs where separators would dominate.
+
+### Tables for genuinely comparative info only
+
+Use tables for the uniform-shape case in "Content shape" above. Don't use
+tables to render content lists that are really bullets — markdown tables
+are noisier in raw form and worse for diffs.
+
+## Section anatomy
+
+How section types commonly render in markdown. These are patterns, not
+contracts — the agent picks the shape that fits the content.
+
+- **Summary / Problem Frame** — prose paragraphs.
+- **Requirements** — bullets with `R<N>.` prefix. When requirements span
+  more than one concern, grouping under bold inline headers is the default
+  shape, not optional polish (group by capability, not by discussion order);
+  render a flat list only when every requirement is about the same thing.
+  When requirements have status, traceability, or severity that warrant
+  additional columns, escalate to a table.
+- **Implementation Units** — H3 heading per unit with `U<N>.` prefix.
+  Fields (Goal, Files, Patterns, Test Scenarios, Verification) render as
+  bullets with bold leader labels, or as sub-headings if the field has
+  multi-paragraph content.
+- **Key Technical Decisions** — bullets with bold decision name + prose
+  rationale, or numbered KTD-N pattern when traceability matters.
+- **Key Flows / Acceptance Examples** — bullets with bold leader labels
+  (Trigger / Actors / Steps / Outcome / Covers / Given-When-Then).
+- **Scope Boundaries** — bullets, optionally split into "Deferred for
+  later" / "Outside this product's identity" sub-headings when the
+  positioning distinction matters.
+
+The agent picks more elaborate or simpler shapes based on what each
+specific artifact's content needs.
+
+## Diagrams
+
+When the section contract calls for a diagram (architecture, sequence,
+flowchart, state machine, swim lane, data-flow), markdown renders it as
+a fenced mermaid block:
+
+```markdown
+` ``mermaid
+flowchart TB
+  A[Start] --> B{Decision}
+  B -->|yes| C[Action]
+  B -->|no| D[Other action]
+` ``
+```
+
+(`TB` direction default — keeps diagrams narrow in source view and in
+narrow rendered viewports.)
+
+For quantitative comparisons (bar charts, scatter plots) markdown has no
+native equivalent — use a table with the data and let prose or caption
+carry the interpretation.
+
+## Inline code and code blocks
+
+- **Inline code** for identifiers (variable names, function names,
+  flag names, file paths, IDs that aren't section anchors).
+- **Fenced code blocks** with language tag for code, shell commands,
+  API request/response samples. Always specify the language for syntax
+  highlighting and accessibility.
+
+```markdown
+The flag `--cdp-url` accepts a URL.
+
+` ``bash
+browser-use --cdp-url http://localhost:9222
+` ``
+```
+
+## No process exhaust
+
+Engineering process metadata stays out of the artifact:
+
+- No "captured at Phase X" notes
+- No `## Next Steps` pointing to the next skill
+- No italic provenance lines ("*Brainstorm completed 2026-05-13*")
+- No engineering-flow shepherding ("Now read this file:", "Next, run that
+  command:")
+
+This information belongs in commit messages, tool output, and agent
+transcripts — not in the artifact a reader returns to weeks later.
+
+## Frontmatter shape
+
+Per-skill frontmatter fields are defined in each skill's section contract
+(`references/brainstorm-sections.md` lists brainstorm frontmatter). Common rules:
+
+- YAML at the top of the file, delimited by `---` on its own line above
+  and below.
+- Field names in lowercase snake_case (`status`, `created_at`, not
+  `Status`, `CreatedAt`).
+- **Status lifecycle is per-contract.** When the section contract
+  defines a `status` field with a lifecycle (plans use
+  `active → completed`, flipped by ce-work at shipping time via direct
+  YAML edit), it is editable in place. When the section contract does
+  not define a status lifecycle (brainstorms have no `active → completed`
+  flip — they are upstream of plans and referenced via the plan's
+  `origin:`), do not introduce one.
+- Stable across artifact revisions — never rename or repurpose a field.
+
+## Post-write audit
+
+Before declaring the markdown file written, scan it for these common
+slips:
+
+- All stable IDs are plain-prefix format, not bolded.
+- No HTML elements mixed in.
+- All file paths are repo-relative.
+- Horizontal rule separators between H2s (for Standard / Deep artifacts).
+- No process exhaust (Phase X notes, Next Steps pointers, provenance
+  lines).
+- Tables only where 5+ uniform-shape items justify them.
+- Frontmatter has all the per-skill required fields with reasonable values.

--- a/skills/ce-brainstorm/references/requirements-capture.md
+++ b/skills/ce-brainstorm/references/requirements-capture.md
@@ -24,6 +24,7 @@ The requirements document is for product definition and scope control. Do **not*
 | Key Decisions | Include when material | Include when material | Include when material |
 | Dependencies / Assumptions | Include when material | Include when material | Include when material |
 | Outstanding Questions | Include when material | Include when material | Include when material |
+| Sources / Research | Include when material | Include when material | Include when material |
 
 ## Summary vs Problem Frame discipline
 
@@ -47,6 +48,25 @@ In the truly-trivial Lightweight case where Summary is skipped (synthesis ≤ 2 
 **Key Flows** — include when the work involves multi-step interaction or coordinates across existing flows. At Deep-product tier, include 2-4 primary flows by default; omit only when the product is not meaningfully flow-shaped (e.g., pure API, policy, or artifact output) and Actors, Requirements, Scope Boundaries, and Acceptance Examples already prevent downstream invention of user/agent paths. When omitting at product tier, note the reason in the doc.
 
 **Acceptance Examples** — include when a requirement's behavior is hard to pin down without a concrete scenario. **Always include AEs covering behavioral-conditional requirements** — any requirement framed as "When X, Y" or "If X, Y" — regardless of tier. Conditional framing signals state-dependent behavior, which is exactly where prose alone leaves implicit ambiguity (e.g., "When `--quiet` is set, errors continue to surface" — does that include warnings? does it include binary-side errors? AE pins it down). Each example disambiguates one or more requirements via a `Covers: R-IDs` back-reference. Non-conditional requirements may be omitted unless ambiguity surfaces in review; the section is not exhaustive.
+
+**Sources / Research** — surface research that orients the planner or justifies framing choices. The test: *"if I were the planner reading this cold, would this breadcrumb help me make better choices?"* Yes → surface (code locations, external docs, RFCs, constraints, prior plans — the category is inclusive, not enumerated). Process exhaust (reading the user's prompt, glancing at obvious files) → omit.
+
+## Prose economy
+
+A section can be material and still be written loosely — the failure mode is a material section padded into a wall of text where contradictions hide and a downstream agent loses the thread. Length that earns its place is fine; wordiness around that length is not.
+
+Hold every kept section to these:
+
+- **One idea per sentence.** A Summary is a handful of sentences, not one sentence with five semicolons and four parentheticals. If a sentence needs a second parenthetical to stay true, split it.
+- **A requirement is one sentence of intent plus at most one qualifier.** When a requirement would specify two outcomes ("either A or B, planning decides"), state the intent and send the fork to Outstanding Questions — don't write both arms in full inside the requirement.
+- **Cut hedges and intensifiers.** "Critically", "deliberately", "explicitly", "genuinely", "actually", "simply" carry nothing a downstream agent acts on.
+- **Prefer the verb to the nominalization.** "Demote the grid", not "the demotion of the grid is the deliberate change in this brief".
+
+Precision is not padding: keep domain terms, conditionals, and exact thresholds verbatim. Economy targets the connective tissue around them, never the precision itself.
+
+**Resolve in place; don't stratify.** When a later decision answers a parked question or supersedes earlier text, rewrite or remove the original entry — don't append a separate "resolutions" layer that leaves the superseded text standing. Version control holds the history. Stacked question/resolution strata double the reading surface and hide which text is live.
+
+**Named test, run before the doc is declared written:** could a reader find a contradiction in each section in one pass? A sentence carrying more than one parenthetical, or a requirement specifying two outcomes, fails the test — split it or defer it.
 
 ## Template
 

--- a/skills/ce-brainstorm/references/synthesis-summary.md
+++ b/skills/ce-brainstorm/references/synthesis-summary.md
@@ -242,10 +242,10 @@ Fall back to a numbered list in chat only when no blocking tool exists or the ca
 
 ## Self-redirect
 
-If the user response indicates they're in the wrong skill or want a different workflow (e.g., "this is too small, just /ce-work it" or "this needs more thought, let me brainstorm differently"):
+If the user response indicates they're in the wrong skill or want a different workflow (e.g., "this is too small, just ce:work it" or "this needs more thought, let me brainstorm differently"):
 
 - Stop ce-brainstorm
-- Suggest the alternative skill the user appears to want (e.g., `/ce-work`, `/ce-debug`)
+- Suggest the alternative skill the user appears to want (e.g., `ce:work`, `ce:debug`)
 - Offer to load it in-session
 - Do not push back or argue — the user's redirect signal is the deliberate choice
 

--- a/skills/ce-brainstorm/references/synthesis-summary.md
+++ b/skills/ce-brainstorm/references/synthesis-summary.md
@@ -1,0 +1,273 @@
+# Synthesis Summary
+
+**Synthesis ≠ requirements doc.** The synthesis is NOT a preview, draft, or substitute for the requirements doc — it's the scope checkpoint that doc-write consumes as input. The requirements doc itself is written in Phase 3 from the confirmed synthesis. Both the synthesis and the requirements doc stay scope-only — implementation detail (file paths, code shapes, exact error wording) is downstream (ce-plan's job), not the requirements doc.
+
+**Two-stage shape: internal draft, then chat-time scoping synthesis.** The synthesis is composed in two stages. Stage 1 is an internal three-bucket draft (Stated / Inferred / Out of scope) the agent uses to think comprehensively about scope. Stage 2 is the scoping synthesis presented to the user — shaped like what two product collaborators would confirm before writing a PRD, not like a comprehensive audit and not like a one-line preview. The user only sees stage 2. The internal draft still informs the doc body via the doc-shape routing below; it just doesn't reach the user verbatim. This split exists because the comprehensive audit shape produced too much detail for the user to actually weigh in on, even when the granularity rules were followed.
+
+**Three-bucket structure is the internal draft, not the user-facing artifact.** It does its scope-thinking job during stage 1 and dissolves when Phase 3 writes the doc: Stated content informs Requirements, Inferred content informs Key Decisions, Out-of-scope content informs Scope Boundaries. The doc has no parallel `## Synthesis` section — only the scoping synthesis prose embeds, as `## Summary`. See "Doc shape after confirmation" below for the routing.
+
+This content is loaded when Phase 2.5 fires — after Phase 2 (approaches chosen) and before Phase 3 (write requirements doc). The synthesis is the user's last opportunity to correct the agent's interpretation before the doc lands. It serves two purposes: synthesis confirmation (the user agreed to many individual things in dialogue but never saw the whole) and a transition checkpoint ("about to write a doc").
+
+Fires for **all tiers** including Lightweight. Skip Phase 2.5 entirely on the Phase 0.1b non-software (universal-brainstorming) route.
+
+**Headless / pipeline mode:** When invoked from a `disable-model-invocation` context (LFG, SLFG, or any automated pipeline), skip the chat-time stage entirely — there is no synchronous user to confirm with. Instead, route the internal three-bucket draft directly into the doc body sections per the "Doc shape after confirmation" table below, and route any Inferred bets to `## Assumptions` in the requirements doc so downstream review (document-review, ce-plan, human PR review) can scrutinize them explicitly. Do not present the scoping synthesis to chat; proceed directly to Phase 3 doc-write.
+
+---
+
+## Stage 1: internal three-bucket draft
+
+The internal draft is structured in three labeled buckets. Items may appear in two buckets when meaningfully both — flag the inclusion-then-exclusion as Inferred so the reasoning is captured.
+
+- **Stated** — what the user said directly (in the original prompt, prior conversation, dialogue answers, approach selection in Phase 2). Items here have explicit user-language anchors.
+- **Inferred** — what the agent assumed to fill gaps. Scope boundaries the user never explicitly named, success criteria extrapolated from intent, technical assumptions made because the brief interview didn't probe them. The Inferred bucket is the most actionable surface for correction — items here are the agent's bets.
+- **Out of scope** — deliberately excluded items. Adjacent work the agent considered but decided not to include, refactors, nice-to-haves, future-work items. Making exclusions explicit lets the agent spot anything that should actually be included.
+
+This draft is internal. Do not paste it verbatim into chat. Compose it as a thinking step, then derive stage 2 from it.
+
+---
+
+## Stage 2: the chat-time scoping synthesis
+
+The scoping synthesis is what the user actually sees. It reflects the dialogue's substance back so the user can pattern-match — long enough to serve a multi-turn conversation, short enough to be high-impact only. The reference shape is what two product collaborators would say to each other after a real discussion: "OK, so we're doing X, with Y trade-off, deferring Z, and one thing I want to double-check is W. Sound right?"
+
+The scoping synthesis has up to four named sections, each **render-conditional** on having something to say. Empty sections are omitted, not padded.
+
+1. **What we're building** (always present) — 1–3 sentences. The shape that emerged from dialogue, forward-looking, plain words. Not a transcript of "you said X."
+2. **Key trade-offs** (conditional) — 1–3 bullets, each with a brief why. Render only when real trade-offs were made in dialogue.
+3. **What's not in scope** (conditional) — 1–3 bullets, or fold into a single sentence. Render only when deferred items would surprise a downstream reader if absent.
+4. **Call outs** (conditional) — 0–3 bullets. Residual forks the dialogue didn't resolve: post-dialogue consequences (combining user answers surfaced something they couldn't see during Q&A), silent agent inferences, or — in pre-loaded contexts with no dialogue — scope bets the user is seeing for the first time. **Not "questions the agent could have asked during Phase 1.3 but didn't"** — if a call-out reads like a missed dialogue question, Phase 1.3's integration check failed; flag the gap rather than padding the section.
+
+Each section answers a different question:
+
+- **What's being built?** → shape
+- **What did we trade off?** → explicit choices made in conversation
+- **What did we cut?** → deferred items a reader would expect to see acknowledged
+- **Where might you redirect?** → residual forks: post-dialogue consequences, silent inferences, late-cycle bets
+
+Then the confirmation: *"Confirm and I'll write the requirements doc next, drawing on our dialogue and this synthesis. Or tell me what to change."* The phrasing sets the expectation that confirm → doc-write, so the user knows what's about to happen and can interrupt without ambiguity.
+
+### Path A vs Path B: the gate that fires the confirmation question
+
+Phase 2.5 has two presentation modes, gated by **two signals**: (1) did any blocking question fire before Phase 2.5? AND (2) what tier did Phase 0.3 classify the scope as? Blocking questions include Phase 0.3 scope disambiguation, Phase 1.3 collaborative dialogue probes, and Phase 2 approach selection (when a menu fires). Internal classification, Phase 1.1 scan, and Phase 1.2 pressure test are not blocking questions — they don't count.
+
+- **Path A — no blocking questions fired AND tier is Lightweight**: announce-mode. Emit "What we're building" prose only (no other sections, no confirmation question), then proceed to Phase 3 doc-write in the same turn. Do NOT end the turn waiting for acknowledgment. The user can revise after the doc lands if the shape is wrong — Lightweight Path A docs are short, post-hoc revision is cheap.
+- **Path B — at least one blocking question fired, OR tier is Standard / Deep-feature / Deep-product**: full tier-aware scoping synthesis with confirmation gate. Two scenarios fire Path B: (a) the user invested answer-time during dialogue, or (b) the user pre-loaded substantive scope content (Phase 0.2 fast-path with a richly-specified opening prompt). Either way, the substance earns a real checkpoint. The confirmation question is unconditional even when zero call-outs survive the keep test.
+
+**Why the tier guard exists.** Phase 0.2's fast path is designed for two very different cases — a tight one-line prompt that needs no dialogue ("fix the typo on line 47"), and a richly pre-loaded brainstorm context that ALSO needs no dialogue because the user pre-stated everything (e.g., handing off accumulated decisions from a prior session for a brainstorm doc backfill). Without a tier guard, both route to Path A, and the richly-loaded case gets a 1-sentence checkpoint for what may be 20+ items worth of scope. Tier-classifying Phase 0.3 distinguishes these cases — pre-loaded substance makes the tier Standard or Deep, which then routes to Path B and produces the full scoping synthesis the substance deserves. Do not simplify the gate back to a single "no questions fired" signal — that was a real defect that produced one-sentence syntheses on Deep-tier pre-loads.
+
+Path A maps to the existing "announce-mode" concept on the Phase 0.2 fast path, but only when the substance genuinely warrants 1–3 sentences. Path B is the default for every other interactive invocation.
+
+### Keep tests per section
+
+Each conditional section has its own keep test. Sections are render-conditional — an empty section is omitted, not padded with weak items.
+
+**Trade-offs keep test:** would the user be surprised if I didn't surface this acknowledgment? Real trade-offs are choices the user explicitly weighed alternatives on in dialogue, or structural choices the agent made that the user would expect to see named. Mechanical or inevitable choices (e.g., "uses the existing rule entity") fail the test and dissolve into the doc body without surfacing.
+
+**Deferred keep test:** is a reasonable downstream reader likely to ask "why isn't X here?" Items the user explicitly deferred, or items adjacent enough that a reader will look for them. Mechanical excludes (e.g., "no rate limiting because it's not in scope") fail and stay in the internal draft only.
+
+**Call-outs keep test (the affirmability test):** would the user need to read code to evaluate this? If yes, it is doc-body content — cut. If no, apply the keep test — one of the following must be true:
+
+- **Real scope fork** — another reasonable agent might choose a different scope on this dimension (who the primary actor is, whether case X is in/out, in scope vs deferred)
+- **Non-obvious scope inclusion** — a behavior the agent assumed is in scope that the user might want excluded
+- **Non-obvious scope exclusion** — an item the agent moved to deferred that the user might want in scope
+- **Cheap-now-expensive-later correction** — a scope bet that's cheap to fix now but expensive after the requirements doc lands and ce-plan consumes it
+- **Non-obvious consequence of multi-turn answers** — a downstream effect of combining user-stated answers that the user is unlikely to have tracked through dialogue. Surfaced forward-looking ("X means Y for the doc"), not retrospectively ("you said X"). This category is the multi-turn-dialogue reason call-outs exist at all in ce-brainstorm; do not filter these as "already implied by Stated"
+
+Cut anything that doesn't match a keep-test category, including:
+
+- Mechanical items where there is no real alternative
+- Implementation choices that will be settled during planning
+- Items already implied by the scoping synthesis prose
+- Re-statements of Q&A turns ("you said you wanted X") — that's transcript, not a call-out
+- Re-statements of the Phase 2 approach the user already picked
+
+### Total bullet budget across sections 2–4
+
+The cap is heuristic, not law. The real discipline is each section's keep test on each candidate. Typical bounds by tier, counting bullets across Trade-offs + Deferred + Call outs combined:
+
+| Tier | Typical total | Hard ceiling |
+|---|---|---|
+| Lightweight | 0–1 | 2 |
+| Standard | 2–4 | 5 |
+| Deep — feature | 3–5 | 7 |
+| Deep — product | 4–7 | 9 |
+
+**Above the hard ceiling, the synthesis is misshapen — do not raise the cap, re-cut at a higher level of abstraction.** Almost always, multiple bullets within a section are sub-decisions of one larger named decision. Collapse related bullets into a single one named at the level the user actually weighs in on.
+
+A useful test: read the bullets aloud. If two or more sound like "and also" extensions of the same idea, they belong as one.
+
+**Path A fires only for Lightweight tier with no blocking questions. Path B is the default for Standard, Deep-feature, and Deep-product regardless of question signal — substance earns the checkpoint, not interaction history.** Zero call-outs on Path B is normal for Lightweight, sometimes for Standard, almost never for Deep. If a Deep scoping synthesis produces zero call-outs after rich content (whether from dialogue or pre-loaded context), double-check the agent hasn't filtered consequence-class call-outs as "already implied."
+
+### Detail level: conversational, not documentary
+
+Each bullet is **1 line ideally, 2 lines maximum**. The reference shape is what two collaborators would say to each other in conversation, not what a requirements doc would say in its body. The synthesis is a forcing function for shape confirmation; the requirements doc is where the substance lives. If a bullet reads like a doc paragraph, it's wrong-shaped — the agent has compressed horizontally (fewer bullets) without compressing vertically (less per bullet), and the cap is meaningless if individual bullets bloat to fill it.
+
+Two tests:
+
+- **Read-aloud test**: would two product collaborators *say* this bullet, or would they *write* it in a spec? Say = right. Write = re-cut to a sentence or cut.
+- **Single-sentence test**: can the bullet land in one sentence? If it needs semicolons stringing clauses or a list within the bullet, it's probably two decisions sharing a bullet — split (and re-cut for count) or cut to the higher-level one.
+
+Bad vs good — detail level:
+
+| Too detailed (wrong) | Conversational (right) |
+|---|---|
+| Per-channel mute scoped to notification rules; mute applies to all events through that rule including @mentions, DMs forwarded as notifications, and bot messages; persists 24h with extension | Per-channel over per-user — support team isn't a single user |
+| Rule-delete loss path is silent and could surprise users who configured extended mutes; consider a confirmation dialog, soft-delete with state preservation, or a 7-day undo window | Rule-delete silently loses pause state — confirm no warning needed |
+
+The "What we're building" prose obeys the same discipline: 1–3 sentences describing the shape, not an enumeration of requirements. If the prose lists what's in / what's out / what's how, it has become a doc preview — cut to shape only.
+
+### Anti-patterns
+
+Each anti-pattern below produces a bullet that fails its section's keep test, or a scoping synthesis that drifts back toward the comprehensive-audit failure mode.
+
+- **Naming implementation detail in any bullet**: file paths, module names, exact JSON keys, HTTP status codes, error message wording, SQL syntax. The synthesis is scope-only; implementation is ce-plan's job. These granularity rules apply to every bullet in every section.
+- **Re-stating a Q&A turn verbatim** ("you said you wanted X"): transcript, not scoping synthesis. Reframe forward-looking ("X means Y for the doc") or cut.
+- **Re-stating the Phase 2 approach the user already picked**: the approach was chosen before Phase 2.5 — its mention belongs in one sentence of "What we're building," not as a call-out.
+- **Padding a section to meet a bullet count**: render-conditional means empty is allowed. Omit the section entirely rather than fill it with weak items.
+- **Pasting the three-bucket internal draft verbatim into chat**: that was the old shape and the volume problem it produced is why stage 2 exists. Compose internally, derive scoping synthesis sections, present compressed.
+- **Floating questions adjacent to stage 2**: if a question genuinely cannot be defaulted, pause synthesis and resolve it before presenting. Pick the question shape that matches: a blocking multiple-choice tool when options are bounded and meaningfully distinct, open-ended when option sets would unintentionally influence the user's answer. Integrate the answer, then present the scoping synthesis. Never present the scoping synthesis with adjacent floating questions — that gives the user no clear resolution path.
+
+---
+
+## Prompt templates
+
+This is directional guidance — adjust phrasing to fit dialogue context. Open-ended feedback (no `question` menu). The justification is Interaction Rule 5(a) in SKILL.md — an option menu would unintentionally influence the user's feedback toward the parts the menu lists.
+
+**Prose discipline for "What we're building" (required):** forward-looking (what *will* be in the doc), not retrospective (what's been discussed). Lead with the actual thing being built in plain words. No qualifiers ("comprehensive," "thoughtful," "substantive"). No re-stating dialogue context the user just lived through. If the work can't be said in 1–3 sentences without filler, the synthesis isn't ready yet.
+
+### Path B template (questions were asked)
+
+```
+Based on our dialogue, here's the scope I'm proposing for the requirements doc:
+
+**What we're building:** [1–3 sentences — the shape that emerged from dialogue, forward-looking, plain words]
+
+**Key trade-offs:** [render only when real trade-offs exist]
+- [explicit choice + brief why]
+- [explicit choice + brief why]
+
+**What's not in scope:** [render only when deferred items would surprise a reader]
+- [deferred item]
+- [deferred item]
+
+**Call outs:** [render only when one or more survived the keep test]
+- [scope-level fork or non-obvious consequence the user can affirm or redirect]
+- [same]
+
+Confirm and I'll write the requirements doc next, drawing on our dialogue and this synthesis. Or tell me what to change — even something I captured correctly earlier is fair game to revise (you may have changed your mind or want to correct an unstated assumption).
+```
+
+### Path A template (no questions were asked — typically Phase 0.2 short-circuit)
+
+```
+Proposing: [1–3 line shape — what the doc will say in plain words].
+
+No open decisions — writing the requirements doc now. Interrupt if the shape is wrong.
+```
+
+Proceed to Phase 3 doc-write in the same turn — do NOT end the turn waiting for an acknowledgment. The "interrupt if wrong" affordance means the user can revise after the doc lands, not before. Lightweight Path A docs are short, so post-hoc revision is cheap.
+
+### Worked example: compression from internal draft to scoping synthesis (Standard tier)
+
+For a notification-mute feature where the internal draft had 5 Stated items, 4 Inferred items, and 3 Out-of-scope items, the compressed Stage 2 looks like:
+
+```
+Based on our dialogue, here's the scope I'm proposing for the requirements doc:
+
+**What we're building:** Per-channel mute on notification rules, with a 24h preset for the support team's 3 AM ping problem. Mute lives on the rule itself and survives rule edits.
+
+**Key trade-offs:**
+- Per-channel over per-user — support team isn't a single user
+- Mute on the rule, not a separate entity — pause state survives edits
+
+**What's not in scope:**
+- Presence-based mute and quiet-hours schedules — deferred for later
+- Cross-rule mute groups — would force a rule-grouping concept we don't have
+
+**Call outs:**
+- Rule-delete silently loses pause state — confirm no warning needed
+
+Confirm and I'll write the requirements doc next, drawing on our dialogue and this synthesis. Or tell me what to change.
+```
+
+What got cut from the 12-item internal draft and why:
+
+- Stated items already covered by the "What we're building" prose dissolved silently
+- "Use existing rule entity" — mechanical, no real trade-off
+- "Use Postgres for persistence" — implementation detail (ce-plan's job), failed granularity rules
+- One Out-of-scope item ("no rate limiting") — mechanical exclude, no reader would ask about it
+- Three Inferred items rolled into the Trade-offs section as the explicit choices behind them
+
+What survived: a scoping synthesis with substance proportional to the dialogue, bounded at the Standard ceiling of 5 bullets across the three conditional sections — any more would have triggered a re-cut at higher abstraction.
+
+---
+
+## Pre-flight re-review
+
+Before emitting the scoping synthesis, re-read the draft as a user would read it. Two failure modes to catch:
+
+- **The scoping synthesis reads like a requirements-doc preview.** Prose enumerates what's in/out, bullets are documentary instead of conversational. The synthesis is a shape-confirmation checkpoint, not a doc preview — if it reads as preview, Phase 2.5 and Phase 3 have collapsed into one step. Revise to conversational shape, or accept that the requirements doc itself will contain the detail and the synthesis should be lighter.
+- **The bullet count fits the cap but each bullet is over-detailed.** Hitting 5 bullets in Standard while each bullet is a paragraph means the agent met the count cap by compressing horizontally (fewer bullets) without compressing vertically (less per bullet). The cap is meaningless if individual bullets bloat to fill it. Re-cut to sentence-level bullets.
+
+This is one mental act — re-read as the user — not a checklist to mechanically run. The forcing function is putting yourself in the user's reading shoes briefly, with explicit attention to detail level alongside the keep tests. Revise before emitting if either failure mode fires.
+
+---
+
+## Re-present after revision; write only on confirm
+
+A revision is not a confirmation. After any user revision (even a trivially-understood swap like "move deferred item X back into scope"), integrate the change, re-present the revised scoping synthesis with the change reflected, and wait for explicit confirmation before writing the doc. The loop is:
+
+1. Present scoping synthesis → user responds
+2. User confirms → write the doc
+3. User revises → integrate, re-present revised scoping synthesis, return to step 1
+
+Doc-write fires only on explicit confirm or after the soft-cut blocking question's "proceed" option (see below). The confirmation step is what makes the scoping synthesis **confirmed** rather than "agent's last proposal" — never write immediately after a revision, even when the revision is small enough that the agent feels it understood.
+
+---
+
+## Soft-cut on circularity (not iteration count)
+
+Track which scoping synthesis items the user touched per round. The soft-cut blocking question fires **only when the same item is revised twice** (or a third-round revision targets an item already revised in round two). New-item revisions across rounds proceed without limit — revising different aspects of a wrong scoping synthesis is exactly what the mechanism should support.
+
+**Identity across rounds is by decision dimension, not surface wording or section.** A revision may cause stage 2 to re-derive — the same underlying decision can come back rephrased, merged with another bullet, or moved to a different section (e.g., what was a Trade-off in round one becomes a Call-out in round two after the user pushed back). "Same item" means the same underlying decision regardless of which section currently holds it. When a re-cut collapses multiple prior bullets into one, the new combined bullet inherits the "touched" status of any of its constituents — soft-cut fires if any underlying decision was already revised once before.
+
+When the soft-cut fires, use the platform's blocking question tool (`question` in OpenCode) with two options:
+
+- `Proceed and write the requirements doc`
+- `Hold off — keep discussing before the doc`
+
+Fall back to a numbered list in chat only when no blocking tool exists or the call errors. Never silently skip.
+
+---
+
+## Self-redirect
+
+If the user response indicates they're in the wrong skill or want a different workflow (e.g., "this is too small, just /ce-work it" or "this needs more thought, let me brainstorm differently"):
+
+- Stop ce-brainstorm
+- Suggest the alternative skill the user appears to want (e.g., `/ce-work`, `/ce-debug`)
+- Offer to load it in-session
+- Do not push back or argue — the user's redirect signal is the deliberate choice
+
+This support exists because the scoping synthesis is an honest checkpoint. If the user discovers the skill choice was wrong by reading the scoping synthesis, redirecting is the right move.
+
+---
+
+## Doc shape after confirmation
+
+After user confirmation (or after the soft-cut decision proceeds), Phase 3 writes the requirements doc. The internal draft does NOT carry into the doc as a `## Synthesis` section. Only the "What we're building" prose embeds, as `## Summary` at the top. Internal-draft content dissolves into the doc's body sections:
+
+| Internal-draft element | Where it goes in the doc |
+|---|---|
+| "What we're building" prose | `## Summary` (1–3 lines, forward-looking, what's proposed) |
+| Stated bullets | `## Requirements` (numbered R-IDs, full detail) and where relevant `## Problem Frame` for narrative context |
+| Inferred bullets | `## Key Decisions` (with rationale) — bets the user accepted in dialogue become decisions in the doc. |
+| Out-of-scope bullets | `## Scope Boundaries` |
+
+The chat-time Trade-offs section dissolves into `## Key Decisions` (the explicit choices acknowledged in chat become documented decisions). The chat-time What's-not-in-scope section dissolves into `## Scope Boundaries`.
+
+**Headless / pipeline mode:** Inferred bets route to `## Assumptions` instead of `## Key Decisions` — they were not user-confirmed in chat and should be surfaced explicitly for downstream review. See `references/requirements-capture.md` for the `## Assumptions` section contract.
+
+No italic capture-context note (e.g., "Captured at Phase 2.5..."). It would leak engineering process into an artifact whose readers do not need that signal.
+
+The doc's `## Summary` and `## Problem Frame` must serve distinct purposes — see `references/brainstorm-sections.md` "Discipline: Summary vs Problem Frame" for the rules.

--- a/skills/ce-brainstorm/references/universal-brainstorming.md
+++ b/skills/ce-brainstorm/references/universal-brainstorming.md
@@ -57,7 +57,7 @@ When the conversation has enough material to narrow — reflect back what you've
 
 **Question:** "Brainstorm wrapped. What would you like to do next?"
 
-- **Create a plan** → hand off to `/ce-plan` with the decided goal and constraints
+- **Create a plan** → hand off to `ce:plan` with the decided goal and constraints
 - **Save summary to disk** → write the summary as a markdown file in the current working directory
 - **Open in Proof (web app) — review and comment to iterate with the agent** → load the `ce-proof` skill to open the doc in Every's Proof editor, iterate with the agent via comments, or copy a link to share with others
 - **Done** → the conversation was the value, no artifact needed

--- a/skills/ce-brainstorm/references/visual-communication.md
+++ b/skills/ce-brainstorm/references/visual-communication.md
@@ -1,0 +1,29 @@
+# Visual Communication in Requirements Documents
+
+Visual aids are conditional on content patterns, not on document depth classification — a Lightweight requirements doc about a complex multi-surface feature may warrant a diagram; a Deep doc about a straightforward change may not.
+
+**When to include:**
+
+| Requirements describe... | Visual aid | Placement |
+|---|---|---|
+| 4+ requirements with non-linear relationships (dependencies, groupings, fan-in/fan-out) | Mermaid dependency or grouping diagram | Before or after the Requirements heading |
+| 3+ interacting system surfaces or cross-layer effects | Mermaid interaction or component diagram | Within the relevant section |
+| 3+ behavioral modes, states, or variants being compared | Markdown comparison table | Within the relevant section |
+| 3+ alternatives or trade-offs under consideration | Markdown comparison table | Within the relevant section |
+
+**When to skip:**
+- The requirements are 3 or fewer items in a straightforward list — prose bullets are sufficient
+- Prose already communicates the relationships clearly
+- The visual would duplicate what surrounding prose already shows
+- The visual describes code-level detail (specific method names, SQL columns, API field lists)
+
+**Format selection:**
+- **Mermaid** (default) for dependency graphs and interaction diagrams — 5–15 nodes, no in-box annotations, standard flowchart shapes. Use `TB` (top-to-bottom) direction so diagrams stay narrow in both rendered and source form. Source should be readable as fallback in diff views and terminals.
+- **ASCII/box-drawing diagrams** for annotated flows that need rich in-box content — decision logic branches, multi-column spatial arrangements. More expressive than mermaid when the diagram's value comes from annotations within nodes. Follow 80-column max for code blocks, use vertical stacking.
+- **Markdown tables** for mode/variant comparisons and alternative comparisons.
+- Keep diagrams proportionate to the document. A simple 4-requirement grouping gets a simple diagram. A complex dependency graph with fan-out and fan-in may need 10–15 nodes — that is fine if every node earns its place.
+- Place inline at the point of relevance, not in a separate section.
+- Requirements-structure level only — groupings, surface interactions, mode comparisons. Not implementation architecture, data schemas, or code structure.
+- Prose is authoritative: when a visual aid and its surrounding prose disagree, the prose governs.
+
+After generating a visual aid, verify it accurately represents the requirements it illustrates — correct relationships, no missing surfaces, no merged requirements.

--- a/skills/ce-plan/SKILL.md
+++ b/skills/ce-plan/SKILL.md
@@ -165,6 +165,55 @@ Classify the work into one of these plan depths:
 
 If depth is unclear, ask one targeted question and then continue.
 
+#### 0.7 Solo-Mode Scoping Synthesis
+
+Surface call-outs to the user — the specific forks in scope or approach where user input materially changes the plan — so scope can be corrected **before Phase 1 research is spent**. Sub-agent dispatch (repo-research-analyst, learnings-researcher, etc.) is the expensive next step this phase guards against wasted effort on.
+
+Fires **only in solo invocation** — when Phase 0.2 found no upstream brainstorm doc AND Phase 0.4 stayed in ce:plan (did not route to ce:debug, ce:work, or universal-planning) AND Phase 0.5 cleared (no unresolved blockers) AND not on Phase 0.1 fast paths (resume normal, deepen-intent). Each guard is an explicit conditional. Skip Phase 0.7 entirely when any guard fails — brainstorm-sourced invocations defer to Phase 5.1.5 instead.
+
+**Read `references/synthesis-summary.md` before composing the scoping synthesis.** It carries the affirmability test, keep-test criteria, detail test, summary shape budgets, granularity rules, anti-patterns, revision-vs-confirmation discipline, doc-shape routing, soft-cut behavior, self-redirect support, the worked PII compression example, and full headless-mode routing — all required for a well-shaped synthesis.
+
+**Required gate output — do not skip; silent proceeding is not allowed.** Compose an internal three-bucket scope draft (Stated / Inferred / Out of scope — internal thinking that feeds plan-body routing at Phase 5.2, not the chat output below). Derive call-outs (specific forks where user input materially changes the plan), then emit one of the two literal templates below in chat before continuing to Phase 1.
+
+**Synthesis is pre-plan-write.** The agent does NOT yet know how plan-write will sequence the work. Do not claim PR count ("one PR"), commit/branch shape, effort or time estimates, Implementation Unit boundaries, or exact file paths in the synthesis. The synthesis surfaces decisions knowable at THIS point — for the solo variant, that's the user's request plus the Phase 0.4 bootstrap dialogue plus the agent's own internal three-bucket draft. Phase 1 research has not happened yet and there is no upstream brainstorm; do not claim grounding from either. Plan-write produces the rest. This rule holds even when the agent has formed plan-write opinions earlier in the session — those stay internal until plan-write.
+
+**Summary shape:** the summary is a **scope claim** — what the plan will target, what it will not — at affirm-or-redirect level. NOT an enumeration of Implementation Units. Form is prose, bullets, or mix; tier budgets are **ceilings, not targets** (Lightweight 1-3 lines; Standard up to 3-5 lines or 2-4 bullets; Deep up to 4-6 lines or 3-6 bullets). 1-2 lines per bullet, conversational not documentary. Less is correct when there isn't more to say. See `references/synthesis-summary.md` for keep test, detail test, and source-vocabulary discipline.
+
+**Do NOT enumerate the touch surface.** Sentences like "The touch surface is...", "This plan touches...", "The implementation reaches into..." are plan-pitch leaks. File paths, module names, directory introductions, and per-file change descriptions belong in the plan body (Implementation Units at Phase 5.2), not the synthesis. The synthesis names *what* the plan targets, not *where* the code lives.
+
+**Pre-emit scans.** Before emitting the synthesis, scan the output:
+- Bare ID references (`AE\d+`, `R\d+`, `F\d+`, `A\d+`, `U\d+`) → replace with plain names.
+- File paths (`path/like.md`, `path/like.py`, etc.) → cut unless the path IS the topic of an explicit fork in the call-outs.
+
+**Tier guard on auto-proceed:** the auto-proceed path (announce without waiting for confirmation) fires only when plan depth is **Lightweight AND zero call-outs survive**. Standard and Deep plans always fire the confirmation gate, even with zero call-outs — substance earns the checkpoint, not interaction history.
+
+**Confirmation template (Standard/Deep regardless of call-out count, or any tier with one or more call-outs surviving):**
+
+````text
+Based on your request and our brief discussion, here's the scope I'm proposing to plan against:
+
+[scope claim — what the plan will target, what it will not; affirm-or-redirect level; NOT an enumeration of Implementation Units]
+
+**Call outs:** (omit this header when zero forks survived the keep test)
+- [decision-level fork in 1-2 lines: name the choice and optional one-clause trade-off in parens. NO multi-sentence rationale, NO "my default is X" pitch]
+
+Confirm and I'll proceed to research, drawing on this scope. (You can also redirect to /ce-brainstorm if this is bigger than you initially thought — I'll stop here and load it for you.)
+````
+
+Wait for user confirmation before continuing to Phase 1.
+
+**Auto-proceed template (Lightweight with zero call-outs only):**
+
+````text
+Planning: [1-3 line scope claim]
+
+No open decisions to weigh in on — proceeding to research. Interrupt if I have the scope wrong.
+````
+
+Then continue to Phase 1 without a blocking question.
+
+**Headless mode**: internal draft is composed but stage 2 (chat-time call-outs) is skipped — no synchronous user to confirm to. Continue to Phase 1 research as normal. At plan-write time (Phase 5.2), Inferred bets from the internal draft route to a `## Assumptions` section in the plan instead of Key Technical Decisions. See `references/synthesis-summary.md` Headless mode for the full routing.
+
 ### Phase 1: Gather Context
 
 #### 1.1 Local Research (Always Runs)
@@ -406,6 +455,12 @@ Examples:
 - Runtime behavior that depends on seeing actual test failures
 - Refactors that may become unnecessary once implementation starts
 
+#### 3.7 Anti-Expansion: Tangential Cleanup and Scope Creep Go to Deferred
+
+Distinct from 3.6 (which is about *unknowns* at plan time): 3.7 is about *known but tangential* work that the agent notices while planning but that falls outside the user's confirmed scope. When research surfaces an adjacent refactor, a "while we're here" cleanup, or a scope-adjacent nice-to-have ("we could also add rate limiting"), route it to the existing `### Deferred to Separate Tasks` subsection in Scope Boundaries (see Core Plan Template), not into active Implementation Units.
+
+This reinforces the synthesis discipline established at Phase 0.7 / Phase 5.1.5 — the user's confirmed scope is what the active plan executes; everything else is deferred. Does NOT impose architectural bias on extend-vs-invent decisions within confirmed scope — that judgment stays with the agent (and is surfaced via the Phase 5.1.5 synthesis when material). The user's explicit ask overrides this default — if the user explicitly requested a refactor, it's in-scope, not deferred.
+
 ### Phase 4: Write the Plan
 
 Use one planning philosophy across all depths. Change the amount of detail, not the boundary between planning and execution.
@@ -636,6 +691,19 @@ For larger `Deep` plans, extend the core template only when useful with sections
 - Do not expand implementation units into micro-step `RED/GREEN/REFACTOR` instructions
 - Do not pretend an execution-time question is settled just to make the plan look complete
 
+#### 4.3b Section Contract and Rendering
+
+Compose the plan using two paired references:
+
+- `references/plan-sections.md` — the section contract. Describes what the plan contains: the outcome the plan must enable for downstream consumers, the hard floor (Summary, Problem Frame, Requirements, KTDs, Implementation Units), the include-when-material catalog (HTD, Scope Boundaries, Open Questions, System-Wide Impact, Risks & Dependencies, Acceptance Examples, Documentation/Operational Notes, Sources & Research), the agency-driven escape hatch (introduce new sections when content warrants), and the ID/content rules.
+- `references/markdown-rendering.md` — how to present the sections in markdown (table-vs-prose by content shape, ID prefix format, diagram rendering, etc.).
+
+The section catalog is the same regardless of plan depth. Format-specific principles live in the rendering reference. The Core Plan Template above (Section 4.2) is the canonical content authority — `plan-sections.md` is a rendering/ordering layer that describes how sections present, not which sections exist.
+
+Omit "include when material" sections that don't carry information for this specific plan. Filling a section with placeholder prose is worse than omitting it.
+
+**Write tight.** A section being material is not license to pad it. Hold every kept section to the prose-economy discipline in `references/plan-sections.md`: one idea per sentence, a requirement or unit is intent plus at most one qualifier, defer forks to Open Questions rather than specifying both arms, resolve superseded text in place rather than stacking strata. Before declaring the plan written, run the named test there — could the implementer find a contradiction in each section in one pass?
+
 #### 4.4 Visual Communication in Plan Documents
 
 When the plan contains 4+ implementation units with non-linear dependencies, 3+ interacting surfaces in System-Wide Impact, 3+ behavioral modes/variants in Overview or Problem Frame, or 3+ interacting decisions in Key Technical Decisions or alternatives in Alternative Approaches, read `references/visual-communication.md` for diagram and table guidance. This covers plan-structure visuals (dependency graphs, interaction diagrams, comparison tables) — not solution-design diagrams, which are covered in Section 3.4.
@@ -665,6 +733,58 @@ If the plan originated from a requirements document, re-read that document and v
 - Scope boundaries and success criteria are preserved
 - Blocking questions were either resolved, explicitly assumed, or sent back to `ce:brainstorm`
 - Every section of the origin document is addressed in the plan — scan each section to confirm nothing was silently dropped
+
+#### 5.1.5 Brainstorm-Sourced Scoping Synthesis
+
+Surface plan-time call-outs to the user before Phase 5.2 commits the plan to disk — the latest cheap moment to catch plan-time scope errors. The brainstorm already validated WHAT to build; this phase surfaces HOW the plan will execute on the forks that matter.
+
+Fires **only when the plan was sourced from an upstream brainstorm doc** (Phase 0.2 found a `*-requirements.md` match) AND not on Phase 0.1 fast paths (resume normal, deepen-intent). Skip Phase 5.1.5 in solo invocation — solo plans handled their synthesis in Phase 0.7.
+
+**Read `references/synthesis-summary.md` before composing the scoping synthesis.** It carries the affirmability test, keep-test criteria, detail test, summary shape budgets, granularity rules, anti-patterns, revision-vs-confirmation discipline, doc-body reading rules, doc-shape routing, soft-cut behavior, self-redirect support, the worked PII compression example, and full headless-mode routing — all required for a well-shaped synthesis.
+
+**Required gate output — do not skip; silent proceeding is not allowed.** Compose an internal three-bucket scope draft (Stated / Inferred / Out of scope — internal thinking that feeds plan-body routing at Phase 5.2, not the chat output below). Derive call-outs (specific forks where user input materially changes the plan), then emit one of the two literal templates below in chat before continuing to Phase 5.2.
+
+**Synthesis is pre-plan-write.** The agent does NOT yet know how plan-write will sequence the work. Do not claim PR count ("one PR"), commit/branch shape, effort or time estimates, Implementation Unit boundaries, or exact file paths in the synthesis. The synthesis surfaces decisions knowable at THIS point (brainstorm + research + agent posture); plan-write produces the rest. This rule holds even when the agent has formed plan-write opinions earlier in the session — those stay internal until plan-write.
+
+**Summary shape: two paragraphs.**
+
+1. **Brainstorm-scope restatement** (1-2 sentences, prose). Restates the brainstorm's scope as orientation, in the brainstorm's own vocabulary. NOT an enumeration of Implementation Units, restated constraints, or listed acceptance examples — the user wrote those.
+2. **Plan-specific scoping decisions** (prose, or bullets when multi-faceted). Scope-level commitments the agent made that the brainstorm did not: full brainstorm coverage vs. narrowed subset; adjacent refactors pulled in vs. held out; test scope at scenario level. Each item must be affirmable by the user without reading code. Form follows substance; tier budgets are **ceilings, not targets** (Lightweight 1-3 lines; Standard up to 3-5 lines or 2-4 bullets; Deep up to 4-6 lines or 3-6 bullets). 1-2 lines per bullet. Less is correct when there isn't more to say. See `references/synthesis-summary.md` for keep test, detail test, and source-vocabulary discipline.
+
+**Do NOT enumerate the touch surface.** Sentences like "The touch surface is...", "This plan touches...", "The implementation reaches into...", "Files modified include..." are plan-pitch leaks. File paths, module names, directory introductions, and per-file change descriptions belong in the plan body (Implementation Units at Phase 5.2), not the synthesis. The synthesis names *what* the plan targets, not *where* the code lives.
+
+**Pre-emit scans.** Before emitting the synthesis, scan the output:
+- Bare ID references (`AE\d+`, `R\d+`, `F\d+`, `A\d+`, `U\d+`) → replace with plain names.
+- File paths (`path/like.md`, `path/like.py`, etc.) → cut unless the path IS the topic of an explicit fork in the call-outs.
+
+**Tier guard on auto-proceed:** the auto-proceed path (announce without waiting for confirmation) fires only when plan depth is **Lightweight AND zero call-outs survive**. Standard and Deep plans always fire the confirmation gate, even with zero call-outs — substance earns the checkpoint, not interaction history.
+
+**Confirmation template (Standard/Deep regardless of call-out count, or any tier with one or more call-outs surviving):**
+
+````text
+The brainstorm scopes [1-2 sentence restatement in the brainstorm's vocabulary as orientation; NOT an enumeration of Implementation Units, constraints, or acceptance examples].
+
+This plan [plan-specific scoping decisions: full-brainstorm coverage vs. narrowed subset; adjacent refactors in or out; test scope at scenario level. NOT PR count, sequencing, IU lists, or file paths].
+
+**Call outs:** (omit this header when zero forks survived the keep test)
+- [plan-time fork in 1-2 lines: name the choice and optional one-clause trade-off in parens. NO multi-sentence rationale, NO "my default is X" pitch]
+
+Confirm and I'll write the plan next, drawing on the brainstorm, research, and this synthesis.
+````
+
+Wait for user confirmation before continuing to Phase 5.2.
+
+**Auto-proceed template (Lightweight with zero call-outs only):**
+
+````text
+Planning [brief brainstorm-scope restatement] — [plan-specific shape in one clause].
+
+No open decisions to weigh in on — proceeding to plan-write. Interrupt if I have the scope wrong.
+````
+
+Then continue to Phase 5.2 without a blocking question.
+
+**Headless mode**: internal draft is composed but stage 2 (chat-time call-outs) is skipped — no synchronous user to confirm to. Proceed to Phase 5.2 plan-write. Inferred bets from the internal draft route to a `## Assumptions` section in the plan instead of Key Technical Decisions. See `references/synthesis-summary.md` Headless mode for the full routing.
 
 #### 5.2 Write Plan File
 

--- a/skills/ce-plan/SKILL.md
+++ b/skills/ce-plan/SKILL.md
@@ -167,7 +167,7 @@ If depth is unclear, ask one targeted question and then continue.
 
 #### 0.7 Solo-Mode Scoping Synthesis
 
-Surface call-outs to the user — the specific forks in scope or approach where user input materially changes the plan — so scope can be corrected **before Phase 1 research is spent**. Sub-agent dispatch (repo-research-analyst, learnings-researcher, etc.) is the expensive next step this phase guards against wasted effort on.
+Surface call-outs to the user — the specific forks in scope or approach where user input materially changes the plan — so scope can be corrected **before Phase 1 research is spent**. Sub-agent dispatch (systematic:research:repo-research-analyst, systematic:research:learnings-researcher, etc.) is the expensive next step this phase guards against wasted effort on.
 
 Fires **only in solo invocation** — when Phase 0.2 found no upstream brainstorm doc AND Phase 0.4 stayed in ce:plan (did not route to ce:debug, ce:work, or universal-planning) AND Phase 0.5 cleared (no unresolved blockers) AND not on Phase 0.1 fast paths (resume normal, deepen-intent). Each guard is an explicit conditional. Skip Phase 0.7 entirely when any guard fails — brainstorm-sourced invocations defer to Phase 5.1.5 instead.
 
@@ -197,7 +197,7 @@ Based on your request and our brief discussion, here's the scope I'm proposing t
 **Call outs:** (omit this header when zero forks survived the keep test)
 - [decision-level fork in 1-2 lines: name the choice and optional one-clause trade-off in parens. NO multi-sentence rationale, NO "my default is X" pitch]
 
-Confirm and I'll proceed to research, drawing on this scope. (You can also redirect to /ce-brainstorm if this is bigger than you initially thought — I'll stop here and load it for you.)
+Confirm and I'll proceed to research, drawing on this scope. (You can also redirect to ce:brainstorm if this is bigger than you initially thought — I'll stop here and load it for you.)
 ````
 
 Wait for user confirmation before continuing to Phase 1.

--- a/skills/ce-plan/references/markdown-rendering.md
+++ b/skills/ce-plan/references/markdown-rendering.md
@@ -1,0 +1,203 @@
+# Markdown Rendering
+
+This is a format-rendering reference — it describes how to render any
+artifact in markdown, independent of which skill is producing it.
+
+It is paired with a section contract (`references/plan-sections.md`)
+that describes *what* the artifact contains. This reference describes
+*how* markdown specifically presents it. The same content rendered by
+different skills shares the same markdown principles.
+
+## Hard invariants
+
+These hold regardless of which skill produced the artifact.
+
+- **YAML frontmatter at the top of the file.** Standard `---` delimited block
+  containing the artifact's stable metadata (title, status, date, type, etc.
+  — exact fields are per-skill, defined in the section contract). Editable
+  in place; tools and agents that do status flips (`active → completed`)
+  update the YAML directly.
+- **ASCII identifiers in anchors.** Markdown headings auto-generate anchors
+  from the heading text. Keep headings ASCII so anchors are predictable
+  (`#implementation-units`, not `#implementación-units`).
+- **Repo-relative paths for file references.** Always. Never absolute paths
+  — they break portability across machines, worktrees, teammates.
+- **No HTML mixed in.** Keep the markdown pure. No `<div>`, no `<details>`,
+  no inline `<style>`. Markdown stays markdown.
+
+## Format principles
+
+These shape what "good" markdown looks like; the agent applies them per
+artifact based on content shape.
+
+### ID prefix format
+
+Stable IDs (R, U, A, F, AE, KTD) appear as plain prefixes at the start of
+the bullet or heading — do NOT bold the prefix. The prefix is visually
+distinctive on its own; bolding it inflates visual noise.
+
+```markdown
+- R1. The plan returns paginated sessions.   ← right
+- **R1.** The plan returns paginated sessions.   ← wrong (bolded prefix)
+```
+
+Same applies to unit headings: `### U1. Cloak detection in preflight contract`.
+
+### Content shape: prose vs bullets vs tables
+
+The same content can be rendered three ways; the agent picks per content
+shape, not by template default.
+
+- **Prose** when the content has narrative flow (motivation, decision
+  rationale, problem framing). Bullets fragment narrative into
+  disconnected pieces.
+- **Bullets** when items share a parallel shape but each carries enough
+  prose to not fit a table cell.
+- **Tables** when 5+ items share uniform structure (`ID + body`,
+  `name + value`, `decision + rationale`, `risk + mitigation`). Tables
+  scan faster at that scale and unlock additional columns (status,
+  traceability, severity) that bullets can't accommodate cleanly.
+
+The test: which shape would a reader scan fastest for this content? If
+items have parallel structure and 5+ instances, table. If items are 3-5
+and each has a few lines of prose, bullets. If the content is a single
+narrative thought, prose.
+
+### Bold leader labels within bullets
+
+When a bullet has substructure that benefits from named fields (Key Flows
+with Trigger / Actors / Steps / Outcome, Acceptance Examples with Covers
+/ Given / When / Then), use bold leader labels at the start of nested
+bullets — not deeper heading levels.
+
+```markdown
+- F1. Anonymous capture
+  - **Trigger:** Agent enters Step 2a with no session.
+  - **Actors:** A1, A2
+  - **Steps:** Preflight detects cloak; agent launches; capture proceeds.
+  - **Covered by:** R1, R2, R5
+```
+
+This gives the bullet structure without needing H4/H5 headings that would
+clutter the doc and break TOC generation.
+
+### Section separators
+
+For substantial artifacts, use horizontal rules (`---`) between top-level
+H2 sections. Omit for short docs where separators would dominate.
+
+### Tables for genuinely comparative info only
+
+Use tables for the uniform-shape case in "Content shape" above. Don't use
+tables to render content lists that are really bullets — markdown tables
+are noisier in raw form and worse for diffs.
+
+## Section anatomy
+
+How section types commonly render in markdown. These are patterns, not
+contracts — the agent picks the shape that fits the content.
+
+- **Summary / Problem Frame** — prose paragraphs.
+- **Requirements** — bullets with `R<N>.` prefix. When requirements span
+  more than one concern, grouping under bold inline headers is the default
+  shape, not optional polish (group by capability, not by discussion order);
+  render a flat list only when every requirement is about the same thing.
+  When requirements have status, traceability, or severity that warrant
+  additional columns, escalate to a table.
+- **Implementation Units** — H3 heading per unit with `U<N>.` prefix.
+  Fields (Goal, Files, Patterns, Test Scenarios, Verification) render as
+  bullets with bold leader labels, or as sub-headings if the field has
+  multi-paragraph content.
+- **Key Technical Decisions** — bullets with bold decision name + prose
+  rationale, or numbered KTD-N pattern when traceability matters.
+- **Key Flows / Acceptance Examples** — bullets with bold leader labels
+  (Trigger / Actors / Steps / Outcome / Covers / Given-When-Then).
+- **Scope Boundaries** — bullets, optionally split into "Deferred to
+  Separate Tasks" / "Outside this product's identity" sub-headings when
+  the positioning distinction matters.
+
+The agent picks more elaborate or simpler shapes based on what each
+specific artifact's content needs.
+
+## Diagrams
+
+When the section contract calls for a diagram (architecture, sequence,
+flowchart, state machine, swim lane, data-flow), markdown renders it as
+a fenced mermaid block:
+
+```markdown
+` ``mermaid
+flowchart TB
+  A[Start] --> B{Decision}
+  B -->|yes| C[Action]
+  B -->|no| D[Other action]
+` ``
+```
+
+(`TB` direction default — keeps diagrams narrow in source view and in
+narrow rendered viewports.)
+
+For quantitative comparisons (bar charts, scatter plots) markdown has no
+native equivalent — use a table with the data and let prose or caption
+carry the interpretation.
+
+## Inline code and code blocks
+
+- **Inline code** for identifiers (variable names, function names,
+  flag names, file paths, IDs that aren't section anchors).
+- **Fenced code blocks** with language tag for code, shell commands,
+  API request/response samples. Always specify the language for syntax
+  highlighting and accessibility.
+
+```markdown
+The flag `--cdp-url` accepts a URL.
+
+` ``bash
+browser-use --cdp-url http://localhost:9222
+` ``
+```
+
+## No process exhaust
+
+Engineering process metadata stays out of the artifact:
+
+- No "captured at Phase X" notes
+- No `## Next Steps` pointing to the next skill
+- No italic provenance lines ("*Brainstorm completed 2026-05-13*")
+- No engineering-flow shepherding ("Now read this file:", "Next, run that
+  command:")
+
+This information belongs in commit messages, tool output, and agent
+transcripts — not in the artifact a reader returns to weeks later.
+
+## Frontmatter shape
+
+Per-skill frontmatter fields are defined in the section contract
+(`plan-sections.md` lists plan frontmatter). Common rules:
+
+- YAML at the top of the file, delimited by `---` on its own line above
+  and below.
+- Field names in lowercase snake_case (`status`, `created_at`, not
+  `Status`, `CreatedAt`).
+- **Status lifecycle is per-contract.** When the section contract
+  defines a `status` field with a lifecycle (plans use
+  `active → completed`, flipped by `ce:work` at shipping time via direct
+  YAML edit), it is editable in place. When the section contract does
+  not define a status lifecycle (brainstorms, for example, have no
+  `active → completed` flip — they are upstream of plans and
+  referenced via the plan's `origin:`), do not introduce one.
+- Stable across artifact revisions — never rename or repurpose a field.
+
+## Post-write audit
+
+Before declaring the markdown file written, scan it for these common
+slips:
+
+- All stable IDs are plain-prefix format, not bolded.
+- No HTML elements mixed in.
+- All file paths are repo-relative.
+- Horizontal rule separators between H2s (for Standard / Deep artifacts).
+- No process exhaust (Phase X notes, Next Steps pointers, provenance
+  lines).
+- Tables only where 5+ uniform-shape items justify them.
+- Frontmatter has all the per-skill required fields with reasonable values.

--- a/skills/ce-plan/references/plan-handoff.md
+++ b/skills/ce-plan/references/plan-handoff.md
@@ -38,7 +38,7 @@ After document-review completes, present the options using the platform's blocki
 **Question:** "Plan ready at `<absolute path to plan>`. What would you like to do next?"
 
 **Options:**
-1. **Start `/ce-work`** (recommended) - Begin implementing this plan in the current session
+1. **Start `ce:work`** (recommended) - Begin implementing this plan in the current session
 2. **Create Issue** - Create a tracked issue from this plan in your configured issue tracker (GitHub or Linear)
 3. **Open in Proof (web app) — review and comment to iterate with the agent** - Open the doc in Every's Proof editor, iterate with the agent via comments, or copy a link to share with others
 4. **Done for now** - Pause; the plan file is saved and can be resumed later
@@ -46,19 +46,19 @@ After document-review completes, present the options using the platform's blocki
 **Surface additional document review contextually, not as a menu fixture:** When the prior document-review pass surfaced residual P0/P1 findings that the user has not addressed, mention them adjacent to the menu and offer another review pass in prose (e.g., "Document review flagged 2 P1 findings you may want to address — want me to run another pass before you pick?"). Do not add it to the option list.
 
 Based on selection:
-- **Start `/ce-work`** -> Call `/ce-work` with the plan path
+- **Start `ce:work`** -> Call `ce:work` with the plan path
 - **Create Issue** -> Follow the Issue Creation section below
 - **Open in Proof (web app) — review and comment to iterate with the agent** -> Load the `ce-proof` skill in HITL-review mode with:
   - source file: `docs/plans/<plan_filename>.md`
   - doc title: `Plan: <plan title from frontmatter>`
   - identity: `ai:systematic` / `Systematic`
-  - recommended next step: `/ce-work` (shown in the ce-proof skill's final terminal output)
+  - recommended next step: `ce:work` (shown in the ce-proof skill's final terminal output)
 
   Follow `references/hitl-review.md` in the ce-proof skill. It uploads the plan, prompts the user for review in Proof's web UI, ingests each thread by reading it fresh and replying in-thread, applies agreed edits as tracked suggestions, and syncs the final markdown back to the plan file atomically on proceed.
 
   When the ce-proof skill returns:
   - `status: proceeded` with `localSynced: true` -> the plan on disk now reflects the review. Re-run `ce-doc-review` on the updated plan before re-rendering the menu — HITL can materially rewrite the plan body, so the prior ce-doc-review pass no longer covers the current file and section 5.3.8 requires a review before any handoff option is offered. Then return to the post-generation options with the refreshed residual findings.
-  - `status: proceeded` with `localSynced: false` -> the reviewed version lives in Proof at `docUrl` but the local copy is stale. Offer to pull the Proof doc to `localPath` using the ce-proof skill's Pull workflow. If the pull happened, re-run `ce-doc-review` on the pulled file before re-rendering the options (same 5.3.8 rationale — the local plan was materially updated by the pull). If the pull was declined, include a one-line note above the menu that `<localPath>` is stale vs. Proof — otherwise `Start /ce-work` or `Create Issue` will silently use the pre-review copy.
+  - `status: proceeded` with `localSynced: false` -> the reviewed version lives in Proof at `docUrl` but the local copy is stale. Offer to pull the Proof doc to `localPath` using the ce-proof skill's Pull workflow. If the pull happened, re-run `ce-doc-review` on the pulled file before re-rendering the options (same 5.3.8 rationale — the local plan was materially updated by the pull). If the pull was declined, include a one-line note above the menu that `<localPath>` is stale vs. Proof — otherwise `Start ce:work` or `Create Issue` will silently use the pre-review copy.
   - `status: done_for_now` -> the plan on disk may be stale if the user edited in Proof before leaving. Offer to pull the Proof doc to `localPath` so the local plan file stays in sync. If the pull happened, re-run `ce-doc-review` on the pulled file before re-rendering the options (same 5.3.8 rationale). If the pull was declined, include the stale-local note above the menu. `done_for_now` means the user stopped the HITL loop — it does not mean they ended the whole plan session; they may still want to start work or create an issue.
   - `status: aborted` -> fall back to the options without changes.
 
@@ -93,4 +93,4 @@ When the user selects "Create Issue", detect their project tracker:
 
 After issue creation:
 - Display the issue URL
-- Ask whether to proceed to `/ce-work` using the platform's blocking question tool
+- Ask whether to proceed to `ce:work` using the platform's blocking question tool

--- a/skills/ce-plan/references/plan-sections.md
+++ b/skills/ce-plan/references/plan-sections.md
@@ -69,131 +69,7 @@ When skipping the plan doc, the work proceeds directly to `ce:work` or to
 implementation, and any decisions made along the way land in the commit
 message or `docs/solutions/` if they're worth carrying forward.
 
-## Hard floor
-
-When a plan doc is warranted, these sections are present. They carry the
-contracts downstream consumers depend on.
-
-- **Summary** — what the plan proposes, in 1-3 lines. Forward-looking; orients
-  the reader before they invest in detail.
-- **Problem Frame** — why the work is being done. Backward-looking /
-  situational. May merge with Summary for compact plans where the motivation
-  is a single sentence.
-- **Requirements** (with stable R-IDs) — what must be true after the work
-  ships. Reviewer's checklist; downstream code review verifies against these.
-- **Key Technical Decisions** (KTDs) — the load-bearing choices that constrain
-  implementation. Each entry is `<decision>: <rationale>`. Without these, the
-  implementer can't tell which design choices are open and which are pinned.
-- **Implementation Units** (with stable U-IDs) — the discrete units of work,
-  sized so each is independently landable. `ce:work` consumes these to
-  execute. For trivial single-step plans the work may collapse into Summary
-  prose and U-IDs may be omitted; this is rare.
-
-## Include when material
-
-These sections are present when they carry information that isn't covered
-elsewhere. The test is not "is this a substantial plan?" — it is
-*"does this specific plan have content this section would surface?"* Filling
-a section with placeholder prose is worse than omitting it.
-
-- **High-Level Technical Design** — include when the technical approach has
-  shape that prose alone doesn't carry well: architecture across components,
-  sequencing across processes, state machines, branching gates.
-  Visualizations (component topology, sequence, swim lane, flowchart,
-  data-flow) typically live here. Skip when the approach is a one-paragraph
-  pattern application that the prose itself conveys.
-
-- **Scope Boundaries** — include when scope is contested, when there are
-  tempting non-goals worth naming explicitly, or when "deferred for later"
-  needs distinguishing from "outside the product's identity." Skip when scope
-  is obvious from Requirements alone.
-
-- **Open Questions** — include when there are genuinely unresolved items that
-  block planning or implementation. Skip when the plan is complete; an empty
-  "Open Questions: none" section signals false uncertainty.
-
-- **System-Wide Impact** — include when the change affects cross-cutting
-  concerns (data lifecycles, auth boundaries, performance posture, cardinal
-  rules, shared infrastructure). Skip for changes localized to one component
-  where the impact is self-evident.
-
-- **Risks & Dependencies** — include when there are real risks worth flagging
-  (external service changes, version pins under churn, behavioral assumptions
-  worth highlighting) or material upstream dependencies. Skip for low-risk
-  localized work.
-
-- **Acceptance Examples** — include when any requirement has a state-dependent
-  or conditional shape ("When X, Y") where the prose alone leaves ambiguity
-  about edge cases. Skip when all requirements are unconditional and
-  unambiguous.
-
-- **Documentation / Operational Notes** — include when documentation,
-  monitoring, runbooks, or rollout steps need explicit notes. Skip when the
-  work is purely internal and uses existing operational scaffolding without
-  modification.
-
-- **Sources / Research** — surface the research that orients the implementer
-  or justifies load-bearing choices. The test: *"if I were the implementer
-  reading this cold, would this breadcrumb help me make better choices?"*
-  Yes → surface (code locations, external docs, RFCs, constraints, prior
-  plans — the category is inclusive, not enumerated). Process exhaust
-  (reading the user's prompt, glancing at obvious entry points, restating
-  prose) → omit. Surface inline next to the KTD or unit it justifies, or
-  as a dedicated section — both shapes work.
-
-## Agent agency
-
-The catalog is a floor, not a ceiling. When the plan's content doesn't fit
-any catalog section, introduce a new one — don't force the content into a
-section it doesn't belong in. Content drives section choices, not vice
-versa.
-
-The agent also picks per artifact:
-
-- Whether Problem Frame merges into Summary
-- Sub-groupings (Requirements by capability, KTDs by component, Units phased
-  into milestones)
-- How much detail each section carries
-- Whether HTD has one diagram, several, or none — and whether visualizations
-  live in HTD or embedded in other sections
-
-## Prose economy
-
-"Include when material" sizes *which* sections appear; this sizes *how the kept
-prose reads*. A section can be material and still be written loosely — the
-failure mode is a material section padded into a wall of text where
-contradictions hide and the implementing agent loses the thread. A deep plan
-earns length through coverage (more units, more traced requirements, real
-risks), never through wordiness around that coverage.
-
-Hold every kept section to these:
-
-- **One idea per sentence.** A Summary is a handful of sentences, not one
-  sentence with five semicolons and four parentheticals. A KTD's rationale is
-  the load-bearing reason, not every reason.
-- **A requirement or unit is one sentence of intent plus at most one
-  qualifier.** When it would specify two outcomes ("either A or B, the
-  implementer decides"), state the intent and send the fork to Open Questions —
-  don't write both arms in full inside the item.
-- **Cut hedges and intensifiers.** "Critically", "deliberately", "explicitly",
-  "genuinely", "actually", "simply" carry nothing the implementer acts on.
-- **Prefer the verb to the nominalization.** "Demote the grid", not "the
-  demotion of the grid is the deliberate change in this plan".
-
-Precision is not padding: keep file paths, IDs, conditionals, and exact
-thresholds verbatim. Economy targets the connective tissue around them, never
-the precision itself.
-
-**Resolve in place; don't stratify.** When deepening, a doc-review pass, or a
-later decision supersedes earlier text, rewrite or remove the original — don't
-leave it standing as strikethrough or stack a separate "resolutions" layer on
-top of it. Version control holds the history. Stacked strata double the reading
-surface and hide which text is live.
-
-**Named test, run before the plan is declared written:** could the implementer
-find a contradiction in each section in one pass? A sentence carrying more than
-one parenthetical, or an item specifying two outcomes, fails the test — split it
-or defer it.
+> **Section inventory and meaning are owned by the Core Plan Template in `ce-plan/SKILL.md`; this file covers only how sections render and order.**
 
 ## Plan metadata fields
 
@@ -231,36 +107,11 @@ repurpose its semantics. Agents composing new plans MUST use these exact
 names; adding new fields is fine, but renaming `status` to `state` or
 `origin` to `source` breaks the downstream consumers above.
 
-## ID and content rules
-
-These apply regardless of rendering format.
-
-- **Stable IDs.** R-IDs (Requirements), U-IDs (Implementation Units), A-IDs
-  (if Actors fire), F-IDs (if Flows fire), AE-IDs (if Acceptance Examples
-  fire). IDs are stable across plan revisions — never renumber to "clean
-  up gaps."
-- **Plain prefix.** `R1.`, `U1.` as bullet prefixes. Do not bold; the prefix
-  is visually distinctive on its own.
-- **Repo-relative paths.** Always. Never absolute paths in plan content;
-  they break portability across machines, worktrees, teammates.
-- **No process exhaust.** No "captured at Phase X" notes, no `## Next Steps`
-  pointing to the next skill, no italic provenance lines. Engineering process
-  metadata belongs in commit messages and tool output, not the artifact.
-- **Group Requirements by concern when they span distinct logical areas.**
-  The trigger is distinct concerns, not item count — even four requirements
-  benefit from grouping if they cover three different topics. Skip grouping
-  only when all requirements are genuinely about the same thing; a long flat
-  list is a smell that subgroups were missed. Group by capability (e.g.,
-  "Packaging", "Migration and compatibility", "Contributor workflow"), not by
-  the order requirements were discussed. R-IDs stay continuous across groups
-  (R1, R2 in the first group; R3, R4 in the second; never restart at R1 per
-  group).
-
 ## Rendering
 
-The format-specific reference describes how to render these sections:
+The format-specific reference describes how to render plan sections:
 
 - **Markdown rendering:** `references/markdown-rendering.md`
 
-This reference (`plan-sections.md`) is about WHAT the plan contains;
-the rendering reference is about HOW markdown presents it.
+This reference (`plan-sections.md`) covers metadata format and rendering conventions;
+section inventory and content rules live in the Core Plan Template in `ce-plan/SKILL.md`.

--- a/skills/ce-plan/references/plan-sections.md
+++ b/skills/ce-plan/references/plan-sections.md
@@ -1,0 +1,266 @@
+# Plan Sections
+
+This reference describes what makes a great implementation plan. It does NOT
+prescribe how the plan looks on the page — rendering is handled by
+`references/markdown-rendering.md`.
+
+## The outcome
+
+A great plan enables three audiences to act:
+
+- **The implementing agent** (`ce:work` or a human) starts from an informed
+  baseline — load-bearing decisions are named, research breadcrumbs orient
+  their own investigation, unit boundaries are clear. The plan gives the
+  implementer a starting point, not a substitute for their own investigation.
+- **The reviewer** identifies the load-bearing decisions and the boundaries
+  of what's being changed in one pass.
+- **The future reader** (anyone returning months later) traces why the work
+  was done, what shaped it, and where the artifacts live.
+
+Sections earn their place by serving one of these audiences. Omit padding.
+
+## Decide whether a plan doc is warranted at all
+
+Not every invocation of `ce:plan` should produce a plan document. For
+genuinely atomic work, the doc is ceremony — the implementer (whether
+`ce:work` or a human) can act directly without IDed units, KTDs, or
+Requirements as a checklist.
+
+**Bias toward producing a plan.** The risk asymmetry favors writing one:
+a thin plan doc for small work is mild ceremony, but skipping a plan when
+one was warranted costs the implementer real time (reinvented decisions,
+lost unit boundaries, no IDed requirements to verify against). When unsure,
+write the plan.
+
+**Skip plan creation only when ALL of these hold:**
+
+- The work is **atomic** — fits in one commit, no meaningful unit boundaries
+  to break out independently.
+- There are **no design choices that constrain implementation** — no
+  Key Technical Decisions worth recording. If the work needs the implementer
+  to make a choice between two approaches, those approaches are KTDs and
+  a plan is warranted.
+- There are **no scope boundaries worth pinning** in writing — the work
+  scope is self-evident from the user's request.
+- **No upstream artifact** (a brainstorm with R-IDs, an incident report,
+  a deferred-follow-up item from a prior plan) needs traceability through
+  this plan.
+
+**Stress test the "looks atomic" case.** Many requests look atomic at first
+glance but hide design decisions:
+
+- *"Add caching to this endpoint"* — sounds atomic, but TTL, invalidation,
+  cache key shape, and backend selection are all KTDs. Write the plan.
+- *"Migrate from package A to package B"* — sounds mechanical, but
+  semantic differences between the packages create migration KTDs. Write
+  the plan.
+- *"Add rate limiting"* — sounds small, but algorithm, scope, and
+  configurability are all KTDs. Write the plan.
+
+vs. genuine skip cases:
+
+- *"Fix typo in README line 47"* — atomic, no KTDs, skip the plan.
+- *"Rename `oldFn` to `newFn` across the repo"* — mechanical, no design
+  choices, skip the plan.
+- *"Bump dependency X to v2.3.1"* — mechanical, skip the plan (unless the
+  bump introduces breaking changes that warrant unit-by-unit migration).
+
+When skipping the plan doc, the work proceeds directly to `ce:work` or to
+implementation, and any decisions made along the way land in the commit
+message or `docs/solutions/` if they're worth carrying forward.
+
+## Hard floor
+
+When a plan doc is warranted, these sections are present. They carry the
+contracts downstream consumers depend on.
+
+- **Summary** — what the plan proposes, in 1-3 lines. Forward-looking; orients
+  the reader before they invest in detail.
+- **Problem Frame** — why the work is being done. Backward-looking /
+  situational. May merge with Summary for compact plans where the motivation
+  is a single sentence.
+- **Requirements** (with stable R-IDs) — what must be true after the work
+  ships. Reviewer's checklist; downstream code review verifies against these.
+- **Key Technical Decisions** (KTDs) — the load-bearing choices that constrain
+  implementation. Each entry is `<decision>: <rationale>`. Without these, the
+  implementer can't tell which design choices are open and which are pinned.
+- **Implementation Units** (with stable U-IDs) — the discrete units of work,
+  sized so each is independently landable. `ce:work` consumes these to
+  execute. For trivial single-step plans the work may collapse into Summary
+  prose and U-IDs may be omitted; this is rare.
+
+## Include when material
+
+These sections are present when they carry information that isn't covered
+elsewhere. The test is not "is this a substantial plan?" — it is
+*"does this specific plan have content this section would surface?"* Filling
+a section with placeholder prose is worse than omitting it.
+
+- **High-Level Technical Design** — include when the technical approach has
+  shape that prose alone doesn't carry well: architecture across components,
+  sequencing across processes, state machines, branching gates.
+  Visualizations (component topology, sequence, swim lane, flowchart,
+  data-flow) typically live here. Skip when the approach is a one-paragraph
+  pattern application that the prose itself conveys.
+
+- **Scope Boundaries** — include when scope is contested, when there are
+  tempting non-goals worth naming explicitly, or when "deferred for later"
+  needs distinguishing from "outside the product's identity." Skip when scope
+  is obvious from Requirements alone.
+
+- **Open Questions** — include when there are genuinely unresolved items that
+  block planning or implementation. Skip when the plan is complete; an empty
+  "Open Questions: none" section signals false uncertainty.
+
+- **System-Wide Impact** — include when the change affects cross-cutting
+  concerns (data lifecycles, auth boundaries, performance posture, cardinal
+  rules, shared infrastructure). Skip for changes localized to one component
+  where the impact is self-evident.
+
+- **Risks & Dependencies** — include when there are real risks worth flagging
+  (external service changes, version pins under churn, behavioral assumptions
+  worth highlighting) or material upstream dependencies. Skip for low-risk
+  localized work.
+
+- **Acceptance Examples** — include when any requirement has a state-dependent
+  or conditional shape ("When X, Y") where the prose alone leaves ambiguity
+  about edge cases. Skip when all requirements are unconditional and
+  unambiguous.
+
+- **Documentation / Operational Notes** — include when documentation,
+  monitoring, runbooks, or rollout steps need explicit notes. Skip when the
+  work is purely internal and uses existing operational scaffolding without
+  modification.
+
+- **Sources / Research** — surface the research that orients the implementer
+  or justifies load-bearing choices. The test: *"if I were the implementer
+  reading this cold, would this breadcrumb help me make better choices?"*
+  Yes → surface (code locations, external docs, RFCs, constraints, prior
+  plans — the category is inclusive, not enumerated). Process exhaust
+  (reading the user's prompt, glancing at obvious entry points, restating
+  prose) → omit. Surface inline next to the KTD or unit it justifies, or
+  as a dedicated section — both shapes work.
+
+## Agent agency
+
+The catalog is a floor, not a ceiling. When the plan's content doesn't fit
+any catalog section, introduce a new one — don't force the content into a
+section it doesn't belong in. Content drives section choices, not vice
+versa.
+
+The agent also picks per artifact:
+
+- Whether Problem Frame merges into Summary
+- Sub-groupings (Requirements by capability, KTDs by component, Units phased
+  into milestones)
+- How much detail each section carries
+- Whether HTD has one diagram, several, or none — and whether visualizations
+  live in HTD or embedded in other sections
+
+## Prose economy
+
+"Include when material" sizes *which* sections appear; this sizes *how the kept
+prose reads*. A section can be material and still be written loosely — the
+failure mode is a material section padded into a wall of text where
+contradictions hide and the implementing agent loses the thread. A deep plan
+earns length through coverage (more units, more traced requirements, real
+risks), never through wordiness around that coverage.
+
+Hold every kept section to these:
+
+- **One idea per sentence.** A Summary is a handful of sentences, not one
+  sentence with five semicolons and four parentheticals. A KTD's rationale is
+  the load-bearing reason, not every reason.
+- **A requirement or unit is one sentence of intent plus at most one
+  qualifier.** When it would specify two outcomes ("either A or B, the
+  implementer decides"), state the intent and send the fork to Open Questions —
+  don't write both arms in full inside the item.
+- **Cut hedges and intensifiers.** "Critically", "deliberately", "explicitly",
+  "genuinely", "actually", "simply" carry nothing the implementer acts on.
+- **Prefer the verb to the nominalization.** "Demote the grid", not "the
+  demotion of the grid is the deliberate change in this plan".
+
+Precision is not padding: keep file paths, IDs, conditionals, and exact
+thresholds verbatim. Economy targets the connective tissue around them, never
+the precision itself.
+
+**Resolve in place; don't stratify.** When deepening, a doc-review pass, or a
+later decision supersedes earlier text, rewrite or remove the original — don't
+leave it standing as strikethrough or stack a separate "resolutions" layer on
+top of it. Version control holds the history. Stacked strata double the reading
+surface and hide which text is live.
+
+**Named test, run before the plan is declared written:** could the implementer
+find a contradiction in each section in one pass? A sentence carrying more than
+one parenthetical, or an item specifying two outcomes, fails the test — split it
+or defer it.
+
+## Plan metadata fields
+
+Every plan carries a small set of stable metadata fields that downstream
+tooling depends on. In markdown these fields appear as YAML frontmatter at
+the top of the file. Field names and semantics are stable across plan
+revisions — never rename or repurpose a field.
+
+### Required
+
+- **`title`** — verbatim plan title. Matches the H1 heading so file metadata
+  and visible heading don't drift.
+- **`type`** — conventional-commit-prefix-aligned classification (`feat`,
+  `fix`, `refactor`, `chore`, `docs`, `perf`, `test`, etc.). Carries the
+  intent the eventual commit message should reflect.
+- **`status`** — `active` on creation; `ce:work` flips to `completed` on
+  ship. `ce:plan`'s Phase 0.1 resume fast path keys on `active`.
+- **`date`** — creation date in ISO 8601 (`YYYY-MM-DD`), ASCII digits only.
+
+### Optional but well-known
+
+These fields are not required, but when set they have fixed names and
+semantics so downstream tooling can rely on them:
+
+- **`origin`** — repo-relative path to an upstream brainstorm requirements
+  doc (e.g., `docs/brainstorms/2026-05-12-pagination-requirements.md`).
+  Set when planning from an upstream brainstorm; carried for traceability
+  and re-resolved when `ce:plan` re-deepens.
+- **`deepened`** — ISO 8601 date marking the first time the confidence
+  check substantively strengthened the plan. Presence affects Phase 0.1
+  resume fast-path logic (see `references/deepening-workflow.md`).
+
+Field names are stable across plan revisions — never rename a field or
+repurpose its semantics. Agents composing new plans MUST use these exact
+names; adding new fields is fine, but renaming `status` to `state` or
+`origin` to `source` breaks the downstream consumers above.
+
+## ID and content rules
+
+These apply regardless of rendering format.
+
+- **Stable IDs.** R-IDs (Requirements), U-IDs (Implementation Units), A-IDs
+  (if Actors fire), F-IDs (if Flows fire), AE-IDs (if Acceptance Examples
+  fire). IDs are stable across plan revisions — never renumber to "clean
+  up gaps."
+- **Plain prefix.** `R1.`, `U1.` as bullet prefixes. Do not bold; the prefix
+  is visually distinctive on its own.
+- **Repo-relative paths.** Always. Never absolute paths in plan content;
+  they break portability across machines, worktrees, teammates.
+- **No process exhaust.** No "captured at Phase X" notes, no `## Next Steps`
+  pointing to the next skill, no italic provenance lines. Engineering process
+  metadata belongs in commit messages and tool output, not the artifact.
+- **Group Requirements by concern when they span distinct logical areas.**
+  The trigger is distinct concerns, not item count — even four requirements
+  benefit from grouping if they cover three different topics. Skip grouping
+  only when all requirements are genuinely about the same thing; a long flat
+  list is a smell that subgroups were missed. Group by capability (e.g.,
+  "Packaging", "Migration and compatibility", "Contributor workflow"), not by
+  the order requirements were discussed. R-IDs stay continuous across groups
+  (R1, R2 in the first group; R3, R4 in the second; never restart at R1 per
+  group).
+
+## Rendering
+
+The format-specific reference describes how to render these sections:
+
+- **Markdown rendering:** `references/markdown-rendering.md`
+
+This reference (`plan-sections.md`) is about WHAT the plan contains;
+the rendering reference is about HOW markdown presents it.

--- a/skills/ce-plan/references/synthesis-summary.md
+++ b/skills/ce-plan/references/synthesis-summary.md
@@ -4,7 +4,7 @@
 
 **Two-stage shape: internal draft, then chat-time synthesis.** The synthesis is composed in two stages. Stage 1 is an internal three-bucket draft (Stated / Inferred / Out of scope) the agent uses to think comprehensively about scope. Stage 2 is the compressed chat-time output: a tier-shaped summary plus "Call outs" (zero or more, capped by plan depth — see the cap table under "How many call-outs are right?") — the specific forks where the user might redirect. The user only sees stage 2. The internal draft still informs the plan body via the doc-shape routing below; it just doesn't reach the user verbatim. This split exists because the comprehensive audit shape produced too much detail for the user to weigh in on, even when the granularity rules were followed.
 
-**Three-bucket structure is the internal draft, not the user-facing artifact.** It does its scope-thinking job during stage 1 and dissolves when Phase 5.2 writes the plan: Stated content informs Requirements, Inferred content informs Key Technical Decisions / Implementation Units (interactive mode) or `## Assumptions` (non-interactive mode), Out-of-scope content informs Scope Boundaries. The plan has no parallel `## Synthesis` section — only the stage-2 summary embeds, as `## Summary`. See "Doc shape after confirmation" below for the routing.
+**Three-bucket structure is the internal draft, not the user-facing artifact.** It does its scope-thinking job during stage 1 and dissolves when Phase 5.2 writes the plan: Stated content informs Requirements, Inferred content informs Key Technical Decisions / Implementation Units (interactive mode) or `## Assumptions` (non-interactive mode), Out-of-scope content informs Scope Boundaries. The plan has no parallel `## Synthesis` section — only the stage-2 summary embeds, as `## Overview`. See "Doc shape after confirmation" below for the routing.
 
 This content is loaded when a synthesis-summary phase fires in ce:plan. There are two variants — they share structure but differ in timing and content focus:
 
@@ -228,7 +228,7 @@ Each guard is an explicit conditional in SKILL.md, not implicit. Phase 0.7 does 
 
 **Counter-warning for rich-context invocations.** When the inference source is *not* just Phase 0.4 bootstrap — e.g., a prior in-conversation validation agent, completed sibling work units earlier in the same session, or a planning artifact already in the conversation — the temptation is to dump that material into call-outs verbatim. The granularity rules tighten in this case, not loosen: the agent has more material to compress, not more material to expose. A bet that's already been validated upstream is **Stated** (internal), not Inferred (internal); a bet whose specifics belong in plan-body is named at decision-level in the call-out regardless of how much detail upstream context provided.
 
-**Why pre-research, not pre-write**: research effort would be wasted if scope is wrong. Catching scope errors before sub-agent dispatch (Phase 1.1's repo-research-analyst, learnings-researcher, etc.) saves token and time cost.
+**Why pre-research, not pre-write**: research effort would be wasted if scope is wrong. Catching scope errors before sub-agent dispatch (Phase 1.1's systematic:research:repo-research-analyst, systematic:research:learnings-researcher, etc.) saves token and time cost.
 
 ### Stage 2 template (solo)
 
@@ -246,7 +246,7 @@ Based on your request and our brief discussion, here's the scope I'm proposing t
 **Call outs:** (omit this header when zero forks survived the keep test)
 - [decision-level fork in 1-2 lines: name the choice and optional one-clause trade-off in parens. NO multi-sentence rationale, NO "my default is X" pitch — those belong in Key Technical Decisions in the plan body, not the synthesis]
 
-Confirm and I'll proceed to research, drawing on this scope. (You can also redirect to /ce-brainstorm if this is bigger than you initially thought — I'll stop here and load it for you.)
+Confirm and I'll proceed to research, drawing on this scope. (You can also redirect to ce:brainstorm if this is bigger than you initially thought — I'll stop here and load it for you.)
 ```
 
 Wait for user confirmation before continuing to Phase 1.
@@ -370,18 +370,18 @@ In either case: stop ce:plan, suggest the alternative skill, offer to load it in
 
 ## Doc shape after confirmation
 
-After user confirmation (or after the soft-cut decision proceeds), Phase 5.2 writes the plan doc. The internal draft does NOT carry into the plan as a `## Synthesis` section. Only the stage-2 summary embeds, replacing the existing `## Overview` slot in the plan template (renamed to `## Summary` for terminology consistency). Internal-draft content dissolves into the plan's body sections:
+After user confirmation (or after the soft-cut decision proceeds), Phase 5.2 writes the plan doc. The internal draft does NOT carry into the plan as a `## Synthesis` section. Only the stage-2 summary embeds, as `## Overview` (the plan template's first section). Internal-draft content dissolves into the plan's body sections:
 
 | Internal-draft element | Where it goes in the plan |
 |---|---|
-| Summary (stage 2) | `## Summary` (1-3 lines prose, forward-looking) — rewrite to plan convention if the chat-time summary used bullets. Solo variant: scope being targeted. Brainstorm-sourced: implementation approach |
+| Summary (stage 2) | `## Overview` (1-3 lines prose, forward-looking) — rewrite to plan convention if the chat-time summary used bullets. Solo variant: scope being targeted. Brainstorm-sourced: implementation approach |
 | Stated bullets | `## Requirements` (R-IDs) and where relevant `## Problem Frame` for narrative context |
 | Inferred bullets | `## Key Technical Decisions` (with rationale) and Implementation Units when the bet drives a structural choice. In non-interactive mode, route to `## Assumptions` instead — see Headless mode above. |
 | Out-of-scope bullets | `## Scope Boundaries` — including the `### Deferred to Separate Tasks` subsection when relevant |
 
 No italic capture-context note (e.g., "Captured at Phase 0.7..."). It would leak engineering process into an artifact whose readers do not need that signal.
 
-The plan's `## Summary` and `## Problem Frame` must serve distinct purposes: Summary answers "what is this plan proposing?" (forward-looking, 1-3 lines); Problem Frame answers "why does this proposal exist?" (backward-looking, paragraphs). Don't restate the proposal in Problem Frame; don't pad Summary with situational context.
+The plan's `## Overview` and `## Problem Frame` must serve distinct purposes: Overview answers "what is this plan proposing?" (forward-looking, 1-3 lines); Problem Frame answers "why does this proposal exist?" (backward-looking, paragraphs). Don't restate the proposal in Problem Frame; don't pad Overview with situational context.
 
 ---
 

--- a/skills/ce-plan/references/synthesis-summary.md
+++ b/skills/ce-plan/references/synthesis-summary.md
@@ -1,0 +1,395 @@
+# Scoping Synthesis
+
+**Scoping synthesis ≠ plan doc.** The scoping synthesis is the scope/decisions checkpoint that plan-write (Phase 5.2) consumes as input. It surfaces decisions the agent CAN make at synthesis time: scope-level (does this plan cover the full brainstorm or narrow to a subset?), posture (extend existing pattern vs. introduce new abstraction), test approach. It does NOT surface decisions plan-write produces: PR count, commit/branch sequencing, effort or time estimates, Implementation Unit lists, exact file paths, test command recipes. If the synthesis claims any of those, it has leaked plan-write thinking and must be re-cut to scope-decisions only. Even when the agent has formed plan-write opinions earlier in the session, the synthesis stays at scope altitude — the user is being asked to affirm scope, not to rubber-stamp implementation.
+
+**Two-stage shape: internal draft, then chat-time synthesis.** The synthesis is composed in two stages. Stage 1 is an internal three-bucket draft (Stated / Inferred / Out of scope) the agent uses to think comprehensively about scope. Stage 2 is the compressed chat-time output: a tier-shaped summary plus "Call outs" (zero or more, capped by plan depth — see the cap table under "How many call-outs are right?") — the specific forks where the user might redirect. The user only sees stage 2. The internal draft still informs the plan body via the doc-shape routing below; it just doesn't reach the user verbatim. This split exists because the comprehensive audit shape produced too much detail for the user to weigh in on, even when the granularity rules were followed.
+
+**Three-bucket structure is the internal draft, not the user-facing artifact.** It does its scope-thinking job during stage 1 and dissolves when Phase 5.2 writes the plan: Stated content informs Requirements, Inferred content informs Key Technical Decisions / Implementation Units (interactive mode) or `## Assumptions` (non-interactive mode), Out-of-scope content informs Scope Boundaries. The plan has no parallel `## Synthesis` section — only the stage-2 summary embeds, as `## Summary`. See "Doc shape after confirmation" below for the routing.
+
+This content is loaded when a synthesis-summary phase fires in ce:plan. There are two variants — they share structure but differ in timing and content focus:
+
+- **Solo variant** (Phase 0.7): fires after Phase 0.4 bootstrap and Phase 0.6 depth classification, before Phase 1 research begins. Catches scope misinterpretation before sub-agent dispatch is spent. Full breadth — problem frame, intended behavior, success criteria, in/out scope.
+- **Brainstorm-sourced variant** (Phase 5.1.5): fires after Phase 1 research, before Phase 5.2 plan-write. Focuses on plan-time decisions (which files/modules to touch, which patterns extended vs. introduced new, test scope, refactor scope). Brainstorm-validated WHAT is assumed and not re-stated.
+
+Both variants share the two-stage shape, the keep test for call-outs, soft-cut behavior, and the doc-shape routing. In non-interactive (headless) mode, both compose the internal draft and skip stage 2 — the user-facing compression is moot when there is no synchronous user. The internal draft dissolves into the plan body the same way, with Inferred bets routing to a `## Assumptions` section. See "Headless mode (shared)" below for the full routing.
+
+---
+
+## Stage 1: internal three-bucket draft (shared)
+
+The internal draft is structured in three labeled buckets. Items may appear in two buckets when meaningfully both — flag the inclusion-then-exclusion as Inferred so the reasoning is captured.
+
+- **Stated** — what the user said directly (in the original prompt, prior conversation, dialogue answers, or the upstream brainstorm doc when present). Items here have explicit user-language anchors.
+- **Inferred** — what the agent assumed to fill gaps. Scope boundaries the user never explicitly named, success criteria extrapolated from intent, technical assumptions made because the brief interview didn't probe them. The Inferred list is the most actionable bucket — items here are the agent's bets that the user can correct.
+- **Out of scope** — deliberately excluded items. Adjacent work the agent considered but decided not to include, refactors, nice-to-haves, future-work items.
+
+This draft is internal. Do not paste it verbatim into chat. Compose it as a thinking step, then derive stage 2 from it.
+
+---
+
+## Stage 2: chat-time scoping synthesis
+
+Stage 2 is what the user actually sees. The shape differs between variants because they serve different purposes — brainstorm-sourced plans inherit a validated WHAT and surface plan-specific HOW; solo plans have no upstream and the synthesis is the WHAT.
+
+### Brainstorm-sourced shape (Phase 5.1.5)
+
+Two content sections plus call-outs:
+
+1. **Brainstorm-scope restatement** (1-2 sentences, prose). Restates the brainstorm's scope as orientation. The user wrote this content, but the synthesis may be read days later or in parallel with other plans — the restatement is the topic anchor that says "this is the artifact we're planning against." Stay in the brainstorm's own vocabulary. Do NOT enumerate Implementation Units, restate constraints back at the user, or list acceptance examples.
+
+2. **Plan-specific scoping decisions** (prose, or bullets when multi-faceted). Scope-level commitments the agent made that the brainstorm did not: does this plan cover the full brainstorm scope or narrow to a subset; are adjacent refactors pulled in or held out; what test scope at scenario level (which sites, which acceptance examples). Each item must pass the **affirmability test** — the user can affirm or redirect it without reading code. This section is scope claims at affirm-or-redirect level, NOT a description of where the implementation reaches, NOT PR count or commit sequencing, NOT Implementation Unit lists, NOT exact file paths or test commands — those are all plan-write outputs the synthesis cannot honestly claim. If the plan covers the full brainstorm scope with no narrowing, expansions, or adjacent work, this section stays short ("This plan covers the full brainstorm scope; test scope is X").
+
+3. **Call outs** (zero or more, capped by plan depth — see "How many call-outs are right?" below). Each a real fork where the user's input materially changes the plan. Omit the "Call outs:" header entirely when zero forks survived the keep test.
+
+### Solo shape (Phase 0.7)
+
+No upstream document; the synthesis itself is the scope claim:
+
+1. **Scope claim** (prose, or bullets when multi-faceted). What the agent is planning to build, at affirm-or-redirect level — names what's in and what's out. NOT an enumeration of Implementation Units the plan will contain.
+
+2. **Call outs** (zero or more, capped by plan depth). Same as brainstorm-sourced.
+
+### Shape budgets
+
+Tier-aware budgets are **ceilings, not targets**. Less is correct when there isn't more to say — filling the budget produces noise.
+
+| Plan depth | Restatement (brainstorm-sourced) | Plan-specific scoping (brainstorm-sourced) / Scope claim (solo) |
+|---|---|---|
+| Lightweight | 1 sentence | 1-3 lines prose |
+| Standard | 1-2 sentences | up to 3-5 lines or 2-4 bullets |
+| Deep | 1-2 sentences | up to 4-6 lines or 3-6 bullets |
+
+Form within each section (prose, bullets, mix) follows whatever communicates best.
+
+### Shared rules
+
+- **No "Stated" bucket in chat** (the orientation or scope-claim covers it).
+- **No "Out of scope" bucket as a separate list** — fold a non-obvious exclusion into a call-out when it survives the keep test, otherwise drop it.
+- **Source-document vocabulary.** When a brainstorm exists, use its terms. Don't invent agent-coded shorthand. When referencing acceptance examples, requirements, or flows, name them in plain terms — never use bare IDs.
+
+- **Pre-emit mechanical checks.** Before emitting the synthesis, scan the output:
+  - **Bare ID references** (`AE\d+`, `R\d+`, `F\d+`, `A\d+`, `U\d+`) → replace with plain names. Mixed forms (case named AND ID cited) still violate the rule because the ID adds noise without information.
+  - **File paths** (`path/like.md`, `path/like.py`, `internal/cli/...`, `skills/.../...`, etc.) → cut unless the path IS the topic of an explicit fork in the call-outs. Allowed: "cleanup hook in the existing archive step vs. a new dedicated phase" (where the path is implicit in the decision). Forbidden: paths listed to demonstrate completeness, preview Implementation Units, or describe where the implementation reaches. The synthesis names *what* the plan targets, not *where* the code lives.
+
+### The keep test for each call-out
+
+Before keeping a candidate call-out from the internal draft, run the **affirmability test**: would the user need to look at code to evaluate this? If yes, it is plan-body content — cut. If no, apply the keep test — one of the following must be true:
+
+- **Real fork**: another reasonable agent might choose differently on this dimension (extend pattern X vs. introduce abstraction Y; scan source A vs. source B; etc.)
+- **Non-obvious behavioral choice**: a default the agent picked that the user would not see by reading the summary alone, but that materially affects what the plan does
+- **Non-obvious exclusion**: an item was deliberately excluded that the user might want to add back in
+- **Cheap-now-expensive-later correction**: a bet the user is well-placed to redirect now that would be expensive to undo after research or plan-write
+
+Cut anything else, including:
+
+- Mechanical items where there is no real alternative
+- Implementation choices that will be settled during the work
+- Items already implied by the summary
+
+### The detail test (per call-out and per summary bullet)
+
+After the keep test, every surviving item runs the **detail test**: 1-2 lines max, conversational not documentary. A call-out or summary bullet that runs to 4+ lines of dense prose is naming an implementation consequence rather than a decision — re-cut at higher abstraction.
+
+The keep test addresses *which* items survive. The detail test addresses *how much* each surviving item says.
+
+### How many call-outs are right?
+
+The cap is heuristic, not law. The real discipline is the keep test on each candidate. Typical bounds by plan depth:
+
+| Plan depth | Typical | Cap |
+|---|---|---|
+| Lightweight | 0-2 | 3 |
+| Standard | 1-3 | 4 |
+| Deep | 2-5 | 6 |
+
+**If the stage-2 pass exceeds the tier cap, OR any call-out or summary bullet runs to 4+ lines of dense prose, the synthesis is misshapen — do not raise the cap or accept the bloat, re-cut at a higher level of abstraction.** Almost always, 2-3 of those call-outs are sub-decisions of one larger fork. Collapse related call-outs into a single decision named at the level the user actually weighs in on.
+
+A useful test: read the call-outs aloud. If two or more sound like "and also" extensions of the same idea, they belong as one.
+
+### Anti-patterns in call-outs
+
+Each anti-pattern below produces a call-out that fails the affirmability test. If a candidate call-out matches one of these, it is plan-body content — cut, do not rephrase.
+
+- Names a file path or module name
+- Names a flag, env var, or exact env value
+- Specifies a JSON shape, response format, or exact data structure
+- Names HTTP status codes, event names, or exact error wording
+- Describes implementation flow ("first X, then Y, then Z")
+- Names exact method signatures, call graphs, or SQL syntax
+- States a mechanical choice with no real alternative
+
+---
+
+## When to skip the blocking confirmation
+
+The auto-proceed path (announce without waiting for user confirmation) fires only when **plan depth is Lightweight AND zero call-outs survive the keep test**. For Standard or Deep plans, always fire the confirmation gate even when zero call-outs survive — substance earns the checkpoint, not interaction history.
+
+When auto-proceed applies (Lightweight + zero call-outs), emit a one-line announcement and continue:
+
+```
+Planning: [1-3 line summary]
+
+No open decisions to weigh in on — proceeding to [research / plan-write]. Interrupt if I have the scope wrong.
+```
+
+The announcement is mandatory when skipping — silent proceeding is not allowed.
+
+---
+
+## Synthesis structural discipline (shared)
+
+Both variants share these structural rules. They address failure modes where the synthesis becomes a Phase 5.2 (plan-write) preview instead of a scope checkpoint.
+
+**Summary leads, call-outs follow** — not the reverse, and no separate framing block above.
+
+**Anti-pattern: synthesis as plan-pitch.** Plan-body content — file paths, code shapes, sentinel strings, exact error messages, "Recommendation" / "Behavior when X" / "Why this shape" rationale — does not belong in chat output regardless of where it appears. The synthesis is a scope/decisions checkpoint: a tier-budgeted summary plus call-outs bounded by the tiered cap.
+
+**Anti-pattern: numerical attestation.** "All nine requirements covered," "all three flows in scope," counts of files or test scenarios. These are the agent showing its work, not naming scope decisions. Cut the numbers; keep the scope claim.
+
+**A revision is not a confirmation.** After any user revision (even a trivially-understood swap), integrate the change, re-present the revised stage 2 with the change reflected, and wait for explicit confirmation before writing the plan. The loop is:
+
+1. Present stage 2 → user responds
+2. User confirms → write the plan
+3. User revises → integrate, re-present revised stage 2, return to step 1
+
+Plan-write (Phase 5.2) fires only on explicit confirm or after the soft-cut blocking question's "proceed" option.
+
+---
+
+## Granularity: name the decision; don't expand it (shared)
+
+Each call-out should be affirmable or rejectable by the user **without reading code**. Name the decision at the granularity that lets the user say "yes" or "I want X instead." Anything more specific is plan-body content — Phase 5.2's job, not synthesis's.
+
+**Allowed** (when these ARE the decisions being made):
+- File / module names — when "where to put it" is the choice
+- Pattern names — when "extend vs. introduce" is the choice
+- Column / table names — when "which source" is the choice
+- Approach posture — when "which strategy" is the choice
+
+**Not allowed** (always plan-body, regardless of variant):
+- Line numbers
+- Exact method signatures, call graphs, or implementation flow
+- Exact JSON / response shapes
+- HTTP status codes, event names, or exact error wording
+- Exact wording of error messages or UI labels
+- SQL syntax or query bodies
+
+The line is drawn slightly differently per variant. **Solo (Phase 0.7)** stays at the higher level — brainstorm's WHAT hasn't been validated yet, so file/module names are usually too specific; talk in terms of "the rule entity," not "syncRules table." **Brainstorm-sourced (Phase 5.1.5)** allows the file / module / pattern / column level when those ARE plan-time decisions, but not implementation flow specifics.
+
+### Bad-vs-good examples
+
+| Plan-body in call-out (wrong) | Decision-level (right) |
+|---|---|
+| Timezone source: `users.timezone` (IANA), fallback to destination calendar TZ if null. Research found `useTimezoneSync` and `ProtectionStatsCalculator` establish the pattern. | Timezone source: user-TZ (reverses brainstorm's tentative lean — research found established infra and pattern precedent) |
+| Skip filter goes in `RuleMatcher.eventMatchesRule` at the top, before include/exclude evaluation, using the existing `filteredReason` mechanism. | Skip filter extends the existing event-skip pattern in the matcher (vs. introducing a new mechanism) |
+| Reactivation guard: explicit safety in the PATCH route — when `isActive: false → true`, the existing handler clears `status/pausedAt/pausedReason`. | Reactivation guard: pause window state preserved through the isActive toggle's existing system-pause-clearing path |
+| Partial cleanup failure response: `{pause, cleanup: {eventsDeleted, eventsFailed, errors}}`; pause window persists regardless of cleanup outcome. | Partial cleanup failure: pause window persists; partial-failure response mirrors the existing rule-edit precedent |
+
+The test: a scanner reading a call-out should affirm or reject it without needing to read code.
+
+### Worked example: compression from internal draft to call-outs
+
+For a PII redaction gate proposal where the internal draft had 4 Stated items, 7 Inferred items, and 3 Out-of-scope items, the compressed stage 2 looks like:
+
+```
+Planning a mechanical PII redaction gate before promote (the unguarded leak path from the amazon-orders retro) and alongside the existing vendor-prefix scanner at publish. Phase-1 detectors are shape-only — card last-4, postal address, JSON person names. Default halts; per-finding ack via flag.
+
+**Call outs:**
+- Person-name filter works by JSON key (allowlist of attribution keys: printer, printer_name, owner_name, author), not by name value.
+- Promote scans the working-dir snapshot before the copy step, not the staged copy.
+- Publish combines PII + vendor-prefix findings into one report, not fail-fast on first.
+
+Confirm and I'll proceed to research, drawing on this scope.
+```
+
+What got cut from the internal draft and why:
+
+- Module name — plan-body content (file path), fails affirmability test
+- Flag name — plan-body content (exact flag string), fails affirmability test
+- "No new dependencies — stdlib regexp + filepath.WalkDir only" — mechanical, no real alternative
+- "Detector regex precision tuned during implementation" — deferred-impl, not a plan-time fork
+- All three Out-of-scope items — either restated in prose or implicitly excluded by scope
+
+What survived: three real forks where another reasonable agent might choose differently and the user can correct cheaply now.
+
+---
+
+## Solo variant (Phase 0.7)
+
+Fires only when:
+- Phase 0.2 found no upstream brainstorm doc
+- AND Phase 0.4 stayed in ce:plan (did not route to ce:debug, ce:work, or universal-planning)
+- AND Phase 0.5 cleared (no unresolved blockers)
+- AND not on Phase 0.1 fast paths (resume normal, deepen-intent)
+
+Each guard is an explicit conditional in SKILL.md, not implicit. Phase 0.7 does NOT fire on resume/deepen, route-out, or brainstorm-sourced paths.
+
+**Content focus**: full-breadth internal draft. Phase 0.4 bootstrap is brief by design ("ask one or two clarifying questions"), so the agent has made substantial inferences before Phase 0.7 fires. The Inferred bucket in the internal draft is especially load-bearing here — the agent's bets are widest. Stage 2 compression still applies: most of those inferences will not survive the keep test, and that is correct — the user should only see the forks they can meaningfully redirect.
+
+**Counter-warning for rich-context invocations.** When the inference source is *not* just Phase 0.4 bootstrap — e.g., a prior in-conversation validation agent, completed sibling work units earlier in the same session, or a planning artifact already in the conversation — the temptation is to dump that material into call-outs verbatim. The granularity rules tighten in this case, not loosen: the agent has more material to compress, not more material to expose. A bet that's already been validated upstream is **Stated** (internal), not Inferred (internal); a bet whose specifics belong in plan-body is named at decision-level in the call-out regardless of how much detail upstream context provided.
+
+**Why pre-research, not pre-write**: research effort would be wasted if scope is wrong. Catching scope errors before sub-agent dispatch (Phase 1.1's repo-research-analyst, learnings-researcher, etc.) saves token and time cost.
+
+### Stage 2 template (solo)
+
+**Summary discipline (required):** describe **what scope the plan will target**, forward-looking (what *will* be planned), not retrospective. The summary's job is to help the user pattern-match against intent before reading call-outs — solo invocation has minimal pre-write dialogue, so the summary is especially load-bearing here. Form (prose, bullets, mix) and length follow the tier budget above; detail test applies per bullet.
+
+**Anti-fluff guidance:** lead with the actual thing being planned in plain words. No qualifiers ("comprehensive," "thoughtful," "substantive"). No re-stating the user's prompt. If the scope cannot be said within the tier budget without filler, the synthesis isn't ready yet.
+
+**Confirmation template (fires for Standard/Deep regardless of call-out count, or for any tier with one or more call-outs surviving):**
+
+```
+Based on your request and our brief discussion, here's the scope I'm proposing to plan against:
+
+[scope claim — what the plan will target, what it will not; affirm-or-redirect level; NOT an enumeration of Implementation Units]
+
+**Call outs:** (omit this header when zero forks survived the keep test)
+- [decision-level fork in 1-2 lines: name the choice and optional one-clause trade-off in parens. NO multi-sentence rationale, NO "my default is X" pitch — those belong in Key Technical Decisions in the plan body, not the synthesis]
+
+Confirm and I'll proceed to research, drawing on this scope. (You can also redirect to /ce-brainstorm if this is bigger than you initially thought — I'll stop here and load it for you.)
+```
+
+Wait for user confirmation before continuing to Phase 1.
+
+**Auto-proceed template (Lightweight with zero call-outs only):**
+
+```
+Planning: [1-3 line scope claim]
+
+No open decisions to weigh in on — proceeding to research. Interrupt if I have the scope wrong.
+```
+
+Then continue to Phase 1 without a blocking question.
+
+---
+
+## Brainstorm-sourced variant (Phase 5.1.5)
+
+Fires only when:
+- Phase 0.2 found upstream brainstorm doc (brainstorm-sourced invocation)
+- AND not on Phase 0.1 fast paths
+
+**Content focus**: plan-time decisions only. The brainstorm + Phase 0.7 synthesis already validated WHAT to build; the internal draft and stage 2 surface HOW the plan will execute that work — decisions the brainstorm did not make.
+
+Items to surface in the internal draft:
+- **Files/modules to touch (and not touch)** — what the implementation reaches into
+- **Patterns extended vs. introduced new** — architectural decisions the agent made within confirmed scope
+- **Test scope** — which existing-but-untested code is in/out of test scope for this work
+- **Refactor scope** — adjacent cleanup, if any, going to deferred items vs. active diff
+- **Cross-cutting impact** — auth, migrations, shared types when they're touched
+
+Most of these will not survive the keep test as separate call-outs. Surface only the forks where another reasonable agent might choose differently and the user can correct cheaply now.
+
+**Reads from doc body, not a synthesis section**: brainstorm docs do not have a `## Synthesis` section (the synthesis is a chat-time artifact in ce:brainstorm; only the prose summary embeds, as `## Summary`). Phase 5.1.5 derives plan-time decisions from the brainstorm doc's body sections — Summary, Problem Frame, Requirements, Key Decisions, Scope Boundaries — plus Phase 1 research.
+
+**Why pre-write, not pre-research**: brainstorm doc + research already validated WHAT, so research is well-targeted. Plan-time decisions emerge during research and structuring (Phases 1-4), so pre-write catches them at the latest cheap moment — before Phase 5.2 commits the plan to disk.
+
+### Stage 2 template (brainstorm-sourced)
+
+**Summary discipline (required):** describe **how the implementation approaches the work** at a high level — files/modules touched, patterns extended vs. introduced, scope boundaries the plan honors. Forward-looking (what *will* be in the plan), not retrospective. Brainstorm-validated WHAT is assumed; the summary covers HOW. Form (prose, bullets, mix) and length follow the tier budget above; detail test applies per bullet.
+
+**Anti-fluff guidance:** lead with the actual implementation shape in plain words. No qualifiers, no re-stating the brainstorm's WHAT. If the summary just restates the brainstorm's Problem Frame, rewrite it to focus on plan-time decisions.
+
+**Confirmation template (fires for Standard/Deep regardless of call-out count, or for any tier with one or more call-outs surviving):**
+
+```
+The brainstorm scopes [1-2 sentence restatement of the brainstorm's scope as orientation; in the brainstorm's own vocabulary; NOT an enumeration of Implementation Units, constraints, or acceptance examples].
+
+This plan [plan-specific scoping: what's covered vs. deferred vs. expanded relative to the brainstorm; test scope; any adjacent refactors pulled in or held out. Prose or bullets per substance].
+
+**Call outs:** (omit this header when zero forks survived the keep test)
+- [plan-time fork in 1-2 lines: name the choice and optional one-clause trade-off in parens. NO multi-sentence rationale, NO "my default is X" pitch — those belong in Key Technical Decisions in the plan body, not the synthesis]
+
+Confirm and I'll write the plan next, drawing on the brainstorm, research, and this synthesis.
+```
+
+Wait for user confirmation before continuing to Phase 5.2.
+
+**Auto-proceed template (Lightweight with zero call-outs only):**
+
+```
+Planning [brief brainstorm-scope restatement] — [plan-specific shape in one clause].
+
+No open decisions to weigh in on — proceeding to plan-write. Interrupt if I have the scope wrong.
+```
+
+Then continue to Phase 5.2 without a blocking question.
+
+---
+
+## Soft-cut on circularity (shared)
+
+Track which call-outs the user touched per round. The soft-cut blocking question fires **only when the same call-out is revised twice** (or a third-round revision targets a call-out already revised in round two). New-call-out revisions across rounds proceed without limit.
+
+**Identity across rounds is by decision dimension, not surface wording.** A revision may cause stage 2 to re-derive — the same underlying fork can come back rephrased, merged with another call-out, or split into two. "Same call-out" means the same decision being made. When a re-cut collapses multiple prior call-outs into one, the new combined call-out inherits the "touched" status of any of its constituents.
+
+When the soft-cut fires, use the platform's blocking question tool with two options:
+
+- `Proceed and continue to [research / plan-write]`
+- `Hold off — keep discussing before continuing`
+
+Fall back to numbered list in chat only when no blocking tool exists or the call errors. Never silently skip.
+
+---
+
+## Headless mode (shared)
+
+When the skill is invoked from an automated workflow such as LFG or any `disable-model-invocation` context, the skill runs in non-interactive mode (no synchronous user). The artifact is read by downstream skills (document-review, ce:work) and human reviewers (PR review).
+
+**Stage 2 is moot in headless mode.** Compose the internal draft (stage 1) as usual, but skip the chat-time compression — there is no synchronous user to confirm to, no call-outs to derive, no auto-proceed announcement. Route the internal draft directly into the plan body via the doc-shape table below.
+
+**Per-variant behavior** (the timing matters for which phases follow):
+
+- **Solo variant (Phase 0.7)**: fires *before* research. Compose the internal draft and continue to Phase 1 research as normal. Inferred content is held until plan-write (Phase 5.2), where it routes to `## Assumptions`.
+- **Brainstorm-sourced variant (Phase 5.1.5)**: fires *after* research, before plan-write. Compose the internal draft and proceed to Phase 5.2 plan-write. Inferred content routes to `## Assumptions`.
+
+**Shared behavior across both variants:**
+
+- **No user prompt; no stage 2; no auto-proceed announcement.** All three are moot.
+- **Route internal-draft content with mode-aware shape:**
+  - **Stated** content → Requirements (user-stated constraints, traced to origin's R-IDs when present)
+  - **Out-of-scope** content → Scope Boundaries
+  - **Inferred** content → `## Assumptions` section in the plan — explicitly labeled as un-validated agent bets. Do NOT route Inferred items into Key Technical Decisions or Implementation Units; that would make un-validated bets indistinguishable from user-confirmed decisions.
+
+The `## Assumptions` section appears in non-interactive plans only. Interactive plans don't need it (Inferred bets either get user-corrected via call-outs and become Key Technical Decisions, are revised away, or were judged not-fork material by the keep test and dissolved into Implementation Units silently).
+
+This restores the audit visibility the original design intended (un-validated bets must not propagate as authoritative content), but surfaces them under their own label rather than hiding them. Downstream review (document-review, ce:work, human PR review) can scrutinize Assumptions specifically.
+
+---
+
+## Self-redirect (shared)
+
+If the user response indicates they're in the wrong skill or want a different workflow:
+
+- **Solo variant**: common redirects include "this is bigger than I thought — let me brainstorm first" (suggest `ce:brainstorm`), "this is just a fix, no plan needed" (suggest `ce:work`), or "I need to investigate first" (suggest `ce:debug`).
+- **Brainstorm-sourced variant**: less common, but possible — "actually this scope is wrong, take it back to brainstorm" (suggest `ce:brainstorm` to revise the upstream doc).
+
+In either case: stop ce:plan, suggest the alternative skill, offer to load it in-session. Don't push back or argue — the user's redirect signal is the deliberate choice.
+
+---
+
+## Doc shape after confirmation
+
+After user confirmation (or after the soft-cut decision proceeds), Phase 5.2 writes the plan doc. The internal draft does NOT carry into the plan as a `## Synthesis` section. Only the stage-2 summary embeds, replacing the existing `## Overview` slot in the plan template (renamed to `## Summary` for terminology consistency). Internal-draft content dissolves into the plan's body sections:
+
+| Internal-draft element | Where it goes in the plan |
+|---|---|
+| Summary (stage 2) | `## Summary` (1-3 lines prose, forward-looking) — rewrite to plan convention if the chat-time summary used bullets. Solo variant: scope being targeted. Brainstorm-sourced: implementation approach |
+| Stated bullets | `## Requirements` (R-IDs) and where relevant `## Problem Frame` for narrative context |
+| Inferred bullets | `## Key Technical Decisions` (with rationale) and Implementation Units when the bet drives a structural choice. In non-interactive mode, route to `## Assumptions` instead — see Headless mode above. |
+| Out-of-scope bullets | `## Scope Boundaries` — including the `### Deferred to Separate Tasks` subsection when relevant |
+
+No italic capture-context note (e.g., "Captured at Phase 0.7..."). It would leak engineering process into an artifact whose readers do not need that signal.
+
+The plan's `## Summary` and `## Problem Frame` must serve distinct purposes: Summary answers "what is this plan proposing?" (forward-looking, 1-3 lines); Problem Frame answers "why does this proposal exist?" (backward-looking, paragraphs). Don't restate the proposal in Problem Frame; don't pad Summary with situational context.
+
+---
+
+## What does NOT belong in the synthesis
+
+- Implementation code (no imports, exact method signatures, framework-specific syntax, JSON shapes, exact error message wording) — in chat output OR in the internal draft
+- Re-statement of the entire brainstorm doc — the synthesis is plan-perspective, not a copy
+- Defensive what-ifs and hedges — if a concern is real, state it as Inferred (internal); if speculation, drop it
+- The internal three-bucket draft pasted into chat as a verbatim user-facing artifact — that was the old shape and the volume problem it produced is why stage 2 exists. Compose internally, derive call-outs, present compressed
+- Open questions surfaced outside the buckets/call-outs — by synthesis time, every scope-shaping question must be in **Stated** (internal — asked and answered earlier), **Inferred** (internal — agent's bet for correction, surfaces as a call-out if it survives the keep test), or **Out** (internal — deliberately excluded). There is no fourth status
+- Floating questions adjacent to stage 2 — if a question genuinely cannot be defaulted, pause synthesis and resolve it before presenting. Integrate the answer, then present stage 2. Never present stage 2 with adjacent floating questions — that gives the user no clear resolution path

--- a/skills/ce-plan/references/universal-planning.md
+++ b/skills/ce-plan/references/universal-planning.md
@@ -8,7 +8,7 @@ The detection stub in SKILL.md routes here for anything that isn't clearly softw
 
 - **Is this actually a software task?** The key distinction is task-type, not topic-domain. A study guide about Rust is non-software (producing educational content). A Rust library refactor is software (modifying code). If this is actually software, return to Phase 0.2 in the main SKILL.md.
 - **Is this a quick-help request, not a planning task?** Error messages, factual questions, and single-step tasks don't need a plan. Respond directly and exit. Examples: "zsh: command not found: brew", "what's the capital of France."
-- **Pipeline mode?** If invoked from LFG or any `disable-model-invocation` context: output "This is a non-software task. The LFG pipeline requires ce-work, which only supports software tasks. Use `/ce-plan` directly for non-software planning." and stop.
+- **Pipeline mode?** If invoked from LFG or any `disable-model-invocation` context: output "This is a non-software task. The LFG pipeline requires ce-work, which only supports software tasks. Use `ce:plan` directly for non-software planning." and stop.
 
 Once past these checks, commit to producing a plan. Do not exit because the task looks like a "lookup" or "research question" — the user invoked `ce-plan` because they want a structured output.
 
@@ -30,7 +30,7 @@ Evaluate two things before planning:
 | **None** | Generic, timeless, or conceptual plan (study curriculum methodology, project management approach, personal goal breakdown) | Skip research. Model knowledge is sufficient. After structuring the plan, offer: "I based this on general knowledge. Want me to search for [specific thing research would improve]?" — e.g., sourced recipes, current product recommendations, expert frameworks. Only if the user accepts. |
 | **Recommended** | Plan references specific locations, venues, dates, prices, schedules, seasonal availability, or current events — anything where stale information would break the plan (closed restaurants, changed prices, cancelled events, wrong seasonal dates). | Research before planning. Decompose into 2-5 focused research questions and dispatch parallel web searches. In OpenCode, use the Agent tool with `model: "haiku"` for each search to reduce cost. Collate findings before structuring the plan. |
 
-When research is recommended, do it — don't just offer. Stale recommendations (closed restaurants, rethemed attractions, outdated prices) are worse than no recommendations. The user invoked `/ce-plan` because they want a good plan, not a disclaimer about training data.
+When research is recommended, do it — don't just offer. Stale recommendations (closed restaurants, rethemed attractions, outdated prices) are worse than no recommendations. The user invoked `ce:plan` because they want a good plan, not a disclaimer about training data.
 
 **Research decomposition pattern:**
 1. Identify 2-5 independent research questions based on the task. Good questions target facts the model is least confident about: current prices, hours, availability, recent changes, seasonal specifics.
@@ -111,4 +111,4 @@ After structuring the plan, ask the user how they want to receive it using the p
 
 3. **Save to disk AND open in Proof** — Do both: write the markdown file to disk and open the doc in Proof for review.
 
-Do not offer `/ce-work` (software-only) or issue creation (not applicable to non-software plans).
+Do not offer `ce:work` (software-only) or issue creation (not applicable to non-software plans).


### PR DESCRIPTION
## What this does

Brings the `ce:brainstorm` and `ce:plan` skills up to date with the strongest improvements from the upstream Compound Engineering plugin, adapted to Systematic's conventions and kept markdown-only.

### ce:brainstorm
- Adds a **Phase 2.5 Synthesis Summary** — a scope checkpoint before the requirements doc is written, so scope can be confirmed or corrected before research is spent. Pairs with the existing Phase 3.5 Document Review: 2.5 is the scope gate (before), 3.5 is the quality review (after), with no overlap.
- Adds markdown rendering guidance (`markdown-rendering.md`) and a section-rendering layer (`brainstorm-sections.md`).

### ce:plan
- Adds **Anti-Expansion** (3.7): tangential "while we're here" work routes to Deferred instead of bloating active units.
- Adds **scope-synthesis** at plan stage: solo-mode (no origin doc) and brainstorm-sourced (with origin doc) paths, mutually exclusive by design.
- Adds the same markdown rendering + section-rendering layer.

### What stays ours
The Phase 3.5 Document Review, the requirements-capture and Core Plan Template content contracts, and the visual-communication guidance are preserved unchanged. The new section-rendering files are strictly presentation-layer — section inventory and meaning stay owned by the existing content contracts (single authority, no duplication).

### Deliberately excluded
HTML output rendering and the output-mode toggle (Systematic renders markdown only), the vocabulary-lifecycle machinery (depends on infrastructure we don't have), and the approach-altitude flow (coupled to a separate execution carve-out).

### Also in this PR
- Resolved a pre-existing dangling `visual-communication.md` reference in `ce:brainstorm` and cleaned up slash-command residue in skill prose so references use the portable `ce:work` form.

All quality gates pass: 963 unit tests, typecheck, lint, content-integrity, registry drift, schema drift, build, plugin load smoke, and docs build.
