### PR TITLE
feat: register discovered skills as slash commands

### DIFF
--- a/docs/plans/2026-07-06-004-feat-discovered-skills-as-commands-plan.md
+++ b/docs/plans/2026-07-06-004-feat-discovered-skills-as-commands-plan.md
@@ -1,0 +1,230 @@
+---
+title: "feat: discovered skills as commands + systematic_skill permission parity"
+type: feat
+status: active
+date: 2026-07-06
+origin: docs/brainstorms/2026-07-06-discovered-skills-as-commands-requirements.md
+---
+
+# feat: Discovered Skills as Commands + `systematic_skill` Permission Parity
+
+## Overview
+
+Two independent v2 deliverables on `main`, shipped as **two separate PRs** from one reviewed brainstorm:
+
+1. **Feature PR — discovered skills as commands.** Systematic already registers its bundled skills as slash commands. This extends the capability to skills OpenCode discovers from user/project roots: each becomes an invokable `/skill-name` command via the config hook. The command template is a one-line skill-tool shim (argument string wrapped as data); command-only skills (`disable-model-invocation: true`) are the sole inline-body exception. Because upstream skips skill-command registration for names already in `config.command`, Systematic's entries *replace* upstream's raw-body skill commands per name — upgrading typed invocation to a permission-gated skill-tool load. No client gating (impossible to double-list by construction); one feature toggle.
+
+2. **Drift PR — `systematic_skill` permission parity.** Upstream's `skill` tool permission-gates every load via `ctx.ask` against `permission.skill` patterns; `systematic_skill` bypasses that system. Source-verified: plugin tool contexts DO expose `ask()` (bridged from the host tool context), so full allow/deny/ask parity is implementable. Also aligns file sampling behavior.
+
+## Problem Frame
+
+Upstream registers every discovered skill as a server-side command (`source: "skill"`, raw SKILL.md body as template) but the TUI intentionally hides them from `/` autocomplete (maintainer-confirmed; parity PR stale-closed). Source verification this session: typed `/skill-name` DOES execute (the TUI submit path checks the unfiltered command list — `packages/tui/src/component/prompt/index.tsx:1065-1115`) — so the feature's value is (a) autocomplete discoverability, (b) upgraded invocation semantics (shim + permission gate instead of upstream's raw body inline), (c) argument-as-data handling, (d) `disable-model-invocation` command-only semantics (Claude Code parity nobody ships, demanded upstream in #12109).
+
+Separately, a user who configures `permission: { skill: { "internal-*": "deny" } }` still gets those skills loaded through `systematic_skill` — a real permission bypass (upstream gates at `tool/skill.ts:28-33`; Systematic has no equivalent).
+
+See origin: `docs/brainstorms/2026-07-06-discovered-skills-as-commands-requirements.md` for full research provenance (upstream history, prior-art table, verified facts F1–F7).
+
+## Requirements Trace
+
+Carried from the origin brainstorm:
+
+- R1. Discover non-bundled skills from the six upstream-documented roots (project `.opencode/skills/`, global `~/.config/opencode/skills/`, project+global `.claude/skills/` and `.agents/skills/`; project paths walk up to the git worktree root).
+- R2. Register each as `config.command[name]` under the bare skill name; duplicate names across roots resolve to the same winner upstream's skill tool resolves (later-discovered wins), never an independent precedence scheme.
+- R3. Model-invocable skills get a one-line skill-tool shim template; the argument string is wrapped as data in a `<user-request>` block (existing `skill-loader.ts` pattern), never concatenated into instruction text.
+- R4. Existing `config.command` entries always win; bundled `systematic:`/`ce:` command registration is untouched.
+- R5. Dropped — no client gating (Systematic's entries replace upstream's skill-sourced entries by name on every client; double-listing impossible by construction).
+- R6. `disable-model-invocation: true` = command-only: registers as a command with an **inline-body** template (the sole R3 exception), excluded from model-facing exposure.
+- R7. A config toggle (`skills_as_commands`, default on) disables the feature entirely; graceful degradation if upstream converges.
+- R8. No filesystem writes; everything happens in the config hook.
+- R9. Only names matching the upstream regex (`^[a-z0-9]+(-[a-z0-9]+)*$`) register; invalid names skip with a debug note, never a crash.
+- R10. `systematic_skill` loads respect `permission.skill` semantics (allow/deny/ask). Source-verified feasible: plugin tool execute context exposes `ask()`. Fail-closed if ask cannot prompt in some context: `ask` patterns treat as `deny` with a warning, never downgrade to allow.
+- R11. File sampling aligns with upstream (hidden files included, deterministic ordering, limit 10, no silently swallowed errors).
+- R12. Deprecation-warning behavior untouched (v3 deletes it).
+- R13. Two separate PRs: feature (R1–R9), drift (R10–R12).
+- R14. Committed docs cover discovery roots, naming, collision policy, the toggle, command-only semantics, and the honest upstream/trust context.
+
+## Scope Boundaries
+
+- No trust gate beyond upstream's (upstream registers the same project-root content ungated; commands are human-invoked). Docs state this trust model plainly (R14).
+- No dispatcher command, no filesystem writes, no prefix option, no remote-skill (`config.skills.urls`) support in v1.
+- No changes to bundled-skill command registration or the bootstrap catalog.
+- No Pi-side work (v3 track).
+
+### Deferred to Separate Tasks
+
+- Prefix option for injected commands: only if users ask.
+- Remote skills (`config.skills.urls`) as command sources: future iteration.
+- Claude Code named-argument frontmatter (`arguments: [issue, branch]` → `$issue`): follow-up if demand appears.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/lib/config-handler.ts` — `collectSkillsAsCommands()` (bundled-skill command emission to mirror), the `config.command` merge that preserves user entries (`isSystematicOwnedCommandKey`), and `registerSkillsPaths()`.
+- `src/lib/skills.ts` — `findSkillsInDir`, `extractFrontmatter` (already parses `disable-model-invocation`, `allowed-tools`, `argument-hint`, etc. from the Claude Code compat work #43).
+- `src/lib/skill-loader.ts` — the `<skill-instruction>`/`<user-request>` wrapped-template pattern (R3's argument-as-data model).
+- `src/lib/skill-tool.ts` — `systematic_skill` implementation (drift PR target); `src/lib/config-schema.ts` for the new toggle field.
+- Upstream (local clone v1.17.6, re-verify at v1.17.13): `packages/opencode/src/skill/index.ts:185-227` (discovery roots + later-wins duplicate handling), `command/index.ts:142-153` (skill-command registration skips existing names), `tool/skill.ts:28-33` (the `ctx.ask` permission gate to mirror), `packages/plugin/src/tool.ts:3-20` + `opencode/src/tool/registry.ts:132-143` (plugin tool `ask()` bridge), `tui/.../prompt/index.tsx:1065-1115` (typed-command execution path).
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/opencode-plugin-hook-silent-defect-swallow-2026-05-19.md` — config-hook code must not throw; discovery failures degrade to skipping, never abort plugin load.
+- `docs/solutions/integration-issues/opencode-plugin-factory-duplicate-registration-2026-05-04.md` — hooks run per-source; command emission must be idempotent.
+- `docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md` — if the runtime drops invalid-name skills silently (R9), no gate mirror is needed (user content, not bundled), but the drop must be observable (debug note).
+- Prior art (origin doc): opencode-claude-code-bridge (shim), mem0 plugin (config.command mutation), upstream's own collision policy.
+
+## Key Technical Decisions
+
+- **Reuse Systematic's own discovery walker over the six roots** rather than trying to read upstream's discovered-skill list: the config hook receives config, not upstream's runtime skill registry — there is no API to consume it at config time. Mirror upstream's discovery order and later-wins duplicate rule exactly so the command winner matches the skill tool's winner (R2).
+- **Replace-by-name is the collision story.** Upstream registers skill commands only for names NOT already in `config.command` — so emitting our entries in the config hook means every client sees exactly one command per skill name, ours. User-defined commands still beat ours (R4) because we skip names present in the user's config before merge.
+- **Shim for model-invocable, inline for command-only** (R3/R6) — pinned at brainstorm review; no third path.
+- **Toggle in the existing config schema** (`skills_as_commands: boolean`, default `true`), not trust-protected (not in `SECURITY_OVERLAY_FIELDS` — it's a UX preference, not a security boundary).
+- **Permission parity uses the bridged `ask()`** (R10) — same semantics as upstream's gate: patterns from `permission.skill`, `always` on allow. Static config reading is the fallback only if `ask()` proves unusable in some agent context; then `ask`→`deny` fail-closed.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Typed `/skill-name` execution: works today (source-verified) — value framing updated accordingly.
+- Plugin `ask()` availability: confirmed at `packages/plugin/src/tool.ts:3-20`.
+- Client gating: dropped (replace-by-name makes double-listing impossible).
+- Discovery reuse vs re-walk: re-walk, mirroring upstream's order + later-wins rule (no config-time API to upstream's registry).
+
+### Deferred to Implementation
+
+- Whether the config hook's cwd is reliably the project directory for the worktree-upward walk (verify against the plugin input's `directory`).
+- Exact debug-note channel for R9 skips (existing `[systematic]` logger vs silent).
+- v1.17.13 line-number re-verification of the five upstream reference points.
+
+## Implementation Units
+
+- [ ] **Unit 1: Discovery of non-bundled skills across the six roots**
+
+**Goal:** A pure function that discovers user/project skills exactly as upstream does — same roots, same order, same later-wins duplicate rule — returning name, description, frontmatter (incl. `disable-model-invocation`), and body path.
+
+**Requirements:** R1, R2 (precedence), R9
+
+**Dependencies:** None
+
+**Files:**
+- Create: `src/lib/discovered-skills.ts`
+- Test: `tests/unit/discovered-skills.test.ts`
+
+**Approach:**
+- Reuse `walkDir`/`findSkillsInDir` machinery where it fits; the six roots and upward walk are new logic. Skip Systematic's own bundled dir (those are handled by the existing path).
+- Order: global claude → global agents → project walk (claude/agents) → opencode config dirs — matching `skill/index.ts:185-227`; later discovery overwrites earlier per name.
+- Invalid names (regex fail) and unreadable dirs skip with a debug note; discovery never throws (hook-defect learning).
+
+**Execution note:** Test-first — the precedence and root-ordering rules are the regression surface.
+
+**Test scenarios:**
+- Happy path: a skill in `.opencode/skills/` is discovered with correct name/description/body path.
+- Precedence: same name in global `.claude/skills/` and project `.agents/skills/` → project wins (later-discovered), matching upstream's winner.
+- Edge: name violating the regex is skipped with a note; a root that doesn't exist is skipped silently.
+- Edge: worktree-upward walk stops at the git root; skills above it are not discovered.
+- Error path: unreadable SKILL.md (permission denied) skips that skill, discovery completes.
+
+**Verification:** unit tests green; discovery output for a fixture tree matches upstream's documented winner for every duplicate case.
+
+- [ ] **Unit 2: Command emission in the config hook**
+
+**Goal:** Convert discovered skills into `config.command` entries — shim template for model-invocable, inline body for command-only — behind the `skills_as_commands` toggle, never clobbering existing commands.
+
+**Requirements:** R2, R3, R4, R6, R7, R8
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `src/lib/config-handler.ts` (new emission step alongside `collectSkillsAsCommands`), `src/lib/config-schema.ts` (+ `skills_as_commands` field), `src/lib/removed-names.ts` untouched
+- Test: `tests/unit/config-handler.test.ts`, `tests/unit/config-schema.test.ts`
+
+**Approach:**
+- Shim template wraps `$ARGUMENTS` in the `<user-request>` block pattern from `skill-loader.ts`; instructs loading via the `skill` tool (upstream's, not `systematic_skill` — discovered skills are upstream-registered skills).
+- Command-only skills inline the SKILL.md body (sole exception, R6); their `$ARGUMENTS` handling follows upstream command substitution (F4).
+- Skip any name already present in user `config.command` BEFORE merge (R4); bundled `systematic:`/`ce:` paths untouched.
+- Toggle default true; `false` emits nothing.
+- Regenerate the JSON schema for the new config field (`bun scripts/generate-config-schema.ts`).
+
+**Test scenarios:**
+- Happy path: discovered model-invocable skill → command entry with shim template + description.
+- Happy path: command-only skill → inline-body template, and it is excluded from any model-facing exposure Systematic controls.
+- Collision: user-defined command of the same name survives untouched.
+- Toggle: `skills_as_commands: false` → zero injected entries; bundled commands unaffected.
+- Idempotency: running the hook twice yields identical config (duplicate-registration learning).
+- Schema: new field validates; unknown values rejected.
+
+**Verification:** unit suite green; schema drift check passes; a fixture project shows `/skill-name` entries in emitted config exactly once per skill.
+
+- [ ] **Unit 3: Docs for the feature**
+
+**Goal:** Committed docs covering discovery roots, naming, replace-by-name collision policy, the toggle, command-only semantics, and the honest upstream/trust framing.
+
+**Requirements:** R14
+
+**Dependencies:** Units 1–2
+
+**Files:**
+- Create/Modify: a docs page under `docs/src/content/docs/` (guides), linked from nav
+- Modify: `docs/src/content/docs/reference/configuration.mdx` regen picks up the new field (`bun run docs:generate`)
+
+**Test scenarios:**
+- Test expectation: none — docs content; `bun run docs:build` green is the gate.
+
+**Verification:** docs build passes; page states the trust model and upstream context plainly.
+
+- [ ] **Unit 4 (separate PR): `systematic_skill` permission parity + sampling alignment**
+
+**Goal:** `systematic_skill` loads gate through `permission.skill` semantics via the bridged `ask()`; file sampling matches upstream behavior.
+
+**Requirements:** R10, R11, R12
+
+**Dependencies:** None (independent of Units 1–3; separate PR)
+
+**Files:**
+- Modify: `src/lib/skill-tool.ts`
+- Test: `tests/unit/skill-tool.test.ts`
+
+**Approach:**
+- Mirror upstream's gate: `ctx.ask({ permission: "skill", patterns: [name], always: [name] })` semantics before loading; deny → actionable error naming the pattern; ask → prompt (or fail-closed deny with warning if prompting is unavailable in context).
+- Sampling: include hidden files, deterministic sort, limit 10, surface (don't swallow) read errors as a note.
+- Do not touch deprecation handling (R12).
+
+**Execution note:** Test-first on the deny path — assert a `"internal-*": "deny"` pattern blocks the load before wiring the ask bridge.
+
+**Test scenarios:**
+- Happy path: no permission config → loads as today.
+- Deny: `"internal-*": "deny"` blocks `internal-docs` with an error naming the pattern.
+- Ask: an ask-pattern routes through `ask()`; if the context cannot prompt, the load is denied with a warning (never silently allowed).
+- Allow-precedence: patterns follow OpenCode's last-match-wins semantics (memory: findLast).
+- Sampling: hidden file appears in `<skill_files>`; unreadable file yields a note, not silence; order deterministic.
+
+**Verification:** unit suite green; manual probe with a permission-configured fixture confirms deny/ask behavior end-to-end.
+
+## System-Wide Impact
+
+- **Interaction graph:** config hook emission order matters — discovered-skill commands must merge after user config is read (to skip existing names) and never touch bundled command emission.
+- **Error propagation:** discovery and emission never throw (hook-defect swallow); the drift PR's deny path throws an actionable tool error (correct — tool errors surface to the model).
+- **API surface parity:** new config field `skills_as_commands` (schema + docs regen); no CLI changes.
+- **Unchanged invariants:** `src/index.ts` exports only `default`; bundled command registration; `SECURITY_OVERLAY_FIELDS` untouched (the toggle is not trust-protected).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Upstream changes discovery roots/order in a future release | Roots + order pinned in one module (Unit 1) with tests naming upstream as the contract; re-verify at version bumps |
+| Upstream flips the TUI filter → our entries become redundant | Replace-by-name means still exactly one entry per skill; toggle removes ours entirely |
+| Replace-by-name suppresses upstream's skill command even when our shim misbehaves | Shim is one line and tested; toggle restores upstream behavior instantly |
+| `ask()` behavior differs at v1.17.13 | Deferred re-verification item; fail-closed fallback specified (ask→deny with warning) |
+| Config-hook cwd ≠ project dir for the upward walk | Deferred check against plugin input `directory`; tests use explicit roots |
+
+## Documentation / Operational Notes
+
+- Feature PR: `feat:` (minor). Drift PR: `fix:` (patch — closes a real permission bypass).
+- Sequence: drift PR can land first (independent); feature PR's docs mention the permission gate the drift PR adds — land drift first for docs accuracy.
+
+## Sources & References
+
+- **Origin document:** docs/brainstorms/2026-07-06-discovered-skills-as-commands-requirements.md
+- Upstream refs: packages/opencode/src/skill/index.ts, command/index.ts, tool/skill.ts, packages/plugin/src/tool.ts, packages/tui/src/component/prompt/index.tsx (local clone v1.17.6)
+- Systematic: src/lib/config-handler.ts, src/lib/skills.ts, src/lib/skill-loader.ts, src/lib/skill-tool.ts, src/lib/config-schema.ts
+- Upstream history: PR #11390, #12109, #11547, #22129, #23987, #29567

--- a/docs/public/schemas/v2/systematic-config.schema.json
+++ b/docs/public/schemas/v2/systematic-config.schema.json
@@ -22,6 +22,9 @@
     },
     "bootstrap": {
       "$ref": "#/definitions/__schema51"
+    },
+    "skills_as_commands": {
+      "$ref": "#/definitions/__schema57"
     }
   },
   "additionalProperties": false,
