### PR TITLE
refactor(complexity): extract helpers from top complexity hotspots

### DIFF
--- a/docs/scripts/generate-config-reference.ts
+++ b/docs/scripts/generate-config-reference.ts
@@ -441,65 +441,82 @@ export function validateFieldExamples(
   const errors: string[] = []
   const currentPrefix = prefix ?? ''
 
-  // Check direct properties
+  checkDirectProperties(schema, currentPrefix, errors)
+  checkAdditionalProperties(schema, currentPrefix, errors)
+
+  return errors
+}
+
+function checkDirectProperties(
+  schema: Record<string, unknown>,
+  currentPrefix: string,
+  errors: string[],
+): void {
   if (
-    schema.properties &&
-    typeof schema.properties === 'object' &&
-    !Array.isArray(schema.properties)
+    !schema.properties ||
+    typeof schema.properties !== 'object' ||
+    Array.isArray(schema.properties)
   ) {
-    const props = schema.properties as Record<string, unknown>
-    for (const [key, value] of Object.entries(props)) {
+    return
+  }
+
+  const props = schema.properties as Record<string, unknown>
+  for (const [key, value] of Object.entries(props)) {
+    const val = value as Record<string, unknown>
+    const fieldPath = currentPrefix ? `${currentPrefix}.${key}` : key
+
+    // Skip objects that serve as containers (they have sub-properties)
+    const hasSubProperties =
+      (val.properties || val.additionalProperties) &&
+      !val.type?.toString().startsWith('array')
+
+    if (hasSubProperties) {
+      // Recurse into sub-properties
+      const subErrors = validateFieldExamples(val, fieldPath)
+      errors.push(...subErrors)
+      // Also check the container itself for examples, if it has a description
+      if (val.description) {
+        checkExamples(val, fieldPath, errors)
+      }
+    } else if (val.description) {
+      checkExamples(val, fieldPath, errors)
+    }
+  }
+}
+
+function checkAdditionalProperties(
+  schema: Record<string, unknown>,
+  currentPrefix: string,
+  errors: string[],
+): void {
+  if (
+    !schema.additionalProperties ||
+    typeof schema.additionalProperties !== 'object' ||
+    Array.isArray(schema.additionalProperties)
+  ) {
+    return
+  }
+
+  const addProps = schema.additionalProperties as Record<string, unknown>
+  // If the additional properties value has sub-properties, recurse
+  if (addProps.properties && typeof addProps.properties === 'object') {
+    const innerProps = addProps.properties as Record<string, unknown>
+    for (const [key, value] of Object.entries(innerProps)) {
       const val = value as Record<string, unknown>
-      const fieldPath = currentPrefix ? `${currentPrefix}.${key}` : key
+      const fieldPath = currentPrefix
+        ? `${currentPrefix}.<name>.${key}`
+        : `<name>.${key}`
 
-      // Skip objects that serve as containers (they have sub-properties)
-      const hasSubProperties =
-        (val.properties || val.additionalProperties) &&
-        !val.type?.toString().startsWith('array')
-
-      if (hasSubProperties) {
-        // Recurse into sub-properties
-        const subErrors = validateFieldExamples(val, fieldPath)
-        errors.push(...subErrors)
-        // Also check the container itself for examples, if it has a description
-        if (val.description) {
-          checkExamples(val, fieldPath, errors)
-        }
-      } else if (val.description) {
+      if (val.description) {
         checkExamples(val, fieldPath, errors)
       }
     }
   }
-
-  // Check additionalProperties (record-type schemas)
-  if (
-    schema.additionalProperties &&
-    typeof schema.additionalProperties === 'object' &&
-    !Array.isArray(schema.additionalProperties)
-  ) {
-    const addProps = schema.additionalProperties as Record<string, unknown>
-    // If the additional properties value has sub-properties, recurse
-    if (addProps.properties && typeof addProps.properties === 'object') {
-      const innerProps = addProps.properties as Record<string, unknown>
-      for (const [key, value] of Object.entries(innerProps)) {
-        const val = value as Record<string, unknown>
-        const fieldPath = currentPrefix
-          ? `${currentPrefix}.<name>.${key}`
-          : `<name>.${key}`
-
-        if (val.description) {
-          checkExamples(val, fieldPath, errors)
-        }
-      }
-    }
-    // Also check the additionalProperties container itself if it has a description
-    if (addProps.description) {
-      const fieldPath = currentPrefix ? `${currentPrefix}.<value>` : '<value>'
-      checkExamples(addProps, fieldPath, errors)
-    }
+  // Also check the additionalProperties container itself if it has a description
+  if (addProps.description) {
+    const fieldPath = currentPrefix ? `${currentPrefix}.<value>` : '<value>'
+    checkExamples(addProps, fieldPath, errors)
   }
-
-  return errors
 }
 
 function checkExamples(

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -71,6 +71,50 @@ export const SKILL_FRONTMATTER_FIELDS = [
   'subtask',
 ] as const
 
+function parseMetadata(
+  data: Record<string, unknown>,
+): Record<string, string> | undefined {
+  const metadataRaw = data.metadata
+  if (!isRecord(metadataRaw)) {
+    return undefined
+  }
+  const entries = Object.entries(metadataRaw)
+  if (!entries.every(([, v]) => typeof v === 'string')) {
+    return undefined
+  }
+  return Object.fromEntries(entries) as Record<string, string>
+}
+
+function parseDeprecated(
+  data: Record<string, unknown>,
+): SkillDeprecated | undefined {
+  const deprecatedRaw = data.deprecated
+  if (!isRecord(deprecatedRaw)) {
+    return undefined
+  }
+
+  const since =
+    typeof deprecatedRaw.since === 'string' && deprecatedRaw.since !== ''
+      ? deprecatedRaw.since
+      : undefined
+  const removal =
+    typeof deprecatedRaw.removal === 'string' && deprecatedRaw.removal !== ''
+      ? deprecatedRaw.removal
+      : undefined
+  if (since === undefined || removal === undefined) {
+    return undefined
+  }
+
+  const deprecated: SkillDeprecated = { since, removal }
+  if (typeof deprecatedRaw.replacement === 'string') {
+    deprecated.replacement = deprecatedRaw.replacement
+  }
+  if (typeof deprecatedRaw.reason === 'string') {
+    deprecated.reason = deprecatedRaw.reason
+  }
+  return deprecated
+}
+
 export function extractFrontmatter(filePath: string): SkillFrontmatter {
   try {
     const content = fs.readFileSync(filePath, 'utf8')
@@ -81,37 +125,8 @@ export function extractFrontmatter(filePath: string): SkillFrontmatter {
       return { name: '', description: '' }
     }
 
-    const metadataRaw = data.metadata
-    let metadata: Record<string, string> | undefined
-    if (isRecord(metadataRaw)) {
-      const entries = Object.entries(metadataRaw)
-      if (entries.every(([, v]) => typeof v === 'string')) {
-        metadata = Object.fromEntries(entries) as Record<string, string>
-      }
-    }
-
-    const deprecatedRaw = data.deprecated
-    let deprecated: SkillDeprecated | undefined
-    if (isRecord(deprecatedRaw)) {
-      const since =
-        typeof deprecatedRaw.since === 'string' && deprecatedRaw.since !== ''
-          ? deprecatedRaw.since
-          : undefined
-      const removal =
-        typeof deprecatedRaw.removal === 'string' &&
-        deprecatedRaw.removal !== ''
-          ? deprecatedRaw.removal
-          : undefined
-      if (since !== undefined && removal !== undefined) {
-        deprecated = { since, removal }
-        if (typeof deprecatedRaw.replacement === 'string') {
-          deprecated.replacement = deprecatedRaw.replacement
-        }
-        if (typeof deprecatedRaw.reason === 'string') {
-          deprecated.reason = deprecatedRaw.reason
-        }
-      }
-    }
+    const metadata = parseMetadata(data)
+    const deprecated = parseDeprecated(data)
 
     const argumentHintRaw = extractNonEmptyString(data, 'argument-hint')
     const argumentHint =


### PR DESCRIPTION
Both of the codebase's worst cognitive-complexity functions were doing too much inline. This splits each into small file-local helpers without changing any behavior.

- **`validateFieldExamples`** (`docs/scripts/generate-config-reference.ts`) was CC 41 — the single worst offender. Its two independent branches (the `properties` walk and the `additionalProperties` walk) now live in `checkDirectProperties` and `checkAdditionalProperties`. Path-string construction (`<name>`, `<value>` placeholders) and error push ordering are preserved verbatim.
- **`extractFrontmatter`** (`src/lib/skills.ts`) was CC 25. The inline `metadata` and `deprecated` parsing blocks moved into `parseMetadata` and `parseDeprecated`, keeping exact semantics: metadata only set when every value is a string; deprecated only set when both `since` and `removal` are non-empty.

Exported signatures are unchanged, so this is invisible to callers.

## Verification

- `bun test tests/unit` — 1039 pass, 0 fail
- `bun run typecheck` — clean
- `bun run lint` — repo-wide `noExcessiveCognitiveComplexity` warnings drop 6 → 4 (remaining 4 are CC 16–19 in build-script, manual-probe, and test files, out of scope here)