### PR TITLE
chore(deps): sync biome.json $schema to 2.4.16

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,


### PR DESCRIPTION
## Summary

Sync `biome.json`'s `$schema` URL to the pinned Biome CLI version (2.4.16). Renovate bumped `@biomejs/biome` to 2.4.16 but left the schema URL at 2.4.14, which the newer CLI treats as a config deserialize error, failing local `bun run lint`.

## Verification

- `bun run lint` now reports 0 errors (only pre-existing warnings).
- No other changes.

Non-releasing (`chore(deps)`).