### PR TITLE
docs: compound packaged-runtime validation

### DIFF
--- a/docs/plans/2026-07-06-002-feat-v3-cleanup-release-plan.md
+++ b/docs/plans/2026-07-06-002-feat-v3-cleanup-release-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: v3.0.0 compatibility cleanup release"
 type: feat
-status: active
+status: completed
 date: 2026-07-06
 origin: docs/brainstorms/2026-07-06-v3-cleanup-release-requirements.md
 target_branch: v3
@@ -154,7 +154,7 @@ Phase 3 (convergence + assurance)
 
 ## Implementation Units
 
-- [ ] **Unit 1: Delete deprecated skills, populate removed-names, regenerate surfaces**
+- [x] **Unit 1: Delete deprecated skills, populate removed-names, regenerate surfaces**
 
 **Goal:** Remove `orchestrating-swarms` and `claude-permissions-optimizer` from the bundle and every generated/active surface, populate the warn-and-ignore removed-name list, and prove removed names load-with-warning while invalid config still throws. Atomic because the content-integrity overlap gate rejects a removed name that still exists in `bundled-names`.
 
@@ -189,7 +189,7 @@ Phase 3 (convergence + assurance)
 
 **Verification:** `bun run docs:generate` + `bun run registry:build` produce no drift; `bun test` green including the new warn-and-ignore + overlap-gate coverage; `orchestrating-subagents` survives, both deleted names gone everywhere.
 
-- [ ] **Unit 2: Remove the runtime converter, its call sites, and the CLI convert command**
+- [x] **Unit 2: Remove the runtime converter, its call sites, and the CLI convert command**
 
 **Goal:** Delete `src/lib/converter.ts` and all runtime + CLI usage, reading bundled frontmatter directly (normalization is proven no-op on bundled data). Now safe because Unit 1 removed the only skills whose bodies needed the converter's transforms.
 
@@ -224,7 +224,7 @@ Phase 3 (convergence + assurance)
 
 **Verification:** `bun run typecheck` clean (no stale imports); `bun test` green; ESM export-shape smoke test still reports exactly `['default']`.
 
-- [ ] **Unit 3: Remove tied dead code (deprecation machinery + temperature fallback)**
+- [x] **Unit 3: Remove tied dead code (deprecation machinery + temperature fallback)**
 
 **Goal:** Delete the now-unreachable deprecation-warning path and the runtime temperature-inference fallback stranded by Units 1–2.
 
@@ -249,7 +249,7 @@ Phase 3 (convergence + assurance)
 
 **Verification:** `bun run typecheck` clean; `bun test` green; content-integrity still rejects a temperature-less agent.
 
-- [ ] **Unit 4: Delete v2 schema, emit v3 + latest, add AJV parity**
+- [x] **Unit 4: Delete v2 schema, emit v3 + latest, add AJV parity**
 
 **Goal:** On the cut, remove the frozen `docs/public/schemas/v2/` and ensure the generator emits `v3/` + `latest/` matching runtime, with an AJV parity test guarding cross-field constraints.
 
@@ -274,7 +274,7 @@ Phase 3 (convergence + assurance)
 
 **Verification:** schema drift check passes; AJV parity test green; `docs/public/schemas/v2/` absent.
 
-- [ ] **Unit 5: Committed migration guidance**
+- [x] **Unit 5: Committed migration guidance**
 
 **Goal:** Ship migration guidance in active docs (not only release notes) covering removed skills, config/profile cleanup, CLI converter removal, and the v2 pin path.
 
@@ -297,7 +297,7 @@ Phase 3 (convergence + assurance)
 
 **Verification:** `bun run docs:build` green (112+ pages); migration page reachable from active nav; narrated release notes will be reconciled against this page at cut (R12 checklist item).
 
