### PR TITLE
feat(agents): make agent mode explicit and gate-enforced

### DIFF
--- a/agents/design/design-implementation-reviewer.md
+++ b/agents/design/design-implementation-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: design-implementation-reviewer
 description: "Visually compares live UI implementation against Figma designs and provides detailed feedback on discrepancies. Use after writing or modifying HTML/CSS/React components to verify design fidelity."
+mode: subagent
 ---
 
 You are an expert UI/UX implementation reviewer specializing in ensuring pixel-perfect fidelity between Figma designs and live implementations. You have deep expertise in visual design principles, CSS, responsive design, and cross-browser compatibility.

--- a/agents/design/design-iterator.md
+++ b/agents/design/design-iterator.md
@@ -2,6 +2,7 @@
 name: design-iterator
 description: "Iteratively refines UI design through N screenshot-analyze-improve cycles. Use PROACTIVELY when design changes aren't coming together after 1-2 attempts, or when user requests iterative refinement."
 color: accent
+mode: subagent
 ---
 
 You are an expert UI/UX design iterator specializing in systematic, progressive refinement of web components. Your methodology combines visual analysis, competitor research, and incremental improvements to transform ordinary interfaces into polished, professional designs.

--- a/agents/design/figma-design-sync.md
+++ b/agents/design/figma-design-sync.md
@@ -2,6 +2,7 @@
 name: figma-design-sync
 description: "Detects and fixes visual differences between a web implementation and its Figma design. Use iteratively when syncing implementation to match Figma specs."
 color: accent
+mode: subagent
 ---
 
 You are an expert design-to-code synchronization specialist with deep expertise in visual design systems, web development, CSS/Tailwind styling, and automated quality assurance. Your mission is to ensure pixel-perfect alignment between Figma designs and their web implementations through systematic comparison, detailed analysis, and precise code adjustments.

--- a/agents/docs/ankane-readme-writer.md
+++ b/agents/docs/ankane-readme-writer.md
@@ -2,6 +2,7 @@
 name: ankane-readme-writer
 description: "Creates or updates README files following Ankane-style template for Ruby gems. Use when writing gem documentation with imperative voice, concise prose, and standard section ordering."
 color: info
+mode: subagent
 ---
 
 You are an expert Ruby gem documentation writer specializing in the Ankane-style README format. You have deep knowledge of Ruby ecosystem conventions and excel at creating clear, concise documentation that follows Andrew Kane's proven template structure.

--- a/agents/document-review/adversarial-document-reviewer.md
+++ b/agents/document-review/adversarial-document-reviewer.md
@@ -2,6 +2,7 @@
 name: adversarial-document-reviewer
 description: "Conditional document-review persona, selected when the document has >5 requirements or implementation units, makes significant architectural decisions, covers high-stakes domains, or proposes new abstractions. Challenges premises, surfaces unstated assumptions, and stress-tests decisions rather than evaluating document quality."
 tools: Read, Grep, Glob, Bash
+mode: subagent
 ---
 
 # Adversarial Reviewer

--- a/agents/document-review/coherence-reviewer.md
+++ b/agents/document-review/coherence-reviewer.md
@@ -2,6 +2,7 @@
 name: coherence-reviewer
 description: "Reviews planning documents for internal consistency -- contradictions between sections, terminology drift, structural issues, and ambiguity where readers would diverge. Spawned by the document-review skill."
 tools: Read, Grep, Glob, Bash
+mode: subagent
 ---
 
 You are a technical editor reading for internal consistency. You don't evaluate whether the plan is good, feasible, or complete -- other reviewers handle that. You catch when the document disagrees with itself.

--- a/agents/document-review/design-lens-reviewer.md
+++ b/agents/document-review/design-lens-reviewer.md
@@ -2,6 +2,7 @@
 name: design-lens-reviewer
 description: "Reviews planning documents for missing design decisions -- information architecture, interaction states, user flows, and AI slop risk. Uses dimensional rating to identify gaps. Spawned by the document-review skill."
 tools: Read, Grep, Glob, Bash
+mode: subagent
 ---
 
 You are a senior product designer reviewing plans for missing design decisions. Not visual design -- whether the plan accounts for decisions that will block or derail implementation. When plans skip these, implementers either block (waiting for answers) or guess (producing inconsistent UX).

--- a/agents/document-review/feasibility-reviewer.md
+++ b/agents/document-review/feasibility-reviewer.md
@@ -2,6 +2,7 @@
 name: feasibility-reviewer
 description: "Evaluates whether proposed technical approaches in planning documents will survive contact with reality -- architecture conflicts, dependency gaps, migration risks, and implementability. Spawned by the document-review skill."
 tools: Read, Grep, Glob, Bash
+mode: subagent
 ---
 
 You are a systems architect evaluating whether this plan can actually be built as described and whether an implementer could start working from it without making major architectural decisions the plan should have made.

--- a/agents/document-review/product-lens-reviewer.md
+++ b/agents/document-review/product-lens-reviewer.md
@@ -2,6 +2,7 @@
 name: product-lens-reviewer
 description: "Reviews planning documents as a senior product leader -- challenges premise claims, assesses strategic consequences (trajectory, identity, adoption, opportunity cost), and surfaces goal-work misalignment. Domain-agnostic: users may be end users, developers, operators, or any audience. Spawned by the document-review skill."
 tools: Read, Grep, Glob, Bash
+mode: subagent
 ---
 
 You are a senior product leader. The most common failure mode is building the wrong thing well. Challenge the premise before evaluating the execution.

--- a/agents/document-review/scope-guardian-reviewer.md
+++ b/agents/document-review/scope-guardian-reviewer.md
@@ -2,6 +2,7 @@
 name: scope-guardian-reviewer
 description: "Reviews planning documents for scope alignment and unjustified complexity -- challenges unnecessary abstractions, premature frameworks, and scope that exceeds stated goals. Spawned by the document-review skill."
 tools: Read, Grep, Glob, Bash
+mode: subagent
 ---
 
 You ask two questions about every plan: "Is this right-sized for its goals?" and "Does every abstraction earn its keep?" You are not reviewing whether the plan solves the right problem (product-lens) or is internally consistent (coherence-reviewer).

--- a/agents/document-review/security-lens-reviewer.md
+++ b/agents/document-review/security-lens-reviewer.md
@@ -2,6 +2,7 @@
 name: security-lens-reviewer
 description: "Evaluates planning documents for security gaps at the plan level -- auth/authz assumptions, data exposure risks, API surface vulnerabilities, and missing threat model elements. Spawned by the document-review skill."
 tools: Read, Grep, Glob, Bash
+mode: subagent
 ---
 
 You are a security architect evaluating whether this plan accounts for security at the planning level. Distinct from code-level security review -- you examine whether the plan makes security-relevant decisions and identifies its attack surface before implementation begins.

--- a/agents/research/best-practices-researcher.md
+++ b/agents/research/best-practices-researcher.md
@@ -1,6 +1,7 @@
 ---
 name: best-practices-researcher
 description: "Researches and synthesizes external best practices, documentation, and examples for any technology or framework. Use when you need industry standards, community conventions, or implementation guidance."
