### PR TITLE
ci: don't fail release on narration dispatch confirmation timeout

### DIFF
--- a/scripts/dispatch-release-notes.sh
+++ b/scripts/dispatch-release-notes.sh
@@ -94,13 +94,13 @@ gh workflow run --ref main fro-bot.yaml \
   -f "prompt=$PROMPT" \
   -f "correlation-id=$CORRELATION_ID"
 
-# Poll up to 90 seconds for a workflow_dispatch run on fro-bot.yaml that was
+# Poll up to 180 seconds for a workflow_dispatch run on fro-bot.yaml that was
 # created strictly after DISPATCH_EPOCH. Once found, this is our dispatched run
 # (no other dispatchers race against this from main.yaml's Release job).
 # Test escape hatches: RELEASE_NOTES_TEST_POLL_BUDGET_SECS and
 # RELEASE_NOTES_TEST_POLL_INTERVAL_SECS shorten the loop for unit tests.
-# Production runs always use 90s budget / 5s interval.
-POLL_BUDGET_SECS="${RELEASE_NOTES_TEST_POLL_BUDGET_SECS:-90}"
+# Production runs always use 180s budget / 5s interval.
+POLL_BUDGET_SECS="${RELEASE_NOTES_TEST_POLL_BUDGET_SECS:-180}"
 POLL_INTERVAL_SECS="${RELEASE_NOTES_TEST_POLL_INTERVAL_SECS:-5}"
 RUN_ID=""
 POLL_DEADLINE=$(( $(date +%s) + POLL_BUDGET_SECS ))
@@ -122,8 +122,8 @@ while [ "$(date +%s)" -lt "$POLL_DEADLINE" ]; do
 done
 
 if [ -z "$RUN_ID" ]; then
-  echo "::error::Dispatched workflow run not found within ${POLL_BUDGET_SECS}s (correlation=$CORRELATION_ID, dispatched_at_epoch=$DISPATCH_EPOCH). GitHub may have rejected the dispatch or the workflow never started."
-  exit 1
+  echo "::warning::Dispatch was sent but its run could not be confirmed within ${POLL_BUDGET_SECS}s (correlation=$CORRELATION_ID, dispatched_at_epoch=$DISPATCH_EPOCH). The narration will still run asynchronously — the release itself is unaffected. This is an observability gap, not a dispatch failure."
+  exit 0
 fi
 
 # Wait for the run to complete, hard-bounded at 10 minutes.

--- a/tests/integration/release-notes-ci.test.ts
+++ b/tests/integration/release-notes-ci.test.ts
@@ -12,7 +12,7 @@
  *  4.  Happy path — neutral conclusion (idempotent short-circuit)
  *  5.  Edge case — timeout (WATCH_EXIT=124)
  *  5b. Edge case — unexpected non-zero WATCH_EXIT (e.g., 137)
- *  6.  Edge case — dispatch not registered within 90s (empty run list)
+ *  6.  Edge case — dispatch not registered within poll budget (empty run list, non-fatal)
  *  7.  Edge case — no run created after dispatch epoch (all runs pre-date cutoff)
  *  8.  Edge case — selects newest workflow_dispatch run created after dispatch epoch
  *  9.  Error — HTTP 401 auth denial
@@ -41,7 +41,7 @@ const REPO_ROOT = path.resolve(import.meta.dirname, '../..')
 const SCRIPT_PATH = path.join(REPO_ROOT, 'scripts/dispatch-release-notes.sh')
 const MOCK_GH_PATH = path.join(REPO_ROOT, 'tests/fixtures/mock-gh.sh')
 
-// Timeout per scenario — the successCmd has a 90s polling loop; we cap it
+// Timeout per scenario — the successCmd has a 180s polling loop; we cap it
 // tightly in tests by making the mock return immediately.
 const SCENARIO_TIMEOUT_MS = 30_000
 
@@ -353,21 +353,22 @@ describe('release-notes-ci successCmd smoke tests', () => {
   )
 
   // -------------------------------------------------------------------------
-  // 6. Edge case — dispatch not registered within 90s
+  // 6. Edge case — dispatch not registered within poll budget (empty run list)
   // -------------------------------------------------------------------------
   it(
-    'exits 1 with ::error:: when dispatched run is never found in run list',
+    'exits 0 with ::warning:: when dispatched run is never found in run list (non-fatal observability gap)',
     () => {
-      // Return an empty run list so the correlation token is never matched
+      // Return an empty run list so the run is never confirmed within the poll budget
       const result = run({
         RELEASE_VERSION: 'v2.23.0',
         MOCK_GH_RUN_LIST_JSON: '[]',
       })
 
-      expect(result.exitCode).toBe(1)
+      expect(result.exitCode).toBe(0)
       const combined = result.stdout + result.stderr
-      expect(combined).toContain('::error::')
-      expect(combined).toMatch(/not found within/i)
+      expect(combined).toContain('::warning::')
+      expect(combined).not.toContain('::error::')
+      expect(combined).toMatch(/not found within|could not be confirmed/i)
     },
     SCENARIO_TIMEOUT_MS,
   )
@@ -376,7 +377,7 @@ describe('release-notes-ci successCmd smoke tests', () => {
   // 7. Edge case — no run created after dispatch epoch
   // -------------------------------------------------------------------------
   it(
-    'exits 1 with ::error:: when all candidate runs pre-date the dispatch epoch',
+    'exits 0 with ::warning:: when all candidate runs pre-date the dispatch epoch (non-fatal observability gap)',
     () => {
       // All runs have a createdAt in the past — before any real DISPATCH_EPOCH.
       // The script's jq filter selects runs with epoch > DISPATCH_EPOCH, so none
@@ -388,10 +389,11 @@ describe('release-notes-ci successCmd smoke tests', () => {
         ]),
       })
 
-      expect(result.exitCode).toBe(1)
+      expect(result.exitCode).toBe(0)
       const combined = result.stdout + result.stderr
-      expect(combined).toContain('::error::')
-      expect(combined).toMatch(/not found within/i)
+      expect(combined).toContain('::warning::')
+      expect(combined).not.toContain('::error::')
+      expect(combined).toMatch(/not found within|could not be confirmed/i)
       expect(combined).toContain('dispatched_at_epoch=')
     },
     SCENARIO_TIMEOUT_MS,


### PR DESCRIPTION
Stops the Release job from failing when the release-notes narration dispatch can't be confirmed in time.

`scripts/dispatch-release-notes.sh` dispatches the Fro Bot workflow to write the release narrative, then polls `gh run list` to find the dispatched run by timestamp. When that confirmation poll timed out, the script exited 1 and turned the whole Release job red — even though the dispatch had already succeeded and the narration ran. This happened on v2.30.1: the release published, the body was narrated, but the job still showed red because GitHub took longer than the poll budget to surface the dispatched run.

A successful `gh workflow run` means the dispatch was accepted; failing to observe the run afterward is an observability gap, not a dispatch failure. The narration is best-effort post-release work, so it should never fail the release.

- Confirmation timeout now emits a `::warning::` and exits 0 instead of failing the job.
- Bumped the confirmation poll budget from 90s to 180s to reduce the race.
- Genuine validation failures (e.g. a malformed release version) still hard-fail with `::error::`.