@@ -1504,6 +1507,19 @@
     },
     "__schema56": {
       "type": "string"
+    },
+    "__schema57": {
+      "default": true,
+      "description": "Register skills discovered from user/project skill directories (OpenCode config and other agent-harness-standard locations) as slash commands. Default true.",
+      "examples": [true, false],
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema58"
+        }
+      ]
+    },
+    "__schema58": {
+      "type": "boolean"
     }
   }
 }

--- a/docs/scripts/generate-config-reference.ts
+++ b/docs/scripts/generate-config-reference.ts
@@ -43,6 +43,7 @@ const TOP_LEVEL_KEYS = [
   'disabled_agents',
   'disabled_commands',
   'bootstrap',
+  'skills_as_commands',
 ] as const
 
 /**

--- a/docs/src/content/docs/guides/skills-as-commands.mdx
+++ b/docs/src/content/docs/guides/skills-as-commands.mdx
@@ -1,0 +1,59 @@
+---
+title: Skills as Commands
+description: Systematic registers the skills you already keep in your project and home directories as slash commands, so you can invoke any discovered skill as /skill-name.
+sidebar:
+  order: 7
+---
+
+OpenCode discovers skills from your project and home directories and exposes them to the model through its built-in `skill` tool. It does not, however, surface them in the TUI's slash-command autocomplete. Systematic closes that gap: every skill OpenCode discovers becomes an invokable `/skill-name` command, the same way Claude Code and other agents treat skills.
+
+This is on by default. If you already keep skills under `.opencode/skills/`, `.claude/skills/`, or `.agents/skills/`, they show up as commands as soon as the plugin loads — no configuration required.
+
+## Where skills are discovered
+
+Systematic mirrors OpenCode's own discovery contract exactly, so the command you invoke resolves to the same skill OpenCode's `skill` tool would load. Skills are discovered from six roots:
+
+| Scope | Locations |
+|-------|-----------|
+| Global | `~/.claude/skills/`, `~/.agents/skills/`, `~/.config/opencode/skills/` |
+| Project | `.opencode/skills/`, `.claude/skills/`, `.agents/skills/` |
+
+Project locations are discovered by walking up from your working directory to the git worktree root, so a skill defined in a subdirectory of a monorepo is found too.
+
+When the same skill name exists in more than one location, the winner follows OpenCode's precedence: `.opencode` skills win over `.claude`/`.agents` skills, and project skills win over global ones. The command Systematic registers always points at that same winner.
+
+## How a command is built
+
+Each discovered skill becomes a `config.command` entry named after the skill (`/git-release`, `/deploy`, and so on). The command instructs the agent to load the skill through OpenCode's native `skill` tool and act on whatever arguments you pass:
+
+```
+/git-release v2.4.0
+```
+
+Arguments after the command name are forwarded to the skill as a request. Because the command loads the skill through the `skill` tool, any skill permissions you have configured still apply.
+
+### Command-only skills
+
+A skill with `disable-model-invocation: true` in its frontmatter is a manual workflow — you invoke it, the model does not load it on its own. For these, Systematic inlines the skill body directly into the command instead of routing through the `skill` tool.
+
+There is one honest limitation here: OpenCode has no mechanism for a plugin to hide a skill from the model's own `skill` tool. Systematic controls the `/command` surface, but a command-only skill remains loadable by the model through OpenCode's skill tool regardless. The `disable-model-invocation` flag shapes the command; it is not a hard guarantee that the model can never reach the skill.
+
+## Trust model
+
+Systematic does not add a trust gate on discovered skills, and this is deliberate. OpenCode already discovers and registers these same skills — including project-local ones from a cloned repository — without a trust prompt, and a command never runs on its own: a human types it. Adding a Systematic-specific gate would restrict less than what OpenCode already exposes while adding friction. Treat skills in a repository you did not write the same way you treat any other code in it.
+
+## Turning it off
+
+Set `skills_as_commands` to `false` in your `systematic.json` to disable the feature entirely:
+
+```json
+{
+  "skills_as_commands": false
+}
+```
+
+Your own commands are never touched — Systematic only registers a discovered skill as a command when no command of that name already exists, so a command you define yourself always wins. Bundled Systematic skills (the `systematic:` and `ce:` commands) are unaffected by this setting.
+
+## Relationship to upstream
+
+OpenCode registers discovered skills as commands internally, but its TUI intentionally keeps them out of slash-command autocomplete in favor of a dedicated skills picker. That is a deliberate upstream choice, so this behavior may converge over time. If it does, Systematic's registration degrades gracefully: because Systematic's entry replaces the skill-sourced one by name, you still see exactly one command per skill, and the `skills_as_commands` toggle removes Systematic's entries entirely.

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -494,6 +494,23 @@ Path to a custom bootstrap prompt file
 ```
 
 
+## skills_as_commands
+
+Register skills discovered from user/project skill directories (OpenCode config and other agent-harness-standard locations) as slash commands. Default true.
+
+**Type:** `boolean`
+**Default:** `true`
+**Examples:**
+
+```json
+true
+```
+
+```json
+false
+```
+
+
 ## Offline IDE behavior
 
 The schema's `$id` points to the canonical online URL above, so IDEs that prefer fetching the canonical schema may attempt to reach the docs site even when the bundled npm copy is also on disk. If you need strict offline behavior, configure your editor to associate `systematic.{json,jsonc}` with `node_modules/@fro.bot/systematic/dist/schemas/systematic-config.schema.json` directly.

--- a/scripts/.drift-allowlist.json
+++ b/scripts/.drift-allowlist.json
@@ -35,6 +35,11 @@
       "reason": "Comments annotate converter-mapped YAML fields (disableModelInvocation, userInvocable, allowedTools, etc.) with their CC-format origin. Historical documentation, not accidental reintroduction. Same category as src/lib/converter.ts."
     },
     {
+      "pathGlob": "src/lib/discovered-skills.ts",
+      "patterns": [".claude/"],
+      "reason": "'.claude/skills' is one of OpenCode's own documented skill-discovery roots (see opencode.ai/docs/skills). Discovery must reference it verbatim to match OpenCode's discovery set. This is an OpenCode-compatibility path constant, not CC coupling."
+    },
+    {
       "pathGlob": "skills/writing-skills/references/examples/skill-testing-walkthrough.md",
       "patterns": ["CLAUDE.md"],
       "reason": "Historical worked example documenting a skill-testing campaign that tested CLAUDE.md documentation variants in agent harnesses. The CLAUDE.md references describe what the walkthrough tested, not Systematic-prescriptive content. Converting to AGENTS.md would falsify the historical record."

--- a/src/lib/config-handler.ts
+++ b/src/lib/config-handler.ts
@@ -528,13 +528,23 @@ function loadDiscoveredSkillAsCommand(skill: DiscoveredSkill): CommandConfig {
   }
 
   return {
-    template: `Load the "${skill.name}" skill using the skill tool, then follow its instructions to address this request:
+    template: buildDiscoveredSkillShimTemplate(skill.name),
+    description,
+  }
+}
+
+/**
+ * Model-invocable shim template instructing the agent to load a discovered
+ * skill via OpenCode's native `skill` tool. The argument string is wrapped as
+ * data (`$ARGUMENTS` inside `<user-request>`), never concatenated into
+ * instruction text.
+ */
+function buildDiscoveredSkillShimTemplate(skillName: string): string {
+  return `Load the "${skillName}" skill using the skill tool, then follow its instructions to address this request:
 
 <user-request>
 $ARGUMENTS
-</user-request>`,
-    description,
-  }
+</user-request>`
 }
 
 /**
@@ -561,14 +571,19 @@ function collectDiscoveredSkillsAsCommands(
       opencodeConfigDirOverride,
     })
   } catch {
+    // Config hook code must not throw (hook-defect-swallow): degrade to no
+    // discovered commands this pass rather than aborting the whole config hook.
     return commands
   }
 
   for (const skill of discovered) {
+    if (skill.frontmatter.userInvocable === false) continue
+
     try {
       commands[skill.name] = loadDiscoveredSkillAsCommand(skill)
     } catch {
-      // Skip this skill; never let one bad SKILL.md abort emission.
+      // Config hook code must not throw (hook-defect-swallow): skip this
+      // skill; never let one bad SKILL.md abort emission for the rest.
     }
   }
 
@@ -709,13 +724,19 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
       ...bundledSkills,
       ...discoveredSkillCommands,
     }
-    const emittedCommandKeys = new Set(Object.keys(emittedCommands))
+    // Drop any existing entry Systematic previously emitted (identified by
+    // the `(Systematic) `/`(Systematic - Skill) ` description marker),
+    // regardless of key. If it's still valid this pass, `emittedCommands`
+    // re-adds it below (mergeSystematicEntries drops-then-adds); if the
+    // source (bundled command/skill, or a discovered on-disk skill) no
+    // longer exists, it stays dropped. This also fixes orphaned
+    // discovered-skill commands: those use a bare key (not a
+    // `systematic:`/`ce:`-prefixed key), so removing a skill from disk left
+    // its stale command behind under the old, narrower key-based predicate.
     config.command = mergeSystematicEntries(
       existingCommands as Record<string, CommandConfig>,
       emittedCommands as Record<string, CommandConfig>,
-      (key, command) =>
-        isSystematicCommandConfig(command) &&
-        (emittedCommandKeys.has(key) || isSystematicOwnedCommandKey(key)),
+      (_key, command) => isSystematicCommandConfig(command),
     )
 
     // skills.paths exists at runtime (v2 SDK types) but not in our v1 import
@@ -759,8 +780,4 @@ function isSystematicSkillPath(path: string): boolean {
 
 function normalizePath(path: string): string {
   return path.replaceAll('\\', '/').replace(/\/+$/u, '')
-}
-
-function isSystematicOwnedCommandKey(key: string): boolean {
-  return key.startsWith('systematic:') || key.startsWith('ce:')
 }

--- a/src/lib/config-handler.ts
+++ b/src/lib/config-handler.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import type { Config } from '@opencode-ai/plugin'
 import type { AgentConfig } from '@opencode-ai/sdk'
 import {
@@ -12,12 +15,18 @@ import { extractAgentFrontmatter, findAgentsInDir } from './agents.js'
 import { extractCommandFrontmatter, findCommandsInDir } from './commands.js'
 import { loadConfigWithSources } from './config.js'
 import { convertFileWithCache } from './converter.js'
+import { type DiscoveredSkill, discoverSkills } from './discovered-skills.js'
 import { parseFrontmatter } from './frontmatter.js'
 import {
   getAvailableModels,
   type OpencodeClientLike,
 } from './model-availability.js'
-import { type LoadedSkill, loadSkill } from './skill-loader.js'
+import {
+  formatSkillDescription,
+  type LoadedSkill,
+  loadSkill,
+  wrapSkillTemplate,
+} from './skill-loader.js'
 import { findSkillsInDir } from './skills.js'
 import { resolveSourceModel } from './source-model-defaults.js'
 import { isRecord, type PermissionSetting } from './validation.js'
@@ -29,6 +38,10 @@ export interface ConfigHandlerDeps {
   bundledCommandsDir: string
   /** OpenCode client for availability lookup. When omitted, availability falls back to empty set (last-resort resolution). */
   client?: OpencodeClientLike
+  /** Home directory for discovered-skill lookups. Defaults to `os.homedir()`; inject a temp dir in tests. */
+  homeDir?: string
+  /** OpenCode global config directory override for discovered-skill lookups. Defaults to `<homeDir>/.config/opencode`. */
+  opencodeConfigDir?: string
 }
 
 type CommandConfig = NonNullable<Config['command']>[string]
@@ -486,6 +499,82 @@ function collectSkillsAsCommands(
   return commands
 }
 
+/**
+ * Convert a discovered (non-bundled) skill into a `config.command` entry.
+ *
+ * Model-invocable skills get a one-line shim instructing the agent to load
+ * the skill via OpenCode's native `skill` tool, with the argument string
+ * wrapped as data (never concatenated into instruction text). Command-only
+ * skills (`disable-model-invocation: true`) get the raw SKILL.md body
+ * inlined instead — the sole R3 exception (R6).
+ *
+ * R6 honesty limit: Systematic cannot unregister a skill from OpenCode's own
+ * model-facing skill tool/catalog — there is no API to hide a discovered
+ * skill from the model. This function only controls the *command* surface
+ * (`/skill-name`); the skill remains loadable by the model via the `skill`
+ * tool regardless of `disable-model-invocation`. Do not attempt to mutate
+ * OpenCode's skill registry or permissions here to compensate.
+ */
+function loadDiscoveredSkillAsCommand(skill: DiscoveredSkill): CommandConfig {
+  const description = formatSkillDescription(skill.description, skill.name)
+
+  if (skill.frontmatter.disableModelInvocation === true) {
+    const content = fs.readFileSync(skill.skillPath, 'utf8')
+    const { body } = parseFrontmatter(content)
+    return {
+      template: wrapSkillTemplate(skill.skillPath, body),
+      description,
+    }
+  }
+
+  return {
+    template: `Load the "${skill.name}" skill using the skill tool, then follow its instructions to address this request:
+
+<user-request>
+$ARGUMENTS
+</user-request>`,
+    description,
+  }
+}
+
+/**
+ * Collect discovered (non-bundled) user/project skills as `config.command`
+ * entries. Never throws: `discoverSkills` is defect-swallowing by contract,
+ * and any unexpected error reading/parsing an individual skill degrades to
+ * skipping that skill rather than aborting emission (hook-defect-swallow
+ * learning — config hook code must not throw).
+ */
+function collectDiscoveredSkillsAsCommands(
+  startDir: string,
+  homeDir: string,
+  configDir: string,
+  opencodeConfigDirOverride: string | undefined,
+): NonNullable<Config['command']> {
+  const commands: NonNullable<Config['command']> = {}
+
+  let discovered: DiscoveredSkill[]
+  try {
+    discovered = discoverSkills({
+      startDir,
+      homeDir,
+      configDir,
+      opencodeConfigDirOverride,
+    })
+  } catch {
+    return commands
+  }
+
+  for (const skill of discovered) {
+    try {
+      commands[skill.name] = loadDiscoveredSkillAsCommand(skill)
+    } catch {
+      // Skip this skill; never let one bad SKILL.md abort emission.
+    }
+  }
+
+  return commands
+}
+
 function collectEnabledSkillNames(
   dir: string,
   disabledSkills: string[],
@@ -509,6 +598,12 @@ function collectEnabledSkillNames(
 export function createConfigHandler(deps: ConfigHandlerDeps) {
   const { directory, bundledSkillsDir, bundledAgentsDir, bundledCommandsDir } =
     deps
+  const homeDir = deps.homeDir ?? os.homedir()
+  const opencodeConfigDir =
+    deps.opencodeConfigDir ?? path.join(homeDir, '.config/opencode')
+  const opencodeConfigDirOverride = process.env.OPENCODE_CONFIG_DIR?.trim()
+    ? process.env.OPENCODE_CONFIG_DIR
+    : undefined
 
   return async (config: Config): Promise<void> => {
     const { config: systematicConfig, overlays } =
@@ -581,6 +676,16 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
       systematicConfig.disabled_commands,
     )
 
+    const discoveredSkillCommands =
+      systematicConfig.skills_as_commands !== false
+        ? collectDiscoveredSkillsAsCommands(
+            directory,
+            homeDir,
+            opencodeConfigDir,
+            opencodeConfigDirOverride,
+          )
+        : {}
+
     // The drop predicate uses the explicit emitted-key set instead of
     // `Object.hasOwn(bundledAgents, key)` so the invariant ("only drop a prior
     // entry when this hook is emitting a replacement") is self-evident and
@@ -599,7 +704,11 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
         bundledAgentKeys.has(key) && isSystematicAgentConfig(agent),
     )
 
-    const emittedCommands = { ...bundledCommands, ...bundledSkills }
+    const emittedCommands = {
+      ...bundledCommands,
+      ...bundledSkills,
+      ...discoveredSkillCommands,
+    }
     const emittedCommandKeys = new Set(Object.keys(emittedCommands))
     config.command = mergeSystematicEntries(
       existingCommands as Record<string, CommandConfig>,

--- a/src/lib/config-schema.ts
+++ b/src/lib/config-schema.ts
@@ -376,6 +376,14 @@ export function createSystematicConfigSchema(
           { enabled: false, file: '.opencode/custom-prompt.md' },
         ],
       }),
+      skills_as_commands: z
+        .boolean()
+        .default(true)
+        .meta({
+          description:
+            'Register skills discovered from user/project skill directories (OpenCode config and other agent-harness-standard locations) as slash commands. Default true.',
+          examples: [true, false],
+        }),
     })
     .strict()
     .meta({

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -49,6 +49,7 @@ export interface SystematicConfig {
   bootstrap: BootstrapConfig
   agents?: OverlayConfigMap
   categories?: OverlayConfigMap
+  skills_as_commands: boolean
 }
 
 export const DEFAULT_CONFIG: SystematicConfig = {
@@ -60,6 +61,7 @@ export const DEFAULT_CONFIG: SystematicConfig = {
   },
   agents: {},
   categories: {},
+  skills_as_commands: true,
 }
 
 interface RawSystematicConfig
@@ -430,6 +432,11 @@ export function loadConfigWithSources(
     },
     agents: overlayValues(overlays.agents),
     categories: overlayValues(overlays.categories),
+    skills_as_commands:
+      customConfig?.skills_as_commands ??
+      projectConfig?.skills_as_commands ??
+      userConfig?.skills_as_commands ??
+      DEFAULT_CONFIG.skills_as_commands,
   }
 
   // Drop removed names from the effective config and warn about each one.

--- a/src/lib/discovered-skills.ts
+++ b/src/lib/discovered-skills.ts
@@ -128,7 +128,9 @@ function buildOpencodeConfigDirs(
 ): string[] {
   const dirs: string[] = [globalConfigDir]
 
-  dirs.push(...upWalk(['.opencode'], startDir, gitRoot ?? undefined))
+  // No git worktree root: bound the walk to startDir itself rather than
+  // climbing to the filesystem root.
+  dirs.push(...upWalk(['.opencode'], startDir, gitRoot ?? startDir))
   dirs.push(...upWalk(['.opencode'], homeDir, homeDir))
 
   if (opencodeConfigDirOverride !== undefined) {
@@ -247,7 +249,7 @@ export function discoverSkills(
   const externalLevels = upWalk(
     ['.claude', '.agents'],
     startDir,
-    gitRoot ?? undefined,
+    gitRoot ?? startDir,
   )
   for (const levelDir of externalLevels) {
     const isClaudeDir = path.basename(levelDir) === '.claude'

--- a/src/lib/discovered-skills.ts
+++ b/src/lib/discovered-skills.ts
@@ -1,0 +1,277 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { extractFrontmatter, type SkillFrontmatter } from './skills.js'
+import { walkDir } from './walk-dir.js'
+
+/**
+ * Provenance ids for discovered skills. When the same skill `name` is found
+ * in multiple roots, the winner is whichever root is discovered LAST in
+ * upstream's sequence (mirrors upstream `skill/index.ts`'s last-write-wins
+ * map keyed by frontmatter name). Discovery order (earliest to latest):
+ * global-claude, global-agents, project-claude/project-agents (walked from
+ * startDir up to the worktree root, closest-first), then all
+ * `.opencode`-style config directories (global-opencode-config wins over
+ * everything above it). Do not reorder without re-verifying against
+ * upstream.
+ */
+type DiscoveryRootId =
+  | 'global-claude'
+  | 'global-agents'
+  | 'project-claude'
+  | 'project-agents'
+  | 'project-opencode'
+  | 'global-opencode-config'
+
+export interface DiscoveredSkill {
+  name: string
+  description: string
+  frontmatter: SkillFrontmatter
+  skillPath: string
+  root: DiscoveryRootId
+}
+
+export interface DiscoverSkillsOptions {
+  /** Directory to start the upward worktree walk from (typically the project cwd). */
+  startDir: string
+  /** Home directory, injected so tests can use a temp dir instead of the real one. */
+  homeDir: string
+  /**
+   * Override for OpenCode's global config directory (mirrors
+   * `$XDG_CONFIG_HOME` resolution). Defaults to `<homeDir>/.config/opencode`
+   * when omitted.
+   */
+  configDir?: string
+  /**
+   * Override mirroring upstream's `OPENCODE_CONFIG_DIR` env var: an extra
+   * config directory appended to the end of the OpenCode config-dir list
+   * (so it wins over every other root, including the default global config
+   * dir). Injected as a param rather than read from `process.env` to keep
+   * discovery pure and testable.
+   */
+  opencodeConfigDirOverride?: string
+}
+
+/** Upstream skill-name regex: lowercase alphanumeric segments joined by single hyphens, 1-64 chars. */
+const SKILL_NAME_REGEX = /^[a-z0-9]+(-[a-z0-9]+)*$/
+
+function isValidSkillName(name: string): boolean {
+  return name.length >= 1 && name.length <= 64 && SKILL_NAME_REGEX.test(name)
+}
+
+/**
+ * Find the git worktree root: the first ancestor of `startDir` (inclusive)
+ * containing a `.git` entry. Returns `null` if none exists. Never throws.
+ */
+function findGitWorktreeRoot(startDir: string): string | null {
+  let current = path.resolve(startDir)
+  // eslint-disable-next-line no-constant-condition -- bounded by filesystem root
+  while (true) {
+    try {
+      if (fs.existsSync(path.join(current, '.git'))) {
+        return current
+      }
+    } catch {
+      return null // unreadable ancestor: stop walking, never throw
+    }
+    const parent = path.dirname(current)
+    if (parent === current) return null
+    current = parent
+  }
+}
+
+/**
+ * Mirrors upstream `FSUtil.up`: walk from `start` toward `stop` (inclusive),
+ * closest-first. At each level, for each target (in target order), yield
+ * `<current>/<target>` if it exists. Never throws.
+ */
+function upWalk(targets: string[], start: string, stop?: string): string[] {
+  const results: string[] = []
+  let current = path.resolve(start)
+  const resolvedStop = stop === undefined ? undefined : path.resolve(stop)
+  // eslint-disable-next-line no-constant-condition -- bounded by filesystem root
+  while (true) {
+    for (const target of targets) {
+      const candidate = path.join(current, target)
+      try {
+        if (fs.existsSync(candidate)) {
+          results.push(candidate)
+        }
+      } catch {
+        // unreadable candidate: skip, never throw
+      }
+    }
+    if (resolvedStop !== undefined && current === resolvedStop) break
+    const parent = path.dirname(current)
+    if (parent === current) break
+    current = parent
+  }
+  return results
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values))
+}
+
+/**
+ * Build the list of OpenCode config directories exactly like upstream's
+ * `ConfigPaths.directories`: the global config dir, then the project-level
+ * `.opencode` up-walk (closest-first), then `<home>/.opencode` if present,
+ * then the `OPENCODE_CONFIG_DIR` override if provided, deduplicated
+ * preserving first-seen order (matches upstream's `unique()` semantics).
+ */
+function buildOpencodeConfigDirs(
+  startDir: string,
+  homeDir: string,
+  gitRoot: string | null,
+  globalConfigDir: string,
+  opencodeConfigDirOverride?: string,
+): string[] {
+  const dirs: string[] = [globalConfigDir]
+
+  dirs.push(...upWalk(['.opencode'], startDir, gitRoot ?? undefined))
+  dirs.push(...upWalk(['.opencode'], homeDir, homeDir))
+
+  if (opencodeConfigDirOverride !== undefined) {
+    dirs.push(opencodeConfigDirOverride)
+  }
+
+  return uniqueStrings(dirs)
+}
+
+/**
+ * Recursively find all `SKILL.md` files matching `<rootDir>/<subdirGlob>/**\/SKILL.md`
+ * for each entry in `subdirNames` (e.g. `['skill', 'skills']` or `['skills']`).
+ * Uses the node-native `walkDir` walker for the recursive `**` matching
+ * (skill trees are shallow; `maxDepth: 10` is a generous cap since walkDir's
+ * default of 3 could miss deeply nested skills).
+ * Never throws: missing roots yield no matches; unreadable nested dirs are
+ * caught and skipped (walkDir does not internally guard readdir errors).
+ */
+function globSkillFiles(rootDir: string, subdirNames: string[]): string[] {
+  const results: string[] = []
+  for (const subdirName of subdirNames) {
+    const scanRoot = path.join(rootDir, subdirName)
+    try {
+      if (!fs.existsSync(scanRoot)) continue
+      const entries = walkDir(scanRoot, {
+        maxDepth: 10,
+        filter: (entry) => !entry.isDirectory && entry.name === 'SKILL.md',
+      })
+      for (const entry of entries) {
+        results.push(entry.path)
+      }
+    } catch {
+      // unreadable dir: skip, never throw
+    }
+  }
+  return results
+}
+
+/**
+ * Turn a discovered `SKILL.md` absolute path into a `DiscoveredSkill`, or
+ * `undefined` if it should be skipped (unreadable, not a file, no
+ * frontmatter name, or invalid name charset/length). Never throws.
+ */
+function toDiscoveredSkill(
+  skillPath: string,
+  rootId: DiscoveryRootId,
+): DiscoveredSkill | undefined {
+  let stat: fs.Stats
+  try {
+    stat = fs.statSync(skillPath)
+  } catch {
+    return undefined // missing or unreadable: skip
+  }
+  if (!stat.isFile()) return undefined
+
+  const frontmatter = extractFrontmatter(skillPath)
+  const name = frontmatter.name
+  if (!name || !isValidSkillName(name)) return undefined
+
+  return {
+    name,
+    description: frontmatter.description,
+    frontmatter,
+    skillPath,
+    root: rootId,
+  }
+}
+
+/**
+ * Discover user/project skills, replicating OpenCode v1.17.6's real
+ * discovery algorithm (verified from source: `skill/index.ts`,
+ * `config/paths.ts`, `util/filesystem.ts`). Builds ONE map keyed by
+ * frontmatter skill `name`; entries are scanned and upserted in upstream's
+ * exact sequence, and later additions overwrite earlier ones:
+ *
+ *   1. Global external: `<home>/.claude/skills/**\/SKILL.md`, then
+ *      `<home>/.agents/skills/**\/SKILL.md`.
+ *   2. Project external (multi-level up-walk): from `startDir` up to the
+ *      git worktree root (inclusive), closest-first; at each level scan
+ *      `.claude/skills/**\/SKILL.md` then `.agents/skills/**\/SKILL.md`.
+ *      Because of last-write-wins, the worktree-root level wins over
+ *      deeper subdirectories.
+ *   3. OpenCode config dirs (`ConfigPaths.directories`-equivalent: global
+ *      config dir, then project `.opencode` up-walk, then `<home>/.opencode`,
+ *      then an optional `OPENCODE_CONFIG_DIR`-style override), each scanned
+ *      for `{skill,skills}/**\/SKILL.md`. Scanned last, so these beat
+ *      everything above.
+ *
+ * The dedup key is the frontmatter `name` (not the containing directory
+ * name); entries with no name, or a name failing the charset/length regex,
+ * are skipped. Never throws: unreadable dirs/files, missing roots, or
+ * malformed frontmatter cause that entry to be skipped, not an abort.
+ */
+export function discoverSkills(
+  options: DiscoverSkillsOptions,
+): DiscoveredSkill[] {
+  const { startDir, homeDir, configDir, opencodeConfigDirOverride } = options
+  const globalConfigDir = configDir ?? path.join(homeDir, '.config/opencode')
+  const gitRoot = findGitWorktreeRoot(startDir)
+
+  const byName = new Map<string, DiscoveredSkill>()
+
+  function upsertAll(skillPaths: string[], rootId: DiscoveryRootId): void {
+    for (const skillPath of skillPaths) {
+      const skill = toDiscoveredSkill(skillPath, rootId)
+      if (skill) byName.set(skill.name, skill)
+    }
+  }
+
+  // 1. Global external: .claude then .agents.
+  upsertAll(globSkillFiles(homeDir, ['.claude/skills']), 'global-claude')
+  upsertAll(globSkillFiles(homeDir, ['.agents/skills']), 'global-agents')
+
+  // 2. Project external: multi-level up-walk from startDir to worktree root,
+  // closest-first, .claude then .agents at each level.
+  const externalLevels = upWalk(
+    ['.claude', '.agents'],
+    startDir,
+    gitRoot ?? undefined,
+  )
+  for (const levelDir of externalLevels) {
+    const isClaudeDir = path.basename(levelDir) === '.claude'
+    const parentDir = path.dirname(levelDir)
+    const subdirGlob = isClaudeDir ? '.claude/skills' : '.agents/skills'
+    const rootId: DiscoveryRootId = isClaudeDir
+      ? 'project-claude'
+      : 'project-agents'
+    upsertAll(globSkillFiles(parentDir, [subdirGlob]), rootId)
+  }
+
+  // 3. OpenCode config dirs: last, so these beat everything above.
+  const configDirs = buildOpencodeConfigDirs(
+    startDir,
+    homeDir,
+    gitRoot,
+    globalConfigDir,
+    opencodeConfigDirOverride,
+  )
+  for (const dir of configDirs) {
+    const rootId: DiscoveryRootId =
+      dir === globalConfigDir ? 'global-opencode-config' : 'project-opencode'
+    upsertAll(globSkillFiles(dir, ['skill', 'skills']), rootId)
+  }
+
+  return Array.from(byName.values())
+}

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -1698,5 +1698,174 @@ model: gpt-4
 
       expect(config.agent?.['correctness-reviewer']?.temperature).toBe(0.9)
     })