+mode: subagent
 ---
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and best practices.

--- a/agents/research/framework-docs-researcher.md
+++ b/agents/research/framework-docs-researcher.md
@@ -1,6 +1,7 @@
 ---
 name: framework-docs-researcher
 description: "Gathers comprehensive documentation and best practices for frameworks, libraries, or dependencies. Use when you need official docs, version-specific constraints, or implementation patterns."
+mode: subagent
 ---
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and version information.

--- a/agents/research/git-history-analyzer.md
+++ b/agents/research/git-history-analyzer.md
@@ -1,6 +1,7 @@
 ---
 name: git-history-analyzer
 description: "Performs archaeological analysis of git history to trace code evolution, identify contributors, and understand why code patterns exist. Use when you need historical context for code changes."
+mode: subagent
 ---
 
 **Note: The current year is 2026.** Use this when interpreting commit dates and recent changes.

--- a/agents/research/issue-intelligence-analyst.md
+++ b/agents/research/issue-intelligence-analyst.md
@@ -1,6 +1,7 @@
 ---
 name: issue-intelligence-analyst
 description: "Fetches and analyzes GitHub issues to surface recurring themes, pain patterns, and severity trends. Use when understanding a project's issue landscape, analyzing bug patterns for ideation, or summarizing what users are reporting."
+mode: subagent
 ---
 
 **Note: The current year is 2026.** Use this when evaluating issue recency and trends.

--- a/agents/research/learnings-researcher.md
+++ b/agents/research/learnings-researcher.md
@@ -1,6 +1,7 @@
 ---
 name: learnings-researcher
 description: "Searches docs/solutions/ for relevant past solutions by frontmatter metadata. Use before implementing features or fixing problems to surface institutional knowledge and prevent repeated mistakes."
+mode: subagent
 ---
 
 You are an expert institutional knowledge researcher specializing in efficiently surfacing relevant documented solutions from the team's knowledge base. Your mission is to find and distill applicable learnings before new work begins, preventing repeated mistakes and leveraging proven patterns.

--- a/agents/research/repo-research-analyst.md
+++ b/agents/research/repo-research-analyst.md
@@ -1,6 +1,7 @@
 ---
 name: repo-research-analyst
 description: "Conducts thorough research on repository structure, documentation, conventions, and implementation patterns. Use when onboarding to a new codebase or understanding project conventions."
+mode: subagent
 ---
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and patterns.

--- a/agents/research/slack-researcher.md
+++ b/agents/research/slack-researcher.md
@@ -1,6 +1,7 @@
 ---
 name: slack-researcher
 description: "Searches Slack for organizational context. Use when the user explicitly asks. Requires a Slack MCP server."
+mode: subagent
 ---
 **Note: The current year is 2026.** Use this when assessing the recency of Slack discussions.
 

