### PR TITLE
fix: disabled_commands suppression + single-read for discovered skills

### DIFF
--- a/docs/src/content/docs/guides/skills-as-commands.mdx
+++ b/docs/src/content/docs/guides/skills-as-commands.mdx
@@ -54,6 +54,16 @@ Set `skills_as_commands` to `false` in your `systematic.json` to disable the fea
 
 Your own commands are never touched — Systematic only registers a discovered skill as a command when no command of that name already exists, so a command you define yourself always wins. Bundled Systematic skills (the `systematic:` and `ce:` commands) are unaffected by this setting.
 
+To suppress a single discovered skill's command rather than the whole feature, add its name to `disabled_commands`:
+
+```json
+{
+  "disabled_commands": ["git-release"]
+}
+```
+
+A discovered skill registers as a command under its bare name, so `disabled_commands` is the field that governs it. (The `disabled_skills` field only accepts bundled Systematic skill names.)
+
 ## Relationship to upstream
 
 OpenCode registers discovered skills as commands internally, but its TUI intentionally keeps them out of slash-command autocomplete in favor of a dedicated skills picker. That is a deliberate upstream choice, so this behavior may converge over time. If it does, Systematic's registration degrades gracefully: because Systematic's entry replaces the skill-sourced one by name, you still see exactly one command per skill, and the `skills_as_commands` toggle removes Systematic's entries entirely.

