### PR TITLE
docs(plans): reconcile shipped plan statuses

### DIFF
--- a/docs/plans/2026-06-04-002-feat-merge-upstream-brainstorm-plan-plan.md
+++ b/docs/plans/2026-06-04-002-feat-merge-upstream-brainstorm-plan-plan.md
@@ -1,7 +1,8 @@
 ---
 title: "feat: Merge upstream ce-brainstorm + ce-plan improvements into ours"
 type: feat
-status: active
+status: completed
+shipped: "PR #486; released in v2.26.0"
 date: 2026-06-04
 origin: docs/brainstorms/2026-06-04-merge-upstream-brainstorm-plan-requirements.md
 ---

--- a/docs/plans/2026-06-05-003-feat-agent-mode-explicit-hardening-plan.md
+++ b/docs/plans/2026-06-05-003-feat-agent-mode-explicit-hardening-plan.md
@@ -1,7 +1,8 @@
 ---
 title: "feat: Agent mode explicit hardening"
 type: feat
-status: active
+status: completed
+shipped: "PR #488; released in v2.27.0"
 date: 2026-06-05
 origin: docs/brainstorms/2026-06-05-agent-mode-explicit-hardening-requirements.md
 ---


### PR DESCRIPTION
Marks two plans completed with release provenance now that their work has shipped:

- The upstream `ce:brainstorm` + `ce:plan` merge — shipped in v2.26.0
- Agent mode explicit hardening — shipped in v2.27.0

Documentation-only; no behavior change.
