### PR TITLE
docs(plans): correct future-dated v3 plan artifacts to 2026-07-06

### DIFF
--- a/docs/plans/2026-06-05-001-feat-v3-compatibility-cleanup-plan.md
+++ b/docs/plans/2026-06-05-001-feat-v3-compatibility-cleanup-plan.md
@@ -2,9 +2,9 @@
 title: "feat: v3 compatibility cleanup"
 type: feat
 status: superseded
-superseded_at: 2026-07-13
-superseded_by: docs/brainstorms/2026-07-13-v3-cleanup-release-requirements.md
-superseded_reason: "The v3 cleanup scope was re-derived from scratch in the 2026-07-13 v3-cleanup-release brainstorm after all v2.x behavior-preserving prerequisites shipped (mode:subagent gate v2.27.0, temperature gate v2.29.0, removed-name safety net #534/v2.32.0). The newer brainstorm supersedes this plan's approach; a fresh v3.0.0 plan is authored from it."
+superseded_at: 2026-07-06
+superseded_by: docs/brainstorms/2026-07-06-v3-cleanup-release-requirements.md
+superseded_reason: "The v3 cleanup scope was re-derived from scratch in the 2026-07-06 v3-cleanup-release brainstorm after all v2.x behavior-preserving prerequisites shipped (mode:subagent gate v2.27.0, temperature gate v2.29.0, removed-name safety net #534/v2.32.0). The newer brainstorm supersedes this plan's approach; a fresh v3.0.0 plan is authored from it."
 date: 2026-06-05
 origin: docs/brainstorms/2026-05-21-v3-converter-removal-and-excision-requirements.md
 deepened: 2026-06-05

--- a/docs/plans/2026-07-06-001-feat-removed-name-config-safety-plan.md
+++ b/docs/plans/2026-07-06-001-feat-removed-name-config-safety-plan.md
@@ -3,8 +3,8 @@ title: "feat: warn-and-ignore removed bundled names in disable lists"
 type: feat
 status: completed
 shipped: "PR #534 (commit 70f1891); released in v2.32.0"
-date: 2026-07-13
-origin: docs/brainstorms/2026-07-13-v3-cleanup-release-requirements.md
+date: 2026-07-06
+origin: docs/brainstorms/2026-07-06-v3-cleanup-release-requirements.md
 ---
 
 # feat: warn-and-ignore removed bundled names in disable lists
