### PR TITLE
docs(plans): reconcile plan statuses and remove taxonomy from test names

### DIFF
--- a/docs/plans/2026-05-27-001-feat-promotion-and-growth-plan.md
+++ b/docs/plans/2026-05-27-001-feat-promotion-and-growth-plan.md
@@ -1,13 +1,13 @@
 ---
 title: "feat: Promotion and growth — analytics, homepage uplift, ecosystem listing, social drafts"
 type: feat
-status: active
+status: completed
 date: 2026-05-27
 origin: docs/brainstorms/2026-05-27-promotion-and-growth-requirements.md
 deepened: 2026-05-27
 review: document-review 4 personas (coherence, feasibility, scope-guardian, adversarial) — all findings resolved
-infra: marcusrbrown/infra#315 Umami LIVE + verified 2026-05-27 (https://metrics.fro.bot) — Units 1–8 unblocked; Unit 9 first precondition met
-shipped: Units 1–6, 8 merged via PR #454, #455, #456, #457, #460 (all non-releasing — docs/chore/ci; docs site deployed manually). Unit 9 analytics activated + verified live 2026-05-30 (umami script + website-id in production). Unit 7 ecosystem PR anomalyco/opencode#29925 OPEN upstream (awaiting maintainer review). Remaining: Unit 7 upstream merge + Unit 9 numeric-gate measurement window (manual Discord test post).
+infra: marcusrbrown/infra#315 Umami LIVE + verified 2026-05-27 (https://metrics.fro.bot)
+shipped: All Systematic-side units complete. Units 1–6, 8 merged via PR #454, #455, #456, #457, #460; Unit 9 analytics activated + verified live in production 2026-05-30. Externally tracked (not Systematic-repo work): Unit 7 ecosystem listing PR anomalyco/opencode#29925 awaits upstream maintainer review; the Unit 9 numeric-gate measurement window is a manual ongoing activity.
 ---
 
 # Promotion and Growth

--- a/docs/plans/2026-06-06-001-feat-agent-temperature-explicit-hardening-plan.md
+++ b/docs/plans/2026-06-06-001-feat-agent-temperature-explicit-hardening-plan.md
@@ -3,6 +3,7 @@ title: "feat: Explicit agent temperature hardening"
 type: feat
 status: completed
 date: 2026-06-06
+shipped: PR #495 merged 9dd0b4c; released @fro.bot/systematic@2.29.0
 ---
 
 # feat: Explicit agent temperature hardening

--- a/docs/plans/2026-06-06-003-feat-skill-frontmatter-tune-up-plan.md
+++ b/docs/plans/2026-06-06-003-feat-skill-frontmatter-tune-up-plan.md
@@ -1,7 +1,8 @@
 ---
 title: "feat: Skill frontmatter tune-up"
 type: feat
-status: active
+status: completed
+shipped: PR #505 merged 75622be; released @fro.bot/systematic@2.31.0
 date: 2026-06-06
 origin: docs/brainstorms/2026-06-06-skill-frontmatter-tune-up-requirements.md
 ---

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1190,7 +1190,7 @@ describe('config', () => {
   })
 
   describe('JSONC precedence', () => {
-    test('AE3: only systematic.json exists — loads it (backward compat)', () => {
+    test('only systematic.json exists -- loads it (backward compat)', () => {
       writeUserConfig({ disabled_skills: ['ce:plan'] })
 
       const result = loadConfig(testDir)
@@ -1198,7 +1198,7 @@ describe('config', () => {
       expect(result.disabled_skills).toEqual(['ce:plan'])
     })
 
-    test('AE2: only systematic.jsonc exists — loads it correctly', () => {
+    test('only systematic.jsonc exists -- loads it correctly', () => {
       const filePath = userConfigPath().replace(/\.json$/, '.jsonc')
       fs.mkdirSync(path.dirname(filePath), { recursive: true })
       fs.writeFileSync(
@@ -1210,7 +1210,7 @@ describe('config', () => {
       expect(result.disabled_skills).toContain('ce:review')
     })
 
-    test('AE2: JSONC with comments and standard JSON structure parses correctly', () => {
+    test('JSONC with comments and standard JSON structure parses correctly', () => {
       const filePath = userConfigPath().replace(/\.json$/, '.jsonc')
       fs.mkdirSync(path.dirname(filePath), { recursive: true })
       fs.writeFileSync(
@@ -1222,7 +1222,7 @@ describe('config', () => {
       expect(result.disabled_skills).toEqual(['ce:plan'])
     })
 
-    test('AE1: both jsonc and json exist — .jsonc is loaded, .json is ignored', () => {
+    test('both jsonc and json exist -- .jsonc is loaded, .json is ignored', () => {
       const jsoncPath = userConfigPath().replace(/\.json$/, '.jsonc')
       const jsonPath = userConfigPath()
       fs.mkdirSync(path.dirname(jsoncPath), { recursive: true })


### PR DESCRIPTION
## Summary

Housekeeping: reconcile plan statuses to shipped reality after v2.31.0, and remove leaked planning-taxonomy prefixes from four test names.

## Changes

- **Plan reconciliation** — three plan docs updated to match shipped state:
  - Agent temperature hardening: added shipped provenance (released in 2.29.0).
  - Skill frontmatter tune-up: marked completed with shipped provenance (released in 2.31.0).
  - Promotion and growth: marked completed; all in-repo units shipped, with the ecosystem listing reframed as externally tracked upstream work.
- **Test name cleanup** — four JSONC-precedence tests in `tests/unit/config.test.ts` carried `AE1`/`AE2`/`AE3` prefixes from a planning document. Stripped the prefixes (keeping the behavioral descriptions) and removed em-dashes, so shipped test files contain no planning taxonomy.

## Verification

- 1007 unit tests pass; content-integrity clean; typecheck clean. Non-releasing.
