### PR TITLE
feat(skills): add argument-hint to ce:compound-refresh and guard the field

### DIFF
--- a/docs/plans/2026-06-06-003-feat-skill-frontmatter-tune-up-plan.md
+++ b/docs/plans/2026-06-06-003-feat-skill-frontmatter-tune-up-plan.md
@@ -70,7 +70,7 @@ A deferred note estimated ~14 skills needed `argument-hint`. Grounding corrected
 
 ## Implementation Units
 
-- [ ] **Unit 1: Add argument-hint to ce-compound-refresh + annotate field table**
+- [x] **Unit 1: Add argument-hint to ce-compound-refresh + annotate field table**
 
 **Goal:** Close the one `argument-hint` gap and annotate the field-semantics table with enforcement status.
 
@@ -95,7 +95,7 @@ A deferred note estimated ~14 skills needed `argument-hint`. Grounding corrected
 **Verification:**
 - `ce-compound-refresh` has an accurate `argument-hint`; no skill uses `$ARGUMENTS` without one; the field table marks enforcement status; content-integrity clean.
 
-- [ ] **Unit 2: Content-integrity argument-hint warning + tests**
+- [x] **Unit 2: Content-integrity argument-hint violation + tests**
 
 **Goal:** A content-integrity violation fires when a skill uses `$ARGUMENTS` (outside code fences) without `argument-hint`, with unit coverage.
 

