### PR TITLE
ci(workflows): run PR checks and review on v3 base branch

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, v3]
   schedule:
     - cron: '30 5 * * 1'
   workflow_dispatch:

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -11,7 +11,7 @@ on:
   issues:
     types: [opened, edited]
   pull_request:
-    branches: [main]
+    branches: [main, v3]
     types: [opened, synchronize, reopened, ready_for_review, review_requested]
   schedule:
     - cron: '0 9 * * 1'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, v3]
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Prep for a long-lived `v3` integration branch. v3.0.0 is a breaking cleanup release that will be developed over time behind PRs, then cut live by merging `v3` into `main`. For that to work, PRs targeting `v3` need the same CI and review that `main` PRs get.

## What this does

Adds `v3` to the `pull_request.branches` filter in three workflows:

- **`main.yaml`** — build, typecheck, lint, test, registry, docs-build, ESM smoke test
- **`fro-bot.yaml`** — automated PR review
- **`codeql-analysis.yaml`** — security analysis

## What this deliberately does not do

`push.branches` stays scoped to `main` in every workflow. The semantic-release job in `main.yaml` only publishes on push to the default branch, so:

- The Release job never even runs on `v3`.
- Breaking commits (`feat!:` / `BREAKING CHANGE:`) can accumulate on `v3` with zero risk of triggering a publish.
- `.releaserc.yaml` is untouched — still `branches: [main]`.

When v3 is ready, a `--no-ff` merge of `v3` into `main` brings the breaking commits onto the default branch and semantic-release cuts `3.0.0` normally.

Note: for `pull_request` events GitHub evaluates the workflow file from the **base branch**, so this must land on `main` before `v3` is branched — otherwise v3 PRs would get no checks.