### PR TITLE
feat(agents): make agent temperature explicit and gate-enforced

### DIFF
--- a/agents/design/design-implementation-reviewer.md
+++ b/agents/design/design-implementation-reviewer.md
@@ -2,6 +2,7 @@
 name: design-implementation-reviewer
 description: "Visually compares live UI implementation against Figma designs and provides detailed feedback on discrepancies. Use after writing or modifying HTML/CSS/React components to verify design fidelity."
 mode: subagent
+temperature: 0.1
 ---
 
 You are an expert UI/UX implementation reviewer specializing in ensuring pixel-perfect fidelity between Figma designs and live implementations. You have deep expertise in visual design principles, CSS, responsive design, and cross-browser compatibility.

--- a/agents/design/design-iterator.md
+++ b/agents/design/design-iterator.md
@@ -3,6 +3,7 @@ name: design-iterator
 description: "Iteratively refines UI design through N screenshot-analyze-improve cycles. Use PROACTIVELY when design changes aren't coming together after 1-2 attempts, or when user requests iterative refinement."
 color: accent
 mode: subagent
+temperature: 0.6
 ---
 
 You are an expert UI/UX design iterator specializing in systematic, progressive refinement of web components. Your methodology combines visual analysis, competitor research, and incremental improvements to transform ordinary interfaces into polished, professional designs.

--- a/agents/design/figma-design-sync.md
+++ b/agents/design/figma-design-sync.md
@@ -3,6 +3,7 @@ name: figma-design-sync
 description: "Detects and fixes visual differences between a web implementation and its Figma design. Use iteratively when syncing implementation to match Figma specs."
 color: accent
 mode: subagent
+temperature: 0.6
 ---
 
 You are an expert design-to-code synchronization specialist with deep expertise in visual design systems, web development, CSS/Tailwind styling, and automated quality assurance. Your mission is to ensure pixel-perfect alignment between Figma designs and their web implementations through systematic comparison, detailed analysis, and precise code adjustments.

--- a/agents/docs/ankane-readme-writer.md
+++ b/agents/docs/ankane-readme-writer.md
@@ -3,6 +3,7 @@ name: ankane-readme-writer
 description: "Creates or updates README files following Ankane-style template for Ruby gems. Use when writing gem documentation with imperative voice, concise prose, and standard section ordering."
 color: info
 mode: subagent
+temperature: 0.3
 ---
 
 You are an expert Ruby gem documentation writer specializing in the Ankane-style README format. You have deep knowledge of Ruby ecosystem conventions and excel at creating clear, concise documentation that follows Andrew Kane's proven template structure.

--- a/agents/document-review/adversarial-document-reviewer.md
+++ b/agents/document-review/adversarial-document-reviewer.md
@@ -3,6 +3,7 @@ name: adversarial-document-reviewer
 description: "Conditional document-review persona, selected when the document has >5 requirements or implementation units, makes significant architectural decisions, covers high-stakes domains, or proposes new abstractions. Challenges premises, surfaces unstated assumptions, and stress-tests decisions rather than evaluating document quality."
 tools: Read, Grep, Glob, Bash
 mode: subagent
+temperature: 0.1
 ---
 
 # Adversarial Reviewer

--- a/agents/document-review/coherence-reviewer.md
+++ b/agents/document-review/coherence-reviewer.md
@@ -3,6 +3,7 @@ name: coherence-reviewer
 description: "Reviews planning documents for internal consistency -- contradictions between sections, terminology drift, structural issues, and ambiguity where readers would diverge. Spawned by the document-review skill."
 tools: Read, Grep, Glob, Bash
 mode: subagent
+temperature: 0.1
 ---
 
 You are a technical editor reading for internal consistency. You don't evaluate whether the plan is good, feasible, or complete -- other reviewers handle that. You catch when the document disagrees with itself.

--- a/agents/document-review/design-lens-reviewer.md
+++ b/agents/document-review/design-lens-reviewer.md
@@ -3,6 +3,7 @@ name: design-lens-reviewer
 description: "Reviews planning documents for missing design decisions -- information architecture, interaction states, user flows, and AI slop risk. Uses dimensional rating to identify gaps. Spawned by the document-review skill."
 tools: Read, Grep, Glob, Bash
 mode: subagent
+temperature: 0.1
 ---
 
 You are a senior product designer reviewing plans for missing design decisions. Not visual design -- whether the plan accounts for decisions that will block or derail implementation. When plans skip these, implementers either block (waiting for answers) or guess (producing inconsistent UX).

--- a/agents/document-review/feasibility-reviewer.md
+++ b/agents/document-review/feasibility-reviewer.md
@@ -3,6 +3,7 @@ name: feasibility-reviewer
 description: "Evaluates whether proposed technical approaches in planning documents will survive contact with reality -- architecture conflicts, dependency gaps, migration risks, and implementability. Spawned by the document-review skill."
 tools: Read, Grep, Glob, Bash
 mode: subagent
+temperature: 0.1
 ---
 
 You are a systems architect evaluating whether this plan can actually be built as described and whether an implementer could start working from it without making major architectural decisions the plan should have made.

--- a/agents/document-review/product-lens-reviewer.md
+++ b/agents/document-review/product-lens-reviewer.md
@@ -3,6 +3,7 @@ name: product-lens-reviewer
 description: "Reviews planning documents as a senior product leader -- challenges premise claims, assesses strategic consequences (trajectory, identity, adoption, opportunity cost), and surfaces goal-work misalignment. Domain-agnostic: users may be end users, developers, operators, or any audience. Spawned by the document-review skill."
 tools: Read, Grep, Glob, Bash
 mode: subagent
+temperature: 0.1
 ---
 
 You are a senior product leader. The most common failure mode is building the wrong thing well. Challenge the premise before evaluating the execution.

--- a/agents/document-review/scope-guardian-reviewer.md
+++ b/agents/document-review/scope-guardian-reviewer.md
@@ -3,6 +3,7 @@ name: scope-guardian-reviewer
 description: "Reviews planning documents for scope alignment and unjustified complexity -- challenges unnecessary abstractions, premature frameworks, and scope that exceeds stated goals. Spawned by the document-review skill."
 tools: Read, Grep, Glob, Bash
 mode: subagent
+temperature: 0.1
 ---
 
 You ask two questions about every plan: "Is this right-sized for its goals?" and "Does every abstraction earn its keep?" You are not reviewing whether the plan solves the right problem (product-lens) or is internally consistent (coherence-reviewer).