--- a/docs/plans/2026-06-06-003-feat-skill-frontmatter-tune-up-plan.md
+++ b/docs/plans/2026-06-06-003-feat-skill-frontmatter-tune-up-plan.md
@@ -1,0 +1,145 @@
+---
+title: "feat: Skill frontmatter tune-up"
+type: feat
+status: active
+date: 2026-06-06
+origin: docs/brainstorms/2026-06-06-skill-frontmatter-tune-up-requirements.md
+---
+
+# feat: Skill frontmatter tune-up
+
+## Overview
+
+A small, durable bundled-skill frontmatter consistency tune-up: add the one missing `argument-hint`, annotate the existing field-semantics table with enforcement status, and add a content-integrity warning so the `$ARGUMENTS`-without-`argument-hint` gap can't silently reappear.
+
+## Problem Frame
+
+A deferred note estimated ~14 skills needed `argument-hint`. Grounding corrected that to a real gap of **one** skill (`ce-compound-refresh`), and the field-semantics docs already largely exist in `foundation-conventions.md`. So the value is closing the one gap, clarifying which frontmatter fields the runtime actually consumes versus reads-but-doesn't-enforce, and making the invariant durable with a gate. See origin: `docs/brainstorms/2026-06-06-skill-frontmatter-tune-up-requirements.md`.
+
+## Requirements Trace
+
+- R1. `skills/ce-compound-refresh/SKILL.md` declares an `argument-hint` reflecting its real usage: `mode:autofix` plus an optional `docs/solutions/` scope hint (e.g. a category, module, or keyword).
+- R2. `foundation-conventions.md`'s frontmatter table annotates each field's enforcement status, distinguishing read-and-acted-on fields from read-but-unenforced ones; `allowed-tools` is marked read-but-unenforced (`src/lib/skills.ts` parses it into `SkillFrontmatter.allowedTools`, but no `src/lib` gate acts on it, and OpenCode doesn't enforce it).
+- R3. The content-integrity gate fails (a hard violation, mirroring `deprecated.reason` / agent-mode checks) when a bundled `SKILL.md` body references `$ARGUMENTS` outside code fences but its frontmatter lacks `argument-hint`. The body scan ignores fenced code blocks so a skill that merely documents `$ARGUMENTS` is not falsely flagged.
+- R4. The new check has unit coverage: `$ARGUMENTS` without `argument-hint` → flagged; with both → clean; with neither → clean.
+
+## Scope Boundaries
+
+- Not adding `argument-hint` to skills that don't take meaningful arguments.
+- Not touching the 8 skills that have `argument-hint` but no literal `$ARGUMENTS` (they parse args differently and are correct).
+- Not changing the runtime loader's recognized-field contract.
+- The R3 check is a hard violation (content-integrity already exits non-zero on violations; no new warning channel is built). After Unit 1 the tree is clean, so it never false-fails.
+
+### Deferred to Separate Tasks
+
+- `config.test.ts` `AE\d+` test-name rename (note #122).
+- Deprecated-skill + converter removal (v3.0.0, note #116).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/content-integrity.ts` — `checkSkillFrontmatterFields` (~line 746) and `checkRequiredSkillField` (~line 718) already scan `skills/*/SKILL.md` frontmatter + body; the new check mirrors this pattern. Wire it end-to-end as a normal violation: add a `CheckResult` field, count it in `totalViolations()`, print it in `printResult()`, and invoke it in `checkContentIntegrity()`. NOTE (verified during review): content-integrity has NO general non-failing warning channel — `allowlistWarnings` is the only warning bucket and is allowlist-specific. So this check is a hard violation, not a warning.
+- `skills/ce-compound-refresh/SKILL.md` — uses `$ARGUMENTS` for `mode:autofix` + scope hint.
+- `skills/writing-systematic-skills/references/foundation-conventions.md` — the existing frontmatter field table to annotate.
+- Existing `argument-hint` examples: `ce-plan` (`"[optional: feature description, ... or any task to plan]"`), `document-review` (`"[mode:headless] [path/to/document.md]"`).
+
+### Institutional Learnings
+
+- Memory: OpenCode `allowed-tools` is metadata, not enforced permissions.
+- The content-integrity gate is the durable home for bundled-asset invariants (mirrors `deprecated.reason`, agent-mode, agent-color checks).
+
+## Key Technical Decisions
+
+- **Hard violation, not warning** (R3): content-integrity has no general non-failing warning channel (verified during review — `allowlistWarnings` is the only warning bucket and is allowlist-specific). Rather than build new warning infra for a one-skill guard, the check is a normal violation that mirrors the existing `deprecated.reason` / agent-mode gates. After Unit 1 the tree is clean, so it never false-fails.
+- **Mirror the existing skill-frontmatter check pattern**: reuse `findSkillsInDir`/`extractFrontmatterBlock` + body scan; don't invent a new scanning mechanism.
+- **Accurate `allowed-tools` framing** (R2): "read but not enforced," not "not read" — the loader parses it; nothing acts on it.
+- **Fence-aware body scan** (R3): the `$ARGUMENTS` scan ignores fenced code blocks so a skill documenting `$ARGUMENTS` (rather than consuming it) isn't falsely flagged. Verified during review that all 13 current `$ARGUMENTS`-using skills are real consumers, so the tree is clean after Unit 1.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Warning vs hard-fail → hard violation (content-integrity has no non-failing warning channel; building one for a one-skill guard isn't justified).
+- `argument-hint` text for `ce-compound-refresh` → reflects its real usage: `mode:autofix` plus an optional `docs/solutions/` scope hint.
+
+### Deferred to Implementation
+
+- Exact annotation shape in the field table (extra column vs inline note) — implementer's call, must clearly mark read-vs-acted-on.
+- Exact fence-stripping approach for the `$ARGUMENTS` body scan — implementer's call, but it must not flag `$ARGUMENTS` inside fenced code blocks.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add argument-hint to ce-compound-refresh + annotate field table**
+
+**Goal:** Close the one `argument-hint` gap and annotate the field-semantics table with enforcement status.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `skills/ce-compound-refresh/SKILL.md` (add `argument-hint` frontmatter)
+- Modify: `skills/writing-systematic-skills/references/foundation-conventions.md` (annotate the field table)
+
+**Approach:**
+- Add an `argument-hint` reflecting the skill's real usage — `mode:autofix` plus an optional `docs/solutions/` scope hint (category, module, or keyword). For example: `argument-hint: "[mode:autofix] [optional: category, module, or keyword scope]"`.
+- In `foundation-conventions.md`, annotate the existing field table so each field's enforcement status is clear: read-and-acted-on (e.g. `name`, `description`, `argument-hint`, `context: fork`, `subtask`) vs read-but-unenforced. Mark `allowed-tools` read-but-unenforced with the accurate explanation.
+
+**Patterns to follow:**
+- Existing `argument-hint` values in `ce-plan` / `document-review`.
+
+**Test scenarios:**
+- Test expectation: none — frontmatter/docs content; verified by content-integrity + `bun run docs:build`.
+
+**Verification:**
+- `ce-compound-refresh` has an accurate `argument-hint`; no skill uses `$ARGUMENTS` without one; the field table marks enforcement status; content-integrity clean.
+
+- [ ] **Unit 2: Content-integrity argument-hint warning + tests**
+
+**Goal:** A content-integrity violation fires when a skill uses `$ARGUMENTS` (outside code fences) without `argument-hint`, with unit coverage.
+
+**Requirements:** R3, R4
+
+**Dependencies:** Unit 1 (so the gate runs clean against the real tree)
+
+**Files:**
+- Modify: `scripts/content-integrity.ts` (new violation check + end-to-end wiring)
+- Test: `tests/unit/content-integrity.test.ts`
+
+**Approach:**
+- Add a check that, for each `skills/*/SKILL.md`, records a VIOLATION when the body references `$ARGUMENTS` outside fenced code blocks but the frontmatter lacks `argument-hint`. Strip/ignore fenced code blocks before scanning for `$ARGUMENTS` so documentation mentions don't false-positive. Mirror `checkSkillFrontmatterFields` and wire end-to-end: `CheckResult` field, `totalViolations()`, `printResult()`, `checkContentIntegrity()`.
+
+**Execution note:** Test-first. RED: a fixture skill using `$ARGUMENTS` without `argument-hint` is flagged as a violation. GREEN: the check + fence-stripping.
+
+**Patterns to follow:**
+- `checkSkillFrontmatterFields` / `checkRequiredSkillField` structure and their tests.
+
+**Test scenarios:**
+- Happy path: a fixture skill with `$ARGUMENTS` in body + no `argument-hint` → violation recorded.
+- Happy path: a fixture skill with both `$ARGUMENTS` and `argument-hint` → no violation.
+- Edge case: a fixture skill with neither → no violation.
+- Edge case (fence false-positive): a fixture skill that mentions `$ARGUMENTS` ONLY inside a fenced code block, with no `argument-hint` → no violation (fence-stripping works).
+- Edge case: malformed/non-object frontmatter → handled like the sibling checks (no crash).
+- Integration: the gate runs clean (zero violations) against the real tree after Unit 1.
+
+**Verification:**
+- The violation fires for the gap and only the gap; fenced `$ARGUMENTS` mentions don't trigger it; the real tree is violation-clean post-Unit-1; `totalViolations` counts it; tests pass.
+
+## System-Wide Impact
+
+- **API surface parity:** the new check joins the other `skills/*/SKILL.md` content-integrity checks.
+- **Unchanged invariants:** no runtime loader change; no hard-fail added; existing checks untouched.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| The check fails CI on the real tree | After Unit 1 the tree is clean (verified during review: all 13 `$ARGUMENTS`-using skills are real consumers with `argument-hint`). An integration test asserts zero violations on the real tree. |
+| `$ARGUMENTS` appears in a code-fence/example, not real usage | The body scan strips fenced code blocks before checking, and a dedicated test covers the fence-only case. |
+| `argument-hint` text inaccurate for ce-compound-refresh | Derived from its real `mode:autofix` + scope-hint usage; verify against the SKILL.md body. |
+
+## Sources & References
+
+- **Origin document:** docs/brainstorms/2026-06-06-skill-frontmatter-tune-up-requirements.md
+- Related code: `scripts/content-integrity.ts`, `skills/ce-compound-refresh/SKILL.md`, `skills/writing-systematic-skills/references/foundation-conventions.md`

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -35,6 +35,11 @@
  *    treated as absent (the runtime's fill-if-absent fallback will be removed in
  *    v3.0.0), so only a real finite number satisfies this invariant.
  *
+ * 8. **Skill argument-hint** — bundled skills whose body references the literal
+ *    `$ARGUMENTS` outside fenced code blocks must declare a non-empty
+ *    `argument-hint` field in frontmatter. Fenced code blocks are stripped before
+ *    scanning so skills that only document the placeholder are not flagged.
+ *
  * Scope is narrow by design: `skills/**\/*.md`, `agents/**\/*.md`, and
  * `src/**\/*.ts` for the full invariant suite. Additionally, `docs/solutions/**\/*.md`
  * is scanned for frontmatter parse-safety only (flags any unquoted inline comment —
@@ -201,6 +206,11 @@ export interface AgentTemperatureViolation {
   message: string
 }
 
+export interface ArgumentHintViolation {
+  file: string
+  message: string
+}
+
 export interface CheckResult {
   rootDir: string
   categories: string[]
@@ -215,6 +225,7 @@ export interface CheckResult {
   agentColorViolations: AgentColorViolation[]
   agentStemViolations: AgentStemViolation[]
   agentTemperatureViolations: AgentTemperatureViolation[]
+  argumentHintViolations: ArgumentHintViolation[]
   exemptHits: ExemptHit[]
   scanStats: {
     markdownFiles: number
@@ -1075,6 +1086,52 @@ export function checkAgentStemUniqueness(
     .sort((a, b) => a.stem.localeCompare(b.stem))
 }
 
+/**
+ * Strip fenced code blocks (``` or ~~~) from a markdown body string.
+ * Returns the body with all fenced regions replaced by empty strings so that
+ * literal patterns inside fences are not matched by subsequent scans.
+ */
+function stripFencedCodeBlocks(body: string): string {
+  // Matches ``` or ~~~ fences (with optional language tag) across multiple lines.
+  return body.replace(/^(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1[ \t]*$/gm, '')
+}
+
+/**
+ * Check that every bundled skill whose body references the literal `$ARGUMENTS`
+ * outside fenced code blocks also declares a non-empty `argument-hint` field in
+ * its frontmatter. Skills that only document `$ARGUMENTS` inside code fences are
+ * not flagged -- the fence-stripping pass removes those occurrences first.
+ */
+export function checkArgumentHint(
+  rootDir: string,
+  markdownFiles: readonly string[],
+): ArgumentHintViolation[] {
+  const violations: ArgumentHintViolation[] = []
+
+  for (const relPath of markdownFiles) {
+    if (!isSkillEntryFile(relPath)) continue
+    const content = readFileSafe(path.join(rootDir, relPath))
+    if (content === null) continue
+    const parsed = parseFrontmatter(content)
+    if (!isRecord(parsed.data)) continue
+
+    const strippedBody = stripFencedCodeBlocks(parsed.body)
+    if (!strippedBody.includes('$ARGUMENTS')) continue
+
+    const hint = parsed.data['argument-hint']
+    if (typeof hint === 'string' && hint.trim() !== '') continue
+
+    violations.push({
+      file: relPath,
+      message:
+        `Skill body references \`$ARGUMENTS\` outside fenced code blocks but frontmatter is missing a non-empty \`argument-hint\` field. ` +
+        `Add \`argument-hint: "<description>"\` to the frontmatter so callers know what to pass.`,
+    })
+  }
+
+  return violations
+}
+
 function isAgentFile(relPath: string): boolean {
   const parts = relPath.split('/')
   return (
@@ -1206,6 +1263,7 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     rootDir,
     targets.markdown,
   )
+  const argumentHintViolations = checkArgumentHint(rootDir, targets.markdown)
   const { hits: bannedPatterns, exempt: exemptHits } = checkBannedPatterns(
     rootDir,
     allScannedFiles,
@@ -1226,6 +1284,7 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     agentColorViolations,
     agentStemViolations,
     agentTemperatureViolations,
+    argumentHintViolations,
     exemptHits,
     scanStats: {
       markdownFiles: targets.markdown.length,
@@ -1274,6 +1333,7 @@ function printResult(result: CheckResult, verbose: boolean): void {
   printAgentColorViolations(result.agentColorViolations)
   printAgentStemViolations(result.agentStemViolations)
   printAgentTemperatureViolations(result.agentTemperatureViolations)
+  printArgumentHintViolations(result.argumentHintViolations)
 
   if (totalViolations(result) === 0) {
     process.stdout.write(
@@ -1402,6 +1462,16 @@ function printAgentTemperatureViolations(
   }
 }
 
+function printArgumentHintViolations(
+  violations: readonly ArgumentHintViolation[],
+): void {
+  if (violations.length === 0) return
+  process.stderr.write(`\nArgument-hint violations (${violations.length}):\n`)
+  for (const v of violations) {
+    process.stderr.write(`  ${v.file}  ${v.message}\n`)
+  }
+}
+
 function totalViolations(result: CheckResult): number {
   return (
     result.phantomRefs.length +
@@ -1413,7 +1483,8 @@ function totalViolations(result: CheckResult): number {
     result.agentModeViolations.length +
     result.agentColorViolations.length +
     result.agentStemViolations.length +
-    result.agentTemperatureViolations.length
+    result.agentTemperatureViolations.length +
+    result.argumentHintViolations.length
   )
 }
 

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -1093,6 +1093,9 @@ export function checkAgentStemUniqueness(
  */
 function stripFencedCodeBlocks(body: string): string {
   // Matches ``` or ~~~ fences (with optional language tag) across multiple lines.
+  // Anchored at line start, so fences indented inside list items or blockquotes
+  // are not stripped. No bundled skill nests a fenced `$ARGUMENTS` that way; if one
+  // ever does, the real-tree integration test will surface the false positive.
   return body.replace(/^(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1[ \t]*$/gm, '')
 }
 

--- a/skills/ce-compound-refresh/SKILL.md
+++ b/skills/ce-compound-refresh/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ce:compound-refresh
 description: Refresh stale or drifting learnings and pattern docs in docs/solutions/ by reviewing, updating, consolidating, replacing, or deleting them against the current codebase. Use after refactors, migrations, dependency upgrades, or when a retrieved learning feels outdated or wrong. Also use when reviewing docs/solutions/ for accuracy, when a recently solved problem contradicts an existing learning, when pattern docs no longer reflect current code, or when multiple docs seem to cover the same topic and might benefit from consolidation.
+argument-hint: "[mode:autofix] [optional: category, module, or keyword scope]"
 disable-model-invocation: true
 ---
 

--- a/skills/writing-systematic-skills/references/foundation-conventions.md
+++ b/skills/writing-systematic-skills/references/foundation-conventions.md
@@ -6,21 +6,21 @@ This reference expands the Systematic-specific rules from `SKILL.md`. The mechan
 
 Systematic skill frontmatter mirrors what the runtime loader actually reads. Do not invent fields for documentation structure. If the loader does not consume the field, put the information in the body.
 
-| Field | Required | When To Use | Example |
-|---|---:|---|---|
-| `name` | Yes | Every skill. Use the unprefixed skill identifier unless another namespace is intentional. | `name: writing-systematic-skills` |
-| `description` | Yes | Trigger-oriented discovery text. Third person. Prefer `Use when...`. | `description: Use when fixing bundled skill frontmatter failures...` |
-| `argument-hint` | No | The skill accepts meaningful invocation arguments. | `argument-hint: "[path/to/document.md]"` |
-| `disable-model-invocation` | No | Dispatcher or routing skills that should not be directly model-invoked. | `disable-model-invocation: true` |
-| `allowed-tools` | No | The skill needs an explicit tool allowlist. | `allowed-tools: Bash, Read` |
-| `license` | No | Licensing metadata matters for distribution. | `license: MIT` |
-| `compatibility` | No | A platform or version caveat is real and useful. | `compatibility: OpenCode` |
-| `metadata` | No | String-only metadata map. Keep it boring. | `metadata: { owner: systematic }` |
-| `user-invocable` | No | Direct user invocation should be explicitly advertised or suppressed. | `user-invocable: false` |
-| `agent` | No | A loader-supported companion agent is required. | `agent: general` |
-| `model` | No | A skill-level model choice is justified for *skill execution* (not bundled agents — see below). | `model: anthropic/claude-haiku-4-5` |
-| `context` | No | Forked execution is required. `fork` derives subtask behavior at runtime. | `context: fork` |
-| `subtask` | No | Explicit forked-subtask dispatch marker. | `subtask: true` |
+| Field | Required | When To Use | Enforcement | Example |
+|---|---:|---|---|---|
+| `name` | Yes | Every skill. Use the unprefixed skill identifier unless another namespace is intentional. | Read + enforced (loader rejects missing/null) | `name: writing-systematic-skills` |
+| `description` | Yes | Trigger-oriented discovery text. Third person. Prefer `Use when...`. | Read + enforced (loader rejects missing/null) | `description: Use when fixing bundled skill frontmatter failures...` |
+| `argument-hint` | No | The skill accepts meaningful invocation arguments. | Read + surfaced to callers | `argument-hint: "[path/to/document.md]"` |
+| `disable-model-invocation` | No | Dispatcher or routing skills that should not be directly model-invoked. | Read + enforced (loader acts on it) | `disable-model-invocation: true` |
+| `allowed-tools` | No | The skill needs an explicit tool allowlist. | **Read but not enforced.** `src/lib/skills.ts` parses it into `SkillFrontmatter.allowedTools` and passes it through, but no permission gate in `src/lib` acts on it. OpenCode treats it as metadata, not enforced permissions. Do not rely on this field to restrict tool access. | `allowed-tools: Bash, Read` |
+| `license` | No | Licensing metadata matters for distribution. | Read, passed through as metadata | `license: MIT` |
+| `compatibility` | No | A platform or version caveat is real and useful. | Read, passed through as metadata | `compatibility: OpenCode` |
+| `metadata` | No | String-only metadata map. Keep it boring. | Read, passed through as metadata | `metadata: { owner: systematic }` |
+| `user-invocable` | No | Direct user invocation should be explicitly advertised or suppressed. | Read + surfaced to callers | `user-invocable: false` |
+| `agent` | No | A loader-supported companion agent is required. | Read + enforced (loader acts on it) | `agent: general` |
+| `model` | No | A skill-level model choice is justified for *skill execution* (not bundled agents -- see below). | Read + enforced (loader acts on it; banned in bundled agent markdown) | `model: anthropic/claude-haiku-4-5` |
+| `context` | No | Forked execution is required. `fork` derives subtask behavior at runtime. | Read + enforced (runtime-recognized) | `context: fork` |
+| `subtask` | No | Explicit forked-subtask dispatch marker. | Read + enforced (runtime-recognized) | `subtask: true` |
 
 ### Required Fields
 

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -11,6 +11,7 @@ import {
   checkAgentModel,
   checkAgentStemUniqueness,
   checkAgentTemperature,
+  checkArgumentHint,
   checkBannedPatterns,
   checkContentIntegrity,
   checkFrontmatter,
@@ -3051,5 +3052,270 @@ describe('ce-work -> systematic-implementer dispatch contract', () => {
     expect(frontmatter).toMatch(/^name:\s*"?systematic-implementer"?$/m)
     expect(frontmatter).toMatch(/^mode:\s*"?subagent"?$/m)
     expect(frontmatter).not.toMatch(/^model:/m)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// checkArgumentHint
+// ---------------------------------------------------------------------------
+
+describe('checkArgumentHint', () => {
+  test('flags skill body referencing $ARGUMENTS without argument-hint in frontmatter', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'needs-hint',
+        [
+          '---',
+          'name: needs-hint',
+          'description: A skill that uses arguments',
+          '---',
+          'Pass $ARGUMENTS to the tool.',
+        ].join('\n'),
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkArgumentHint(root, targets.markdown)
+      expect(violations).toHaveLength(1)
+      expect(violations[0]?.file).toBe('skills/needs-hint/SKILL.md')
+      expect(violations[0]?.message).toContain('argument-hint')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('no violation when body references $ARGUMENTS and frontmatter has argument-hint', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'has-hint',
+        [
+          '---',
+          'name: has-hint',
+          'description: A skill that uses arguments',
+          'argument-hint: "[topic]"',
+          '---',
+          'Pass $ARGUMENTS to the tool.',
+        ].join('\n'),
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkArgumentHint(root, targets.markdown)
+      expect(violations).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('no violation when body has neither $ARGUMENTS nor argument-hint', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeCompliantSkill(
+        root,
+        'plain',
+        'Just a plain skill body with no arguments.',
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkArgumentHint(root, targets.markdown)
+      expect(violations).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('no violation when $ARGUMENTS appears only inside a fenced code block (fence-stripping works)', () => {
+    // A skill that DOCUMENTS $ARGUMENTS inside a code fence must not be flagged.
+    // The check must strip fenced code blocks before scanning for the literal.
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'docs-only',
+        [
+          '---',
+          'name: docs-only',
+          'description: Documents the $ARGUMENTS placeholder',
+          '---',
+          'This skill shows how to use the placeholder:',
+          '',
+          '```',
+          'bun run skill $ARGUMENTS',
+          '```',
+          '',
+          'The above is just an example.',
+        ].join('\n'),
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkArgumentHint(root, targets.markdown)
+      expect(violations).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags skill when $ARGUMENTS appears both inside and outside a fenced code block', () => {
+    // Outside-fence occurrence must still trigger the violation even when
+    // there is also an inside-fence occurrence.
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'mixed',
+        [
+          '---',
+          'name: mixed',
+          'description: Mixed usage',
+          '---',
+          'Run with $ARGUMENTS as the input.',
+          '',
+          '```',
+          'example: $ARGUMENTS',
+          '```',
+        ].join('\n'),
+      )
+      const targets = collectScanTargets(root)
+      const violations = checkArgumentHint(root, targets.markdown)
+      expect(violations).toHaveLength(1)
+      expect(violations[0]?.file).toBe('skills/mixed/SKILL.md')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('scans only skill entry files (SKILL.md), not agent files or sub-files', () => {
+    const root = makeFixtureRepo()
+    try {
+      // Agent file with $ARGUMENTS in body -- must not be flagged.
+      writeFile(
+        root,
+        'agents/research/a.md',
+        '---\nname: a\nmode: subagent\ntemperature: 0.3\n---\nUse $ARGUMENTS here.',
+      )
+      // Skill sub-file with $ARGUMENTS -- must not be flagged.
+      writeFile(
+        root,
+        'skills/foo/references/ref.md',
+        'Reference using $ARGUMENTS.',
+      )
+      // Compliant SKILL.md with no $ARGUMENTS -- no violation.
+      writeCompliantSkill(root, 'foo', 'body')
+      const targets = collectScanTargets(root)
+      const violations = checkArgumentHint(root, targets.markdown)
+      expect(violations).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('no crash on malformed frontmatter (non-object data)', () => {
+    // Malformed frontmatter produces non-object parsed.data; the check must
+    // not throw. Fail-closed: if we cannot parse frontmatter we skip the file.
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'malformed',
+        '---\n- item: one\n---\nBody with $ARGUMENTS here.',
+      )
+      const targets = collectScanTargets(root)
+      // Must not throw regardless of outcome.
+      expect(() => checkArgumentHint(root, targets.markdown)).not.toThrow()
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('integration: real repo skills produce zero argument-hint violations', () => {
+    const violations = checkArgumentHint(
+      REPO_ROOT,
+      collectScanTargets(REPO_ROOT).markdown,
+    )
+    expect(violations).toEqual([])
+  })
+})
+
+describe('checkContentIntegrity -- argumentHintViolations wiring', () => {
+  test('populates argumentHintViolations when a skill uses $ARGUMENTS without argument-hint', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'needs-hint',
+        [
+          '---',
+          'name: needs-hint',
+          'description: A skill',
+          '---',
+          'Run with $ARGUMENTS.',
+        ].join('\n'),
+      )
+
+      const result = checkContentIntegrity(root)
+
+      expect(result.argumentHintViolations).toHaveLength(1)
+      expect(result.argumentHintViolations[0]?.file).toBe(
+        'skills/needs-hint/SKILL.md',
+      )
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('argumentHintViolations counts toward totalViolations (CLI exits 1)', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'needs-hint',
+        [
+          '---',
+          'name: needs-hint',
+          'description: A skill',
+          '---',
+          'Run with $ARGUMENTS.',
+        ].join('\n'),
+      )
+
+      const proc = Bun.spawnSync(['bun', SCRIPT_PATH, root], {
+        cwd: REPO_ROOT,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      expect(proc.exitCode).toBe(1)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('printArgumentHintViolations -- CLI print path', () => {
+  test('emits the argument-hint-violation heading and offending file to stderr', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'needs-hint',
+        [
+          '---',
+          'name: needs-hint',
+          'description: A skill',
+          '---',
+          'Run with $ARGUMENTS.',
+        ].join('\n'),
+      )
+
+      const proc = Bun.spawnSync(['bun', SCRIPT_PATH, root], {
+        cwd: REPO_ROOT,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+
+      expect(proc.exitCode).toBe(1)
+      const stderr = proc.stderr.toString()
+      expect(stderr).toContain('Argument-hint violations')
+      expect(stderr).toContain('skills/needs-hint/SKILL.md')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## Summary

Tightens bundled-skill frontmatter consistency around `argument-hint`, documents which frontmatter fields are enforced, and adds a content-integrity guard so the gap cannot reappear.

## Changes

- **`argument-hint` on `ce:compound-refresh`** — the one bundled skill that consumes `$ARGUMENTS` (a `mode:autofix` flag plus an optional `docs/solutions/` scope hint) but lacked the hint. Now declared so callers and the OpenCode command surface know what to pass.
- **Field enforcement status documented** — `writing-systematic-skills/references/foundation-conventions.md` gains an enforcement column on the frontmatter table. Notably, `allowed-tools` is clarified as **read but not enforced**: the loader parses it, but no permission gate acts on it and OpenCode treats it as metadata, not enforced permissions.
- **Content-integrity guard** — a new check fails when a skill body references `$ARGUMENTS` outside fenced code blocks without declaring `argument-hint`. The scan strips fenced code blocks first, so a skill that merely documents `$ARGUMENTS` in an example is not flagged.

## Verification

- 1007 unit tests pass (11 new, including the fenced-code false-positive case)
- content-integrity clean on the real tree, typecheck, lint, registry/schema drift, build, Node ESM smoke, docs build all green