-- [ ] **Unit 6: Isolated packaged-plugin runtime validation**
+- [x] **Unit 6: Isolated packaged-plugin runtime validation**
 
 **Goal:** Verify the packaged v3 plugin in an isolated OpenCode runtime — loads without converter, catalog exposes `orchestrating-subagents` and omits removed skills, a removed name in `disabled_skills` loads with a warning, genuinely-invalid config rejects plugin initialization (the OpenCode host catches/logs the loader failure and omits the plugin's hooks, not a process-level throw). Must load the packaged artifact, not only source-local TypeScript.
 

--- a/docs/solutions/integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md
+++ b/docs/solutions/integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md
@@ -1,6 +1,7 @@
 ---
 title: Isolate OpenCode subprocess integration fixtures
 date: 2026-05-14
+last_updated: 2026-07-13
 category: integration-issues
 module: opencode integration tests
 problem_type: integration_issue
@@ -9,10 +10,12 @@ symptoms:
   - Live OpenCode integration tests can read user-installed Systematic plugins instead of the checkout under test
   - Test runs can write sessions or state into the real project `.opencode` directory
   - Mixed installed-version behavior can happen accidentally instead of through an explicit compatibility scenario
+  - Packaged-runtime tests can exercise stale `dist` output when `npm pack` runs without an explicit build
+  - OpenCode can catch a plugin initialization failure and exit successfully, making exit code alone a false success signal
 root_cause: test_isolation
 resolution_type: test_fix
 severity: medium
-tags: [opencode, integration-tests, fixture-isolation, subprocess]
+tags: [opencode, integration-tests, fixture-isolation, subprocess, npm-pack, packaged-artifact, plugin-loader, runtime-boundary]
 ---
 
 # Isolate OpenCode subprocess integration fixtures
@@ -34,6 +37,9 @@ Live `opencode run` integration tests need to verify the current checkout, not w
 - Letting user config load implicitly creates accidental mixed-version coverage instead of a controlled compatibility test.
 - Top-level `.opencode` snapshots miss mutations inside existing directories.
 - Capturing only final prompt text cannot distinguish normal chat transforms from title-generation transforms.
+- Running `npm pack` without first building can package stale `dist` files; this repository's `prepublishOnly` script is not an `npm pack` build guarantee.
+- Loading `dist/index.js` directly does not exercise package-root resolution or prove that the expected files reached the tarball.
+- Requiring a nonzero child-process exit for invalid plugin config does not match OpenCode 1.17.18. The host catches plugin-factory failures, logs them, omits the hooks, and exits zero.
 
 ## Solution
 
@@ -68,6 +74,34 @@ function buildSourceLocalConfig(): string {
 }
 ```
 
+Add a separate packaged-artifact path when the package boundary is the behavior under test. Build explicitly, pack once for the suite, then extract the same tarball into a fresh fixture for each test:
+
+```ts
+beforeAll(() => {
+  assertSuccessful(Bun.spawnSync(['bun', 'run', 'build'], { cwd: REPO_ROOT }))
+  packedTarballPath = npmPackOnce()
+})
+
+beforeEach(() => {
+  fixture = createIsolatedFixture()
+  pluginUrl = extractPackageRootIntoFixture(fixture, packedTarballPath)
+})
+```
+
+Load the extracted package directory rather than `dist/index.js` so Node resolves the package's real `main` entry. Read runtime dependency names from the extracted `package.json`, create scoped parent directories when needed, and link those dependencies into the isolated fixture. This keeps the test offline and verifies packaged files, package metadata, and runtime loading. It does **not** verify registry dependency resolution or a clean consumer install.
+
+Prove successful registration through behavior, not just the absence of errors. The packaged-runtime fixture uses a probe plugin's `tool.definition` hook to capture the `systematic_skill` description, then asserts both surviving catalog membership and removed-name absence. It also invokes a surviving skill through the real OpenCode model path.
+
+Match failure assertions to the host contract. For OpenCode 1.17.18, invalid plugin config is caught at the plugin boundary:
+
+```ts
+expect(result.exitCode).toBe(0)
+expect(result.stderr).toContain('failed to load plugin')
+expect(result.stderr).toContain('Invalid Systematic config in')
+```
+
+Keep direct unit coverage for Systematic's own throw contract. The black-box test verifies how the pinned OpenCode host reports that failure.
+
 Keep mixed installed-version checks explicit and gated:
 
 ```ts
@@ -94,6 +128,10 @@ OpenCode subprocesses inherit their filesystem and plugin identity from environm
 
 Explicit source-local and mixed-version scenarios keep the test's claim honest. The default path verifies the checkout under test. The gated mixed-version path verifies interoperability with the globally published version only when intentionally requested.
 
+The packaged-artifact scenario closes a different gap: it validates the output of the real build-and-pack pipeline through package-root resolution. Building before packing prevents stale `dist` state from masquerading as a passing package test. Reusing one tarball controls setup cost, while per-test extraction preserves runtime isolation.
+
+OpenCode's successful process exit only describes the host process. It does not prove that a plugin factory or hook completed. Exact loader diagnostics plus positive registration probes distinguish a healthy plugin from a caught-and-logged failure. Each probe starts a fresh OpenCode process because active processes cache loaded plugin instances.
+
 ## Prevention
 
 - Treat live CLI integration tests as subprocess sandbox tests, not just command-output assertions.
@@ -102,8 +140,18 @@ Explicit source-local and mixed-version scenarios keep the test's claim honest. 
 - Redact token-like env values from failure diagnostics and test the redaction path directly.
 - Make mixed installed-version probes opt-in and fixture-scoped.
 - When guarding against project contamination, snapshot recursively and compare file contents, not just top-level entries.
+- Run the build explicitly before `npm pack`; do not infer freshness from a lifecycle script name.
+- Pack once per suite, but extract into a fresh fixture for each test.
+- Load the package root so package metadata participates in resolution.
+- Assert a positive registration marker such as `tool.definition`; process exit zero is not proof that plugin initialization succeeded.
+- Keep the offline dependency-linking boundary explicit: it validates the packed plugin, not registry installation behavior.
+- Use a fresh OpenCode process when validating a rebuilt plugin.
 
 ## Related Issues
 
 - `tests/integration/opencode.test.ts`
 - `docs/plans/2026-05-14-001-fix-isolated-opencode-integration-plan.md`
+- `docs/plans/2026-07-06-002-feat-v3-cleanup-release-plan.md`
+- `docs/solutions/integration-issues/opencode-plugin-hook-silent-defect-swallow-2026-05-19.md`
+- `docs/solutions/integration-issues/opencode-plugin-named-exports-break-loader-2026-05-11.md`
+- [PR #617: Validate the packaged v3 runtime](https://github.com/marcusrbrown/systematic/pull/617)


### PR DESCRIPTION
## Summary
- refresh the isolated OpenCode fixture learning with an explicit build-before-pack package boundary
- document OpenCode 1.17.18 catch-and-log behavior and positive hook-registration probes
- mark all six v3 cleanup plan units complete

## Verification
- `bun run docs:build`
- `git diff --check`