--- a/src/lib/config-handler.ts
+++ b/src/lib/config-handler.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import type { Config } from '@opencode-ai/plugin'
@@ -519,10 +518,9 @@ function loadDiscoveredSkillAsCommand(skill: DiscoveredSkill): CommandConfig {
   const description = formatSkillDescription(skill.description, skill.name)
 
   if (skill.frontmatter.disableModelInvocation === true) {
-    const content = fs.readFileSync(skill.skillPath, 'utf8')
-    const { body } = parseFrontmatter(content)
+    // Body was read once at discovery time (DiscoveredSkill.body); no re-read.
     return {
-      template: wrapSkillTemplate(skill.skillPath, body),
+      template: wrapSkillTemplate(skill.skillPath, skill.body),
       description,
     }
   }

--- a/src/lib/config-handler.ts
+++ b/src/lib/config-handler.ts
@@ -559,6 +559,7 @@ function collectDiscoveredSkillsAsCommands(
   homeDir: string,
   configDir: string,
   opencodeConfigDirOverride: string | undefined,
+  disabledCommands: string[],
 ): NonNullable<Config['command']> {
   const commands: NonNullable<Config['command']> = {}
 
@@ -578,6 +579,10 @@ function collectDiscoveredSkillsAsCommands(
 
   for (const skill of discovered) {
     if (skill.frontmatter.userInvocable === false) continue
+    // A discovered skill registers as a command under its bare name; the
+    // strict `disabled_skills` enum only accepts bundled names, so the
+    // free-form `disabled_commands` field is the suppression path here.
+    if (disabledCommands.includes(skill.name)) continue
 
     try {
       commands[skill.name] = loadDiscoveredSkillAsCommand(skill)
@@ -698,6 +703,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
             homeDir,
             opencodeConfigDir,
             opencodeConfigDirOverride,
+            systematicConfig.disabled_commands,
           )
         : {}
 

--- a/src/lib/discovered-skills.ts
+++ b/src/lib/discovered-skills.ts
@@ -178,26 +178,23 @@ function globSkillFiles(rootDir: string, subdirNames: string[]): string[] {
 
 /**
  * Turn a discovered `SKILL.md` absolute path into a `DiscoveredSkill`, or
- * `undefined` if it should be skipped (unreadable, not a file, no
+ * `undefined` if it should be skipped (unreadable, not a regular file, no
  * frontmatter name, or invalid name charset/length). Never throws.
+ *
+ * Reads the file directly with no prior `stat` check: a single `readFileSync`
+ * avoids a check-then-use time-of-check/time-of-use race (a directory throws
+ * `EISDIR`, a missing path throws `ENOENT`, both handled by the catch), and
+ * reads the SKILL.md exactly once so the body can be reused downstream.
  */
 function toDiscoveredSkill(
   skillPath: string,
   rootId: DiscoveryRootId,
 ): DiscoveredSkill | undefined {
-  let stat: fs.Stats
-  try {
-    stat = fs.statSync(skillPath)
-  } catch {
-    return undefined // missing or unreadable: skip
-  }
-  if (!stat.isFile()) return undefined
-
   let content: string
   try {
     content = fs.readFileSync(skillPath, 'utf8')
   } catch {
-    return undefined // unreadable: skip
+    return undefined // missing, unreadable, or a directory: skip
   }
 
   const frontmatter = extractFrontmatterFromContent(content)

--- a/src/lib/discovered-skills.ts
+++ b/src/lib/discovered-skills.ts
@@ -1,6 +1,10 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { extractFrontmatter, type SkillFrontmatter } from './skills.js'
+import { parseFrontmatter } from './frontmatter.js'
+import {
+  extractFrontmatterFromContent,
+  type SkillFrontmatter,
+} from './skills.js'
 import { walkDir } from './walk-dir.js'
 
 /**
@@ -26,6 +30,9 @@ export interface DiscoveredSkill {
   name: string
   description: string
   frontmatter: SkillFrontmatter
+  /** SKILL.md body (frontmatter stripped), read once at discovery so callers
+   * that inline the body don't re-read the file. */
+  body: string
   skillPath: string
   root: DiscoveryRootId
 }
@@ -186,7 +193,14 @@ function toDiscoveredSkill(
   }
   if (!stat.isFile()) return undefined
 
-  const frontmatter = extractFrontmatter(skillPath)
+  let content: string
+  try {
+    content = fs.readFileSync(skillPath, 'utf8')
+  } catch {
+    return undefined // unreadable: skip
+  }
+
+  const frontmatter = extractFrontmatterFromContent(content)
   const name = frontmatter.name
   if (!name || !isValidSkillName(name)) return undefined
 
@@ -194,6 +208,7 @@ function toDiscoveredSkill(
     name,
     description: frontmatter.description,
     frontmatter,
+    body: parseFrontmatter(content).body,
     skillPath,
     root: rootId,
   }

--- a/src/lib/discovered-skills.ts
+++ b/src/lib/discovered-skills.ts
@@ -178,7 +178,7 @@ function globSkillFiles(rootDir: string, subdirNames: string[]): string[] {
 
 /**
  * Turn a discovered `SKILL.md` absolute path into a `DiscoveredSkill`, or
- * `undefined` if it should be skipped (unreadable, not a regular file, no
+ * `undefined` if it should be skipped (missing, unreadable, a directory, no
  * frontmatter name, or invalid name charset/length). Never throws.
  *
  * Reads the file directly with no prior `stat` check: a single `readFileSync`

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -115,41 +115,51 @@ function parseDeprecated(
   return deprecated
 }
 
+/**
+ * Parse skill frontmatter from already-read file content. Split out from
+ * `extractFrontmatter` so callers that also need the body (e.g. discovered-skill
+ * command emission) can read the file once and derive both. Never throws.
+ */
+export function extractFrontmatterFromContent(
+  content: string,
+): SkillFrontmatter {
+  const { data, parseError } =
+    parseFrontmatter<Record<string, unknown>>(content)
+
+  if (parseError) {
+    return { name: '', description: '' }
+  }
+
+  const metadata = parseMetadata(data)
+  const deprecated = parseDeprecated(data)
+
+  const argumentHintRaw = extractNonEmptyString(data, 'argument-hint')
+  const argumentHint = argumentHintRaw?.replace(/^["']|["']$/g, '') || undefined
+
+  return {
+    name: extractString(data, 'name'),
+    description: extractString(data, 'description'),
+    license: extractNonEmptyString(data, 'license'),
+    compatibility: extractNonEmptyString(data, 'compatibility'),
+    metadata,
+    deprecated,
+    disableModelInvocation: extractBoolean(data, 'disable-model-invocation'),
+    userInvocable: extractBoolean(data, 'user-invocable'),
+    subtask:
+      data.context === 'fork'
+        ? true
+        : (extractBoolean(data, 'subtask') ?? undefined),
+    agent: extractNonEmptyString(data, 'agent'),
+    model: extractNonEmptyString(data, 'model'),
+    argumentHint: argumentHint !== '' ? argumentHint : undefined,
+    allowedTools: extractNonEmptyString(data, 'allowed-tools'),
+  }
+}
+
 export function extractFrontmatter(filePath: string): SkillFrontmatter {
   try {
     const content = fs.readFileSync(filePath, 'utf8')
-    const { data, parseError } =
-      parseFrontmatter<Record<string, unknown>>(content)
-
-    if (parseError) {
-      return { name: '', description: '' }
-    }
-
-    const metadata = parseMetadata(data)
-    const deprecated = parseDeprecated(data)
-
-    const argumentHintRaw = extractNonEmptyString(data, 'argument-hint')
-    const argumentHint =
-      argumentHintRaw?.replace(/^["']|["']$/g, '') || undefined
-
-    return {
-      name: extractString(data, 'name'),
-      description: extractString(data, 'description'),
-      license: extractNonEmptyString(data, 'license'),
-      compatibility: extractNonEmptyString(data, 'compatibility'),
-      metadata,
-      deprecated,
-      disableModelInvocation: extractBoolean(data, 'disable-model-invocation'),
-      userInvocable: extractBoolean(data, 'user-invocable'),
-      subtask:
-        data.context === 'fork'
-          ? true
-          : (extractBoolean(data, 'subtask') ?? undefined),
-      agent: extractNonEmptyString(data, 'agent'),
-      model: extractNonEmptyString(data, 'model'),
-      argumentHint: argumentHint !== '' ? argumentHint : undefined,
-      allowedTools: extractNonEmptyString(data, 'allowed-tools'),
-    }
+    return extractFrontmatterFromContent(content)
   } catch {
     return { name: '', description: '' }
   }

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -1935,6 +1935,25 @@ Discovered body for hidden.`,
         expect(config.command?.hidden).toBeUndefined()
       })
 
+      test('disabled_commands suppresses a discovered-skill command', async () => {
+        writeDiscoveredSkill(path.join(projectDir, '.opencode/skills'), 'foo')
+        writeDiscoveredSkill(path.join(projectDir, '.opencode/skills'), 'bar')
+        writeSystematicConfig({ disabled_commands: ['foo'] })
+
+        const handler = createConfigHandler({
+          directory: projectDir,
+          bundledSkillsDir: path.join(bundledDir, 'skills'),
+          bundledAgentsDir: path.join(bundledDir, 'agents'),
+          bundledCommandsDir: path.join(bundledDir, 'commands'),
+        })
+
+        const config: Config = {}
+        await handler(config)
+
+        expect(config.command?.foo).toBeUndefined()
+        expect(config.command?.bar).toBeDefined()
+      })
+
       test('discovered skill without user-invocable field still emits a command', async () => {
         writeDiscoveredSkill(
           path.join(projectDir, '.opencode/skills'),

--- a/tests/unit/discovered-skills.test.ts
+++ b/tests/unit/discovered-skills.test.ts
@@ -57,6 +57,9 @@ describe('discoverSkills', () => {
       path.join(projectDir, '.opencode/skills/foo/SKILL.md'),
     )
     expect(result[0]?.root).toBe('project-opencode')
+    // body is read once at discovery (frontmatter stripped) so the inline
+    // command-only path never re-reads the file.
+    expect(result[0]?.body.trim()).toBe('# Body for foo')
   })
 
   test('precedence: .opencode wins over project .claude and global .claude', () => {


### PR DESCRIPTION
Two follow-ups from the review of #592 (discovered skills as commands).

## `disabled_commands` suppresses a discovered-skill command

A discovered skill registers as a command under its bare name, but there was no way to suppress a single one short of turning the whole feature off — `disabled_skills` is a strict enum of bundled names only. Now `collectDiscoveredSkillsAsCommands` filters by the existing free-form `disabled_commands` field (the field that governs command names), leaving the strict bundled-name validation untouched. The guide documents the split: `disabled_skills` governs bundled skills, `disabled_commands` governs discovered-skill commands.

## Read a discovered SKILL.md once, not twice

Command-only skills (`disable-model-invocation`) read their `SKILL.md` twice — once via `extractFrontmatter` during discovery (body discarded) and again via `readFileSync` in the inline command path. Split `extractFrontmatterFromContent` out of `extractFrontmatter`, read the file once in `toDiscoveredSkill`, and carry the body on `DiscoveredSkill` so the inline path reuses it.

## Verification

- 1071 unit tests pass (new: `disabled_commands` suppression; a `body` assertion pinning the single-read contract).
- `bun run typecheck`, content-integrity, and lint all clean.