### PR TITLE
docs(guides): add v3 migration guide

### DIFF
--- a/docs/src/content/docs/guides/v3-migration.mdx
+++ b/docs/src/content/docs/guides/v3-migration.mdx
@@ -14,7 +14,7 @@ Stale `disabled_skills` / `disabled_agents` entries for removed names produce a 
 | Removed | Use instead |
 | --- | --- |
 | `orchestrating-swarms` | `orchestrating-subagents` |
-| `claude-permissions-optimizer` | — (Claude Code-specific; out of scope) |
+| `claude-permissions-optimizer` | — (no Systematic replacement; configure permissions manually via OpenCode's own `permission` block in `opencode.jsonc`) |
 | `dspy-ruby`, `dhh-rails-style`, `andrew-kane-gem-writer` | — (Ruby/Rails vertical; add project-local skills if needed) |
 | `every-style-editor` | — |
 | `rclone`, `gemini-imagegen`, `test-xcode`, `proof` | — (vendor integrations; add project-local skills if needed) |
@@ -35,6 +35,34 @@ Stale `disabled_skills` / `disabled_agents` entries for removed names produce a 
 | `schema-drift-detector`, `lint` | — (Rails/Ruby-specific) |
 | `figma-design-sync`, `design-implementation-reviewer` | `design-iterator` (tool-agnostic) |
 | `ankane-readme-writer` | — |
+
+## Config cleanup (optional)
+
+If your `systematic.json`/`systematic.jsonc` lists a removed name in `disabled_skills` or `disabled_agents`, Systematic does **not** fail to load. It drops the stale entry and logs a warning once per name, per load:
+
+```
+[systematic] "orchestrating-swarms" in `disabled_skills` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning. See https://fro.bot/systematic/guides/v3-migration/ for migration guidance.
+```
+
+Removing the stale entry silences the warning — it's cleanup, not a required fix. A genuinely-unknown name (a typo, or a name that never existed) is still a hard validation error.
+
+## CLI converter removal
+
+The `systematic convert` CLI command (Claude Code → OpenCode skill format) is gone in v3. If you need one-off conversion, pin the last v2 release for that task:
+
+```bash
+npm install @fro.bot/systematic@2
+```
+
+Run the conversion under the pinned v2 install, then upgrade back to the current `@fro.bot/systematic@latest` for day-to-day use.
+
+## Deprecated skill frontmatter
+
+Skill frontmatter no longer recognizes a `deprecated:` block. Any skill still shipping one will surface it as an unrecognized field during content-integrity validation — remove the block.
+
+## Bundled agents: explicit `temperature:` (contributor note)
+
+If you maintain or contribute bundled agents, every bundled agent must declare an explicit `temperature:` in its frontmatter. Runtime inference of a default temperature is no longer supported. This only affects agents shipped inside this repo — it does not affect your project config.
 
 ## Why
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -109,6 +109,8 @@ export function computeDroppedNames(
   return names.filter((n) => !allowedSet.has(n))
 }
 
+const MIGRATION_DOCS_URL = 'https://fro.bot/systematic/guides/v3-migration/'
+
 /**
  * Emit a `[systematic]` warning for each dropped name that has not already
  * been warned about in this load invocation. The `warned` set is local to a
@@ -124,7 +126,7 @@ export function warnDroppedNames(
     if (warned.has(name)) continue
     warned.add(name)
     console.warn(
-      `[systematic] "${name}" in \`${field}\` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning.`,
+      `[systematic] "${name}" in \`${field}\` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning. See ${MIGRATION_DOCS_URL} for migration guidance.`,
     )
   }
 }

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1214,7 +1214,7 @@ describe('config', () => {
 
       expect(result?.disabled_skills).not.toContain('orchestrating-swarms')
       expect(warnSpy).toHaveBeenCalledWith(
-        '[systematic] "orchestrating-swarms" in `disabled_skills` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning.',
+        '[systematic] "orchestrating-swarms" in `disabled_skills` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning. See https://fro.bot/systematic/guides/v3-migration/ for migration guidance.',
       )
       warnSpy.mockRestore()
     })
@@ -1232,7 +1232,7 @@ describe('config', () => {
         'claude-permissions-optimizer',
       )
       expect(warnSpy).toHaveBeenCalledWith(
-        '[systematic] "claude-permissions-optimizer" in `disabled_skills` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning.',
+        '[systematic] "claude-permissions-optimizer" in `disabled_skills` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning. See https://fro.bot/systematic/guides/v3-migration/ for migration guidance.',
       )
       warnSpy.mockRestore()
     })
@@ -1248,7 +1248,7 @@ describe('config', () => {
 
       expect(result?.disabled_skills).not.toContain('writing-systematic-skills')
       expect(warnSpy).toHaveBeenCalledWith(
-        '[systematic] "writing-systematic-skills" in `disabled_skills` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning.',
+        '[systematic] "writing-systematic-skills" in `disabled_skills` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning. See https://fro.bot/systematic/guides/v3-migration/ for migration guidance.',
       )
       warnSpy.mockRestore()
     })
@@ -1271,7 +1271,7 @@ describe('config', () => {
       expect(result.disabled_skills).not.toContain('orchestrating-swarms')
       expect(result.disabled_skills).toContain('ce:review')
       expect(warnSpy).toHaveBeenCalledWith(
-        '[systematic] "orchestrating-swarms" in `disabled_skills` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning.',
+        '[systematic] "orchestrating-swarms" in `disabled_skills` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning. See https://fro.bot/systematic/guides/v3-migration/ for migration guidance.',
       )
       warnSpy.mockRestore()
     })
@@ -1287,7 +1287,7 @@ describe('config', () => {
 
       expect(result?.disabled_skills).not.toContain('rclone')
       expect(warnSpy).toHaveBeenCalledWith(
-        '[systematic] "rclone" in `disabled_skills` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning.',
+        '[systematic] "rclone" in `disabled_skills` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning. See https://fro.bot/systematic/guides/v3-migration/ for migration guidance.',
       )
       warnSpy.mockRestore()
     })
@@ -1303,7 +1303,7 @@ describe('config', () => {
       expect(result.disabled_skills).toContain('test-driven-development')
       expect(result.disabled_skills).not.toContain('setup')
       expect(warnSpy).toHaveBeenCalledWith(
-        '[systematic] "setup" in `disabled_skills` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning.',
+        '[systematic] "setup" in `disabled_skills` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning. See https://fro.bot/systematic/guides/v3-migration/ for migration guidance.',
       )
       warnSpy.mockRestore()
     })
@@ -1323,7 +1323,7 @@ describe('config', () => {
 
       expect(result?.disabled_skills).not.toContain('todo-create')
       expect(warnSpy).toHaveBeenCalledWith(
-        '[systematic] "todo-create" in `disabled_skills` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning.',
+        '[systematic] "todo-create" in `disabled_skills` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning. See https://fro.bot/systematic/guides/v3-migration/ for migration guidance.',
       )
       warnSpy.mockRestore()
     })
@@ -1339,7 +1339,7 @@ describe('config', () => {
 
       expect(result?.disabled_agents).not.toContain('security-sentinel')
       expect(warnSpy).toHaveBeenCalledWith(
-        '[systematic] "security-sentinel" in `disabled_agents` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning.',
+        '[systematic] "security-sentinel" in `disabled_agents` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning. See https://fro.bot/systematic/guides/v3-migration/ for migration guidance.',
       )
       warnSpy.mockRestore()
     })
@@ -1355,7 +1355,7 @@ describe('config', () => {
       expect(result.disabled_agents).toContain('correctness-reviewer')
       expect(result.disabled_agents).not.toContain('performance-oracle')
       expect(warnSpy).toHaveBeenCalledWith(
-        '[systematic] "performance-oracle" in `disabled_agents` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning.',
+        '[systematic] "performance-oracle" in `disabled_agents` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning. See https://fro.bot/systematic/guides/v3-migration/ for migration guidance.',
       )
       warnSpy.mockRestore()
     })
@@ -1371,7 +1371,7 @@ describe('config', () => {
 
       expect(result?.disabled_agents).not.toContain('review/security-sentinel')
       expect(warnSpy).toHaveBeenCalledWith(
-        '[systematic] "review/security-sentinel" in `disabled_agents` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning.',
+        '[systematic] "review/security-sentinel" in `disabled_agents` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning. See https://fro.bot/systematic/guides/v3-migration/ for migration guidance.',
       )
       warnSpy.mockRestore()
     })
@@ -1387,7 +1387,7 @@ describe('config', () => {
 
       expect(result?.disabled_agents).not.toContain('design/figma-design-sync')
       expect(warnSpy).toHaveBeenCalledWith(
-        '[systematic] "design/figma-design-sync" in `disabled_agents` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning.',
+        '[systematic] "design/figma-design-sync" in `disabled_agents` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning. See https://fro.bot/systematic/guides/v3-migration/ for migration guidance.',
       )
       warnSpy.mockRestore()
     })


### PR DESCRIPTION
## What

v3 cleanup plan 002, Unit 5 — committed migration guidance:

- New `guides/v3-migration` page mapping every v3 removal to its replacement: the two deprecated skills (with the honest claude-permissions-optimizer gap → OpenCode's own `permission` config), the curation batch (12 skills + 14 agents, todo trio → `todos`, writing-systematic-skills → `writing-skills`), CLI converter removal + the `@2` pin path, deprecated-frontmatter and explicit-temperature notes.
- Warn-and-ignore framing: stale `disabled_skills`/`disabled_agents` entries are optional cleanup, not errors; a genuinely-unknown name still fails validation.
- The runtime warning in `src/lib/config.ts` now carries the migration-doc anchor (plan's deferred "wire the anchor once the page path is fixed" item), with test expectations updated.

## Verification

- `bun run docs:build` green — page renders in the built output and appears in nav
- `bun test tests/unit` green (updated warning-text assertions), typecheck clean, content-integrity clean

Part of the v3.0.0 release arc (plan 002); docs scope is non-releasing.