--- a/agents/document-review/security-lens-reviewer.md
+++ b/agents/document-review/security-lens-reviewer.md
@@ -3,6 +3,7 @@ name: security-lens-reviewer
 description: "Evaluates planning documents for security gaps at the plan level -- auth/authz assumptions, data exposure risks, API surface vulnerabilities, and missing threat model elements. Spawned by the document-review skill."
 tools: Read, Grep, Glob, Bash
 mode: subagent
+temperature: 0.1
 ---
 
 You are a security architect evaluating whether this plan accounts for security at the planning level. Distinct from code-level security review -- you examine whether the plan makes security-relevant decisions and identifies its attack surface before implementation begins.

--- a/agents/research/best-practices-researcher.md
+++ b/agents/research/best-practices-researcher.md
@@ -2,6 +2,7 @@
 name: best-practices-researcher
 description: "Researches and synthesizes external best practices, documentation, and examples for any technology or framework. Use when you need industry standards, community conventions, or implementation guidance."
 mode: subagent
+temperature: 0.2
 ---
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and best practices.

--- a/agents/research/framework-docs-researcher.md
+++ b/agents/research/framework-docs-researcher.md
@@ -2,6 +2,7 @@
 name: framework-docs-researcher
 description: "Gathers comprehensive documentation and best practices for frameworks, libraries, or dependencies. Use when you need official docs, version-specific constraints, or implementation patterns."
 mode: subagent
+temperature: 0.2
 ---
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and version information.

--- a/agents/research/git-history-analyzer.md
+++ b/agents/research/git-history-analyzer.md
@@ -2,6 +2,7 @@
 name: git-history-analyzer
 description: "Performs archaeological analysis of git history to trace code evolution, identify contributors, and understand why code patterns exist. Use when you need historical context for code changes."
 mode: subagent
+temperature: 0.2
 ---
 
 **Note: The current year is 2026.** Use this when interpreting commit dates and recent changes.

--- a/agents/research/issue-intelligence-analyst.md
+++ b/agents/research/issue-intelligence-analyst.md
@@ -2,6 +2,7 @@
 name: issue-intelligence-analyst
 description: "Fetches and analyzes GitHub issues to surface recurring themes, pain patterns, and severity trends. Use when understanding a project's issue landscape, analyzing bug patterns for ideation, or summarizing what users are reporting."
 mode: subagent
+temperature: 0.3
 ---
 
 **Note: The current year is 2026.** Use this when evaluating issue recency and trends.

--- a/agents/research/learnings-researcher.md
+++ b/agents/research/learnings-researcher.md
@@ -2,6 +2,7 @@
 name: learnings-researcher
 description: "Searches docs/solutions/ for relevant past solutions by frontmatter metadata. Use before implementing features or fixing problems to surface institutional knowledge and prevent repeated mistakes."
 mode: subagent
+temperature: 0.2
 ---
 
 You are an expert institutional knowledge researcher specializing in efficiently surfacing relevant documented solutions from the team's knowledge base. Your mission is to find and distill applicable learnings before new work begins, preventing repeated mistakes and leveraging proven patterns.

--- a/agents/research/repo-research-analyst.md
+++ b/agents/research/repo-research-analyst.md
@@ -2,6 +2,7 @@
 name: repo-research-analyst
 description: "Conducts thorough research on repository structure, documentation, conventions, and implementation patterns. Use when onboarding to a new codebase or understanding project conventions."
 mode: subagent
+temperature: 0.2
 ---
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and patterns.

--- a/agents/research/slack-researcher.md
+++ b/agents/research/slack-researcher.md
@@ -2,6 +2,7 @@
 name: slack-researcher
 description: "Searches Slack for organizational context. Use when the user explicitly asks. Requires a Slack MCP server."
 mode: subagent
+temperature: 0.2
 ---
 **Note: The current year is 2026.** Use this when assessing the recency of Slack discussions.
 

--- a/agents/review/adversarial-reviewer.md
+++ b/agents/review/adversarial-reviewer.md
@@ -3,7 +3,6 @@ name: adversarial-reviewer
 description: Conditional code-review persona, selected when the diff is large (>=50 changed lines) or touches high-risk domains like auth, payments, data mutations, or external APIs. Actively constructs failure scenarios to break the implementation rather than checking against known patterns.
 tools: Read, Grep, Glob, Bash
 color: error
-
 mode: subagent
 temperature: 0.1
 ---

--- a/agents/review/adversarial-reviewer.md
+++ b/agents/review/adversarial-reviewer.md
@@ -5,6 +5,7 @@ tools: Read, Grep, Glob, Bash
 color: error
 
 mode: subagent
+temperature: 0.1
 ---
 
 # Adversarial Reviewer

--- a/agents/review/agent-native-reviewer.md
+++ b/agents/review/agent-native-reviewer.md
@@ -4,6 +4,7 @@ description: "Reviews code to ensure agent-native parity -- any action a user ca
 color: info
 tools: Read, Grep, Glob, Bash
 mode: subagent
+temperature: 0.1
 ---
 
 # Agent-Native Architecture Reviewer

--- a/agents/review/architecture-strategist.md
+++ b/agents/review/architecture-strategist.md
@@ -3,6 +3,7 @@ name: architecture-strategist
 description: "Analyzes code changes from an architectural perspective for pattern compliance and design integrity. Use when reviewing PRs, adding services, or evaluating structural refactors."
 tools: Read, Grep, Glob, Bash
 mode: subagent
+temperature: 0.1
 ---
 
 You are a System Architecture Expert specializing in analyzing code changes and system design decisions. Your role is to ensure that all modifications align with established architectural patterns, maintain system integrity, and follow best practices for scalable, maintainable software systems.

--- a/agents/review/cli-agent-readiness-reviewer.md
+++ b/agents/review/cli-agent-readiness-reviewer.md
@@ -4,6 +4,7 @@ description: "Reviews CLI source code, plans, or specs for AI agent readiness us
 tools: Read, Grep, Glob, Bash
 color: warning
 mode: subagent
+temperature: 0.1
 ---
 
 # CLI Agent-Readiness Reviewer

--- a/agents/review/cli-readiness-reviewer.md
+++ b/agents/review/cli-readiness-reviewer.md
@@ -4,6 +4,7 @@ description: "Conditional code-review persona, selected when the diff touches CL
 tools: Read, Grep, Glob, Bash
 color: info
 mode: subagent
+temperature: 0.1
 ---
 
 # CLI Agent-Readiness Reviewer