@@ -17,7 +17,7 @@ This ships as a v2.x patch BEFORE the v3.0.0 cleanup (which deletes `orchestrati
 
 ## Problem Frame
 
-Verified release-blocker (see origin: `docs/brainstorms/2026-07-13-v3-cleanup-release-requirements.md`). `disabled_skills` is `z.array(z.enum(skillNames))` and `disabled_agents` is `z.array(z.enum([...agentNames, ...qualifiedAgentIds]))` (`src/lib/config-schema.ts:315-342`). A name not in the enum fails `safeParse`; `loadConfigSource` then calls `throwTopLevelConfigSchemaError`, which throws (`src/lib/config.ts:276-299, 238-274`). That throw escapes uncaught from both plugin init (`src/index.ts`) and the config hook (`src/lib/config-handler.ts:513-528`), aborting plugin load.
+Verified release-blocker (see origin: `docs/brainstorms/2026-07-06-v3-cleanup-release-requirements.md`). `disabled_skills` is `z.array(z.enum(skillNames))` and `disabled_agents` is `z.array(z.enum([...agentNames, ...qualifiedAgentIds]))` (`src/lib/config-schema.ts:315-342`). A name not in the enum fails `safeParse`; `loadConfigSource` then calls `throwTopLevelConfigSchemaError`, which throws (`src/lib/config.ts:276-299, 238-274`). That throw escapes uncaught from both plugin init (`src/index.ts`) and the config hook (`src/lib/config-handler.ts:513-528`), aborting plugin load.
 
 v2.19.0 deprecation guidance told users to set `disabled_skills: ["orchestrating-swarms"]`. When v3 deletes that skill, those exact users would be bricked on upgrade. Shipping the warn-and-ignore net first means the v3 deletion only has to add names to the removed list, not also introduce new validation behavior in the same breaking release.
 
@@ -212,7 +212,7 @@ v2.19.0 deprecation guidance told users to set `disabled_skills: ["orchestrating
 
 ## Sources & References
 
-- **Origin document:** `docs/brainstorms/2026-07-13-v3-cleanup-release-requirements.md`
+- **Origin document:** `docs/brainstorms/2026-07-06-v3-cleanup-release-requirements.md`
 - Verified failure path: `src/lib/config-schema.ts:315-342`, `src/lib/config.ts:238-299`, `src/index.ts`, `src/lib/config-handler.ts:513-528`
 - Oracle sequencing recommendation (this session): ship the safety net as a v2.x patch before the v3 deletion.
 - Related future plan: v3.0.0 cleanup (to be written from the same origin brainstorm).

--- a/docs/plans/2026-07-06-002-feat-v3-cleanup-release-plan.md
+++ b/docs/plans/2026-07-06-002-feat-v3-cleanup-release-plan.md
@@ -2,8 +2,8 @@
 title: "feat: v3.0.0 compatibility cleanup release"
 type: feat
 status: active
-date: 2026-07-13
-origin: docs/brainstorms/2026-07-13-v3-cleanup-release-requirements.md
+date: 2026-07-06
+origin: docs/brainstorms/2026-07-06-v3-cleanup-release-requirements.md
 target_branch: v3
 ---
 
@@ -25,7 +25,7 @@ Two deprecated skills remain discoverable: `orchestrating-swarms` (a CEP/Claude-
 
 ## Requirements Trace
 
-Carried from the origin brainstorm (see origin: `docs/brainstorms/2026-07-13-v3-cleanup-release-requirements.md`):
+Carried from the origin brainstorm (see origin: `docs/brainstorms/2026-07-06-v3-cleanup-release-requirements.md`):
 
 - R1. Remove runtime converter use from all three callers, replicating or intentionally dropping its normalization rather than only deleting call sites.
 - R2. Delete `src/lib/converter.ts` after a zero-import/zero-call-site audit.
@@ -353,9 +353,9 @@ Phase 3 (convergence + assurance)
 
 ## Sources & References
 
-- **Origin document:** docs/brainstorms/2026-07-13-v3-cleanup-release-requirements.md
+- **Origin document:** docs/brainstorms/2026-07-06-v3-cleanup-release-requirements.md
 - Superseded prior plan: docs/plans/2026-06-05-001-feat-v3-compatibility-cleanup-plan.md
-- Sibling (shipped) prerequisite: docs/plans/2026-07-13-001-feat-removed-name-config-safety-plan.md (warn-and-ignore mechanism, #534 / v2.32.0)
+- Sibling (shipped) prerequisite: docs/plans/2026-07-06-001-feat-removed-name-config-safety-plan.md (warn-and-ignore mechanism, #534 / v2.32.0)
 - Converter removal targets: src/lib/converter.ts, src/lib/config-handler.ts, src/lib/skill-loader.ts, src/cli.ts
 - Generated surfaces: registry/registry.jsonc, src/lib/bundled-names.ts, docs/public/schemas/, docs/src/content/docs/reference/, docs/src/data/stats.json
 - Gates: scripts/content-integrity.ts (overlap gate, reference integrity), schema/registry drift checks

--- a/docs/plans/2026-07-06-003-feat-pi-harness-support-plan.md
+++ b/docs/plans/2026-07-06-003-feat-pi-harness-support-plan.md
@@ -2,8 +2,8 @@
 title: "feat: Pi coding-agent harness support"
 type: feat
 status: active
-date: 2026-07-13
-origin: docs/brainstorms/2026-07-13-pi-harness-support-requirements.md
+date: 2026-07-06
+origin: docs/brainstorms/2026-07-06-pi-harness-support-requirements.md
 target_branch: v3
 ---
 
@@ -13,7 +13,7 @@ target_branch: v3
 
 Add **Pi** (`earendil-works/pi`) as a second supported harness, shipped from the **same single `@fro.bot/systematic` npm package** at full parity with the OpenCode experience: Pi users get the bundled skills, the agents as real in-process subagents, the `systematic_skill` tool, and the `using-systematic` bootstrap. The OpenCode plugin (`src/index.ts`) is unchanged in behavior; a new second entry `src/pi.ts` is a thin adapter over the existing `src/lib/*` core, built to `dist/pi.js` and wired via a `pi` manifest key in `package.json`.
 
-This rides the long-lived `v3` branch alongside the v3 cleanup plan (`docs/plans/2026-07-13-002-feat-v3-cleanup-release-plan.md`) but is an independent set of PRs. The two coordinate only on `src/cli.ts` (cleanup removes the `convert` command; this plan adds `setup --harness`).
+This rides the long-lived `v3` branch alongside the v3 cleanup plan (`docs/plans/2026-07-06-002-feat-v3-cleanup-release-plan.md`) but is an independent set of PRs. The two coordinate only on `src/cli.ts` (cleanup removes the `convert` command; this plan adds `setup --harness`).
 
 ## Problem Frame
 
@@ -21,7 +21,7 @@ Systematic is currently OpenCode-only. Pi implements the same Agent Skills stand
 
 ## Requirements Trace
 
-Carried from the origin brainstorm (see origin: `docs/brainstorms/2026-07-13-pi-harness-support-requirements.md`):
+Carried from the origin brainstorm (see origin: `docs/brainstorms/2026-07-06-pi-harness-support-requirements.md`):
 
 - R1. Single package; `src/pi.ts` second entry; build `dist/index.js` + `dist/pi.js` from shared `src/lib/*`.
 - R2. `package.json` carries `"pi": { "extensions": ["./dist/pi.js"], "skills": ["./skills"] }`; keep `skills/`+`agents/` in `files`.
@@ -396,8 +396,8 @@ delegateTool.execute({ agent, task }, ctx):
 
 ## Sources & References
 
-- **Origin document:** docs/brainstorms/2026-07-13-pi-harness-support-requirements.md
-- Related plan (shared v3 branch): docs/plans/2026-07-13-002-feat-v3-cleanup-release-plan.md
+- **Origin document:** docs/brainstorms/2026-07-06-pi-harness-support-requirements.md
+- Related plan (shared v3 branch): docs/plans/2026-07-06-002-feat-v3-cleanup-release-plan.md
 - Packaging targets: package.json, src/index.ts, src/pi.ts (new), src/cli.ts, .github/workflows/main.yaml
 - Shared core: src/lib/skill-loader.ts, src/lib/skills.ts, src/lib/bootstrap.ts, src/lib/agents.ts
 - Test model: tests/integration/opencode.test.ts; cortexkit AFT tests/pi-rpc


### PR DESCRIPTION
The v3-lineage plan artifacts were dated `2026-07-13` — a week in the future. Renames them to the correct `2026-07-06` and fixes every internal date and cross-reference:

- `2026-07-13-001-feat-removed-name-config-safety-plan.md` → `2026-07-06-001-...`
- `2026-07-13-002-feat-v3-cleanup-release-plan.md` → `2026-07-06-002-...`
- `2026-07-13-003-feat-pi-harness-support-plan.md` → `2026-07-06-003-...`
- `2026-06-05-001-feat-v3-compatibility-cleanup-plan.md` — `superseded_at`/`superseded_by`/reason pointers updated to match

Rename + reference fixes only; no content changes. A matching PR corrects `main`'s copy of the 001 plan and the 2026-06-05 pointers.