+
+    describe('discovered skills as commands', () => {
+      function writeDiscoveredSkill(
+        dir: string,
+        name: string,
+        opts: {
+          description?: string
+          disableModelInvocation?: boolean
+        } = {},
+      ): void {
+        const skillDir = path.join(dir, name)
+        fs.mkdirSync(skillDir, { recursive: true })
+        const description = opts.description ?? `Description for ${name}`
+        const extraFrontmatter =
+          opts.disableModelInvocation === true
+            ? 'disable-model-invocation: true\n'
+            : ''
+        fs.writeFileSync(
+          path.join(skillDir, 'SKILL.md'),
+          `---
+name: ${name}
+description: ${description}
+${extraFrontmatter}---
+# ${name}
+
+Discovered body for ${name}.`,
+        )
+      }
+
+      test('model-invocable discovered skill becomes a shim command', async () => {
+        writeDiscoveredSkill(path.join(projectDir, '.opencode/skills'), 'foo', {
+          description: 'A discovered skill',
+        })
+
+        const handler = createConfigHandler({
+          directory: projectDir,
+          bundledSkillsDir: path.join(bundledDir, 'skills'),
+          bundledAgentsDir: path.join(bundledDir, 'agents'),
+          bundledCommandsDir: path.join(bundledDir, 'commands'),
+        })
+
+        const config: Config = {}
+        await handler(config)
+
+        const command = config.command?.foo
+        expect(command).toBeDefined()
+        expect(command?.description).toBe(
+          '(Systematic - Skill) A discovered skill',
+        )
+        expect(command?.template).toContain('skill tool')
+        expect(command?.template).toContain('<user-request>\n$ARGUMENTS')
+      })
+
+      test('command-only discovered skill (disable-model-invocation) inlines the body', async () => {
+        writeDiscoveredSkill(path.join(projectDir, '.opencode/skills'), 'bar', {
+          description: 'A command-only skill',
+          disableModelInvocation: true,
+        })
+
+        const handler = createConfigHandler({
+          directory: projectDir,
+          bundledSkillsDir: path.join(bundledDir, 'skills'),
+          bundledAgentsDir: path.join(bundledDir, 'agents'),
+          bundledCommandsDir: path.join(bundledDir, 'commands'),
+        })
+
+        const config: Config = {}
+        await handler(config)
+
+        const command = config.command?.bar
+        expect(command).toBeDefined()
+        expect(command?.description).toBe(
+          '(Systematic - Skill) A command-only skill',
+        )
+        expect(command?.template).toContain('<skill-instruction>')
+        expect(command?.template).toContain('Discovered body for bar')
+        expect(command?.template).not.toContain('skill tool')
+      })
+
+      test('user-defined command of the same name survives untouched (R4)', async () => {
+        writeDiscoveredSkill(path.join(projectDir, '.opencode/skills'), 'foo')
+
+        const handler = createConfigHandler({
+          directory: projectDir,
+          bundledSkillsDir: path.join(bundledDir, 'skills'),
+          bundledAgentsDir: path.join(bundledDir, 'agents'),
+          bundledCommandsDir: path.join(bundledDir, 'commands'),
+        })
+
+        const config: Config = {
+          command: {
+            foo: {
+              description: 'User command',
+              template: 'User template',
+            },
+          },
+        }
+        await handler(config)
+
+        expect(config.command?.foo?.description).toBe('User command')
+        expect(config.command?.foo?.template).toBe('User template')
+      })
+
+      test('skills_as_commands: false disables discovered emission but keeps bundled', async () => {
+        writeDiscoveredSkill(path.join(projectDir, '.opencode/skills'), 'foo')
+        createSkill(
+          path.join(bundledDir, 'skills'),
+          'bundled-skill',
+          'A bundled skill',
+        )
+        writeSystematicConfig({ skills_as_commands: false })
+
+        const handler = createConfigHandler({
+          directory: projectDir,
+          bundledSkillsDir: path.join(bundledDir, 'skills'),
+          bundledAgentsDir: path.join(bundledDir, 'agents'),
+          bundledCommandsDir: path.join(bundledDir, 'commands'),
+        })
+
+        const config: Config = {}
+        await handler(config)
+
+        expect(config.command?.foo).toBeUndefined()
+        expect(config.command?.['systematic:bundled-skill']).toBeDefined()
+      })
+
+      test('running the handler twice yields identical config.command (idempotent)', async () => {
+        writeDiscoveredSkill(path.join(projectDir, '.opencode/skills'), 'foo')
+
+        const handler = createConfigHandler({
+          directory: projectDir,
+          bundledSkillsDir: path.join(bundledDir, 'skills'),
+          bundledAgentsDir: path.join(bundledDir, 'agents'),
+          bundledCommandsDir: path.join(bundledDir, 'commands'),
+        })
+
+        const config: Config = {}
+        await handler(config)
+        const firstRun = JSON.parse(JSON.stringify(config.command))
+
+        await handler(config)
+        const secondRun = JSON.parse(JSON.stringify(config.command))
+
+        expect(secondRun).toEqual(firstRun)
+        expect(Object.keys(config.command ?? {})).toEqual(['foo'])
+      })
+
+      test('bundled systematic:/ce: commands still emitted with discovery enabled', async () => {
+        writeDiscoveredSkill(path.join(projectDir, '.opencode/skills'), 'foo')
+        createSkill(
+          path.join(bundledDir, 'skills'),
+          'ce:review',
+          'A review skill',
+        )
+
+        const handler = createConfigHandler({
+          directory: projectDir,
+          bundledSkillsDir: path.join(bundledDir, 'skills'),
+          bundledAgentsDir: path.join(bundledDir, 'agents'),
+          bundledCommandsDir: path.join(bundledDir, 'commands'),
+        })
+
+        const config: Config = {}
+        await handler(config)
+
+        expect(config.command?.['ce:review']).toBeDefined()
+        expect(config.command?.foo).toBeDefined()
+      })
+    })
   })
 })

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -517,10 +517,16 @@ Skill content for ce:plan.`,
       expect(config.agent?.['systematic-implementer']?.prompt).toContain(
         'Agent prompt for systematic-implementer.',
       )
-      expect(config.command?.['native-command']).toEqual({
-        description: '(Systematic) Native command',
-        template: 'native command template',
-      })
+      // Unlike agents (which still use a key-based `bundledAgentKeys` guard),
+      // the command drop predicate was simplified to drop ANY existing entry
+      // carrying the `(Systematic) `/`(Systematic - Skill) ` marker,
+      // regardless of key — this is required to clean up orphaned
+      // discovered-skill commands (which use bare, unprefixed keys with no
+      // way to distinguish "still owned" from "stale" other than the
+      // marker). A side effect: a bare, non-prefixed key that merely *looks*
+      // like Systematic output but isn't re-emitted (like this synthetic
+      // 'native-command' fixture) is now dropped rather than preserved.
+      expect(config.command?.['native-command']).toBeUndefined()
       expect(config.command?.['ce:plan']?.description).toBe(
         '(Systematic - Skill) A plan skill',
       )
@@ -1843,6 +1849,109 @@ Discovered body for ${name}.`,
 
         expect(secondRun).toEqual(firstRun)
         expect(Object.keys(config.command ?? {})).toEqual(['foo'])