--- a/agents/review/adversarial-reviewer.md
+++ b/agents/review/adversarial-reviewer.md
@@ -4,6 +4,7 @@ description: Conditional code-review persona, selected when the diff is large (>
 tools: Read, Grep, Glob, Bash
 color: error
 
+mode: subagent
 ---
 
 # Adversarial Reviewer

--- a/agents/review/agent-native-reviewer.md
+++ b/agents/review/agent-native-reviewer.md
@@ -3,6 +3,7 @@ name: agent-native-reviewer
 description: "Reviews code to ensure agent-native parity -- any action a user can take, an agent can also take. Use after adding UI features, agent tools, or system prompts."
 color: info
 tools: Read, Grep, Glob, Bash
+mode: subagent
 ---
 
 # Agent-Native Architecture Reviewer

--- a/agents/review/architecture-strategist.md
+++ b/agents/review/architecture-strategist.md
@@ -2,6 +2,7 @@
 name: architecture-strategist
 description: "Analyzes code changes from an architectural perspective for pattern compliance and design integrity. Use when reviewing PRs, adding services, or evaluating structural refactors."
 tools: Read, Grep, Glob, Bash
+mode: subagent
 ---
 
 You are a System Architecture Expert specializing in analyzing code changes and system design decisions. Your role is to ensure that all modifications align with established architectural patterns, maintain system integrity, and follow best practices for scalable, maintainable software systems.

--- a/agents/review/cli-agent-readiness-reviewer.md
+++ b/agents/review/cli-agent-readiness-reviewer.md
@@ -3,6 +3,7 @@ name: cli-agent-readiness-reviewer
 description: "Reviews CLI source code, plans, or specs for AI agent readiness using a severity-based rubric focused on whether a CLI is merely usable by agents or genuinely optimized for them."
 tools: Read, Grep, Glob, Bash
 color: warning
+mode: subagent
 ---
 
 # CLI Agent-Readiness Reviewer

--- a/agents/review/cli-readiness-reviewer.md
+++ b/agents/review/cli-readiness-reviewer.md
@@ -3,6 +3,7 @@ name: cli-readiness-reviewer
 description: "Conditional code-review persona, selected when the diff touches CLI command definitions, argument parsing, or command handler implementations. Reviews CLI code for agent readiness -- how well the CLI serves autonomous agents, not just human users."
 tools: Read, Grep, Glob, Bash
 color: info
+mode: subagent
 ---
 
 # CLI Agent-Readiness Reviewer

--- a/agents/review/code-simplicity-reviewer.md
+++ b/agents/review/code-simplicity-reviewer.md
@@ -2,6 +2,7 @@
 name: code-simplicity-reviewer
 description: "Final review pass to ensure code is as simple and minimal as possible. Use after implementation is complete to identify YAGNI violations and simplification opportunities."
 tools: Read, Grep, Glob, Bash
+mode: subagent
 ---
 
 You are a code simplicity expert specializing in minimalism and the YAGNI (You Aren't Gonna Need It) principle. Your mission is to ruthlessly simplify code while maintaining functionality and clarity.

--- a/agents/review/data-integrity-guardian.md
+++ b/agents/review/data-integrity-guardian.md
@@ -2,6 +2,7 @@
 name: data-integrity-guardian
 description: "Reviews database migrations, data models, and persistent data code for safety. Use when checking migration safety, data constraints, transaction boundaries, or privacy compliance."
 tools: Read, Grep, Glob, Bash
+mode: subagent
 ---
 
 You are a Data Integrity Guardian, an expert in database design, data migration safety, and data governance. Your deep expertise spans relational database theory, ACID properties, data privacy regulations (GDPR, CCPA), and production database management.

--- a/agents/review/data-migration-expert.md
+++ b/agents/review/data-migration-expert.md
@@ -2,6 +2,7 @@
 name: data-migration-expert
 description: "Validates data migrations, backfills, and production data transformations against reality. Use when PRs involve ID mappings, column renames, enum conversions, or schema changes."
 tools: Read, Grep, Glob, Bash
+mode: subagent
 ---
 
 You are a Data Migration Expert. Your mission is to prevent data corruption by validating that migrations match production reality, not fixture or assumed values.

--- a/agents/review/deployment-verification-agent.md
+++ b/agents/review/deployment-verification-agent.md
@@ -2,6 +2,7 @@
 name: deployment-verification-agent
 description: "Produces Go/No-Go deployment checklists with SQL verification queries, rollback procedures, and monitoring plans. Use when PRs touch production data, migrations, or risky data changes."
 tools: Read, Grep, Glob, Bash
+mode: subagent
 ---
 
 You are a Deployment Verification Agent. Your mission is to produce concrete, executable checklists for risky data deployments so engineers aren't guessing at launch time.

--- a/agents/review/pattern-recognition-specialist.md
+++ b/agents/review/pattern-recognition-specialist.md
@@ -2,6 +2,7 @@
 name: pattern-recognition-specialist
 description: "Analyzes code for design patterns, anti-patterns, naming conventions, and duplication. Use when checking codebase consistency or verifying new code follows established patterns."
 tools: Read, Grep, Glob, Bash
+mode: subagent
 ---
 
 You are a Code Pattern Analysis Expert specializing in identifying design patterns, anti-patterns, and code quality issues across codebases. Your expertise spans multiple programming languages with deep knowledge of software architecture principles and best practices.

--- a/agents/review/performance-oracle.md
+++ b/agents/review/performance-oracle.md
@@ -2,6 +2,7 @@
 name: performance-oracle
 description: "Analyzes code for performance bottlenecks, algorithmic complexity, database queries, memory usage, and scalability. Use after implementing features or when performance concerns arise."
 tools: Read, Grep, Glob, Bash
+mode: subagent
 ---
 
 You are the Performance Oracle, an elite performance optimization expert specializing in identifying and resolving performance bottlenecks in software systems. Your deep expertise spans algorithmic complexity analysis, database optimization, memory management, caching strategies, and system scalability.

--- a/agents/review/previous-comments-reviewer.md
+++ b/agents/review/previous-comments-reviewer.md
@@ -4,6 +4,7 @@ description: Conditional code-review persona, selected when reviewing a PR that 
 tools: Read, Grep, Glob, Bash
 color: warning
 
+mode: subagent
 ---
 
 # Previous Comments Reviewer

--- a/agents/review/project-standards-reviewer.md
+++ b/agents/review/project-standards-reviewer.md
@@ -4,6 +4,7 @@ description: Always-on code-review persona. Audits changes against the project's
 tools: Read, Grep, Glob, Bash
 color: info
 
+mode: subagent
 ---
 
 # Project Standards Reviewer

--- a/agents/review/schema-drift-detector.md
+++ b/agents/review/schema-drift-detector.md
@@ -2,6 +2,7 @@
 name: schema-drift-detector
 description: "Detects unrelated schema.rb changes in PRs by cross-referencing against included migrations. Use when reviewing PRs with database schema changes."
 tools: Read, Grep, Glob, Bash
+mode: subagent
 ---
 
 You are a Schema Drift Detector. Your mission is to prevent accidental inclusion of unrelated schema.rb changes in PRs - a common issue when developers run migrations from other branches.

--- a/agents/review/security-sentinel.md
+++ b/agents/review/security-sentinel.md
@@ -2,6 +2,7 @@
 name: security-sentinel
 description: "Performs security audits for vulnerabilities, input validation, auth/authz, hardcoded secrets, and OWASP compliance. Use when reviewing code for security issues or before deployment."
 tools: Read, Grep, Glob, Bash
+mode: subagent
 ---
 
 You are an elite Application Security Specialist with deep expertise in identifying and mitigating security vulnerabilities. You think like an attacker, constantly asking: Where are the vulnerabilities? What could go wrong? How could this be exploited?

--- a/agents/review/testing-reviewer.md
+++ b/agents/review/testing-reviewer.md
@@ -4,6 +4,7 @@ description: Always-on code-review persona. Reviews code for test coverage gaps,
 tools: Read, Grep, Glob, Bash
 color: info
 
+mode: subagent
 ---
 
 # Testing Reviewer

--- a/agents/workflow/pr-comment-resolver.md
+++ b/agents/workflow/pr-comment-resolver.md
@@ -2,6 +2,7 @@
 name: pr-comment-resolver
 description: "Evaluates and resolves one or more related PR review threads -- assesses validity, implements fixes, and returns structured summaries with reply text. Spawned by the resolve-pr-feedback skill."
 color: info
+mode: subagent
 ---
 
 You resolve PR review threads. You receive thread details -- one thread in standard mode, or multiple related threads with a cluster brief in cluster mode. Your job: evaluate whether the feedback is valid, fix it if so, and return structured summaries.

--- a/agents/workflow/spec-flow-analyzer.md
+++ b/agents/workflow/spec-flow-analyzer.md
@@ -1,6 +1,7 @@
 ---
 name: spec-flow-analyzer
 description: "Analyzes specifications and feature descriptions for user flow completeness and gap identification. Use when a spec, plan, or feature description needs flow analysis, edge case discovery, or requirements validation."
+mode: subagent
 ---
 
 Analyze specifications, plans, and feature descriptions from the end user's perspective. The goal is to surface missing flows, ambiguous requirements, and unspecified edge cases before implementation begins -- when they are cheapest to fix.

--- a/docs/plans/2026-06-05-003-feat-agent-mode-explicit-hardening-plan.md
+++ b/docs/plans/2026-06-05-003-feat-agent-mode-explicit-hardening-plan.md
@@ -69,7 +69,7 @@ The runtime converter (`src/lib/converter.ts`) injects `mode: subagent` as a fil
 
 ## Implementation Units
 
-- [ ] **Unit 1: Add explicit `mode: subagent` to the 36 agents**
+- [x] **Unit 1: Add explicit `mode: subagent` to the 36 agents**
 
 **Goal:** Every bundled agent declares an explicit `mode:` field; the 36 that relied on the converter default now state `mode: subagent`.
 
@@ -92,7 +92,7 @@ The runtime converter (`src/lib/converter.ts`) injects `mode: subagent` as a fil
 **Verification:**
 - Every agent entry declares an explicit `mode:` field (checked by the gate's agent-file predicate, not a broad `grep` over `agents/`).
 
-- [ ] **Unit 2: Enforce explicit agent mode in the content-integrity gate**
+- [x] **Unit 2: Enforce explicit agent mode in the content-integrity gate**
 
 **Goal:** A bundled agent missing an explicit `mode:` field fails content-integrity, locking in the hardening so future agents cannot regress to the converter default.
 
@@ -124,7 +124,7 @@ The runtime converter (`src/lib/converter.ts`) injects `mode: subagent` as a fil
 - The equivalence test proves explicit `mode: subagent` resolves identically to the converter-defaulted form.
 - Full unit suite green.
 
-- [ ] **Unit 3: Record the converter-injected-field audit as a v3.0.0 finding**
+- [x] **Unit 3: Record the converter-injected-field audit as a v3.0.0 finding**
 
 **Goal:** The converter-injected-field audit (especially the `temperature` heuristic) is documented precisely enough that the v3.0.0 plan can act on it without re-deriving it.
 

--- a/docs/plans/2026-06-05-003-feat-agent-mode-explicit-hardening-plan.md
+++ b/docs/plans/2026-06-05-003-feat-agent-mode-explicit-hardening-plan.md
@@ -1,0 +1,179 @@
+---
+title: "feat: Agent mode explicit hardening"
+type: feat
+status: active
+date: 2026-06-05
+origin: docs/brainstorms/2026-06-05-agent-mode-explicit-hardening-requirements.md
+---
+
+# feat: Agent mode explicit hardening
+
+## Overview
+
+Add explicit `mode: subagent` frontmatter to the 36 bundled agents that currently rely on the converter's implicit default, and enforce the invariant in the content-integrity gate. This is a zero-runtime-behavior-change v2.x hardening patch that removes a hidden converter dependency and de-risks the eventual v3.0.0 converter removal. The plan also records a precise converter-injected-field audit as a v3.0.0 finding.
+
+## Problem Frame
+
+The runtime converter (`src/lib/converter.ts`) injects `mode: subagent` as a fill-if-absent default for every bundled agent at load time. 15 of 51 bundled agents declare `mode: subagent` explicitly; the other 36 resolve to `subagent` only because the converter fills it (`transformAgentFrontmatter`: `result.mode = isAgentMode(data.mode) ? data.mode : agentMode`, with `agentMode: 'subagent'` passed from `config-handler.ts`). The v3.0.0 initiative removes the converter; doing so without first making `mode` explicit would let those 36 agents fall back to OpenCode's native default (`all`), making internal review/research/design agents primary-visible — a regression. Making `mode` explicit is behavior-preserving today and severs the converter dependency for v3.0.0. (see origin: docs/brainstorms/2026-06-05-agent-mode-explicit-hardening-requirements.md)
+
+## Requirements Trace
+
+**Implementation hardening (ships now):**
+- R1. Add explicit `mode: subagent` to the 36 bundled agents that lack it; all 51 declare an explicit `mode:`.
+- R2. Enforce explicit agent `mode` in the content-integrity gate, with unit coverage.
+
+**Deferred documentation (tracked finding, no behavior change):**
+- R3. Record the converter-injected-field audit (especially the `temperature` heuristic) as a v3.0.0 finding, in a tracked artifact (this plan's audit table).
+
+## Scope Boundaries
+
+- Not touching `src/lib/converter.ts` — converter removal is v3.0.0 work.
+- Not hardening `temperature`/`steps`/`tools`/`permission`/`hidden` values — verified and documented as a v3.0.0 finding (R3), no values added here.
+- Not changing any agent's runtime behavior — the converter already resolves these 36 to `subagent`, so making it explicit is a no-op at runtime today.
+- This patch does NOT make Systematic v3.0.0-ready; `temperature` (computed for every agent) remains an open converter dependency.
+
+### Deferred to Separate Tasks
+
+- Hardening `temperature` and the other converter-injected fields: v3.0.0 converter-removal work, tracked via R3 + the parent v3 brainstorm (`docs/brainstorms/2026-05-21-v3-converter-removal-and-excision-requirements.md`).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/content-integrity.ts` — `checkAgentModel` (line ~952) is the exact pattern R2 mirrors: iterates `targets.markdown`, gates on `isAgentFile(relPath)`, checks a frontmatter field, returns violations. `checkAgentColors`/`checkAgentStemUniqueness` are sibling examples. Wired into `main()` alongside `agentModelViolations`/`agentColorViolations` (line ~1124).
+- `src/lib/agents.ts` — `extractAgentFrontmatter` / `AgentFrontmatter` (the `mode` field already typed as `'subagent' | 'primary' | 'all'`).
+- `tests/unit/content-integrity.test.ts` — existing `checkAgentModel`/`checkAgentColors` test blocks are the pattern for R2's coverage.
+
+### Institutional Learnings
+
+- Adding a runtime/gate invariant: mirror the rule in the content-integrity gate so an asset cannot pass CI while violating the contract (the gate is the durable enforcement surface, not the data alone).
+
+## Key Technical Decisions
+
+- **R1 is purely additive** — only the `mode: subagent` line is added to each of the 36 files; no other frontmatter touched. The 15 agents already declaring `mode` are untouched.
+- **R2 mirrors `checkAgentModel`** — new `checkAgentMode` function using the same `isAgentFile` predicate and `main()` wiring, rather than overloading the existing model check. Keeps each invariant a discrete, clearly-messaged rule.
+- **R2 requires `mode: subagent` specifically** for bundled agents (not just any `mode`), matching the converter's prior default and the actual bundle (all 51 are subagents). A future intentionally-primary bundled agent would be a deliberate gate change, not an accident.
+- **R3 is documentation-only** — the field audit lands as a tracked finding for the v3.0.0 plan, not scope creep here.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Where does R2 plug in? — A new `checkAgentMode` mirroring `checkAgentModel`, wired into `main()` and the violation reporting, using `isAgentFile`.
+- Which files need R1? — The 36 enumerated via the gate's agent-file predicate (all under `agents/<category>/`), verified against the 15/36/51 split.
+- How is "zero behavior change" verified? — Resolved-value equivalence (parsed config identical), not byte-identical emitted strings, because the converter still runs and may reorder YAML keys.
+
+### Deferred to Implementation
+
+- Exact violation message wording for `checkAgentMode` — settle during implementation, matching the tone of the existing `checkAgentModel` message.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add explicit `mode: subagent` to the 36 agents**
+
+**Goal:** Every bundled agent declares an explicit `mode:` field; the 36 that relied on the converter default now state `mode: subagent`.
+
+**Requirements:** R1
+
+**Dependencies:** None
+
+**Files:**
+- Modify: the 36 agent markdown files under `agents/research/`, `agents/design/`, `agents/document-review/`, `agents/docs/`, `agents/review/`, `agents/workflow/` that lack `mode:` (enumerate via the gate's agent-file predicate; do not touch the 15 that already declare it).
+
+**Approach:**
+- Insert `mode: subagent` into each file's YAML frontmatter (consistent placement, e.g., after `description`). Additive only — no other field changes.
+
+**Patterns to follow:**
+- The 15 agents already declaring `mode: subagent` — match their frontmatter placement/style.
+
+**Test scenarios:**
+- Test expectation: none — pure frontmatter data addition, no behavioral change. The zero-behavior-change claim is mechanically enforced by Unit 2's equivalence test.
+
+**Verification:**
+- Every agent entry declares an explicit `mode:` field (checked by the gate's agent-file predicate, not a broad `grep` over `agents/`).
+
+- [ ] **Unit 2: Enforce explicit agent mode in the content-integrity gate**
+
+**Goal:** A bundled agent missing an explicit `mode:` field fails content-integrity, locking in the hardening so future agents cannot regress to the converter default.
+
+**Requirements:** R2
+
+**Dependencies:** Unit 1 (gate must pass on the hardened tree). Land both units in one PR so CI never sees the gate active against an un-hardened tree.
+
+**Files:**
+- Modify: `scripts/content-integrity.ts` (add `checkAgentMode`, wire into `main()` + violation reporting)
+- Test: `tests/unit/content-integrity.test.ts`
+
+**Approach:**
+- Add `checkAgentMode(rootDir, targets.markdown)` mirroring `checkAgentModel`: iterate markdown targets, skip non-agent files via `isAgentFile`, parse frontmatter, flag any agent whose `mode` is absent or not `subagent`. Wire its violations into `main()` alongside the existing agent-check aggregation and the stderr reporting block.
+
+**Execution note:** Implement test-first — add the failing fixture-agent test before the gate function.
+
+**Patterns to follow:**
+- `checkAgentModel` / `checkAgentColors` in `scripts/content-integrity.ts` and their test blocks in `tests/unit/content-integrity.test.ts`.
+
+**Test scenarios:**
+- Happy path: hardened tree (all agents declare `mode: subagent`) → zero mode violations.
+- Error path: fixture agent with no `mode:` field → one violation with a clear message.
+- Error path: fixture agent with `mode:` set to a non-`subagent` value (e.g., `all`) → one violation.
+- Edge case: non-agent markdown under `agents/` (e.g., a template/README, if any) → not flagged (gated by `isAgentFile`).
+- Integration (equivalence — enforces Unit 1's zero-behavior-change claim): convert a fixture agent with NO `mode` using `agentMode: 'subagent'`, then convert the same fixture with explicit `mode: subagent`; parse both emitted configs and assert resolved-value equality (the explicit form must produce the same resolved `mode` and every other field).
+
+**Verification:**
+- Content-integrity passes on the hardened tree and fails on a fixture agent missing/with-wrong `mode:`.
+- The equivalence test proves explicit `mode: subagent` resolves identically to the converter-defaulted form.
+- Full unit suite green.
+
+- [ ] **Unit 3: Record the converter-injected-field audit as a v3.0.0 finding**
+
+**Goal:** The converter-injected-field audit (especially the `temperature` heuristic) is documented precisely enough that the v3.0.0 plan can act on it without re-deriving it.
+
+**Requirements:** R3
+
+**Dependencies:** None (documentation)
+
+**Files:**
+- Modify: this plan (the audit table below travels with the PR) and/or `docs/solutions/` — a **tracked** artifact. Do NOT record the audit solely in `docs/brainstorms/` (gitignored — it would not travel with the repo and the v3.0.0 work would lose the finding). Optionally mirror into the v3 brainstorm for local continuity.
+
+**Approach:**
+- Record the verified converter behavior per field in this tracked plan (and/or a `docs/solutions/` doc): `mode` resolved by this patch; `temperature` always computed via `inferTemperature`, HIGH risk; `description`/`steps`/`tools`/`permission`/`hidden` per the audit. Note the "not v3.0.0-ready until temperature hardened" boundary so the v3.0.0 plan inherits it. The Converter-Injected-Field Audit table is recorded directly in this plan (below) so it is captured in a tracked artifact regardless of brainstorm state.
+
+**Test scenarios:**
+- Test expectation: none — documentation only.
+
+**Verification:**
+- The v3.0.0 plan/brainstorm contains the field audit; content-integrity passes (no broken refs).
+
+## System-Wide Impact
+
+- **Interaction graph:** Only the converter's mode-fill path is affected conceptually; at runtime nothing changes because the converter already resolves these agents to `subagent`. The gate gains one new agent-frontmatter check.
+- **API surface parity:** No public API change. The bundled-agent frontmatter contract gains an explicit `mode` requirement enforced by CI.
+- **Unchanged invariants:** All agent runtime behavior, model inheritance (agents still omit `model`), colors, and stem-uniqueness are unchanged. This patch only makes an already-resolved value explicit and gate-enforced.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| R2 gate rejects a legitimately non-subagent bundled agent | Verified all 51 bundled agents are subagents; a future primary agent would require a deliberate gate change, which is correct. |
+| "Behavior change" from explicit `mode` reordering emitted YAML | Success criterion is resolved-value equivalence (parsed config), not byte-identical strings; the converter still runs in this patch. |
+| Implementer chases a phantom registry-regen step | None needed: `generate-registry.ts` consumes only agent `description` + file path, not `mode`, so adding `mode:` cannot change registry output. No registry regeneration required for this patch. |
+
+## Converter-Injected-Field Audit (v3.0.0 finding — R3)
+
+Verified against `src/lib/converter.ts` (`transformAgentFrontmatter`, `inferTemperature`). Recorded here in a tracked artifact so the v3.0.0 converter-removal plan inherits it without re-deriving. Converter removal must address every HIGH/MEDIUM field below; **`temperature` in particular blocks v3.0.0 readiness.**
+
+| Field | Converter behavior when absent | v3.0.0 removal risk |
+|-------|-------------------------------|---------------------|
+| `mode` | fill-if-absent `subagent` | HIGH — **resolved by this patch (R1/R2)** |
+| `temperature` | **always computed** via `inferTemperature(name, description)` → 0.1 / 0.2 / 0.3 / 0.6 (default 0.3) | HIGH — removal silently reverts every agent without explicit `temperature` to the OpenCode default |
+| `description` | synthesizes `"<name> agent"` | LOW (cosmetic) |
+| `steps` | maps legacy `maxTurns`/`maxSteps` → `steps`; no static default | LOW |
+| `tools` | normalizes array form → map form; no default set | LOW–MEDIUM (agents using array-form `tools`) |
+| `permission` | maps CC `permissionMode` → `permission` | LOW–MEDIUM (agents using `permissionMode`) |
+| `hidden` | derives from `disable-model-invocation` | LOW (rename only) |
+
+## Sources & References
+
+- **Origin document:** docs/brainstorms/2026-06-05-agent-mode-explicit-hardening-requirements.md
+- Related code: `src/lib/converter.ts` (`transformAgentFrontmatter`, `inferTemperature`), `scripts/content-integrity.ts` (`checkAgentModel`), `src/lib/config-handler.ts`
+- Parent v3 scope: docs/brainstorms/2026-05-21-v3-converter-removal-and-excision-requirements.md

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -2,7 +2,7 @@
 /**
  * Content-Integrity Gate
  *
- * Enforces five content invariants across Systematic's shipped assets:
+ * Enforces six content invariants across Systematic's shipped assets:
  *
  * 1. **Cross-skill reference integrity** — every `systematic:<category>:<name>`
  *    reference in bundled skills and agents resolves to an actual
@@ -25,6 +25,10 @@
  *
  * 5. **Agent model portability** — bundled agents inherit the user's configured
  *    model instead of hardcoding provider-specific model IDs.
+ *
+ * 6. **Agent mode** — bundled agents must declare `mode: subagent` explicitly so
+ *    they remain invisible to primary-agent discovery regardless of future
+ *    OpenCode default changes.
  *
  * Scope is narrow by design: `skills/**\/*.md`, `agents/**\/*.md`, and
  * `src/**\/*.ts` for the full invariant suite. Additionally, `docs/solutions/**\/*.md`
@@ -990,8 +994,7 @@ export function checkAgentMode(
     const content = readFileSafe(path.join(rootDir, relPath))
     if (content === null) continue
     const parsed = parseFrontmatter(content)
-    if (!isRecord(parsed.data)) continue
-    if (parsed.data.mode !== 'subagent') {
+    if (!isRecord(parsed.data) || parsed.data.mode !== 'subagent') {
       violations.push({
         file: relPath,
         message:
@@ -1242,6 +1245,7 @@ function printResult(result: CheckResult, verbose: boolean): void {
         `frontmatterViolations: ${result.frontmatterViolations.length}\n` +
         `parseSafetyViolations: ${result.parseSafetyViolations.length}\n` +
         `agentModelViolations: ${result.agentModelViolations.length}\n` +
+        `agentModeViolations: ${result.agentModeViolations.length}\n` +
         `agentColorViolations: ${result.agentColorViolations.length}\n` +
         `agentStemViolations: ${result.agentStemViolations.length}\n` +
         `exemptHits: ${result.exemptHits.length}\n`,

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -176,6 +176,11 @@ export interface AgentModelViolation {
   message: string
 }
 
+export interface AgentModeViolation {
+  file: string
+  message: string
+}
+
 export interface AgentStemViolation {
   stem: string
   files: string[]
@@ -192,6 +197,7 @@ export interface CheckResult {
   frontmatterViolations: FrontmatterViolation[]
   parseSafetyViolations: FrontmatterViolation[]
   agentModelViolations: AgentModelViolation[]
+  agentModeViolations: AgentModeViolation[]
   agentColorViolations: AgentColorViolation[]
   agentStemViolations: AgentStemViolation[]
   exemptHits: ExemptHit[]
@@ -973,6 +979,30 @@ export function checkAgentModel(
   return violations
 }
 
+export function checkAgentMode(
+  rootDir: string,
+  markdownFiles: readonly string[],
+): AgentModeViolation[] {
+  const violations: AgentModeViolation[] = []
+
+  for (const relPath of markdownFiles) {
+    if (!isAgentFile(relPath)) continue
+    const content = readFileSafe(path.join(rootDir, relPath))
+    if (content === null) continue
+    const parsed = parseFrontmatter(content)
+    if (!isRecord(parsed.data)) continue
+    if (parsed.data.mode !== 'subagent') {
+      violations.push({
+        file: relPath,
+        message:
+          "Bundled agents must declare `mode: subagent` explicitly. The converter's fill-if-absent default will be removed in v3.0.0; without an explicit `mode`, agents would fall back to OpenCode's native default (`all`), making internal agents primary-visible.",
+      })
+    }
+  }
+
+  return violations
+}
+
 export function checkAgentStemUniqueness(
   rootDir: string,
   markdownFiles: readonly string[],
@@ -1122,6 +1152,7 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     targets.solutionMarkdown,
   )
   const agentModelViolations = checkAgentModel(rootDir, targets.markdown)
+  const agentModeViolations = checkAgentMode(rootDir, targets.markdown)
   const agentColorViolations = checkAgentColors(rootDir, targets.markdown)
   const agentStemViolations = checkAgentStemUniqueness(
     rootDir,
@@ -1143,6 +1174,7 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     frontmatterViolations,
     parseSafetyViolations,
     agentModelViolations,
+    agentModeViolations,
     agentColorViolations,
     agentStemViolations,
     exemptHits,
@@ -1189,6 +1221,7 @@ function printResult(result: CheckResult, verbose: boolean): void {
     'Parse-safety violations',
   )
   printAgentModelViolations(result.agentModelViolations)
+  printAgentModeViolations(result.agentModeViolations)
   printAgentColorViolations(result.agentColorViolations)
   printAgentStemViolations(result.agentStemViolations)
 
@@ -1271,6 +1304,16 @@ function printAgentModelViolations(
   }
 }
 
+function printAgentModeViolations(
+  violations: readonly AgentModeViolation[],
+): void {
+  if (violations.length === 0) return
+  process.stderr.write(`\nAgent mode violations (${violations.length}):\n`)
+  for (const v of violations) {
+    process.stderr.write(`  ${v.file}  ${v.message}\n`)
+  }
+}
+
 function printAgentColorViolations(
   violations: readonly AgentColorViolation[],
 ): void {
@@ -1304,6 +1347,7 @@ function totalViolations(result: CheckResult): number {
     result.frontmatterViolations.length +
     result.parseSafetyViolations.length +
     result.agentModelViolations.length +
+    result.agentModeViolations.length +
     result.agentColorViolations.length +
     result.agentStemViolations.length
   )

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -1307,6 +1307,26 @@ describe('checkAgentMode', () => {
       fs.rmSync(root, { recursive: true, force: true })
     }
   })
+
+  test('flags an agent whose frontmatter is a valid YAML list (non-object top-level)', () => {
+    const root = makeFixtureRepo()
+    try {
+      // A YAML list at the top level is valid YAML but not a record — the agent
+      // cannot declare mode: subagent, so it must be flagged.
+      writeFile(
+        root,
+        'agents/research/list-fm.md',
+        '---\n- name: list-fm\n- mode: subagent\n---\nbody',
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkAgentMode(root, targets.markdown)
+      expect(violations).toHaveLength(1)
+      expect(violations[0]?.file).toBe('agents/research/list-fm.md')
+      expect(violations[0]?.message).toContain('mode: subagent')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('converter equivalence: explicit mode: subagent is behavior-preserving', () => {
@@ -1343,29 +1363,41 @@ Agent body`
     expect(parsedWithout.data).toEqual(parsedWith.data)
   })
 
-  test('explicit mode: subagent does not alter any other resolved field', () => {
-    const base = `---
+  test('explicit mode: subagent does not alter any other resolved field, including tools, color, and temperature', () => {
+    // Uses a fixture that mirrors a real agent's frontmatter shape to prove
+    // behavior-preservation across the full set of fields, not just the trivial case.
+    const withoutMode = `---
 name: security-sentinel
 description: Security review agent
+tools:
+  - read
+  - grep
+color: red
+temperature: 0.3
 ---
 Agent body`
 
-    const withMode = `---
+    const withExplicitMode = `---
 name: security-sentinel
 description: Security review agent
+tools:
+  - read
+  - grep
+color: red
+temperature: 0.3
 mode: subagent
 ---
 Agent body`
 
-    const parsedBase = parseFrontmatter(
-      convertContent(base, 'agent', { agentMode: 'subagent' }),
+    const parsedWithout = parseFrontmatter(
+      convertContent(withoutMode, 'agent', { agentMode: 'subagent' }),
     )
     const parsedWith = parseFrontmatter(
-      convertContent(withMode, 'agent', { agentMode: 'subagent' }),
+      convertContent(withExplicitMode, 'agent', { agentMode: 'subagent' }),
     )
 
     // All resolved fields must be identical — adding explicit mode is a no-op.
-    expect(parsedBase.data).toEqual(parsedWith.data)
+    expect(parsedWithout.data).toEqual(parsedWith.data)
   })
 })
 
@@ -1507,6 +1539,30 @@ describe('checkContentIntegrity (top-level)', () => {
         'agents/research/same-stem.md',
         'agents/review/same-stem.md',
       ])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('populates agentModeViolations when an agent is missing mode: subagent', () => {
+    const root = makeFixtureRepo()
+    try {
+      // Agent without mode field — the gate must surface this through the
+      // aggregate entry point, proving the wiring from checkAgentMode into
+      // checkContentIntegrity is intact.
+      writeFile(
+        root,
+        'agents/research/no-mode.md',
+        '---\nname: no-mode\n---\nagent body',
+      )
+
+      const result = checkContentIntegrity(root)
+
+      expect(result.agentModeViolations).toHaveLength(1)
+      expect(result.agentModeViolations[0]?.file).toBe(
+        'agents/research/no-mode.md',
+      )
+      expect(result.agentModeViolations[0]?.message).toContain('mode: subagent')
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }
@@ -2479,69 +2535,90 @@ describe('checkContentIntegrity (sub-file refs)', () => {
   })
 })
 
+/**
+ * Throws a descriptive error when a violation array is non-empty.
+ * Keeps the integration test body flat and under the cognitive-complexity limit.
+ */
+function assertNoViolations(
+  violations: readonly unknown[],
+  format: (v: unknown) => string,
+  label: string,
+): void {
+  if (violations.length > 0) {
+    const details = violations.map(format).join('\n  ')
+    throw new Error(`${label}:\n  ${details}`)
+  }
+}
+
 describe('integration: real repo', () => {
   test('content-integrity gate passes against current HEAD', () => {
     const result = checkContentIntegrity(REPO_ROOT)
 
     // Zero phantoms, zero non-exempt banned patterns, zero warnings.
-    if (result.phantomRefs.length > 0) {
-      const details = result.phantomRefs
-        .map((p) => `${p.file}:${p.line}  ${p.reference}`)
-        .join('\n  ')
-      throw new Error(`Phantom references in repo:\n  ${details}`)
-    }
-
-    if (result.bannedPatterns.length > 0) {
-      const details = result.bannedPatterns
-        .map(
-          (h) =>
-            `${h.file}:${h.line}  ${JSON.stringify(h.pattern)}  ${h.lineContent}`,
-        )
-        .join('\n  ')
-      throw new Error(`Banned patterns outside allowlist:\n  ${details}`)
-    }
-
-    if (result.brokenSubfileRefs.length > 0) {
-      const details = result.brokenSubfileRefs
-        .map((r) => `${r.file}:${r.line}  ${r.reference}  → ${r.resolvedPath}`)
-        .join('\n  ')
-      throw new Error(`Broken sub-file references in repo:\n  ${details}`)
-    }
-
-    if (result.frontmatterViolations.length > 0) {
-      const details = result.frontmatterViolations
-        .map((v) => `${v.file}  ${v.rule}  ${v.field ?? ''}`)
-        .join('\n  ')
-      throw new Error(`Frontmatter violations in repo:\n  ${details}`)
-    }
-
-    if (result.agentModelViolations.length > 0) {
-      const details = result.agentModelViolations
-        .map((v) => `${v.file}  ${v.message}`)
-        .join('\n  ')
-      throw new Error(`Agent model violations in repo:\n  ${details}`)
-    }
-
-    if (result.agentStemViolations.length > 0) {
-      const details = result.agentStemViolations
-        .map((v) => `${v.stem}  ${v.files.join(', ')}`)
-        .join('\n  ')
-      throw new Error(`Duplicate bundled agent stems in repo:\n  ${details}`)
-    }
-
-    if (result.parseSafetyViolations.length > 0) {
-      const details = result.parseSafetyViolations
-        .map((v) => `${v.file}  ${v.field ?? ''}  ${v.message}`)
-        .join('\n  ')
-      throw new Error(`Parse-safety violations in repo:\n  ${details}`)
-    }
-
-    if (result.agentModeViolations.length > 0) {
-      const details = result.agentModeViolations
-        .map((v) => `${v.file}  ${v.message}`)
-        .join('\n  ')
-      throw new Error(`Agent mode violations in repo:\n  ${details}`)
-    }
+    assertNoViolations(
+      result.phantomRefs,
+      (v) => {
+        const p = v as (typeof result.phantomRefs)[number]
+        return `${p.file}:${p.line}  ${p.reference}`
+      },
+      'Phantom references in repo',
+    )
+    assertNoViolations(
+      result.bannedPatterns,
+      (v) => {
+        const h = v as (typeof result.bannedPatterns)[number]
+        return `${h.file}:${h.line}  ${JSON.stringify(h.pattern)}  ${h.lineContent}`
+      },
+      'Banned patterns outside allowlist',
+    )
+    assertNoViolations(
+      result.brokenSubfileRefs,
+      (v) => {
+        const r = v as (typeof result.brokenSubfileRefs)[number]
+        return `${r.file}:${r.line}  ${r.reference}  → ${r.resolvedPath}`
+      },
+      'Broken sub-file references in repo',
+    )
+    assertNoViolations(
+      result.frontmatterViolations,
+      (v) => {
+        const fv = v as (typeof result.frontmatterViolations)[number]
+        return `${fv.file}  ${fv.rule}  ${fv.field ?? ''}`
+      },
+      'Frontmatter violations in repo',
+    )
+    assertNoViolations(
+      result.agentModelViolations,
+      (v) => {
+        const av = v as (typeof result.agentModelViolations)[number]
+        return `${av.file}  ${av.message}`
+      },
+      'Agent model violations in repo',
+    )
+    assertNoViolations(
+      result.agentStemViolations,
+      (v) => {
+        const sv = v as (typeof result.agentStemViolations)[number]
+        return `${sv.stem}  ${sv.files.join(', ')}`
+      },
+      'Duplicate bundled agent stems in repo',
+    )
+    assertNoViolations(
+      result.parseSafetyViolations,
+      (v) => {
+        const pv = v as (typeof result.parseSafetyViolations)[number]
+        return `${pv.file}  ${pv.field ?? ''}  ${pv.message}`
+      },
+      'Parse-safety violations in repo',
+    )
+    assertNoViolations(
+      result.agentModeViolations,
+      (v) => {
+        const mv = v as (typeof result.agentModeViolations)[number]
+        return `${mv.file}  ${mv.message}`
+      },
+      'Agent mode violations in repo',
+    )
 
     expect(result.phantomRefs).toEqual([])
     expect(result.brokenSubfileRefs).toEqual([])

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -7,6 +7,7 @@ import {
   type AllowlistEntry,
   BANNED_PATTERNS,
   checkAgentColors,
+  checkAgentMode,
   checkAgentModel,
   checkAgentStemUniqueness,
   checkBannedPatterns,
@@ -21,6 +22,8 @@ import {
   matchesPathGlob,
   SUBFILE_DIRECTORY_NAMES,
 } from '../../scripts/content-integrity.ts'
+import { convertContent } from '../../src/lib/converter.ts'
+import { parseFrontmatter } from '../../src/lib/frontmatter.ts'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -55,12 +58,12 @@ function writeAllowlist(root: string, exemptions: AllowlistEntry[]): void {
 }
 
 function writeAgent(root: string, category: string, name: string): void {
-  // Bundled agents must omit the `model` field per content-integrity gate;
-  // OpenCode subagents inherit the invoking primary agent's model when unset.
+  // Bundled agents must omit the `model` field and declare `mode: subagent`
+  // per content-integrity gate invariants.
   writeFile(
     root,
     `agents/${category}/${name}.md`,
-    `---\nname: ${name}\n---\nagent body`,
+    `---\nname: ${name}\nmode: subagent\n---\nagent body`,
   )
 }
 
@@ -1213,6 +1216,156 @@ describe('checkAgentModel', () => {
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }
+  })
+})
+
+describe('checkAgentMode', () => {
+  test('returns no violations when all agents declare mode: subagent', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/analyst.md',
+        '---\nname: analyst\nmode: subagent\n---\nbody',
+      )
+      writeFile(
+        root,
+        'agents/review/sentinel.md',
+        '---\nname: sentinel\nmode: subagent\n---\nbody',
+      )
+      const targets = collectScanTargets(root)
+      expect(checkAgentMode(root, targets.markdown)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags an agent with no mode field', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/no-mode.md',
+        '---\nname: no-mode\n---\nbody',
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkAgentMode(root, targets.markdown)
+      expect(violations).toHaveLength(1)
+      expect(violations[0]?.file).toBe('agents/research/no-mode.md')
+      expect(violations[0]?.message).toContain('mode: subagent')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags an agent with mode set to a non-subagent value', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/wrong-mode.md',
+        '---\nname: wrong-mode\nmode: all\n---\nbody',
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkAgentMode(root, targets.markdown)
+      expect(violations).toHaveLength(1)
+      expect(violations[0]?.file).toBe('agents/research/wrong-mode.md')
+      expect(violations[0]?.message).toContain('mode: subagent')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('does not flag non-agent markdown files under agents/ (e.g. README-style files excluded by isAgentFile)', () => {
+    const root = makeFixtureRepo()
+    try {
+      // A file at agents/README.md has only 2 path parts — isAgentFile requires exactly 3.
+      writeFile(root, 'agents/README.md', '---\nname: readme\n---\nbody')
+      // A skill file is also not an agent file.
+      writeCompliantSkill(root, 'foo', 'body')
+      const targets = collectScanTargets(root)
+      expect(checkAgentMode(root, targets.markdown)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('scans only agent markdown files, not skill files', () => {
+    const root = makeFixtureRepo()
+    try {
+      // Skill with no mode field — must not be flagged.
+      writeCompliantSkill(root, 'foo', 'body')
+      // Agent with correct mode — no violation.
+      writeFile(
+        root,
+        'agents/research/a.md',
+        '---\nname: a\nmode: subagent\n---\nbody',
+      )
+      const targets = collectScanTargets(root)
+      expect(checkAgentMode(root, targets.markdown)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('converter equivalence: explicit mode: subagent is behavior-preserving', () => {
+  test('converting an agent with no mode field produces the same resolved mode as one with explicit mode: subagent', () => {
+    const withoutMode = `---
+name: test-agent
+description: A test agent
+---
+Agent body`
+
+    const withExplicitMode = `---
+name: test-agent
+description: A test agent
+mode: subagent
+---
+Agent body`
+
+    const convertedWithout = convertContent(withoutMode, 'agent', {
+      agentMode: 'subagent',
+    })
+    const convertedWith = convertContent(withExplicitMode, 'agent', {
+      agentMode: 'subagent',
+    })
+
+    // Both must emit mode: subagent
+    expect(convertedWithout).toContain('mode: subagent')
+    expect(convertedWith).toContain('mode: subagent')
+
+    // Parse both emitted configs and compare resolved field values.
+    // The converter may reorder YAML keys, so we compare parsed objects, not strings.
+    const parsedWithout = parseFrontmatter(convertedWithout)
+    const parsedWith = parseFrontmatter(convertedWith)
+
+    expect(parsedWithout.data).toEqual(parsedWith.data)
+  })
+
+  test('explicit mode: subagent does not alter any other resolved field', () => {
+    const base = `---
+name: security-sentinel
+description: Security review agent
+---
+Agent body`
+
+    const withMode = `---
+name: security-sentinel
+description: Security review agent
+mode: subagent
+---
+Agent body`
+
+    const parsedBase = parseFrontmatter(
+      convertContent(base, 'agent', { agentMode: 'subagent' }),
+    )
+    const parsedWith = parseFrontmatter(
+      convertContent(withMode, 'agent', { agentMode: 'subagent' }),
+    )
+
+    // All resolved fields must be identical — adding explicit mode is a no-op.
+    expect(parsedBase.data).toEqual(parsedWith.data)
   })
 })
 
@@ -2383,6 +2536,13 @@ describe('integration: real repo', () => {
       throw new Error(`Parse-safety violations in repo:\n  ${details}`)
     }
 
+    if (result.agentModeViolations.length > 0) {
+      const details = result.agentModeViolations
+        .map((v) => `${v.file}  ${v.message}`)
+        .join('\n  ')
+      throw new Error(`Agent mode violations in repo:\n  ${details}`)
+    }
+
     expect(result.phantomRefs).toEqual([])
     expect(result.brokenSubfileRefs).toEqual([])
     expect(result.bannedPatterns).toEqual([])
@@ -2390,6 +2550,7 @@ describe('integration: real repo', () => {
     expect(result.agentModelViolations).toEqual([])
     expect(result.agentStemViolations).toEqual([])
     expect(result.parseSafetyViolations).toEqual([])
+    expect(result.agentModeViolations).toEqual([])
     expect(result.allowlistWarnings).toEqual([])
     expect(result.scanStats.markdownFiles).toBeGreaterThan(0)
     expect(result.scanStats.typescriptFiles).toBeGreaterThan(0)


### PR DESCRIPTION
## What this does

Makes the `mode: subagent` field explicit on all 51 bundled agents and enforces it in the content-integrity gate. Previously, 36 agents relied on the runtime converter to inject `mode: subagent` as a fill-if-absent default — an invisible dependency that would break when the converter is removed in v3.0.0. Without an explicit `mode`, those agents would fall back to OpenCode's native default (`all`) and become primary-visible in the agent picker.

This is a zero-runtime-behavior-change hardening: the converter already resolves these agents to `subagent`, so making it explicit changes nothing today while severing the converter dependency for the future.

## Changes

- **Explicit mode on 36 agents** — added `mode: subagent` to every bundled agent that lacked it (the 15 that already declared it are untouched). Purely additive frontmatter.
- **Gate enforcement** — a new `checkAgentMode` check in `scripts/content-integrity.ts` fails CI if any bundled agent is missing an explicit `mode: subagent` (or sets a non-subagent value, or has non-object frontmatter), so the invariant can't regress.
- **Equivalence test** — a converter test that converts an agent both with and without an explicit `mode` and asserts the resolved config is identical, mechanically proving the change is behavior-preserving.
- **Converter-injected-field audit** — the plan records a tracked audit of every field the converter injects (notably `temperature`, which is *computed* for every agent via a name/description heuristic and is an equally high-risk dependency for v3.0.0). This patch deliberately does not make Systematic v3.0.0-ready — it resolves only the `mode` dependency.

## Verification

typecheck, lint, content-integrity, registry drift, schema drift, build, Node ESM smoke, 972 unit tests, and docs build all pass. The change emits resolved-value-identical agent config (verified by the equivalence test).
