### PR TITLE
docs(plans): reconcile stale v3-adjacent plan statuses

### DIFF
--- a/docs/plans/2026-06-05-001-feat-v3-compatibility-cleanup-plan.md
+++ b/docs/plans/2026-06-05-001-feat-v3-compatibility-cleanup-plan.md
@@ -1,7 +1,8 @@
 ---
 title: "feat: v3 compatibility cleanup"
 type: feat
-status: active
+status: superseded
+superseded_by: docs/brainstorms/2026-07-13-v3-cleanup-release-requirements.md
 date: 2026-06-05
 origin: docs/brainstorms/2026-05-21-v3-converter-removal-and-excision-requirements.md
 deepened: 2026-06-05

--- a/docs/plans/2026-06-05-001-feat-v3-compatibility-cleanup-plan.md
+++ b/docs/plans/2026-06-05-001-feat-v3-compatibility-cleanup-plan.md
@@ -2,7 +2,9 @@
 title: "feat: v3 compatibility cleanup"
 type: feat
 status: superseded
+superseded_at: 2026-07-13
 superseded_by: docs/brainstorms/2026-07-13-v3-cleanup-release-requirements.md
+superseded_reason: "The v3 cleanup scope was re-derived from scratch in the 2026-07-13 v3-cleanup-release brainstorm after all v2.x behavior-preserving prerequisites shipped (mode:subagent gate v2.27.0, temperature gate v2.29.0, removed-name safety net #534/v2.32.0). The newer brainstorm supersedes this plan's approach; a fresh v3.0.0 plan is authored from it."
 date: 2026-06-05
 origin: docs/brainstorms/2026-05-21-v3-converter-removal-and-excision-requirements.md
 deepened: 2026-06-05

--- a/docs/plans/2026-07-13-001-feat-removed-name-config-safety-plan.md
+++ b/docs/plans/2026-07-13-001-feat-removed-name-config-safety-plan.md
@@ -1,7 +1,8 @@
 ---
 title: "feat: warn-and-ignore removed bundled names in disable lists"
 type: feat
-status: executed-pending-pr
+status: completed
+shipped: "PR #534 (commit 70f1891); released in v2.32.0"
 date: 2026-07-13
 origin: docs/brainstorms/2026-07-13-v3-cleanup-release-requirements.md
 ---


### PR DESCRIPTION
Two plan files in `docs/plans/` had stale status frontmatter that no longer matched shipped reality. This reconciles them against the actual repo state.

- **`2026-07-13-001-feat-removed-name-config-safety-plan.md`** was still `status: executed-pending-pr`, but the work shipped in **PR #534** (commit `70f1891`, released in **v2.32.0**). Marked `completed` with shipped provenance.
- **`2026-06-05-001-feat-v3-compatibility-cleanup-plan.md`** was `status: active`, but it has been superseded by the newer `2026-07-13-v3-cleanup-release-requirements.md` brainstorm. Marked `superseded` with a `superseded_by` pointer.

Frontmatter only — no body or behavior changes.