+      })
+
+      test('orphaned discovered-skill command is removed once its skill is deleted from disk', async () => {
+        const discoveredDir = path.join(projectDir, '.opencode/skills')
+        writeDiscoveredSkill(discoveredDir, 'foo')
+
+        const handler = createConfigHandler({
+          directory: projectDir,
+          bundledSkillsDir: path.join(bundledDir, 'skills'),
+          bundledAgentsDir: path.join(bundledDir, 'agents'),
+          bundledCommandsDir: path.join(bundledDir, 'commands'),
+        })
+
+        const config: Config = {}
+        await handler(config)
+        expect(config.command?.foo).toBeDefined()
+
+        fs.rmSync(path.join(discoveredDir, 'foo'), {
+          recursive: true,
+          force: true,
+        })
+
+        await handler(config)
+        expect(config.command?.foo).toBeUndefined()
+      })
+
+      test('user-defined command of the same name still survives after the skill is removed (R4)', async () => {
+        const discoveredDir = path.join(projectDir, '.opencode/skills')
+        writeDiscoveredSkill(discoveredDir, 'foo')
+
+        const handler = createConfigHandler({
+          directory: projectDir,
+          bundledSkillsDir: path.join(bundledDir, 'skills'),
+          bundledAgentsDir: path.join(bundledDir, 'agents'),
+          bundledCommandsDir: path.join(bundledDir, 'commands'),
+        })
+
+        const config: Config = {
+          command: {
+            foo: {
+              description: 'User command',
+              template: 'User template',
+            },
+          },
+        }
+        await handler(config)
+        expect(config.command?.foo?.description).toBe('User command')
+
+        fs.rmSync(path.join(discoveredDir, 'foo'), {
+          recursive: true,
+          force: true,
+        })
+
+        await handler(config)
+        expect(config.command?.foo?.description).toBe('User command')
+        expect(config.command?.foo?.template).toBe('User template')
+      })
+
+      test('discovered skill with user-invocable: false does not emit a command', async () => {
+        const skillDir = path.join(projectDir, '.opencode/skills', 'hidden')
+        fs.mkdirSync(skillDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(skillDir, 'SKILL.md'),
+          `---
+name: hidden
+description: A hidden discovered skill
+user-invocable: false
+---
+# hidden
+
+Discovered body for hidden.`,
+        )
+
+        const handler = createConfigHandler({
+          directory: projectDir,
+          bundledSkillsDir: path.join(bundledDir, 'skills'),
+          bundledAgentsDir: path.join(bundledDir, 'agents'),
+          bundledCommandsDir: path.join(bundledDir, 'commands'),
+        })
+
+        const config: Config = {}
+        await handler(config)
+
+        expect(config.command?.hidden).toBeUndefined()
+      })
+
+      test('discovered skill without user-invocable field still emits a command', async () => {
+        writeDiscoveredSkill(
+          path.join(projectDir, '.opencode/skills'),
+          'visible',
+        )
+
+        const handler = createConfigHandler({
+          directory: projectDir,
+          bundledSkillsDir: path.join(bundledDir, 'skills'),
+          bundledAgentsDir: path.join(bundledDir, 'agents'),
+          bundledCommandsDir: path.join(bundledDir, 'commands'),
+        })
+
+        const config: Config = {}
+        await handler(config)
+
+        expect(config.command?.visible).toBeDefined()
       })
 
       test('bundled systematic:/ce: commands still emitted with discovery enabled', async () => {

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -89,7 +89,8 @@ describe('SystematicConfigSchema', () => {
       expect(result.data.bootstrap.enabled).toBe(true)
       expect(result.data.agents).toEqual({})
       expect(result.data.categories).toEqual({})
-      // Verify all six top-level keys exist
+      expect(result.data.skills_as_commands).toBe(true)
+      // Verify all seven top-level keys exist
       expect(Object.keys(result.data).sort()).toEqual([
         'agents',
         'bootstrap',
@@ -97,8 +98,36 @@ describe('SystematicConfigSchema', () => {
         'disabled_agents',
         'disabled_commands',
         'disabled_skills',
+        'skills_as_commands',
       ])
     }
+  })
+
+  describe('skills_as_commands', () => {
+    test('defaults to true when omitted', () => {
+      const result = SystematicConfigSchema.safeParse({})
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.skills_as_commands).toBe(true)
+      }
+    })
+
+    test('accepts explicit false', () => {
+      const result = SystematicConfigSchema.safeParse({
+        skills_as_commands: false,
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.skills_as_commands).toBe(false)
+      }
+    })
+
+    test('rejects non-boolean value', () => {
+      const result = SystematicConfigSchema.safeParse({
+        skills_as_commands: 'yes',
+      })
+      expect(result.success).toBe(false)
+    })
   })
 
   test('rejects unknown top-level keys with a path-named error', () => {

--- a/tests/unit/discovered-skills.test.ts
+++ b/tests/unit/discovered-skills.test.ts
@@ -226,6 +226,79 @@ describe('discoverSkills', () => {
     expect(result[0]?.root).toBe('global-opencode-config')
   })
 
+  test('no git worktree root: discovers a skill at startDir itself but does not climb to ancestors', () => {
+    const noGitRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'systematic-nogit-'),
+    )
+    try {
+      const startDir = path.join(noGitRoot, 'nested', 'start')
+      fs.mkdirSync(startDir, { recursive: true })
+
+      // Skill at startDir itself: should be discovered.
+      writeSkill(path.join(startDir, '.claude/skills/foo'), 'foo')
+
+      // Skill at a parent of startDir (no .git anywhere): must NOT be
+      // discovered — the walk should not climb past startDir when there is
+      // no git worktree root.
+      writeSkill(path.join(noGitRoot, '.claude/skills/bar'), 'bar')
+
+      const result = discoverSkills({ startDir, homeDir })
+
+      expect(result.map((s) => s.name)).toEqual(['foo'])
+    } finally {
+      fs.rmSync(noGitRoot, { recursive: true, force: true })
+    }
+  })
+
+  test('precedence: project .opencode/skills wins over global .config/opencode/skills', () => {
+    writeSkill(path.join(homeDir, '.config/opencode/skills/foo'), 'foo', {
+      description: 'global opencode config version',
+    })
+    writeSkill(path.join(projectDir, '.opencode/skills/foo'), 'foo', {
+      description: 'project opencode version',
+    })
+
+    const result = discoverSkills({ startDir: projectDir, homeDir })
+    const winners = result.filter((s) => s.name === 'foo')
+
+    expect(winners).toHaveLength(1)
+    expect(winners[0]?.root).toBe('project-opencode')
+    expect(winners[0]?.skillPath).toBe(
+      path.join(projectDir, '.opencode/skills/foo/SKILL.md'),
+    )
+  })
+
+  test('precedence: project .opencode/skills wins over global .agents/skills', () => {
+    writeSkill(path.join(homeDir, '.agents/skills/foo'), 'foo', {
+      description: 'global agents version',
+    })
+    writeSkill(path.join(projectDir, '.opencode/skills/foo'), 'foo', {
+      description: 'project opencode version',
+    })
+
+    const result = discoverSkills({ startDir: projectDir, homeDir })
+    const winners = result.filter((s) => s.name === 'foo')
+
+    expect(winners).toHaveLength(1)
+    expect(winners[0]?.root).toBe('project-opencode')
+    expect(winners[0]?.skillPath).toBe(
+      path.join(projectDir, '.opencode/skills/foo/SKILL.md'),
+    )
+  })
+
+  test('discovery: project-level .agents/skills skill is discovered with root project-agents', () => {
+    writeSkill(path.join(projectDir, '.agents/skills/agent-only'), 'agent-only')
+
+    const result = discoverSkills({ startDir: projectDir, homeDir })
+    const found = result.find((s) => s.name === 'agent-only')
+
+    expect(found).toBeDefined()
+    expect(found?.root).toBe('project-agents')
+    expect(found?.skillPath).toBe(
+      path.join(projectDir, '.agents/skills/agent-only/SKILL.md'),
+    )
+  })
+
   test('opencodeConfigDirOverride: wins over everything, including the default global config dir', () => {
     writeSkill(path.join(homeDir, '.claude/skills/foo'), 'foo', {
       description: 'global claude version',

--- a/tests/unit/discovered-skills.test.ts
+++ b/tests/unit/discovered-skills.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { discoverSkills } from '../../src/lib/discovered-skills.ts'
+
+function writeSkill(
+  dir: string,
+  name: string,
+  opts: { frontmatterName?: string; description?: string; extra?: string } = {},
+): void {
+  fs.mkdirSync(dir, { recursive: true })
+  const frontmatterName = opts.frontmatterName ?? name
+  const description = opts.description ?? `Description for ${name}`
+  const extra = opts.extra ?? ''
+  fs.writeFileSync(
+    path.join(dir, 'SKILL.md'),
+    `---
+name: ${frontmatterName}
+description: ${description}
+${extra}---
+# Body for ${name}
+`,
+  )
+}
+
+describe('discoverSkills', () => {
+  let root: string
+  let homeDir: string
+  let projectDir: string
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'systematic-discovered-'))
+    homeDir = path.join(root, 'home')
+    projectDir = path.join(root, 'project')
+    fs.mkdirSync(homeDir, { recursive: true })
+    fs.mkdirSync(projectDir, { recursive: true })
+    // mark projectDir as a git worktree root
+    fs.mkdirSync(path.join(projectDir, '.git'), { recursive: true })
+  })
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  test('happy path: discovers a skill in project .opencode/skills', () => {
+    writeSkill(path.join(projectDir, '.opencode/skills/foo'), 'foo', {
+      description: 'A project opencode skill',
+    })
+
+    const result = discoverSkills({ startDir: projectDir, homeDir })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.name).toBe('foo')
+    expect(result[0]?.description).toBe('A project opencode skill')
+    expect(result[0]?.skillPath).toBe(
+      path.join(projectDir, '.opencode/skills/foo/SKILL.md'),
+    )
+    expect(result[0]?.root).toBe('project-opencode')
+  })
+
+  test('precedence: .opencode wins over project .claude and global .claude', () => {
+    // global claude
+    writeSkill(path.join(homeDir, '.claude/skills/foo'), 'foo', {
+      description: 'global claude version',
+    })
+    // project .claude at worktree root
+    writeSkill(path.join(projectDir, '.claude/skills/foo'), 'foo', {
+      description: 'project claude version',
+    })
+    // project .opencode: must win over both external sources
+    writeSkill(path.join(projectDir, '.opencode/skills/foo'), 'foo', {
+      description: 'project opencode version',
+    })
+
+    const result = discoverSkills({ startDir: projectDir, homeDir })
+    const winners = result.filter((s) => s.name === 'foo')
+
+    expect(winners).toHaveLength(1)
+    expect(winners[0]?.skillPath).toBe(
+      path.join(projectDir, '.opencode/skills/foo/SKILL.md'),
+    )
+    expect(winners[0]?.root).toBe('project-opencode')
+    expect(winners[0]?.description).toBe('project opencode version')
+  })
+
+  test('multi-level up-walk: worktree-root .claude skill wins over subdir-level .claude skill', () => {
+    const nested = path.join(projectDir, 'nested', 'deep')
+    fs.mkdirSync(nested, { recursive: true })
+
+    // same name at the subdir level and at the worktree root
+    writeSkill(path.join(nested, '.claude/skills/foo'), 'foo', {
+      description: 'subdir level version',
+    })
+    writeSkill(path.join(projectDir, '.claude/skills/foo'), 'foo', {
+      description: 'worktree root version',
+    })
+
+    const result = discoverSkills({ startDir: nested, homeDir })
+    const winners = result.filter((s) => s.name === 'foo')
+
+    expect(winners).toHaveLength(1)
+    expect(winners[0]?.skillPath).toBe(
+      path.join(projectDir, '.claude/skills/foo/SKILL.md'),
+    )
+    expect(winners[0]?.description).toBe('worktree root version')
+  })
+
+  test('multi-level up-walk: a skill only present at a subdirectory level is still discovered', () => {
+    const nested = path.join(projectDir, 'nested', 'deep')
+    fs.mkdirSync(nested, { recursive: true })
+
+    writeSkill(path.join(nested, '.claude/skills/subdir-only'), 'subdir-only')
+
+    const result = discoverSkills({ startDir: nested, homeDir })
+
+    expect(result.map((s) => s.name)).toContain('subdir-only')
+    const found = result.find((s) => s.name === 'subdir-only')
+    expect(found?.skillPath).toBe(
+      path.join(nested, '.claude/skills/subdir-only/SKILL.md'),
+    )
+  })
+
+  test('recursive external glob: skills nested more than one level under skills/ are discovered', () => {
+    writeSkill(
+      path.join(homeDir, '.agents/skills/nested/deep/foo'),
+      'nested-deep-foo',
+    )
+
+    const result = discoverSkills({ startDir: projectDir, homeDir })
+
+    expect(result.map((s) => s.name)).toContain('nested-deep-foo')
+  })
+
+  test('{skill,skills}: a skill under the singular .opencode/skill/ dir is found', () => {
+    writeSkill(path.join(projectDir, '.opencode/skill/singular'), 'singular')
+
+    const result = discoverSkills({ startDir: projectDir, homeDir })
+
+    expect(result.map((s) => s.name)).toEqual(['singular'])
+    expect(result[0]?.root).toBe('project-opencode')
+  })
+
+  test('dedup by frontmatter name, not directory name', () => {
+    // dir named "alpha" but frontmatter name is "beta"
+    writeSkill(path.join(projectDir, '.opencode/skills/alpha'), 'alpha', {
+      frontmatterName: 'beta',
+      description: 'alpha dir, beta name',
+    })
+
+    const result = discoverSkills({ startDir: projectDir, homeDir })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.name).toBe('beta')
+    expect(result[0]?.description).toBe('alpha dir, beta name')
+  })
+
+  test('frontmatter: disable-model-invocation surfaces in result', () => {
+    writeSkill(path.join(projectDir, '.opencode/skills/cmdonly'), 'cmdonly', {
+      extra: 'disable-model-invocation: true\n',
+    })
+
+    const result = discoverSkills({ startDir: projectDir, homeDir })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.frontmatter.disableModelInvocation).toBe(true)
+  })
+
+  test('regex skip: invalid frontmatter name is skipped, others still discovered', () => {
+    // invalid frontmatter name (uppercase, underscore) — dir name is irrelevant now
+    writeSkill(path.join(projectDir, '.opencode/skills/Foo_Bar'), 'Foo_Bar', {
+      frontmatterName: 'Foo_Bar',
+    })
+    writeSkill(path.join(projectDir, '.opencode/skills/valid-one'), 'valid-one')
+
+    const result = discoverSkills({ startDir: projectDir, homeDir })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.name).toBe('valid-one')
+  })
+
+  test('missing root: none of the roots exist returns empty array, no throw', () => {
+    // remove project skill dirs; only .git exists
+    const result = discoverSkills({ startDir: projectDir, homeDir })
+    expect(result).toEqual([])
+  })
+
+  test('worktree walk: skills above the worktree root are not discovered', () => {
+    const nested = path.join(projectDir, 'nested', 'deep')
+    fs.mkdirSync(nested, { recursive: true })
+
+    // skill above the git root (in root/, not in projectDir) should NOT be discovered
+    writeSkill(path.join(root, '.opencode/skills/above'), 'above')
+    // skill inside the project worktree root
+    writeSkill(path.join(projectDir, '.opencode/skills/inside'), 'inside')
+
+    const result = discoverSkills({ startDir: nested, homeDir })
+
+    expect(result.map((s) => s.name)).toEqual(['inside'])
+  })
+
+  test('error path: unreadable SKILL.md (directory named SKILL.md) is skipped, discovery completes', () => {
+    const skillDir = path.join(projectDir, '.opencode/skills/broken')
+    fs.mkdirSync(skillDir, { recursive: true })
+    // SKILL.md is a directory, not a file - simulates unreadable content
+    fs.mkdirSync(path.join(skillDir, 'SKILL.md'), { recursive: true })
+
+    writeSkill(path.join(projectDir, '.opencode/skills/ok'), 'ok')
+
+    const result = discoverSkills({ startDir: projectDir, homeDir })
+
+    expect(result.map((s) => s.name)).toEqual(['ok'])
+  })
+
+  test('configDir override: skills discovered from custom OpenCode config dir', () => {
+    const configDir = path.join(root, 'custom-config')
+    writeSkill(path.join(configDir, 'skills/customcfg'), 'customcfg')
+
+    const result = discoverSkills({
+      startDir: projectDir,
+      homeDir,
+      configDir,
+    })
+
+    expect(result.map((s) => s.name)).toEqual(['customcfg'])
+    expect(result[0]?.root).toBe('global-opencode-config')
+  })
+
+  test('opencodeConfigDirOverride: wins over everything, including the default global config dir', () => {
+    writeSkill(path.join(homeDir, '.claude/skills/foo'), 'foo', {
+      description: 'global claude version',
+    })
+    const overrideDir = path.join(root, 'env-override-config')
+    writeSkill(path.join(overrideDir, 'skills/foo'), 'foo', {
+      description: 'override config version',
+    })
+
+    const result = discoverSkills({
+      startDir: projectDir,
+      homeDir,
+      opencodeConfigDirOverride: overrideDir,
+    })
+    const winners = result.filter((s) => s.name === 'foo')
+
+    expect(winners).toHaveLength(1)
+    expect(winners[0]?.description).toBe('override config version')
+  })
+})


