### PR TITLE
feat(config): warn-and-ignore removed bundled names in disable lists

### DIFF
--- a/docs/plans/2026-07-13-001-feat-removed-name-config-safety-plan.md
+++ b/docs/plans/2026-07-13-001-feat-removed-name-config-safety-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: warn-and-ignore removed bundled names in disable lists"
 type: feat
-status: active
+status: executed-pending-pr
 date: 2026-07-13
 origin: docs/brainstorms/2026-07-13-v3-cleanup-release-requirements.md
 ---
@@ -84,7 +84,7 @@ v2.19.0 deprecation guidance told users to set `disabled_skills: ["orchestrating
 
 ## Implementation Units
 
-- [ ] **Unit 1: Removed-names mechanism in the schema factory**
+- [x] **Unit 1: Removed-names mechanism in the schema factory**
 
 **Goal:** Accept known-removed names in `disabled_skills`/`disabled_agents` without throwing, while preserving strict rejection for unknown names.
 
@@ -123,7 +123,7 @@ v2.19.0 deprecation guidance told users to set `disabled_skills: ["orchestrating
 **Verification:**
 - The factory accepts synthetic removed names without throwing; unknown names still throw; the overlap gate rejects removed/current collisions.
 
-- [ ] **Unit 2: Warn on dropped names + wire through config load**
+- [x] **Unit 2: Warn on dropped names + wire through config load**
 
 **Goal:** After a successful parse, drop removed names from the effective config and emit a stateless, per-load-deduplicated `[systematic]` warning, without mutating raw config or failing load.
 
@@ -157,7 +157,7 @@ v2.19.0 deprecation guidance told users to set `disabled_skills: ["orchestrating
 **Verification:**
 - Removed names warn-and-load end to end; unknown names still throw; dedup is per-load and stateless; raw config preserved.
 
-- [ ] **Unit 3: Thread removed-names through the schema generator**
+- [x] **Unit 3: Thread removed-names through the schema generator**
 
 **Goal:** Keep the published JSON Schema enum aligned with runtime acceptance so editors and runtime agree once the list is populated.
 

--- a/docs/plans/2026-07-13-001-feat-removed-name-config-safety-plan.md
+++ b/docs/plans/2026-07-13-001-feat-removed-name-config-safety-plan.md
@@ -1,0 +1,217 @@
+---
+title: "feat: warn-and-ignore removed bundled names in disable lists"
+type: feat
+status: active
+date: 2026-07-13
+origin: docs/brainstorms/2026-07-13-v3-cleanup-release-requirements.md
+---
+
+# feat: warn-and-ignore removed bundled names in disable lists
+
+## Overview
+
+Add a forward-compatible safety net so that future removal of a bundled skill or agent cannot brick plugin load for users who disabled that skill/agent. Today `disabled_skills` and `disabled_agents` are strict enums; an unknown name throws uncaught and aborts plugin load. This patch introduces a known-removed-names mechanism: names on that list are accepted, dropped from the effective config, and reported with a `[systematic]` warning. Genuinely-invalid names still fail strict validation.
+
+This ships as a v2.x patch BEFORE the v3.0.0 cleanup (which deletes `orchestrating-swarms` and `claude-permissions-optimizer`), so the safety net exists before any skill is actually removed. The patch is behavior-neutral today: with an empty removed-names list, validation behaves exactly as it does now.
+
+## Problem Frame
+
+Verified release-blocker (see origin: `docs/brainstorms/2026-07-13-v3-cleanup-release-requirements.md`). `disabled_skills` is `z.array(z.enum(skillNames))` and `disabled_agents` is `z.array(z.enum([...agentNames, ...qualifiedAgentIds]))` (`src/lib/config-schema.ts:315-342`). A name not in the enum fails `safeParse`; `loadConfigSource` then calls `throwTopLevelConfigSchemaError`, which throws (`src/lib/config.ts:276-299, 238-274`). That throw escapes uncaught from both plugin init (`src/index.ts`) and the config hook (`src/lib/config-handler.ts:513-528`), aborting plugin load.
+
+v2.19.0 deprecation guidance told users to set `disabled_skills: ["orchestrating-swarms"]`. When v3 deletes that skill, those exact users would be bricked on upgrade. Shipping the warn-and-ignore net first means the v3 deletion only has to add names to the removed list, not also introduce new validation behavior in the same breaking release.
+
+## Requirements Trace
+
+- R1. A name on the known-removed list, present in `disabled_skills` or `disabled_agents`, is accepted by validation (no throw), dropped from the effective config, and reported via a `[systematic]` warning naming the stale entry and pointing at cleanup.
+- R2. Strict validation is preserved for genuinely-unknown names (typos, never-existed names) in both fields: they still throw the existing actionable error. The accepted set is a strict disjoint union of current bundled names and explicitly-listed removed names, with no normalization, aliasing, or prefix inference.
+- R3. No accepted/rejected-config behavior change for existing inputs when the removed-names list is empty (this patch ships with an empty list). This is narrower than "behavior-neutral": an invariant test asserts current valid configs still parse and current invalid configs still throw, including error-message stability where user-visible.
+- R4. The accept-and-drop path is proven NOW via tests that pass synthetic removed names through the schema factory (the factory takes name-set options), so the mechanism is exercised even though the shipped production list is empty.
+- R5. A durable gate asserts removed-name lists never overlap current bundled names (so a removed entry can never shadow or backdoor a live name).
+- R6. The warning is deduplicated per load invocation (stateless, keyed to a single load), not via sticky module-global state that could suppress unrelated later warnings in a long-lived process. If plugin-init and the config hook are separate loads that each warn once, that is acceptable and documented.
+- R7. The schema generator threads the same removed-names so the published JSON Schema enum and the runtime accept the same set — preventing editor/runtime divergence once the list is populated in v3. (No-op now with an empty list.)
+
+## Scope Boundaries
+
+- This patch does NOT delete any skill or agent. `orchestrating-swarms` and `claude-permissions-optimizer` remain present and valid.
+- The removed-names list ships EMPTY in this patch. Populating it happens in v3.0.0 when the skills are actually deleted.
+- No change to `disabled_commands` (already a permissive `z.array(z.string())`).
+- No change to the strict `agents.<key>` overlay validation or any other config field.
+
+### Deferred to Separate Tasks
+
+- Populating the removed-names list and deleting the skills: v3.0.0 (`docs/plans/2026-06-05-001` to be superseded by the v3 plan from the new brainstorm).
+- The JSON Schema enum's treatment of removed names (deprecation wording vs divergence): resolve in v3 when names are actually removed, since the schema only matters once a name is removed.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/lib/config-schema.ts:270-366` — `createSystematicConfigSchema(opts)` factory already takes `{ agentNames, qualifiedAgentIds, skillNames }`. The removed-names mechanism extends this options object.
+- `src/lib/config-schema.ts:315-342` — the two strict enum fields to modify.
+- `src/lib/config.ts:276-299` — `loadConfigSource` calls `safeParse` then throws on failure, and on success returns RAW config (not `result.data`) to preserve merge precedence. The post-parse drop+warn lives here, computed from raw config.
+- `src/lib/config.ts:238-274` — `throwTopLevelConfigSchemaError` (the throw path that must NOT fire for removed names).
+- `src/lib/bundled-names.ts` — `BUNDLED_SKILL_NAMES`, `BUNDLED_AGENT_NAMES`, `BUNDLED_AGENT_QUALIFIED_IDS`. The removed-names constants live alongside these (or in a dedicated module).
+- `scripts/content-integrity.ts` — pattern for a durable gate, if a gate is warranted (e.g., to assert removed names never overlap current bundled names).
+- `tests/unit/config.test.ts` and `tests/unit/config-schema.test.ts` — test homes.
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/opencode-plugin-named-exports-break-loader-2026-05-11.md` and the v2.5.0/v2.12.2 incidents: a throw escaping the plugin entry/hook removes ALL Systematic functionality. This is the failure class being prevented.
+- `docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md`: when a runtime accepts-but-drops input, mirror the rule in a gate so the contract cannot silently drift.
+
+## Key Technical Decisions
+
+- **Enum accepts current ∪ removed; drop+warn happens post-parse in `config.ts`, NOT in a Zod transform.** Add `removedSkillNames`/`removedAgentNames` to the factory options and include them in the enum tuples so removed names do not throw. But `loadConfigSource` deliberately returns RAW config (not `result.data`) to preserve merge precedence (`src/lib/config.ts:293-297`), and a Zod transform cannot cleanly surface "which names were dropped" back to the loader. So: after `safeParse` succeeds, compute the dropped-name set by comparing the raw `disabled_*` arrays against the current allowed-set, warn, and leave the raw config object untouched. The effective drop (removing the name from what's applied) happens where disabled names are consumed, or via a returned `{ dropped }` companion — implementer's choice, but raw config is not mutated.
+- **Strict disjoint union, no normalization.** The accepted set is exactly current-names + explicitly-removed-names. No case-folding, aliasing, or bare/qualified inference that could let an otherwise-invalid name through the "removed" bucket. A gate asserts removed and current sets never overlap.
+- **Warn, don't silently drop.** The `[systematic]` warning names each dropped entry and points at cleanup, but never fails load.
+- **Empty list ships now; mechanism proven by synthetic-name tests.** The production removed-list is empty, so there is no user-visible behavior change for existing configs. The accept-and-drop path is proven now by passing synthetic removed names through the factory in tests, not deferred to v3.
+- **Stateless per-load dedup.** Deduplicate warnings within a single load invocation. Do not use sticky module-global suppression that could swallow unrelated later warnings in a long-lived process. Init and config-hook are separate loads; each warning once is acceptable.
+- **Generator threads removed-names too.** `scripts/generate-config-schema.ts` passes the same removed-names into the factory so the published JSON Schema enum matches runtime acceptance, avoiding editor/runtime divergence when the list is populated in v3.
+- **`fix:` not `feat:`.** This prevents a latent plugin-load brick; corrective framing is honest. It is a patch release.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Where does the drop+warn live — schema transform or post-parse in `config.ts`? Resolved: **post-parse in `config.ts`**, not a Zod transform. `loadConfigSource` returns raw config (not `result.data`) to preserve merge precedence (`src/lib/config.ts:293-297`); a transform cannot surface the dropped-set back to the loader cleanly. After `safeParse` succeeds, compute dropped names by comparing raw `disabled_*` against the current allowed-set, warn, and leave raw config untouched.
+- Should removed names also be accepted in `agents.<key>` overlays? Resolved: NO. This patch scopes only the two disable lists (the documented brick path). Overlay keys referencing a removed agent are a separate, lower-frequency case and stay strict for now.
+- Schema/runtime divergence? Resolved: the generator threads removed-names too (R7), so the published schema enum matches runtime. No-op now (empty list), aligned by construction when v3 populates it.
+- `feat:` vs `fix:`? Resolved: `fix:` (prevents a latent brick), patch release.
+
+### Deferred to Implementation
+
+- Exact `[systematic]` warning wording and whether it links to a docs anchor (the migration doc lands in v3; for now the warning can name the entry and say it is no longer a bundled name).
+
+## Implementation Units
+
+- [ ] **Unit 1: Removed-names mechanism in the schema factory**
+
+**Goal:** Accept known-removed names in `disabled_skills`/`disabled_agents` without throwing, while preserving strict rejection for unknown names.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** None
+
+**Files:**
+- Create: `src/lib/removed-names.ts` — `REMOVED_BUNDLED_SKILL_NAMES`, `REMOVED_BUNDLED_AGENT_NAMES`, both empty arrays in this patch
+- Modify: `src/lib/config-schema.ts` — extend `SystematicConfigSchemaOptions` + `createSystematicConfigSchema` to accept removed names and include them in the enum tuples so they parse; the default runtime `SystematicConfigSchema` passes the (empty) constants
+- Modify: `scripts/content-integrity.ts` — gate: removed-name lists must not overlap current bundled names (R5)
+- Test: `tests/unit/config-schema.test.ts`
+- Test: `tests/unit/content-integrity.test.ts`
+
+**Approach:**
+- Extend the factory options with `removedSkillNames`/`removedAgentNames`; the enum for each field accepts the strict disjoint union `current ∪ removed` (no normalization/aliasing).
+- The schema only ACCEPTS removed names (no throw). The actual drop+warn is Unit 2's post-parse step in `config.ts` (the schema returns the array as-parsed; the loader computes/drops). Keep the enum change minimal.
+- The default runtime schema passes the empty removed-name constants so existing behavior is unchanged.
+- Genuinely-unknown names remain outside both sets and still fail the enum.
+- Add the overlap gate so a removed name can never shadow a live bundled name.
+
+**Execution note:** Implement test-first — write the failing "removed name does not throw" test before changing the schema. Pass synthetic removed names through the factory in tests (R4) to exercise the path despite the empty production list.
+
+**Patterns to follow:**
+- `createSystematicConfigSchema` options pattern (`src/lib/config-schema.ts:270-366`).
+- `bundled-names.ts` constant style; `checkAgentMode`/`checkAgentTemperature` gate style in `content-integrity.ts`.
+
+**Test scenarios:**
+- Happy path: schema built with synthetic `removedSkillNames: ["gone-skill"]` parses `disabled_skills: ["gone-skill"]` without throwing.
+- Edge case: mixed `disabled_skills: ["gone-skill", "ce:plan"]` parses without throwing.
+- Error path: `disabled_skills: ["never-existed"]` still fails validation (in neither set).
+- Disjoint-union: a removed name that equals a current name is rejected by the overlap gate (cannot register a removed name that shadows a live one).
+- Invariant (R3): with empty removed lists, a removed-style name throws exactly as today, and current valid configs parse identically.
+- Same coverage for `disabled_agents` (bare and qualified IDs); confirm no qualified/bare inference lets an invalid name through.
+
+**Verification:**
+- The factory accepts synthetic removed names without throwing; unknown names still throw; the overlap gate rejects removed/current collisions.
+
+- [ ] **Unit 2: Warn on dropped names + wire through config load**
+
+**Goal:** After a successful parse, drop removed names from the effective config and emit a stateless, per-load-deduplicated `[systematic]` warning, without mutating raw config or failing load.
+
+**Requirements:** R1, R3, R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `src/lib/config.ts` — on `safeParse` success, compare raw `disabled_skills`/`disabled_agents` against the current allowed-set, compute the dropped set, emit the warning, and apply the drop where disabled names are consumed (or via a returned companion). Do NOT mutate the raw config object (`config.ts:293-297` preserves it for merge precedence).
+- Test: `tests/unit/config.test.ts`
+
+**Approach:**
+- Drop+warn happens post-parse in the loader, not in a Zod transform (the loader returns raw config by design).
+- Compute the dropped set from raw `disabled_*` minus current allowed names; warn naming each dropped entry.
+- Dedup within a single load invocation only (stateless — e.g., a local set per `loadConfigWithSources` call). No sticky module-global suppression. If init and the config hook are separate loads that each warn once, that is accepted and documented.
+- Preserve raw-config-for-merge semantics; the drop affects effective applied config, not the merge inputs.
+
+**Execution note:** Test-first — assert the warning is emitted and load succeeds before wiring.
+
+**Patterns to follow:**
+- Existing `[systematic]` warning style (provider-availability warnings).
+- The raw-config-preservation merge handling in `loadConfigWithSources`.
+
+**Test scenarios:**
+- Happy path: a config with a synthetic removed name loads successfully AND emits a `[systematic]` warning naming the entry.
+- Error path: a config with an unknown name still throws the actionable schema error (warning path does not swallow it).
+- Edge case: empty removed-name list → no warning, no behavior change.
+- Dedup: within one load, the same stale entry warns once; across separate init+hook loads, each-once is acceptable (assert no sticky cross-load suppression of a DIFFERENT entry).
+- Integration: merge precedence across config sources is unchanged when a removed name is dropped from one source; raw config object is not mutated.
+
+**Verification:**
+- Removed names warn-and-load end to end; unknown names still throw; dedup is per-load and stateless; raw config preserved.
+
+- [ ] **Unit 3: Thread removed-names through the schema generator**
+
+**Goal:** Keep the published JSON Schema enum aligned with runtime acceptance so editors and runtime agree once the list is populated.
+
+**Requirements:** R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `scripts/generate-config-schema.ts` — pass the removed-name constants into `createSystematicConfigSchema` so generated enums include them
+- Test: `tests/unit/config-schema.test.ts` or the schema-generation test home
+
+**Approach:**
+- The generator already builds the schema via the factory with filesystem-discovered names; thread the removed-name constants alongside.
+- No-op now (empty list); proven via a synthetic-name test asserting the generated enum would include a removed name.
+
+**Execution note:** Verify generator output is byte-stable with the empty list (no drift) and includes a synthetic removed name when one is provided.
+
+**Patterns to follow:**
+- Existing generator factory call in `scripts/generate-config-schema.ts`.
+
+**Test scenarios:**
+- Happy path: generator with a synthetic removed name emits a schema whose `disabled_skills` enum includes that name.
+- Regression: with the empty production list, generated schema is byte-identical to current (no drift).
+
+**Verification:**
+- Generated schema enum matches the runtime accepted set; empty-list output is unchanged (drift check passes).
+
+## System-Wide Impact
+
+- **Interaction graph:** config loading runs in plugin init (`src/index.ts`) and the config hook (`src/lib/config-handler.ts`); both must tolerate removed names identically.
+- **Error propagation:** the change narrows what throws — removed names no longer throw; everything else still does.
+- **State lifecycle risks:** dropped names must not alter merge precedence or raw-config preservation.
+- **API surface parity:** only `disabled_skills`/`disabled_agents` change; `disabled_commands` and overlay keys are untouched.
+- **Unchanged invariants:** strict validation for unknown names and overlay fields; `src/index.ts` still exports only `default`; the schema's `.strict()` top-level behavior is preserved.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Enum expansion leaks acceptance of an invalid name | Strict disjoint union, no normalization/aliasing; overlap gate (R5) rejects removed/current collisions; tested for bare + qualified IDs. |
+| Mechanism unproven because production list is empty | Synthetic removed names exercise the accept-and-drop path in tests now (R4). |
+| Warning dedup becomes sticky global state, suppressing unrelated warnings | Stateless per-load dedup only (R6); test asserts no cross-load suppression of a different entry. |
+| Drop mutates raw config and breaks merge precedence | Post-parse drop computes from raw but does not mutate it; integration test merge across sources (config.ts:293-297). |
+| Schema/runtime divergence when v3 populates the list | Generator threads the same removed-names (R7); enum matches runtime by construction. |
+| "Behavior-neutral" overclaim | Narrowed to "no change for existing inputs"; invariant test asserts current valid parse / invalid throw with empty list. |
+
+## Documentation / Operational Notes
+
+- No accepted/rejected-config behavior change for existing inputs (empty list), so no user-facing migration doc is needed in this patch. The v3 release that populates the list owns the migration guidance.
+- `fix:` → patch release. This prevents a latent plugin-load brick; corrective framing is honest and the change adds no user-visible behavior for existing configs.
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-07-13-v3-cleanup-release-requirements.md`
+- Verified failure path: `src/lib/config-schema.ts:315-342`, `src/lib/config.ts:238-299`, `src/index.ts`, `src/lib/config-handler.ts:513-528`
+- Oracle sequencing recommendation (this session): ship the safety net as a v2.x patch before the v3 deletion.
+- Related future plan: v3.0.0 cleanup (to be written from the same origin brainstorm).

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -70,9 +70,18 @@ import {
   OPENCODE_AGENT_COLOR_TOKENS,
 } from '../src/lib/agent-colors.js'
 import {
+  BUNDLED_AGENT_NAMES,
+  BUNDLED_AGENT_QUALIFIED_IDS,
+  BUNDLED_SKILL_NAMES,
+} from '../src/lib/bundled-names.js'
+import {
   extractFrontmatterBlock,
   parseFrontmatter,
 } from '../src/lib/frontmatter.js'
+import {
+  REMOVED_BUNDLED_AGENT_NAMES,
+  REMOVED_BUNDLED_SKILL_NAMES,
+} from '../src/lib/removed-names.js'
 import { SKILL_FRONTMATTER_FIELDS } from '../src/lib/skills.js'
 import { walkDir } from '../src/lib/walk-dir.js'
 
@@ -211,6 +220,12 @@ export interface ArgumentHintViolation {
   message: string
 }
 
+export interface RemovedNamesOverlapViolation {
+  kind: 'skill' | 'agent'
+  name: string
+  message: string
+}
+
 export interface CheckResult {
   rootDir: string
   categories: string[]
@@ -226,6 +241,7 @@ export interface CheckResult {
   agentStemViolations: AgentStemViolation[]
   agentTemperatureViolations: AgentTemperatureViolation[]
   argumentHintViolations: ArgumentHintViolation[]
+  removedNamesOverlapViolations: RemovedNamesOverlapViolation[]
   exemptHits: ExemptHit[]
   scanStats: {
     markdownFiles: number
@@ -1135,6 +1151,62 @@ export function checkArgumentHint(
   return violations
 }
 
+// ---------------------------------------------------------------------------
+// Removed-names overlap gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Assert that removed-name lists have no overlap with current bundled names.
+ *
+ * A removed name must never shadow a live bundled name. If a name appears in
+ * both the removed list and the current bundled set, it would be accepted by
+ * the schema even if it were re-added to the catalog, silently bypassing
+ * strict validation. This gate prevents that drift.
+ *
+ * Parameters are explicit rather than reading module-level constants so the
+ * function is testable with synthetic name sets.
+ */
+export function checkRemovedNamesOverlap(
+  removedSkillNames: readonly string[],
+  removedAgentNames: readonly string[],
+  currentSkillNames: readonly string[],
+  currentAgentNames: readonly string[],
+  currentQualifiedAgentIds: readonly string[],
+): RemovedNamesOverlapViolation[] {
+  const violations: RemovedNamesOverlapViolation[] = []
+
+  const currentSkillSet = new Set(currentSkillNames)
+  for (const name of removedSkillNames) {
+    if (currentSkillSet.has(name)) {
+      violations.push({
+        kind: 'skill',
+        name,
+        message:
+          `Removed skill name "${name}" overlaps with a current bundled skill name. ` +
+          'Remove it from REMOVED_BUNDLED_SKILL_NAMES or delete it from the bundled catalog first.',
+      })
+    }
+  }
+
+  const currentAgentSet = new Set([
+    ...currentAgentNames,
+    ...currentQualifiedAgentIds,
+  ])
+  for (const name of removedAgentNames) {
+    if (currentAgentSet.has(name)) {
+      violations.push({
+        kind: 'agent',
+        name,
+        message:
+          `Removed agent name "${name}" overlaps with a current bundled agent name or qualified id. ` +
+          'Remove it from REMOVED_BUNDLED_AGENT_NAMES or delete it from the bundled catalog first.',
+      })
+    }
+  }
+
+  return violations
+}
+
 function isAgentFile(relPath: string): boolean {
   const parts = relPath.split('/')
   return (
@@ -1267,6 +1339,13 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     targets.markdown,
   )
   const argumentHintViolations = checkArgumentHint(rootDir, targets.markdown)
+  const removedNamesOverlapViolations = checkRemovedNamesOverlap(
+    REMOVED_BUNDLED_SKILL_NAMES,
+    REMOVED_BUNDLED_AGENT_NAMES,
+    BUNDLED_SKILL_NAMES,
+    BUNDLED_AGENT_NAMES,
+    BUNDLED_AGENT_QUALIFIED_IDS,
+  )
   const { hits: bannedPatterns, exempt: exemptHits } = checkBannedPatterns(
     rootDir,
     allScannedFiles,
@@ -1288,6 +1367,7 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     agentStemViolations,
     agentTemperatureViolations,
     argumentHintViolations,
+    removedNamesOverlapViolations,
     exemptHits,
     scanStats: {
       markdownFiles: targets.markdown.length,
@@ -1337,6 +1417,7 @@ function printResult(result: CheckResult, verbose: boolean): void {
   printAgentStemViolations(result.agentStemViolations)
   printAgentTemperatureViolations(result.agentTemperatureViolations)
   printArgumentHintViolations(result.argumentHintViolations)
+  printRemovedNamesOverlapViolations(result.removedNamesOverlapViolations)
 
   if (totalViolations(result) === 0) {
     process.stdout.write(
@@ -1475,6 +1556,18 @@ function printArgumentHintViolations(
   }
 }
 
+function printRemovedNamesOverlapViolations(
+  violations: readonly RemovedNamesOverlapViolation[],
+): void {
+  if (violations.length === 0) return
+  process.stderr.write(
+    `\nRemoved-names overlap violations (${violations.length}):\n`,
+  )
+  for (const v of violations) {
+    process.stderr.write(`  [${v.kind}] ${v.name}  ${v.message}\n`)
+  }
+}
+
 function totalViolations(result: CheckResult): number {
   return (
     result.phantomRefs.length +
@@ -1487,7 +1580,8 @@ function totalViolations(result: CheckResult): number {
     result.agentColorViolations.length +
     result.agentStemViolations.length +
     result.agentTemperatureViolations.length +
-    result.argumentHintViolations.length
+    result.argumentHintViolations.length +
+    result.removedNamesOverlapViolations.length
   )
 }
 

--- a/scripts/generate-config-schema.ts
+++ b/scripts/generate-config-schema.ts
@@ -27,6 +27,10 @@ import {
   createSystematicConfigSchema,
   SystematicConfigSchema,
 } from '../src/lib/config-schema.js'
+import {
+  REMOVED_BUNDLED_AGENT_NAMES,
+  REMOVED_BUNDLED_SKILL_NAMES,
+} from '../src/lib/removed-names.js'
 import { findSkillsInDir } from '../src/lib/skills.js'
 import {
   getZodDefaultInnerType,
@@ -990,6 +994,8 @@ async function main(): Promise<void> {
     agentNames: agents,
     qualifiedAgentIds: agentQualifiedIds,
     skillNames: skills,
+    removedSkillNames: REMOVED_BUNDLED_SKILL_NAMES,
+    removedAgentNames: REMOVED_BUNDLED_AGENT_NAMES,
   })
 
   const schemaContent = generateSchemaContentFromSchema(

--- a/src/lib/config-schema.ts
+++ b/src/lib/config-schema.ts
@@ -21,6 +21,10 @@ import {
   BUNDLED_AGENT_QUALIFIED_IDS,
   BUNDLED_SKILL_NAMES,
 } from './bundled-names.js'
+import {
+  REMOVED_BUNDLED_AGENT_NAMES,
+  REMOVED_BUNDLED_SKILL_NAMES,
+} from './removed-names.js'
 
 const permissionSettingSchema = z.enum(['ask', 'allow', 'deny'] as const)
 
@@ -249,6 +253,8 @@ export interface SystematicConfigSchemaOptions {
   readonly agentNames: readonly string[]
   readonly qualifiedAgentIds: readonly string[]
   readonly skillNames: readonly string[]
+  readonly removedSkillNames?: readonly string[]
+  readonly removedAgentNames?: readonly string[]
 }
 
 /**
@@ -270,7 +276,13 @@ export interface SystematicConfigSchemaOptions {
 export function createSystematicConfigSchema(
   opts: SystematicConfigSchemaOptions,
 ): z.ZodObject<z.core.$ZodLooseShape> {
-  const { agentNames, qualifiedAgentIds, skillNames } = opts
+  const {
+    agentNames,
+    qualifiedAgentIds,
+    skillNames,
+    removedSkillNames = [],
+    removedAgentNames = [],
+  } = opts
   return z
     .object({
       $schema: z
@@ -314,8 +326,15 @@ export function createSystematicConfigSchema(
         }),
       disabled_skills: z
         // z.enum requires a non-empty tuple; skillNames is guaranteed non-empty
-        // by the sanity check in generateBundledNamesContent.
-        .array(z.enum(skillNames as readonly [string, ...string[]]))
+        // by the sanity check in generateBundledNamesContent. Removed names are
+        // appended so they parse without throwing; the actual drop+warn happens
+        // post-parse in config.ts (not here).
+        .array(
+          z.enum([...skillNames, ...removedSkillNames] as unknown as readonly [
+            string,
+            ...string[],
+          ]),
+        )
         .default([])
         .meta({
           description:
@@ -325,11 +344,14 @@ export function createSystematicConfigSchema(
       disabled_agents: z
         .array(
           // z.enum requires a non-empty tuple; the combined list is guaranteed
-          // non-empty by the sanity check in generateBundledNamesContent.
-          z.enum([...agentNames, ...qualifiedAgentIds] as unknown as readonly [
-            string,
-            ...string[],
-          ]),
+          // non-empty by the sanity check in generateBundledNamesContent. Removed
+          // names are appended so they parse without throwing; the actual
+          // drop+warn happens post-parse in config.ts (not here).
+          z.enum([
+            ...agentNames,
+            ...qualifiedAgentIds,
+            ...removedAgentNames,
+          ] as unknown as readonly [string, ...string[]]),
         )
         .default([])
         .meta({
@@ -369,6 +391,8 @@ export const SystematicConfigSchema = createSystematicConfigSchema({
   agentNames: BUNDLED_AGENT_NAMES,
   qualifiedAgentIds: BUNDLED_AGENT_QUALIFIED_IDS,
   skillNames: BUNDLED_SKILL_NAMES,
+  removedSkillNames: REMOVED_BUNDLED_SKILL_NAMES,
+  removedAgentNames: REMOVED_BUNDLED_AGENT_NAMES,
 })
 
 export type ValidationResult =

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -8,6 +8,11 @@ import {
 } from 'jsonc-parser'
 import type { z } from 'zod'
 import {
+  BUNDLED_AGENT_NAMES,
+  BUNDLED_AGENT_QUALIFIED_IDS,
+  BUNDLED_SKILL_NAMES,
+} from './bundled-names.js'
+import {
   SECURITY_OVERLAY_FIELDS as SCHEMA_SECURITY_OVERLAY_FIELDS,
   SystematicConfigSchema,
 } from './config-schema.js'
@@ -70,6 +75,57 @@ interface ConfigSource {
 }
 
 const SECURITY_OVERLAY_FIELDS = new Set(SCHEMA_SECURITY_OVERLAY_FIELDS)
+
+/**
+ * The set of currently-bundled skill names. Used to identify removed names
+ * that parsed successfully (because they are in the removed-names list) but
+ * are no longer active and must be dropped from the effective config.
+ */
+const CURRENT_SKILL_NAMES_SET: ReadonlySet<string> = new Set(
+  BUNDLED_SKILL_NAMES,
+)
+
+/**
+ * The set of currently-bundled agent names (bare and qualified). Used to
+ * identify removed names that parsed successfully but are no longer active.
+ */
+const CURRENT_AGENT_NAMES_SET: ReadonlySet<string> = new Set([
+  ...BUNDLED_AGENT_NAMES,
+  ...BUNDLED_AGENT_QUALIFIED_IDS,
+])
+
+/**
+ * Return the subset of `names` that are absent from `allowedSet`. These are
+ * names that parsed successfully (they are in the removed-names list so the
+ * schema accepted them) but are no longer active bundled names and must be
+ * dropped from the effective config.
+ */
+export function computeDroppedNames(
+  names: readonly string[],
+  allowedSet: ReadonlySet<string>,
+): string[] {
+  return names.filter((n) => !allowedSet.has(n))
+}
+
+/**
+ * Emit a `[systematic]` warning for each dropped name that has not already
+ * been warned about in this load invocation. The `warned` set is local to a
+ * single load call -- callers must NOT share it across independent loads.
+ * Passing a fresh set per load ensures no cross-load suppression.
+ */
+export function warnDroppedNames(
+  dropped: string[],
+  field: string,
+  warned: Set<string>,
+): void {
+  for (const name of dropped) {
+    if (warned.has(name)) continue
+    warned.add(name)
+    console.warn(
+      `[systematic] "${name}" in \`${field}\` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning.`,
+    )
+  }
+}
 
 /**
  * Resolve a config file path by checking `.jsonc` first, then `.json`.
@@ -376,7 +432,41 @@ export function loadConfigWithSources(
     categories: overlayValues(overlays.categories),
   }
 
-  return { config: result, overlays }
+  // Drop removed names from the effective config and warn about each one.
+  // This runs on the merged output, not on the raw config objects, so merge
+  // precedence and raw-config preservation are both unaffected. A local Set
+  // deduplicates warnings within this single load invocation without any
+  // sticky module-global state that could suppress unrelated later warnings.
+  const warned = new Set<string>()
+  const droppedSkills = computeDroppedNames(
+    result.disabled_skills,
+    CURRENT_SKILL_NAMES_SET,
+  )
+  warnDroppedNames(droppedSkills, 'disabled_skills', warned)
+
+  const droppedAgents = computeDroppedNames(
+    result.disabled_agents,
+    CURRENT_AGENT_NAMES_SET,
+  )
+  warnDroppedNames(droppedAgents, 'disabled_agents', warned)
+
+  const droppedSkillSet = new Set(droppedSkills)
+  const droppedAgentSet = new Set(droppedAgents)
+
+  const effectiveConfig: SystematicConfig =
+    droppedSkillSet.size === 0 && droppedAgentSet.size === 0
+      ? result
+      : {
+          ...result,
+          disabled_skills: result.disabled_skills.filter(
+            (n) => !droppedSkillSet.has(n),
+          ),
+          disabled_agents: result.disabled_agents.filter(
+            (n) => !droppedAgentSet.has(n),
+          ),
+        }
+
+  return { config: effectiveConfig, overlays }
 }
 
 function mergeOverlaySources(sources: ConfigSource[]): SourcedOverlayConfigMap {

--- a/src/lib/removed-names.ts
+++ b/src/lib/removed-names.ts
@@ -1,0 +1,17 @@
+/**
+ * Known-removed bundled skill and agent names.
+ *
+ * Names listed here were present in a past release but have since been removed
+ * from the bundled catalog. They are accepted (warn-and-ignore) in
+ * `disabled_skills` and `disabled_agents` so that upgrading does not brick
+ * configs that disabled them before removal. Genuinely-unknown names (typos,
+ * names that never existed) are still rejected by strict validation.
+ *
+ * This list is empty until v3 populates it with the first removed names.
+ * Add a name here only when the corresponding skill or agent directory is
+ * actually deleted from the repo.
+ */
+
+export const REMOVED_BUNDLED_SKILL_NAMES: readonly string[] = [] as const
+
+export const REMOVED_BUNDLED_AGENT_NAMES: readonly string[] = [] as const

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -786,3 +786,143 @@ describe('createSystematicConfigSchema factory', () => {
     )
   })
 })
+
+describe('removed-names in createSystematicConfigSchema', () => {
+  // Synthetic removed names used throughout this block to exercise the
+  // accept-and-parse path without depending on the (currently empty)
+  // production removed-names lists.
+  const SYNTHETIC_REMOVED_SKILL = 'gone-skill'
+  const SYNTHETIC_REMOVED_AGENT_BARE = 'gone-agent'
+  const SYNTHETIC_REMOVED_AGENT_QUALIFIED = 'review/gone-agent'
+
+  const schemaWithRemovedSkill = createSystematicConfigSchema({
+    agentNames: BUNDLED_AGENT_NAMES,
+    qualifiedAgentIds: BUNDLED_AGENT_QUALIFIED_IDS,
+    skillNames: BUNDLED_SKILL_NAMES,
+    removedSkillNames: [SYNTHETIC_REMOVED_SKILL],
+    removedAgentNames: [],
+  })
+
+  const schemaWithRemovedAgent = createSystematicConfigSchema({
+    agentNames: BUNDLED_AGENT_NAMES,
+    qualifiedAgentIds: BUNDLED_AGENT_QUALIFIED_IDS,
+    skillNames: BUNDLED_SKILL_NAMES,
+    removedSkillNames: [],
+    removedAgentNames: [
+      SYNTHETIC_REMOVED_AGENT_BARE,
+      SYNTHETIC_REMOVED_AGENT_QUALIFIED,
+    ],
+  })
+
+  // Happy path: a removed skill name parses without throwing.
+  test('removed skill name parses without throwing', () => {
+    const result = schemaWithRemovedSkill.safeParse({
+      disabled_skills: [SYNTHETIC_REMOVED_SKILL],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  // Edge case: mix of removed and current skill names parses without throwing.
+  test('mix of removed and current skill names parses without throwing', () => {
+    const result = schemaWithRemovedSkill.safeParse({
+      disabled_skills: [SYNTHETIC_REMOVED_SKILL, 'ce:plan'],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  // Error path: a name in neither current nor removed set still fails.
+  test('name in neither current nor removed set still fails validation', () => {
+    const result = schemaWithRemovedSkill.safeParse({
+      disabled_skills: ['never-existed'],
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join('.'))
+      expect(paths.some((p) => p.startsWith('disabled_skills'))).toBe(true)
+    }
+  })
+
+  // Invariant: with empty removed lists, a made-up name still throws exactly as today.
+  test('empty removed lists: unknown name still fails (invariant)', () => {
+    const schemaEmptyRemoved = createSystematicConfigSchema({
+      agentNames: BUNDLED_AGENT_NAMES,
+      qualifiedAgentIds: BUNDLED_AGENT_QUALIFIED_IDS,
+      skillNames: BUNDLED_SKILL_NAMES,
+      removedSkillNames: [],
+      removedAgentNames: [],
+    })
+    const result = schemaEmptyRemoved.safeParse({
+      disabled_skills: ['never-existed'],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  // Invariant: with empty removed lists, current valid configs still parse.
+  test('empty removed lists: current valid configs still parse (invariant)', () => {
+    const schemaEmptyRemoved = createSystematicConfigSchema({
+      agentNames: BUNDLED_AGENT_NAMES,
+      qualifiedAgentIds: BUNDLED_AGENT_QUALIFIED_IDS,
+      skillNames: BUNDLED_SKILL_NAMES,
+      removedSkillNames: [],
+      removedAgentNames: [],
+    })
+    const result = schemaEmptyRemoved.safeParse({
+      disabled_skills: ['ce:plan'],
+      disabled_agents: ['correctness-reviewer'],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  // Removed agent bare name parses without throwing.
+  test('removed agent bare name parses without throwing', () => {
+    const result = schemaWithRemovedAgent.safeParse({
+      disabled_agents: [SYNTHETIC_REMOVED_AGENT_BARE],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  // Removed agent qualified id parses without throwing.
+  test('removed agent qualified id parses without throwing', () => {
+    const result = schemaWithRemovedAgent.safeParse({
+      disabled_agents: [SYNTHETIC_REMOVED_AGENT_QUALIFIED],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  // Mix of removed and current agent names parses without throwing.
+  test('mix of removed and current agent names parses without throwing', () => {
+    const result = schemaWithRemovedAgent.safeParse({
+      disabled_agents: [SYNTHETIC_REMOVED_AGENT_BARE, 'correctness-reviewer'],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  // Invalid agent name not in either set still fails.
+  test('invalid agent name not in either set still fails', () => {
+    const result = schemaWithRemovedAgent.safeParse({
+      disabled_agents: ['never-existed-agent'],
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join('.'))
+      expect(paths.some((p) => p.startsWith('disabled_agents'))).toBe(true)
+    }
+  })
+
+  // No bare/qualified inference: a removed bare name does not let through
+  // a qualified variant that was not explicitly listed.
+  test('removed bare name does not let through unlisted qualified variant', () => {
+    const schemaBarOnly = createSystematicConfigSchema({
+      agentNames: BUNDLED_AGENT_NAMES,
+      qualifiedAgentIds: BUNDLED_AGENT_QUALIFIED_IDS,
+      skillNames: BUNDLED_SKILL_NAMES,
+      removedSkillNames: [],
+      removedAgentNames: [SYNTHETIC_REMOVED_AGENT_BARE],
+    })
+    // The qualified form was not listed in removedAgentNames, so it must fail.
+    const result = schemaBarOnly.safeParse({
+      disabled_agents: [SYNTHETIC_REMOVED_AGENT_QUALIFIED],
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,13 +1,16 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+
 import {
+  computeDroppedNames,
   DEFAULT_CONFIG,
   getConfigPaths,
   loadConfig,
   loadConfigWithSources,
+  warnDroppedNames,
 } from '../../src/lib/config.js'
 
 describe('config', () => {
@@ -1323,6 +1326,206 @@ describe('config', () => {
       expect(() => loadConfig(testDir)).not.toThrow()
       const result = loadConfig(testDir)
       expect(result.disabled_skills).toEqual([])
+    })
+  })
+
+  describe('removed-name drop and warn', () => {
+    // These tests exercise the drop+warn helpers directly with synthetic inputs.
+    // The production removed-names list is empty (the mechanism ships before any
+    // name is actually removed), so the real load path cannot be exercised
+    // end-to-end without injecting synthetic removed names. The helpers are
+    // exported for exactly this purpose.
+
+    test('computeDroppedNames returns names absent from the allowed set', () => {
+      const allowed = new Set(['ce:plan', 'ce:review'])
+      const result = computeDroppedNames(['ce:plan', 'gone-skill'], allowed)
+      expect(result).toEqual(['gone-skill'])
+    })
+
+    test('computeDroppedNames returns empty array when all names are in the allowed set', () => {
+      const allowed = new Set(['ce:plan', 'ce:review'])
+      const result = computeDroppedNames(['ce:plan', 'ce:review'], allowed)
+      expect(result).toEqual([])
+    })
+
+    test('computeDroppedNames returns empty array for empty input', () => {
+      const allowed = new Set(['ce:plan'])
+      const result = computeDroppedNames([], allowed)
+      expect(result).toEqual([])
+    })
+
+    test('computeDroppedNames returns all names when allowed set is empty', () => {
+      const allowed = new Set<string>()
+      const result = computeDroppedNames(['gone-a', 'gone-b'], allowed)
+      expect(result).toEqual(['gone-a', 'gone-b'])
+    })
+
+    test('warnDroppedNames emits a [systematic] warning naming each dropped entry', () => {
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        warnDroppedNames(['gone-skill'], 'disabled_skills', new Set())
+        const calls = warnSpy.mock.calls as unknown[][]
+        expect(calls).toHaveLength(1)
+        const msg = (calls[0] as unknown[])[0] as string
+        expect(msg).toContain('[systematic]')
+        expect(msg).toContain('gone-skill')
+        expect(msg).toContain('disabled_skills')
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
+    test('warnDroppedNames emits no warning when dropped list is empty', () => {
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        warnDroppedNames([], 'disabled_skills', new Set())
+        expect(warnSpy.mock.calls).toHaveLength(0)
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
+    test('warnDroppedNames deduplicates within a single call via the provided warned set', () => {
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const warned = new Set<string>()
+        // Two entries with the same name -- should warn only once
+        warnDroppedNames(
+          ['gone-skill', 'gone-skill'],
+          'disabled_skills',
+          warned,
+        )
+        expect(warnSpy.mock.calls).toHaveLength(1)
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
+    test('warnDroppedNames does not suppress a different entry across separate calls (no sticky global state)', () => {
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        // First load invocation
+        const warned1 = new Set<string>()
+        warnDroppedNames(['gone-skill-a'], 'disabled_skills', warned1)
+
+        // Second independent load invocation uses a fresh warned set
+        const warned2 = new Set<string>()
+        warnDroppedNames(['gone-skill-b'], 'disabled_skills', warned2)
+
+        const calls = warnSpy.mock.calls as unknown[][]
+        expect(calls).toHaveLength(2)
+        expect((calls[0] as unknown[])[0] as string).toContain('gone-skill-a')
+        expect((calls[1] as unknown[])[0] as string).toContain('gone-skill-b')
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
+    test('warnDroppedNames does not suppress the same entry in a second independent load (no cross-load suppression)', () => {
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        // First load invocation
+        const warned1 = new Set<string>()
+        warnDroppedNames(['gone-skill'], 'disabled_skills', warned1)
+
+        // Second independent load -- fresh warned set, same entry should warn again
+        const warned2 = new Set<string>()
+        warnDroppedNames(['gone-skill'], 'disabled_skills', warned2)
+
+        expect(warnSpy.mock.calls).toHaveLength(2)
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
+    test('warnDroppedNames names each dropped entry individually when multiple are dropped', () => {
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const warned = new Set<string>()
+        warnDroppedNames(['gone-a', 'gone-b'], 'disabled_agents', warned)
+        const calls = warnSpy.mock.calls as unknown[][]
+        const combined = calls
+          .map((c) => (c as unknown[])[0] as string)
+          .join('\n')
+        expect(combined).toContain('gone-a')
+        expect(combined).toContain('gone-b')
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
+    test('empty removed-name lists produce no stale-name warning and no behavior change (invariant)', () => {
+      // With empty removed lists, the production schema behaves identically to before.
+      // A valid config still loads; no stale-name warning is emitted.
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(projectConfigDir, 'systematic.json'),
+          JSON.stringify({ disabled_skills: ['ce:plan'] }),
+        )
+
+        const result = loadConfig(testDir)
+        expect(result.disabled_skills).toContain('ce:plan')
+
+        const staleWarnings = (warnSpy.mock.calls as unknown[][]).filter(
+          (args) =>
+            typeof (args as unknown[])[0] === 'string' &&
+            ((args as unknown[])[0] as string).includes(
+              'no longer a bundled name',
+            ),
+        )
+        expect(staleWarnings).toHaveLength(0)
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
+    test('unknown name still throws the actionable schema error (warning path does not swallow it)', () => {
+      const projectConfigDir = path.join(testDir, '.opencode')
+      fs.mkdirSync(projectConfigDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(projectConfigDir, 'systematic.json'),
+        JSON.stringify({ disabled_skills: ['never-existed-skill'] }),
+      )
+
+      expect(() => loadConfig(testDir)).toThrow(/never-existed-skill/)
+    })
+
+    test('merge precedence is unchanged when a valid name is present alongside other config', () => {
+      // Verifies that the drop+warn step does not disturb merge precedence for
+      // other fields. Project bootstrap.enabled:true overrides user false.
+      writeUserConfig({ bootstrap: { enabled: false } })
+
+      const projectConfigDir = path.join(testDir, '.opencode')
+      fs.mkdirSync(projectConfigDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(projectConfigDir, 'systematic.json'),
+        JSON.stringify({ bootstrap: { enabled: true } }),
+      )
+
+      const result = loadConfig(testDir)
+      expect(result.bootstrap.enabled).toBe(true)
+    })
+
+    test('raw config object is not mutated by the drop step', () => {
+      // loadConfigWithSources returns the raw config in overlays; the drop must
+      // not mutate it. We verify by checking that the returned config reflects
+      // the drop while the raw source config (accessible via a second load) is
+      // still intact. Since we cannot directly inspect the raw config object
+      // from outside, we verify the effective config is correct and that a
+      // second load produces the same result (no mutation side-effect).
+      const projectConfigDir = path.join(testDir, '.opencode')
+      fs.mkdirSync(projectConfigDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(projectConfigDir, 'systematic.json'),
+        JSON.stringify({ disabled_skills: ['ce:plan'] }),
+      )
+
+      const result1 = loadConfig(testDir)
+      const result2 = loadConfig(testDir)
+      expect(result1.disabled_skills).toEqual(result2.disabled_skills)
     })
   })
 })

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -17,6 +17,7 @@ import {
   checkFrontmatter,
   checkFrontmatterParseSafety,
   checkReferenceIntegrity,
+  checkRemovedNamesOverlap,
   checkSubfileReferences,
   collectScanTargets,
   discoverCategories,
@@ -3317,5 +3318,84 @@ describe('printArgumentHintViolations -- CLI print path', () => {
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }
+  })
+})
+
+describe('checkRemovedNamesOverlap', () => {
+  // Disjoint lists: no overlap between removed and current bundled names.
+  test('disjoint removed and current names: no violations', () => {
+    const violations = checkRemovedNamesOverlap(
+      ['gone-skill'],
+      [],
+      ['ce:plan', 'ce:review'],
+      [],
+      [],
+    )
+    expect(violations).toHaveLength(0)
+  })
+
+  // A removed skill name that equals a current bundled skill name must fail.
+  test('removed skill name overlapping current bundled skill name: violation', () => {
+    const violations = checkRemovedNamesOverlap(
+      ['ce:plan'],
+      [],
+      ['ce:plan', 'ce:review'],
+      [],
+      [],
+    )
+    expect(violations.length).toBeGreaterThan(0)
+    expect(violations.some((v) => v.name === 'ce:plan')).toBe(true)
+  })
+
+  // A removed agent name that equals a current bundled agent bare name must fail.
+  test('removed agent name overlapping current bundled agent bare name: violation', () => {
+    const violations = checkRemovedNamesOverlap(
+      [],
+      ['correctness-reviewer'],
+      [],
+      ['correctness-reviewer'],
+      [],
+    )
+    expect(violations.length).toBeGreaterThan(0)
+    expect(violations.some((v) => v.name === 'correctness-reviewer')).toBe(true)
+  })
+
+  // A removed agent name that equals a current bundled qualified id must fail.
+  test('removed agent name overlapping current bundled qualified id: violation', () => {
+    const violations = checkRemovedNamesOverlap(
+      [],
+      ['review/correctness-reviewer'],
+      [],
+      [],
+      ['review/correctness-reviewer'],
+    )
+    expect(violations.length).toBeGreaterThan(0)
+    expect(
+      violations.some((v) => v.name === 'review/correctness-reviewer'),
+    ).toBe(true)
+  })
+
+  // Multiple overlaps are all reported.
+  test('multiple overlapping names: all reported', () => {
+    const violations = checkRemovedNamesOverlap(
+      ['ce:plan', 'ce:review'],
+      ['correctness-reviewer'],
+      ['ce:plan', 'ce:review'],
+      ['correctness-reviewer'],
+      [],
+    )
+    expect(violations.length).toBe(3)
+  })
+
+  // Empty removed lists: no violations regardless of current names.
+  test('empty removed lists: no violations', () => {
+    const violations = checkRemovedNamesOverlap(
+      [],
+      [],
+      ['ce:plan', 'ce:review'],
+      ['correctness-reviewer'],
+      ['review/correctness-reviewer'],
+    )
+    expect(violations).toHaveLength(0)
   })
 })

--- a/tests/unit/generate-config-schema.test.ts
+++ b/tests/unit/generate-config-schema.test.ts
@@ -4,6 +4,12 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import {
+  BUNDLED_AGENT_NAMES,
+  BUNDLED_AGENT_QUALIFIED_IDS,
+  BUNDLED_SKILL_NAMES,
+} from '../../src/lib/bundled-names.js'
+import { createSystematicConfigSchema } from '../../src/lib/config-schema.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -243,6 +249,56 @@ describe('generateSchemaContent', () => {
     const first = generateSchemaContentFn('3.0.0')
     const second = generateSchemaContentFn('3.0.0')
     expect(first).toBe(second)
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════
+// generateSchemaContentFromSchema removed-names threading
+// ═════════════════════════════════════════════════════════════════
+
+describe('generateSchemaContentFromSchema removed-names threading', () => {
+  let generateSchemaContentFromSchemaFn: (
+    version: string,
+    schema: import('zod').ZodType,
+  ) => string
+  let generateSchemaContentFn: (version: string) => string
+
+  beforeAll(async () => {
+    const mod = await import('../../scripts/generate-config-schema.js')
+    generateSchemaContentFromSchemaFn = mod.generateSchemaContentFromSchema
+    generateSchemaContentFn = mod.generateSchemaContent
+  })
+
+  test('synthetic removed skill name appears in disabled_skills enum of generated JSON Schema', () => {
+    // Build a schema with a synthetic removed skill name to prove the
+    // removed-names are threaded through to the JSON Schema output.
+    const schema = createSystematicConfigSchema({
+      agentNames: BUNDLED_AGENT_NAMES,
+      qualifiedAgentIds: BUNDLED_AGENT_QUALIFIED_IDS,
+      skillNames: BUNDLED_SKILL_NAMES,
+      removedSkillNames: ['gone-skill'],
+      removedAgentNames: [],
+    })
+    const content = generateSchemaContentFromSchemaFn('3.0.0', schema)
+    // The generated JSON must contain the synthetic name somewhere in the
+    // disabled_skills enum (exact path varies with Zod's $ref deduplication).
+    expect(content).toContain('"gone-skill"')
+  })
+
+  test('empty removed lists produce byte-identical output to the baseline (no drift)', () => {
+    // With both removed lists empty, the factory schema is equivalent to the
+    // committed SystematicConfigSchema. The generated JSON Schema must be
+    // byte-identical to the baseline generateSchemaContent output.
+    const schema = createSystematicConfigSchema({
+      agentNames: BUNDLED_AGENT_NAMES,
+      qualifiedAgentIds: BUNDLED_AGENT_QUALIFIED_IDS,
+      skillNames: BUNDLED_SKILL_NAMES,
+      removedSkillNames: [],
+      removedAgentNames: [],
+    })
+    const fromFactory = generateSchemaContentFromSchemaFn('3.0.0', schema)
+    const baseline = generateSchemaContentFn('3.0.0')
+    expect(fromFactory).toBe(baseline)
   })
 })
 


### PR DESCRIPTION
## Summary

Add a forward-compatible safety net so removing a bundled skill or agent in a future release cannot brick plugin load for users who disabled it. Today `disabled_skills` and `disabled_agents` are strict enums; a name not in the enum throws uncaught during config load and aborts the plugin. This change makes known-removed names warn-and-ignore instead.

## Why

The deprecation guidance for `orchestrating-swarms` told users to set `disabled_skills: ["orchestrating-swarms"]`. When that skill is eventually removed, those exact users would otherwise have their plugin fail to load on upgrade, with no graceful message. This patch lands the safety net first, before any skill is removed.

## What changes

- A `removed-names` mechanism: `disabled_skills`/`disabled_agents` accept the strict disjoint union of current bundled names and an explicit removed-names list. Genuinely-unknown names (typos) still fail validation.
- After a successful parse, known-removed names are dropped from the effective config and reported with a `[systematic]` warning. Raw config is preserved for merge precedence; warning dedup is stateless per load.
- The schema generator threads the same removed-names so the published JSON Schema enum matches runtime acceptance.
- A content-integrity gate asserts removed names never overlap current bundled names.

The removed-names list ships **empty**, so there is no behavior change for existing configs. The accept-and-drop path is proven via tests using synthetic names.

## Verification

- 1039 unit tests pass (+32); content-integrity, schema drift, registry drift clean; build + Node ESM smoke (default-only export) pass; docs build passes.

Patch release (`fix`-class behavior preventing a latent load failure).
