### PR TITLE
test(schema): v3 removed-name AJV parity + release-gated v2 schema cleanup

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -50,6 +50,28 @@ jobs:
       - name: Generate reference content
         run: bun run docs:generate
 
+      # Transition cleanup: the v2 -> v3 schema path migration (deleting
+      # docs/public/schemas/v2/, committing v3/) is gated to land only once a
+      # real v3.0.0+ tag exists. Until that release, v2/ must keep deploying
+      # so IDE $schema URLs pointing at /v2/ keep resolving. This step is a
+      # release-time-only removal of the *workspace copy* (the Astro build
+      # input), gated on the checked-out release tag being v3.0.0 or a higher
+      # major — never on branch/PR/main builds. Safe to delete this step
+      # entirely once the v2 -> v3 directory cut lands for real.
+      - name: Remove legacy v2 schema mirror for v3+ releases
+        if: github.event_name == 'release'
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          tag="${RELEASE_TAG#v}"
+          major="${tag%%.*}"
+          if [ "$major" -ge 3 ] 2>/dev/null; then
+            echo "Release tag ${RELEASE_TAG} is v${major}+ — removing docs/public/schemas/v2/"
+            rm -rf docs/public/schemas/v2
+          else
+            echo "Release tag ${RELEASE_TAG} is pre-v3 — keeping docs/public/schemas/v2/"
+          fi
+
       - name: Resolve registry version
         id: registry-version
         env:

--- a/docs/public/schemas/v2/systematic-config.schema.json
+++ b/docs/public/schemas/v2/systematic-config.schema.json
@@ -42,7 +42,7 @@
     "__schema0": {
       "description": "JSON Schema URL for IDE autocomplete. The value is informational only — the loader does not fetch or validate against it. Add this to enable IDE schema activation and field-level autocomplete in editors that support JSON Schema (VSCode, Zed, IntelliJ).",
       "examples": [
-        "https://fro.bot/systematic/schemas/v2/systematic-config.schema.json"
+        "https://fro.bot/systematic/schemas/latest/systematic-config.schema.json"
       ],
       "allOf": [
         {

--- a/src/lib/config-schema.ts
+++ b/src/lib/config-schema.ts
@@ -293,7 +293,7 @@ export function createSystematicConfigSchema(
           description:
             'JSON Schema URL for IDE autocomplete. The value is informational only — the loader does not fetch or validate against it. Add this to enable IDE schema activation and field-level autocomplete in editors that support JSON Schema (VSCode, Zed, IntelliJ).',
           examples: [
-            'https://fro.bot/systematic/schemas/v2/systematic-config.schema.json',
+            'https://fro.bot/systematic/schemas/latest/systematic-config.schema.json',
           ],
         }),
       agents: z

--- a/tests/unit/generate-config-schema.test.ts
+++ b/tests/unit/generate-config-schema.test.ts
@@ -969,6 +969,55 @@ describe('AJV parity: Zod runtime contract vs generated JSON Schema', () => {
     expect(zodParse(config).success).toBe(true)
     expect(ajvValidate(config)).toBe(true)
   })
+
+  // v3 removed-name parity: REMOVED_BUNDLED_SKILL_NAMES / REMOVED_BUNDLED_AGENT_NAMES
+  // are threaded into the enum so removed names still PARSE (accept-and-warn at
+  // runtime in config.ts, not reject at parse time). Genuinely-unknown names
+  // (typos, names that never existed) must still be rejected by both sides.
+  test('parity: removed bundled skill name accepted by both (accept-and-warn)', () => {
+    if (!ajvAvailable) {
+      console.warn('SKIP: ajv not available')
+      return
+    }
+    // 'orchestrating-swarms' is in REMOVED_BUNDLED_SKILL_NAMES (src/lib/removed-names.ts)
+    const config = { disabled_skills: ['orchestrating-swarms'] }
+    expect(zodParse(config).success).toBe(true)
+    expect(ajvValidate(config)).toBe(true)
+  })
+
+  test('parity: never-existed skill name rejected by both', () => {
+    if (!ajvAvailable) {
+      console.warn('SKIP: ajv not available')
+      return
+    }
+    const config = { disabled_skills: ['never-existed-skill'] }
+    expect(zodParse(config).success).toBe(false)
+    expect(ajvValidate(config)).toBe(false)
+  })
+
+  test('parity: removed bundled agent name accepted by both (accept-and-warn)', () => {
+    if (!ajvAvailable) {
+      console.warn('SKIP: ajv not available')
+      return
+    }
+    // 'security-sentinel' is in REMOVED_BUNDLED_AGENT_NAMES (src/lib/removed-names.ts).
+    // disabled_agents is enum-validated the same way as disabled_skills (both
+    // thread removedAgentNames/removedSkillNames into the z.enum in
+    // createSystematicConfigSchema — see src/lib/config-schema.ts).
+    const config = { disabled_agents: ['security-sentinel'] }
+    expect(zodParse(config).success).toBe(true)
+    expect(ajvValidate(config)).toBe(true)
+  })
+
+  test('parity: never-existed agent name rejected by both', () => {
+    if (!ajvAvailable) {
+      console.warn('SKIP: ajv not available')
+      return
+    }
+    const config = { disabled_agents: ['never-existed-agent'] }
+    expect(zodParse(config).success).toBe(false)
+    expect(ajvValidate(config)).toBe(false)
+  })
 })
 
 // Meta-schema smoke test: the generated JSON Schema must itself be a valid


### PR DESCRIPTION
## What

v3 cleanup plan 002, Unit 4 — the pre-cut half (the v2→v3 schema *path* transition is gated to the real 3.0.0 tag; sequencing per architecture review):

- **AJV/Zod parity tests** for the removed-name matrix: removed bundled skill/agent names in `disabled_skills`/`disabled_agents` are accepted by both validators (warn-and-ignore contract), never-existed names rejected by both (81→85 tests).
- **Version-neutral `$schema` example** in `config-schema.ts` — the embedded example URL pointed at `/schemas/v2/`, which a future v3-generated schema would have carried verbatim; now `/schemas/latest/`. Committed `v2/` artifact regenerated via the script (version resolved naturally from git tags — no hand-faked major).
- **Release-gated docs cleanup step** in `docs.yaml`: on a v3.0.0+ release build only, the workspace `docs/public/schemas/v2/` is removed before the Astro build so the published site stops serving the retired v2 URL at the cut. Inert on every branch/PR/pre-v3 build; commented as transition cleanup, removable post-cut.

## Why

Drift-check resolves the schema major from git tags (v2.33.2 on this branch), so deleting `v2/`or committing `v3/` pre-cut hard-fails CI. This lands everything that is version-independent now and leaves the path rename to a natural post-tag regeneration.

## Verification

- 983 unit tests green (85 in the schema suite), typecheck, lint, `schema:drift` clean, content-integrity clean
- docs.yaml YAML-validated; tag-guard truth table checked (`v3.0.0` removes, `v2.33.2` keeps, non-semver keeps)

Known limit: the cleanup step keys on `release` events; a manual `workflow_dispatch` docs build pre-tag won't trigger it (correct — no tag exists) and post-cut the step is superseded by the real directory deletion.