### PR DESCRIPTION
Registers the skills you already keep in your project and home directories as slash commands, so any discovered skill is invokable as `/skill-name` — the way Claude Code and other agents treat skills. This shores up a gap in OpenCode, which discovers these skills and exposes them to the model but intentionally keeps them out of the TUI's slash-command autocomplete.

## What it does

- **Discovery** (`src/lib/discovered-skills.ts`) mirrors OpenCode's own contract exactly — six roots (`~/.claude`, `~/.agents`, `~/.config/opencode` global; `.opencode`, `.claude`, `.agents` project, walked up to the git worktree root) with OpenCode's last-write-wins precedence (`.opencode` beats `.claude`/`.agents` beats global), keyed on frontmatter name. Node-native (`walkDir`) so it works under any plugin runtime.
- **Emission** (`config-handler.ts`) registers each discovered skill as a `config.command` entry. Model-invocable skills get a one-line shim that loads the skill through OpenCode's native `skill` tool with `$ARGUMENTS` wrapped as data; command-only skills (`disable-model-invocation`) inline the body. Entries carry the `(Systematic - Skill)` marker so re-runs are idempotent and user-defined commands of the same name always win.
- **Toggle**: `skills_as_commands` (default on) turns the whole feature off.

## Scope and honesty

- Bundled `systematic:`/`ce:` command registration is unchanged.
- No trust gate is added: OpenCode already discovers and registers these same skills ungated, and a command is only ever human-invoked. Documented plainly in the guide.
- Honest limitation documented: OpenCode has no way for a plugin to hide a skill from the model's own `skill` tool, so `disable-model-invocation` shapes the `/command` surface but does not hard-guarantee the model can never reach the skill.
- The `systematic_skill` permission-parity fix is a **separate PR** — this one is purely the discovered-skills feature.

## Verification

- 1070 unit tests pass (discovery precedence/edge cases, emission, idempotency, R4 collision, toggle, command-only inline).
- `bun run typecheck`, content-integrity gate, schema/registry drift, and `docs:build` all clean.
- A 10-persona `ce:review` pass ran on the branch; its findings (orphaned-command cleanup, `user-invocable` parity, up-walk bounding, test-gap fills) are applied in the final commit. Two low-severity items (`disabled_skills` filtering of discovered skills; a command-only double-read) are deferred as follow-ups.

The `.claude/` reference in `discovered-skills.ts` is allowlisted in the content-integrity gate — those are OpenCode's own documented discovery roots, not Claude Code coupling.