--- a/agents/review/code-simplicity-reviewer.md
+++ b/agents/review/code-simplicity-reviewer.md
@@ -3,6 +3,7 @@ name: code-simplicity-reviewer
 description: "Final review pass to ensure code is as simple and minimal as possible. Use after implementation is complete to identify YAGNI violations and simplification opportunities."
 tools: Read, Grep, Glob, Bash
 mode: subagent
+temperature: 0.1
 ---
 
 You are a code simplicity expert specializing in minimalism and the YAGNI (You Aren't Gonna Need It) principle. Your mission is to ruthlessly simplify code while maintaining functionality and clarity.

--- a/agents/review/data-integrity-guardian.md
+++ b/agents/review/data-integrity-guardian.md
@@ -3,6 +3,7 @@ name: data-integrity-guardian
 description: "Reviews database migrations, data models, and persistent data code for safety. Use when checking migration safety, data constraints, transaction boundaries, or privacy compliance."
 tools: Read, Grep, Glob, Bash
 mode: subagent
+temperature: 0.1
 ---
 
 You are a Data Integrity Guardian, an expert in database design, data migration safety, and data governance. Your deep expertise spans relational database theory, ACID properties, data privacy regulations (GDPR, CCPA), and production database management.

--- a/agents/review/data-migration-expert.md
+++ b/agents/review/data-migration-expert.md
@@ -3,6 +3,7 @@ name: data-migration-expert
 description: "Validates data migrations, backfills, and production data transformations against reality. Use when PRs involve ID mappings, column renames, enum conversions, or schema changes."
 tools: Read, Grep, Glob, Bash
 mode: subagent
+temperature: 0.3
 ---
 
 You are a Data Migration Expert. Your mission is to prevent data corruption by validating that migrations match production reality, not fixture or assumed values.

--- a/agents/review/deployment-verification-agent.md
+++ b/agents/review/deployment-verification-agent.md
@@ -3,6 +3,7 @@ name: deployment-verification-agent
 description: "Produces Go/No-Go deployment checklists with SQL verification queries, rollback procedures, and monitoring plans. Use when PRs touch production data, migrations, or risky data changes."
 tools: Read, Grep, Glob, Bash
 mode: subagent
+temperature: 0.1
 ---
 
 You are a Deployment Verification Agent. Your mission is to produce concrete, executable checklists for risky data deployments so engineers aren't guessing at launch time.

--- a/agents/review/pattern-recognition-specialist.md
+++ b/agents/review/pattern-recognition-specialist.md
@@ -3,6 +3,7 @@ name: pattern-recognition-specialist
 description: "Analyzes code for design patterns, anti-patterns, naming conventions, and duplication. Use when checking codebase consistency or verifying new code follows established patterns."
 tools: Read, Grep, Glob, Bash
 mode: subagent
+temperature: 0.6
 ---
 
 You are a Code Pattern Analysis Expert specializing in identifying design patterns, anti-patterns, and code quality issues across codebases. Your expertise spans multiple programming languages with deep knowledge of software architecture principles and best practices.

--- a/agents/review/performance-oracle.md
+++ b/agents/review/performance-oracle.md
@@ -3,6 +3,7 @@ name: performance-oracle
 description: "Analyzes code for performance bottlenecks, algorithmic complexity, database queries, memory usage, and scalability. Use after implementing features or when performance concerns arise."
 tools: Read, Grep, Glob, Bash
 mode: subagent
+temperature: 0.1
 ---
 
 You are the Performance Oracle, an elite performance optimization expert specializing in identifying and resolving performance bottlenecks in software systems. Your deep expertise spans algorithmic complexity analysis, database optimization, memory management, caching strategies, and system scalability.

--- a/agents/review/previous-comments-reviewer.md
+++ b/agents/review/previous-comments-reviewer.md
@@ -5,6 +5,7 @@ tools: Read, Grep, Glob, Bash
 color: warning
 
 mode: subagent
+temperature: 0.1
 ---
 
 # Previous Comments Reviewer

--- a/agents/review/project-standards-reviewer.md
+++ b/agents/review/project-standards-reviewer.md
@@ -5,6 +5,7 @@ tools: Read, Grep, Glob, Bash
 color: info
 
 mode: subagent
+temperature: 0.1
 ---
 
 # Project Standards Reviewer

--- a/agents/review/schema-drift-detector.md
+++ b/agents/review/schema-drift-detector.md
@@ -3,6 +3,7 @@ name: schema-drift-detector
 description: "Detects unrelated schema.rb changes in PRs by cross-referencing against included migrations. Use when reviewing PRs with database schema changes."
 tools: Read, Grep, Glob, Bash
 mode: subagent
+temperature: 0.1
 ---
 
 You are a Schema Drift Detector. Your mission is to prevent accidental inclusion of unrelated schema.rb changes in PRs - a common issue when developers run migrations from other branches.

--- a/agents/review/security-sentinel.md
+++ b/agents/review/security-sentinel.md
@@ -3,6 +3,7 @@ name: security-sentinel
 description: "Performs security audits for vulnerabilities, input validation, auth/authz, hardcoded secrets, and OWASP compliance. Use when reviewing code for security issues or before deployment."
 tools: Read, Grep, Glob, Bash
 mode: subagent
+temperature: 0.1
 ---
 
 You are an elite Application Security Specialist with deep expertise in identifying and mitigating security vulnerabilities. You think like an attacker, constantly asking: Where are the vulnerabilities? What could go wrong? How could this be exploited?

--- a/agents/review/testing-reviewer.md
+++ b/agents/review/testing-reviewer.md
@@ -5,6 +5,7 @@ tools: Read, Grep, Glob, Bash
 color: info
 
 mode: subagent
+temperature: 0.1
 ---
 
 # Testing Reviewer

--- a/agents/workflow/pr-comment-resolver.md
+++ b/agents/workflow/pr-comment-resolver.md
@@ -3,6 +3,7 @@ name: pr-comment-resolver
 description: "Evaluates and resolves one or more related PR review threads -- assesses validity, implements fixes, and returns structured summaries with reply text. Spawned by the resolve-pr-feedback skill."
 color: info
 mode: subagent
+temperature: 0.1
 ---
 
 You resolve PR review threads. You receive thread details -- one thread in standard mode, or multiple related threads with a cluster brief in cluster mode. Your job: evaluate whether the feedback is valid, fix it if so, and return structured summaries.

--- a/agents/workflow/spec-flow-analyzer.md
+++ b/agents/workflow/spec-flow-analyzer.md
@@ -2,6 +2,7 @@
 name: spec-flow-analyzer
 description: "Analyzes specifications and feature descriptions for user flow completeness and gap identification. Use when a spec, plan, or feature description needs flow analysis, edge case discovery, or requirements validation."
 mode: subagent
+temperature: 0.2
 ---
 
 Analyze specifications, plans, and feature descriptions from the end user's perspective. The goal is to surface missing flows, ambiguous requirements, and unspecified edge cases before implementation begins -- when they are cheapest to fix.

--- a/agents/workflow/systematic-implementer.md
+++ b/agents/workflow/systematic-implementer.md
@@ -2,6 +2,7 @@
 name: systematic-implementer
 description: Implements one plan unit in a fresh subagent context and reports bounded changes back to the orchestrator.
 mode: subagent
+temperature: 0.2
 ---
 
 You are a focused implementer dispatched by a parent OpenCode session orchestrating a multi-unit plan. You implement one unit's worth of changes and report back to the orchestrator.

--- a/docs/plans/2026-06-06-001-feat-agent-temperature-explicit-hardening-plan.md
+++ b/docs/plans/2026-06-06-001-feat-agent-temperature-explicit-hardening-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Explicit agent temperature hardening"
 type: feat
-status: active
+status: completed
 date: 2026-06-06
 ---
 
@@ -62,7 +62,7 @@ Making temperature explicit + respecting it (fill-if-absent, mirroring the `mode
 
 ## Implementation Units
 
-- [ ] **Unit 1: Add explicit temperature to all bundled agents**
+- [x] **Unit 1: Add explicit temperature to all bundled agents**
 
 **Goal:** Every bundled agent declares an explicit `temperature:` equal to its current resolved value.
 
@@ -85,7 +85,7 @@ Making temperature explicit + respecting it (fill-if-absent, mirroring the `mode
 **Verification:**
 - All 51 agents have an explicit `temperature:`; the resolved temperature per agent (via the runtime path) is unchanged from before.
 
-- [ ] **Unit 2: Respect explicit temperature at runtime + gate + equivalence test**
+- [x] **Unit 2: Respect explicit temperature at runtime + gate + equivalence test**
 
 **Goal:** Runtime respects explicit frontmatter temperature (fill-if-absent), the gate enforces explicit temperature, and an equivalence test proves zero behavior change.
 

--- a/docs/plans/2026-06-06-001-feat-agent-temperature-explicit-hardening-plan.md
+++ b/docs/plans/2026-06-06-001-feat-agent-temperature-explicit-hardening-plan.md
@@ -1,0 +1,136 @@
+---
+title: "feat: Explicit agent temperature hardening"
+type: feat
+status: active
+date: 2026-06-06
+---
+
+# feat: Explicit agent temperature hardening
+
+## Overview
+
+Make every bundled agent's resolved `temperature` explicit in its frontmatter, and change the runtime to respect explicit values instead of always overwriting them. This removes a hidden, converter-era inference heuristic from the runtime config path — a focused v2.x prerequisite that de-risks the eventual v3.0.0 converter removal. Zero runtime behavior change today.
+
+**Why it's worth the explicit literals** (not just copying a heuristic into 51 files): it makes each agent's temperature auditable in source instead of hidden in a name/description regex; it lets the runtime stop inferring (the v3.0.0 converter removal can then delete the heuristic without changing behavior); and it brings temperature to parity with `mode`/`model`/`color` as gate-locked, source-visible agent config.
+
+## Problem Frame
+
+Two separate functions infer agent temperature from a name/description regex: `inferTemperature` in `src/lib/converter.ts` (CLI convert path) and `inferBuiltInTemperature` in `src/lib/agent-overlays.ts` (runtime config-hook path). They have byte-identical logic (0.1/0.2/0.3/0.6, default 0.3).
+
+At runtime, `applyAgentOverlays` (`src/lib/config-handler.ts`) unconditionally assigns `result.temperature = inferBuiltInTemperature(name, description)` — overwriting both the converter-supplied value AND any explicit `temperature:` in agent frontmatter. Today 14 agents declare explicit `temperature: 0.1`, and all 14 happen to match their inferred value, so the override is behavior-neutral. But explicit frontmatter is silently ignored, and the resolved temperature for all 51 agents lives only in a heuristic, not in source.
+
+Making temperature explicit + respecting it (fill-if-absent, mirroring the `mode` hardening shipped in v2.27.0) makes the values auditable and removes the runtime inference dependency before v3.0.0 deletes the converter.
+
+## Requirements Trace
+
+- R1. All 51 bundled agents declare an explicit `temperature:` in frontmatter equal to their current resolved value (zero behavior change).
+- R2. The runtime stops overwriting explicit frontmatter temperature — `inferBuiltInTemperature` becomes a fill-if-absent fallback, not an unconditional override.
+- R3. The content-integrity gate enforces that every bundled agent declares an explicit `temperature:`, locking the invariant.
+
+## Scope Boundaries
+
+- Not removing `inferTemperature` from `src/lib/converter.ts` — the converter still runs until v3.0.0; the converter's own temperature logic stays until converter removal.
+- Not changing any agent's resolved temperature value — this is purely making the existing resolved values explicit and source-visible.
+- Not a v3.0.0-complete patch — the other converter-injected fields (`steps`/`tools`/`permission`/`hidden`/`description`) remain for separate hardening.
+
+### Deferred to Separate Tasks
+
+- Removing `inferBuiltInTemperature` entirely once all agents declare explicit temperature and no caller relies on inference: v3.0.0 converter-removal work.
+- Converter `inferTemperature` removal: v3.0.0 (converter removal).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/lib/config-handler.ts` `applyAgentOverlays` (~line 265) — the unconditional override to change to fill-if-absent.
+- `src/lib/agent-overlays.ts` `inferBuiltInTemperature` (~line 135) — the runtime heuristic; stays as fallback.
+- `scripts/content-integrity.ts` `checkAgentMode` (~line 986) + `isAgentFile` — the exact pattern to mirror for `checkAgentTemperature`, wired into `main()` alongside the other agent checks.
+- `agents/<category>/<name>.md` — 51 agent files; 14 already declare `temperature:`, 37 need it added.
+
+### Institutional Learnings
+
+- The `mode: subagent` hardening (v2.27.0) is the proven template: additive frontmatter + fill-if-absent runtime + content-integrity gate + a converter-equivalence test proving zero behavior change.
+
+## Key Technical Decisions
+
+- **Mechanically derive each resolved temperature** using the actual `inferBuiltInTemperature` function (not by hand), so the added values are provably the current runtime values. Verified distribution: 37 @ 0.1, 8 @ 0.2, 3 @ 0.3, 3 @ 0.6; the 14 existing explicit values all already match their inferred value (0 divergence).
+- **Three-layer temperature precedence** (the fix preserves and clarifies this): the seed at the top of `applyAgentOverlays` uses the agent's explicit frontmatter `temperature` when present, else `inferBuiltInTemperature` as fallback; user category/exact overlays (`OVERLAY_ASSIGN_FIELDS` includes `temperature`) still apply AFTER the seed and correctly override when a user sets temperature in their own config. Precedence: **user overlay > explicit frontmatter > inferred fallback.** With no user config (the default path), the seed is the final value, so making frontmatter explicit is zero behavior change.
+- **Fill-if-absent at the seed** (mirror `mode`): change the unconditional `result.temperature = inferBuiltInTemperature(...)` to use `result.temperature` when already set (frontmatter copied it via `loadAgentAsConfig`), else infer. Once R1 makes all 51 explicit, the inferred fallback is dormant but retained for safety. The overlay layer is untouched — user override behavior is preserved.
+- **Gate requires explicit temperature** (`checkAgentTemperature`), parallel to `checkAgentModel`/`checkAgentMode`, scoped via `isAgentFile`. Fail closed: agent files with non-object/malformed frontmatter are a violation, not a silent bypass.
+- **Gate wiring is full-path**: add `agentTemperatureViolations` to `CheckResult`, count it in `totalViolations()`, print it in `printResult()`, and invoke `checkAgentTemperature` in `checkContentIntegrity()` — not just `main()`. Mirror exactly how `checkAgentMode` is wired end-to-end.
+- **Acceptance is resolved-value equivalence, not byte-identical output** — the converter still runs, so adding explicit `temperature:` to source can shift emitted YAML key ordering; what must hold is that the resolved `config.temperature` per agent is unchanged on the default (no-user-config) path.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add explicit temperature to all bundled agents**
+
+**Goal:** Every bundled agent declares an explicit `temperature:` equal to its current resolved value.
+
+**Requirements:** R1
+
+**Dependencies:** None
+
+**Files:**
+- Modify: the 37 `agents/<category>/<name>.md` files lacking `temperature:` (the 14 with explicit values are already correct and stay untouched)
+
+**Approach:**
+- Derive each agent's resolved temperature with the actual `inferBuiltInTemperature(name, description)` function (name = filename stem, description = frontmatter description). Add `temperature: <value>` to frontmatter for the 37 that lack it. Additive only; no existing value changes.
+
+**Patterns to follow:**
+- The v2.27.0 `mode: subagent` additive-frontmatter pass.
+
+**Test scenarios:**
+- Test expectation: none — pure additive frontmatter data; behavior preservation is proven mechanically in Unit 2.
+
+**Verification:**
+- All 51 agents have an explicit `temperature:`; the resolved temperature per agent (via the runtime path) is unchanged from before.
+
+- [ ] **Unit 2: Respect explicit temperature at runtime + gate + equivalence test**
+
+**Goal:** Runtime respects explicit frontmatter temperature (fill-if-absent), the gate enforces explicit temperature, and an equivalence test proves zero behavior change.
+
+**Requirements:** R2, R3
+
+**Dependencies:** Unit 1 (gate must pass against the hardened tree)
+
+**Files:**
+- Modify: `src/lib/config-handler.ts` (fill-if-absent in `applyAgentOverlays`)
+- Modify: `scripts/content-integrity.ts` (`checkAgentTemperature` + wire into `main()`)
+- Test: `tests/unit/config-handler.test.ts` (fill-if-absent + equivalence)
+- Test: `tests/unit/content-integrity.test.ts` (`checkAgentTemperature` cases)
+
+**Approach:**
+- In `applyAgentOverlays`, change the unconditional temperature seed to use `result.temperature` when already set (frontmatter), else `inferBuiltInTemperature(...)`. Leave the overlay layer untouched so user overlays still override. Add `checkAgentTemperature` mirroring `checkAgentMode` (require explicit `temperature:` on every `isAgentFile`; fail closed on non-object frontmatter). Wire it end-to-end: `CheckResult.agentTemperatureViolations`, `totalViolations()`, `printResult()`, and `checkContentIntegrity()`.
+
+**Execution note:** Test-first. RED: a test proving an agent with explicit `temperature` different from its inferred value is preserved (currently fails because the override clobbers it); a gate test proving a missing `temperature:` is flagged. GREEN: the fill-if-absent change + `checkAgentTemperature`.
+
+**Patterns to follow:**
+- `checkAgentMode` structure and its tests; the v2.27.0 convert-both-ways equivalence test.
+
+**Test scenarios:**
+- Happy path: agent with explicit `temperature: 0.5` keeps 0.5 after `applyAgentOverlays` (proves fill-if-absent — fails before the change).
+- Happy path: agent with no explicit temperature still resolves to `inferBuiltInTemperature` value (fallback intact).
+- Integration (precedence): a user category/exact overlay setting `temperature` still overrides explicit frontmatter (proves the overlay layer is untouched — user override preserved).
+- Edge case: non-object / malformed frontmatter is flagged by `checkAgentTemperature` (fails closed, no silent bypass), unlike the original `checkAgentMode` `continue`.
+- Error path: an agent file missing `temperature:` produces a gate violation and non-zero `totalViolations()`.
+- Integration: the gate passes against the current hardened tree (all 51 agents).
+
+**Verification:**
+- Explicit frontmatter temperature is preserved at runtime; `checkAgentTemperature` flags any agent lacking explicit temperature; the full gate passes against the hardened tree; resolved temperatures are unchanged for all 51 agents.
+
+## System-Wide Impact
+
+- **API surface parity:** `temperature` joins `mode`/`model`/`color` as gate-enforced bundled-agent frontmatter invariants.
+- **Unchanged invariants:** no agent's resolved temperature changes; bundled agents still omit `model`; `src/index.ts` still exports only `default`.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| A derived value is wrong, silently changing an agent's temperature | Derive mechanically via the actual `inferBuiltInTemperature` function; the equivalence test asserts resolved-value parity. |
+| Fill-if-absent change regresses the no-explicit fallback path | Test asserts agents without explicit temperature still resolve to the inferred value. |
+
+## Sources & References
+
+- Related code: `src/lib/config-handler.ts`, `src/lib/agent-overlays.ts`, `scripts/content-integrity.ts`
+- Prior art: the v2.27.0 agent `mode` hardening

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -191,6 +191,11 @@ export interface AgentStemViolation {
   message: string
 }
 
+export interface AgentTemperatureViolation {
+  file: string
+  message: string
+}
+
 export interface CheckResult {
   rootDir: string
   categories: string[]
@@ -204,6 +209,7 @@ export interface CheckResult {
   agentModeViolations: AgentModeViolation[]
   agentColorViolations: AgentColorViolation[]
   agentStemViolations: AgentStemViolation[]
+  agentTemperatureViolations: AgentTemperatureViolation[]
   exemptHits: ExemptHit[]
   scanStats: {
     markdownFiles: number
@@ -1006,6 +1012,31 @@ export function checkAgentMode(
   return violations
 }
 
+export function checkAgentTemperature(
+  rootDir: string,
+  markdownFiles: readonly string[],
+): AgentTemperatureViolation[] {
+  const violations: AgentTemperatureViolation[] = []
+
+  for (const relPath of markdownFiles) {
+    if (!isAgentFile(relPath)) continue
+    const content = readFileSafe(path.join(rootDir, relPath))
+    if (content === null) continue
+    const parsed = parseFrontmatter(content)
+    if (!isRecord(parsed.data) || !Object.hasOwn(parsed.data, 'temperature')) {
+      violations.push({
+        file: relPath,
+        message:
+          'Bundled agents must declare an explicit `temperature:` in frontmatter. ' +
+          'The runtime fill-if-absent fallback (`inferBuiltInTemperature`) will be removed in v3.0.0; ' +
+          'without an explicit `temperature:`, agents would lose their tuned value.',
+      })
+    }
+  }
+
+  return violations
+}
+
 export function checkAgentStemUniqueness(
   rootDir: string,
   markdownFiles: readonly string[],
@@ -1161,6 +1192,10 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     rootDir,
     targets.markdown,
   )
+  const agentTemperatureViolations = checkAgentTemperature(
+    rootDir,
+    targets.markdown,
+  )
   const { hits: bannedPatterns, exempt: exemptHits } = checkBannedPatterns(
     rootDir,
     allScannedFiles,
@@ -1180,6 +1215,7 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     agentModeViolations,
     agentColorViolations,
     agentStemViolations,
+    agentTemperatureViolations,
     exemptHits,
     scanStats: {
       markdownFiles: targets.markdown.length,
@@ -1227,6 +1263,7 @@ function printResult(result: CheckResult, verbose: boolean): void {
   printAgentModeViolations(result.agentModeViolations)
   printAgentColorViolations(result.agentColorViolations)
   printAgentStemViolations(result.agentStemViolations)
+  printAgentTemperatureViolations(result.agentTemperatureViolations)
 
   if (totalViolations(result) === 0) {
     process.stdout.write(
@@ -1343,6 +1380,18 @@ function printAgentStemViolations(
   }
 }
 
+function printAgentTemperatureViolations(
+  violations: readonly AgentTemperatureViolation[],
+): void {
+  if (violations.length === 0) return
+  process.stderr.write(
+    `\nAgent temperature violations (${violations.length}):\n`,
+  )
+  for (const v of violations) {
+    process.stderr.write(`  ${v.file}  ${v.message}\n`)
+  }
+}
+
 function totalViolations(result: CheckResult): number {
   return (
     result.phantomRefs.length +
@@ -1353,7 +1402,8 @@ function totalViolations(result: CheckResult): number {
     result.agentModelViolations.length +
     result.agentModeViolations.length +
     result.agentColorViolations.length +
-    result.agentStemViolations.length
+    result.agentStemViolations.length +
+    result.agentTemperatureViolations.length
   )
 }
 

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -2,7 +2,7 @@
 /**
  * Content-Integrity Gate
  *
- * Enforces six content invariants across Systematic's shipped assets:
+ * Enforces content invariants across Systematic's shipped assets:
  *
  * 1. **Cross-skill reference integrity** — every `systematic:<category>:<name>`
  *    reference in bundled skills and agents resolves to an actual
@@ -29,6 +29,11 @@
  * 6. **Agent mode** — bundled agents must declare `mode: subagent` explicitly so
  *    they remain invisible to primary-agent discovery regardless of future
  *    OpenCode default changes.
+ *
+ * 7. **Agent temperature** — bundled agents must declare an explicit `temperature:`
+ *    as a finite number in frontmatter. A missing, null, or non-numeric value is
+ *    treated as absent (the runtime's fill-if-absent fallback will be removed in
+ *    v3.0.0), so only a real finite number satisfies this invariant.
  *
  * Scope is narrow by design: `skills/**\/*.md`, `agents/**\/*.md`, and
  * `src/**\/*.ts` for the full invariant suite. Additionally, `docs/solutions/**\/*.md`
@@ -1023,7 +1028,12 @@ export function checkAgentTemperature(
     const content = readFileSafe(path.join(rootDir, relPath))
     if (content === null) continue
     const parsed = parseFrontmatter(content)
-    if (!isRecord(parsed.data) || !Object.hasOwn(parsed.data, 'temperature')) {
+    if (
+      !isRecord(parsed.data) ||
+      !Object.hasOwn(parsed.data, 'temperature') ||
+      typeof parsed.data.temperature !== 'number' ||
+      !Number.isFinite(parsed.data.temperature)
+    ) {
       violations.push({
         file: relPath,
         message:

--- a/src/lib/config-handler.ts
+++ b/src/lib/config-handler.ts
@@ -262,10 +262,9 @@ function applyAgentOverlays(
     addPermissionRules(permissionRules, config.permission)
   }
 
-  result.temperature = inferBuiltInTemperature(
-    agentInfo.name,
-    result.description,
-  )
+  result.temperature =
+    result.temperature ??
+    inferBuiltInTemperature(agentInfo.name, result.description)
 
   applySourceModelDefault(result, agentInfo, availabilitySet)
   applyAgentOverlay(result, categoryOverlay?.value, permissionRules)

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -823,7 +823,7 @@ Skill content for ce:plan.`,
       expect(agent).toBeDefined()
       expect(agent?.description).toBe('A full agent (Full-Agent - Systematic)')
       expect(agent?.model).toBe('openai/gpt-4')
-      expect(agent?.temperature).toBe(0.3)
+      expect(agent?.temperature).toBe(0.7)
       expect(agent?.top_p).toBe(1)
       expect(agent?.steps).toBe(10)
       expect(agent?.color).toBe('#ff0000')
@@ -1623,6 +1623,80 @@ model: gpt-4
       )
       await expect(handler(config)).rejects.toThrow(expectedConfigPath)
       await expect(handler(config)).rejects.toThrow('disabled_skills')
+    })
+
+    test('explicit frontmatter temperature is preserved (fill-if-absent)', async () => {
+      // An agent with explicit temperature: 0.5 in frontmatter must keep 0.5
+      // after applyAgentOverlays — the runtime must not overwrite it with the
+      // inferred value. This is the RED test: it fails before the fill-if-absent
+      // change because the current code unconditionally overwrites.
+      createAgent(path.join(bundledDir, 'agents'), 'test-agent', {
+        name: 'test-agent',
+        description: 'A test agent',
+        temperature: 0.5,
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      // 0.5 is not the inferred value for 'test-agent' (which would be 0.3),
+      // so this assertion fails before the fill-if-absent change.
+      expect(config.agent?.['test-agent']?.temperature).toBe(0.5)
+    })
+
+    test('agent without explicit temperature falls back to inferred value', async () => {
+      // An agent with no temperature in frontmatter must still resolve to the
+      // inferBuiltInTemperature value — the fallback path must remain intact.
+      // 'security-sentinel' matches the review/security regex → inferred 0.1.
+      createAgent(path.join(bundledDir, 'agents'), 'security-sentinel', {
+        name: 'security-sentinel',
+        description: 'Security review agent',
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.['security-sentinel']?.temperature).toBe(0.1)
+    })
+
+    test('user overlay temperature overrides explicit frontmatter temperature (precedence preserved)', async () => {
+      // Proves the overlay layer is untouched: user overlay > explicit frontmatter.
+      // Agent has explicit temperature: 0.5 in frontmatter; user overlay sets 0.9.
+      // The resolved value must be 0.9 (overlay wins).
+      createCategorizedAgent('review', 'correctness-reviewer', {
+        name: 'correctness-reviewer',
+        description: 'Reviews correctness',
+        temperature: 0.5,
+      })
+      writeSystematicConfig({
+        agents: { 'correctness-reviewer': { temperature: 0.9 } },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      const config: Config = {}
+      await handler(config)
+
+      expect(config.agent?.['correctness-reviewer']?.temperature).toBe(0.9)
     })
   })
 })

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -10,6 +10,7 @@ import {
   checkAgentMode,
   checkAgentModel,
   checkAgentStemUniqueness,
+  checkAgentTemperature,
   checkBannedPatterns,
   checkContentIntegrity,
   checkFrontmatter,
@@ -58,12 +59,12 @@ function writeAllowlist(root: string, exemptions: AllowlistEntry[]): void {
 }
 
 function writeAgent(root: string, category: string, name: string): void {
-  // Bundled agents must omit the `model` field and declare `mode: subagent`
-  // per content-integrity gate invariants.
+  // Bundled agents must omit the `model` field, declare `mode: subagent`,
+  // and declare an explicit `temperature:` per content-integrity gate invariants.
   writeFile(
     root,
     `agents/${category}/${name}.md`,
-    `---\nname: ${name}\nmode: subagent\n---\nagent body`,
+    `---\nname: ${name}\nmode: subagent\ntemperature: 0.3\n---\nagent body`,
   )
 }
 
@@ -1323,6 +1324,135 @@ describe('checkAgentMode', () => {
       expect(violations).toHaveLength(1)
       expect(violations[0]?.file).toBe('agents/research/list-fm.md')
       expect(violations[0]?.message).toContain('mode: subagent')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('checkAgentTemperature', () => {
+  test('returns no violations when all agents declare an explicit temperature', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/analyst.md',
+        '---\nname: analyst\nmode: subagent\ntemperature: 0.2\n---\nbody',
+      )
+      writeFile(
+        root,
+        'agents/review/sentinel.md',
+        '---\nname: sentinel\nmode: subagent\ntemperature: 0.1\n---\nbody',
+      )
+      const targets = collectScanTargets(root)
+      expect(checkAgentTemperature(root, targets.markdown)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags an agent with no temperature field', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/no-temp.md',
+        '---\nname: no-temp\nmode: subagent\n---\nbody',
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkAgentTemperature(root, targets.markdown)
+      expect(violations).toHaveLength(1)
+      expect(violations[0]?.file).toBe('agents/research/no-temp.md')
+      expect(violations[0]?.message).toContain('temperature')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags an agent whose frontmatter is a valid YAML list (non-object top-level, fail-closed)', () => {
+    // A YAML list at the top level is valid YAML but not a record — the agent
+    // cannot declare temperature, so it must be flagged (fail closed, not skipped).
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/list-fm.md',
+        '---\n- name: list-fm\n- temperature: 0.3\n---\nbody',
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkAgentTemperature(root, targets.markdown)
+      expect(violations).toHaveLength(1)
+      expect(violations[0]?.file).toBe('agents/research/list-fm.md')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('scans only agent markdown files, not skill files', () => {
+    const root = makeFixtureRepo()
+    try {
+      // Skill with no temperature field — must not be flagged.
+      writeCompliantSkill(root, 'foo', 'body')
+      // Agent with explicit temperature — no violation.
+      writeFile(
+        root,
+        'agents/research/a.md',
+        '---\nname: a\nmode: subagent\ntemperature: 0.3\n---\nbody',
+      )
+      const targets = collectScanTargets(root)
+      expect(checkAgentTemperature(root, targets.markdown)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('integration: gate passes against the current hardened real tree (all agents have explicit temperature)', () => {
+    const violations = checkAgentTemperature(
+      REPO_ROOT,
+      collectScanTargets(REPO_ROOT).markdown,
+    )
+    expect(violations).toEqual([])
+  })
+})
+
+describe('checkContentIntegrity — agentTemperatureViolations wiring', () => {
+  test('populates agentTemperatureViolations when an agent is missing temperature', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/no-temp.md',
+        '---\nname: no-temp\nmode: subagent\n---\nagent body',
+      )
+
+      const result = checkContentIntegrity(root)
+
+      expect(result.agentTemperatureViolations).toHaveLength(1)
+      expect(result.agentTemperatureViolations[0]?.file).toBe(
+        'agents/research/no-temp.md',
+      )
+      expect(result.agentTemperatureViolations[0]?.message).toContain(
+        'temperature',
+      )
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('agentTemperatureViolations counts toward totalViolations (non-zero exit)', () => {
+    // Proves the wiring: a missing temperature must cause a non-clean result.
+    // We verify this indirectly by checking that agentTemperatureViolations is
+    // non-empty — the totalViolations function sums it.
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/no-temp.md',
+        '---\nname: no-temp\nmode: subagent\n---\nagent body',
+      )
+
+      const result = checkContentIntegrity(root)
+      expect(result.agentTemperatureViolations.length).toBeGreaterThan(0)
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }
@@ -2619,6 +2749,14 @@ describe('integration: real repo', () => {
       },
       'Agent mode violations in repo',
     )
+    assertNoViolations(
+      result.agentTemperatureViolations,
+      (v) => {
+        const tv = v as (typeof result.agentTemperatureViolations)[number]
+        return `${tv.file}  ${tv.message}`
+      },
+      'Agent temperature violations in repo',
+    )
 
     expect(result.phantomRefs).toEqual([])
     expect(result.brokenSubfileRefs).toEqual([])
@@ -2628,6 +2766,7 @@ describe('integration: real repo', () => {
     expect(result.agentStemViolations).toEqual([])
     expect(result.parseSafetyViolations).toEqual([])
     expect(result.agentModeViolations).toEqual([])
+    expect(result.agentTemperatureViolations).toEqual([])
     expect(result.allowlistWarnings).toEqual([])
     expect(result.scanStats.markdownFiles).toBeGreaterThan(0)
     expect(result.scanStats.typescriptFiles).toBeGreaterThan(0)

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -1406,6 +1406,76 @@ describe('checkAgentTemperature', () => {
     }
   })
 
+  test('flags an agent with temperature: null (null is not a finite number)', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/null-temp.md',
+        '---\nname: null-temp\nmode: subagent\ntemperature: null\n---\nbody',
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkAgentTemperature(root, targets.markdown)
+      expect(violations).toHaveLength(1)
+      expect(violations[0]?.file).toBe('agents/research/null-temp.md')
+      expect(violations[0]?.message).toContain('temperature')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags an agent with temperature: "0.3" (string is not a finite number)', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/string-temp.md',
+        '---\nname: string-temp\nmode: subagent\ntemperature: "0.3"\n---\nbody',
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkAgentTemperature(root, targets.markdown)
+      expect(violations).toHaveLength(1)
+      expect(violations[0]?.file).toBe('agents/research/string-temp.md')
+      expect(violations[0]?.message).toContain('temperature')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags an agent with empty temperature: (YAML null, not a finite number)', () => {
+    // `temperature:` with no value parses as null in YAML — same as temperature: null.
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/empty-temp.md',
+        '---\nname: empty-temp\nmode: subagent\ntemperature:\n---\nbody',
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkAgentTemperature(root, targets.markdown)
+      expect(violations).toHaveLength(1)
+      expect(violations[0]?.file).toBe('agents/research/empty-temp.md')
+      expect(violations[0]?.message).toContain('temperature')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('passes for an agent with temperature: 0.3 (finite number)', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/valid-temp.md',
+        '---\nname: valid-temp\nmode: subagent\ntemperature: 0.3\n---\nbody',
+      )
+      const targets = collectScanTargets(root)
+      expect(checkAgentTemperature(root, targets.markdown)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   test('integration: gate passes against the current hardened real tree (all agents have explicit temperature)', () => {
     const violations = checkAgentTemperature(
       REPO_ROOT,
@@ -1439,10 +1509,11 @@ describe('checkContentIntegrity — agentTemperatureViolations wiring', () => {
     }
   })
 
-  test('agentTemperatureViolations counts toward totalViolations (non-zero exit)', () => {
-    // Proves the wiring: a missing temperature must cause a non-clean result.
-    // We verify this indirectly by checking that agentTemperatureViolations is
-    // non-empty — the totalViolations function sums it.
+  test('agentTemperatureViolations counts toward totalViolations (CLI exits 1)', () => {
+    // Proves the wiring end-to-end: agentTemperatureViolations must cause the
+    // CLI to exit 1. A result with only agentTemperatureViolations non-empty
+    // and all other arrays empty must produce a non-zero exit — deleting the
+    // agentTemperatureViolations term from totalViolations() would break this.
     const root = makeFixtureRepo()
     try {
       writeFile(
@@ -1451,8 +1522,38 @@ describe('checkContentIntegrity — agentTemperatureViolations wiring', () => {
         '---\nname: no-temp\nmode: subagent\n---\nagent body',
       )
 
-      const result = checkContentIntegrity(root)
-      expect(result.agentTemperatureViolations.length).toBeGreaterThan(0)
+      const proc = Bun.spawnSync(['bun', SCRIPT_PATH, root], {
+        cwd: REPO_ROOT,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      expect(proc.exitCode).toBe(1)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('printAgentTemperatureViolations — CLI print path', () => {
+  test('emits the agent-temperature-violation heading and offending file to stderr', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/no-temp.md',
+        '---\nname: no-temp\nmode: subagent\n---\nagent body',
+      )
+
+      const proc = Bun.spawnSync(['bun', SCRIPT_PATH, root], {
+        cwd: REPO_ROOT,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+
+      expect(proc.exitCode).toBe(1)
+      const stderr = proc.stderr.toString()
+      expect(stderr).toContain('Agent temperature violations (1)')
+      expect(stderr).toContain('agents/research/no-temp.md')
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }


### PR DESCRIPTION
Makes every bundled agent's `temperature` explicit in frontmatter and changes the runtime to respect it, removing a hidden inference heuristic from the config path.

## What changed

- All 51 bundled agents now declare an explicit `temperature:`. The 37 that previously relied on runtime inference get their resolved value written into frontmatter — derived mechanically from the same function the runtime uses, so no agent's temperature changes.
- The config hook now respects an agent's explicit `temperature` instead of always overwriting it with the inferred value. User config overlays still override, preserving the precedence: user overlay > explicit frontmatter > inferred fallback.
- A content-integrity check requires every bundled agent to declare an explicit, finite-number `temperature:`, and fails closed on malformed frontmatter.

## Why

Temperature was computed at load time from a name/description regex and silently clobbered any explicit value in frontmatter. Making it explicit and source-visible brings it to parity with `mode`/`model`/`color`, makes each agent's temperature auditable, and lets the load-time inference be retired without changing behavior.

## Verification

- Resolved temperature is unchanged for all 51 agents (verified mechanically against the runtime inference function — zero mismatches).
- A test proves explicit frontmatter temperature is now preserved (it would fail before this change), and that user overlays still override it.
- typecheck, lint, content-integrity, registry/schema drift, build, Node ESM smoke, full unit suite, and docs build all pass.
