### PR TITLE
feat(pi): add systematic skill tool parity

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "rimraf": "6.1.3",
         "semantic-release": "25.0.5",
         "semantic-release-export-data": "1.2.0",
+        "typebox": "1.1.38",
         "typescript": "6.0.3",
       },
       "peerDependencies": {

--- a/docs/solutions/best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md
+++ b/docs/solutions/best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md
@@ -1,0 +1,136 @@
+---
+title: Pin cross-harness adapter contracts at the boundary
+date: 2026-07-14
+category: best-practices
+module: harness-adapter-testing
+problem_type: best_practice
+component: testing_framework
+severity: medium
+applies_when:
+  - Extracting shared core logic from an existing harness adapter
+  - Exposing the same tool through multiple harness SDKs
+tags: [adapter-parity, contract-tests, shared-core, opencode, pi, testing]
+---
+
+# Pin cross-harness adapter contracts at the boundary
+
+## Context
+
+Extracting a shared core removes duplicated business logic, but shared-core tests alone do not
+prove that two harness adapters behave the same. Both adapters can agree with the helper while one
+still wraps successful output incorrectly, translates errors, or changes harness-specific side
+effects.
+
+Systematic's `systematic_skill` tool has two boundaries:
+
+- the OpenCode adapter returns the loaded skill as a string and records permission and metadata;
+- the Pi adapter returns the same string in Pi's text-content envelope.
+
+The shared core owns catalog lookup, content loading, and not-found errors. Adapter tests must
+pin what remains outside that core.
+
+## Guidance
+
+### Compare the actual adapters
+
+Instantiate both public adapters with the same real skill fixture. Invoke the OpenCode tool and the
+tool captured from Pi's `registerTool`, then compare their observable output:
+
+```ts
+const openCodeResult = await openCodeTool.execute(
+  { name: skillName },
+  openCodeContext,
+)
+// Pi requires a tool-call ID; parity is asserted on the observable result.
+const piResult = await piTool.execute(
+  'tool-call-id',
+  { name: skillName },
+  undefined,
+  undefined,
+  piContext,
+)
+
+expect(piResult.content).toEqual([
+  { type: 'text', text: openCodeResult },
+])
+expect(piResult.details.skillDir).toBe(
+  openCodeMetadataCalls[0]?.metadata.dir,
+)
+```
+
+Do the same for failure behavior. Capture each adapter's error for the same unknown skill and assert
+that the messages are identical. Comparing each adapter only with the shared core is weaker: that
+proves delegation, not adapter parity.
+
+### Characterize adapter-only side effects
+
+When shared logic moves, keep regression coverage on behavior intentionally left in the adapter.
+For OpenCode, a successful load must request the exact skill permission before publishing metadata:
+
+```ts
+expect(askCalls).toEqual([
+  {
+    permission: 'skill',
+    patterns: ['ce:plan'],
+    always: ['ce:plan'],
+    metadata: {},
+  },
+])
+
+expect(metadataCalls).toEqual([
+  {
+    title: 'Loaded skill: ce:plan',
+    metadata: { name: 'ce:plan', dir: skillDir },
+  },
+])
+```
+
+Resolution failures must happen before either side effect:
+
+```ts
+await expect(
+  tool.execute({ name: 'nonexistent' }, context),
+).rejects.toThrow('Skill "nonexistent" not found')
+
+expect(askCalls).toEqual([])
+expect(metadataCalls).toEqual([])
+```
+
+### Keep three test layers distinct
+
+| Layer | Use when | What it proves |
+|---|---|---|
+| Shared-core tests | Resolver or catalog logic changes | Core behavior only |
+| Adapter contract tests | Envelopes, errors, or adapter-only effects change | Cross-harness parity |
+| Subprocess/package tests | Installation, lifecycle, or real harness wiring changes | End-to-end harness behavior |
+
+Do not use a subprocess test to replace fast contract tests, and do not claim runtime integration
+from a fake SDK boundary. Each layer catches a different failure class.
+
+## Why This Matters
+
+A shared core is a convergence mechanism, not proof of parity. Direct adapter comparison catches
+wrong envelopes and translated errors. Side-effect characterization protects permission and metadata
+behavior that a pure resolver cannot represent. Together, these tests make later refactors safe
+without coupling the shared core to either SDK.
+
+## When to Apply
+
+- A second harness exposes an existing tool through a different result envelope.
+- Business logic moves from an adapter into a shared module.
+- One adapter performs permissions, metadata, logging, or lifecycle work outside the shared core.
+- Review claims two harnesses are equivalent based only on helper-level tests.
+
+## Examples
+
+Use this pattern for a fast unit-level contract test that pins envelope parity, while keeping real
+installation and lifecycle behavior in separate integration tests. Systematic applies it to the
+OpenCode and Pi `systematic_skill` adapters in `tests/unit/pi.test.ts` and
+`tests/unit/skill-tool.test.ts`.
+
+## Related
+
+- [Isolate OpenCode subprocess fixtures from the real installation](../integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md)
+- [OpenCode swallows plugin hook defects unless tests force invocation](../integration-issues/opencode-plugin-hook-silent-defect-swallow-2026-05-19.md)
+- [Pi harness support plan](../../plans/2026-07-06-003-feat-pi-harness-support-plan.md)
+- [Pi harness support requirements](../../brainstorms/2026-07-06-pi-harness-support-requirements.md)

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "rimraf": "6.1.3",
     "semantic-release": "25.0.5",
     "semantic-release-export-data": "1.2.0",
+    "typebox": "1.1.38",
     "typescript": "6.0.3"
   },
   "dependencies": {

--- a/src/lib/AGENTS.md
+++ b/src/lib/AGENTS.md
@@ -11,7 +11,7 @@ loadConfig() → createConfigHandler() → {
   findCommandsInDir() → loadCommandAsConfig() → OpenCode config
 }
 
-createSkillTool() → discoverSkillFiles() → loadSkill() → formatted output
+createSkillTool() → buildSkillToolDescription()/buildSkillToolParameterHint()/buildSkillContentOutput()/resolveSkill() → OpenCode tool
 getBootstrapContent() → reads using-systematic SKILL.md → system prompt
 ```
 
@@ -34,6 +34,7 @@ All discovery follows same pattern: `dir → walkDir() → find files → parseF
 | Module | Key Exports | Role |
 |--------|-------------|------|
 | `skill-loader.ts` | `loadSkill`, `LoadedSkill`, `SKILL_PREFIX` | Loads + wraps skill content in XML template |
+| `skill-resolver.ts` | `resolveSkill`, `buildSkillToolDescription`, `buildSkillToolParameterHint`, `buildSkillContentOutput`, `discoverSkillFiles` | Harness-neutral skill resolution, wrapped output, and catalog helpers shared by both adapters |
 | `validation.ts` | `isAgentMode`, `isPermissionSetting`, `normalizePermission`, `extractString`, `extractBoolean` | Agent config extraction + type guards + safe value extraction |
 
 ### Config & Integration Layer
@@ -44,7 +45,7 @@ All discovery follows same pattern: `dir → walkDir() → find files → parseF
 | `config-schema.ts` | `SystematicConfigSchema`, `validateConfig`, `SECURITY_OVERLAY_FIELDS`, `AgentOverlaySchema`, `CategoryOverlaySchema`, `BootstrapSchema` | Canonical Zod schema for user config; security field list |
 | `agent-colors.ts` | `isValidAgentColor`, `OPENCODE_AGENT_COLOR_TOKENS` | Color validator (hex or named token) + accepted token enum |
 | `config-handler.ts` | `createConfigHandler`, `ConfigHandlerDeps`, `formatAgentDescription`, `toTitleCase` | OpenCode config hook (collects + emits all assets) |
-| `skill-tool.ts` | `createSkillTool`, `SkillToolOptions` | `systematic_skill` tool (XML description, skill execution) |
+| `skill-tool.ts` | `createSkillTool`, `SkillToolOptions` | OpenCode `systematic_skill` adapter (tool wiring, permission/metadata side effects, execution bridging) |
 | `bootstrap.ts` | `getBootstrapContent`, `INTERNAL_AGENT_SIGNATURES`, `BootstrapDeps` | System prompt injection (using-systematic skill) |
 
 ## Key Types

--- a/src/lib/skill-resolver.ts
+++ b/src/lib/skill-resolver.ts
@@ -1,0 +1,170 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { buildCatalogEntries, renderCatalogCompact } from './skill-catalog.js'
+import {
+  extractSkillBody,
+  type LoadedSkill,
+  loadSkill,
+} from './skill-loader.js'
+import { findSkillsInDir } from './skills.js'
+
+/**
+ * Harness-neutral options shared by every adapter (OpenCode, Pi, ...).
+ */
+export interface SkillResolverOptions {
+  bundledSkillsDir: string
+  disabledSkills: string[]
+}
+
+function getAllSkills(options: SkillResolverOptions): LoadedSkill[] {
+  const { bundledSkillsDir, disabledSkills } = options
+  return findSkillsInDir(bundledSkillsDir)
+    .filter((s) => !disabledSkills.includes(s.name))
+    .map((skillInfo) => loadSkill(skillInfo))
+    .filter((s): s is LoadedSkill => s !== null)
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/**
+ * Resolves a requested skill name (with or without the `systematic:` prefix)
+ * against the bundled skill catalog. Throws the same not-found error text
+ * regardless of the calling harness.
+ */
+export function resolveSkill(
+  options: SkillResolverOptions,
+  requestedName: string,
+): LoadedSkill {
+  const normalizedName = requestedName.startsWith('systematic:')
+    ? requestedName.slice('systematic:'.length)
+    : requestedName
+
+  const skills = getAllSkills(options)
+  const matchedSkill = skills.find((s) => s.name === normalizedName)
+
+  if (!matchedSkill) {
+    const availableSystematic = buildCatalogEntries(options).map(
+      (s) => s.prefixedName,
+    )
+    throw new Error(
+      `Skill "${requestedName}" not found. Available systematic skills: ${availableSystematic.join(', ')}`,
+    )
+  }
+
+  return matchedSkill
+}
+
+/**
+ * Deterministic, catalog-derived tool description shared by every harness.
+ */
+export function buildSkillToolDescription(
+  options: SkillResolverOptions,
+): string {
+  const catalog = renderCatalogCompact(options)
+
+  return `Load a specialized skill that provides domain-specific instructions and workflows.
+
+When you recognize that a task matches one of the available skills listed below, use this tool to load the full skill instructions.
+
+The skill will inject detailed instructions, workflows, and access to bundled resources (scripts, references, templates) into the conversation context.
+
+Tool output includes a \`<skill_content name="...">\` block with the loaded content.
+
+${catalog}`
+}
+
+/**
+ * Deterministic, catalog-derived parameter hint shared by every harness.
+ */
+export function buildSkillToolParameterHint(
+  options: SkillResolverOptions,
+): string {
+  const entries = buildCatalogEntries(options)
+  const examples = entries
+    .slice(0, 3)
+    .map((s) => `'${s.prefixedName}'`)
+    .join(', ')
+  const hint = examples.length > 0 ? ` (e.g., ${examples}, ...)` : ''
+  return `The name of the skill from available_skills${hint}`
+}
+
+/**
+ * Builds the exact `<skill_content>`-wrapped output shared by every harness.
+ */
+export function buildSkillContentOutput(matchedSkill: LoadedSkill): {
+  output: string
+  dir: string
+} {
+  const body = extractSkillBody(matchedSkill.wrappedTemplate)
+  const dir = path.dirname(matchedSkill.skillFile)
+  const base = pathToFileURL(dir).href
+  const files = discoverSkillFiles(dir)
+
+  const lines = [
+    `<skill_content name="${matchedSkill.prefixedName}">`,
+    `# Skill: ${matchedSkill.prefixedName}`,
+    '',
+    body.trim(),
+    '',
+    `Base directory for this skill: ${base}`,
+    'Relative paths in this skill (e.g., scripts/, reference/) are relative to this base directory.',
+    'Note: file list is sampled.',
+  ]
+
+  if (files) {
+    lines.push('', '<skill_files>', files, '</skill_files>')
+  }
+
+  lines.push('</skill_content>')
+
+  return { output: lines.join('\n'), dir }
+}
+
+/**
+ * Discovers skill files in a directory and formats them as XML tags.
+ * Recursively searches subdirectories, includes hidden files, excludes .git and SKILL.md.
+ * Matches OpenCode v1.1.50 behavior exactly.
+ *
+ * @param dir - Directory path to search for skill files
+ * @param limit - Maximum number of files to return (default: 10)
+ * @returns String with absolute file paths formatted as XML tags, one per line
+ */
+export function discoverSkillFiles(dir: string, limit = 10): string {
+  const files: string[] = []
+
+  function shouldSkipDirectory(name: string): boolean {
+    return name === '.git'
+  }
+
+  function shouldIncludeFile(name: string): boolean {
+    return name !== 'SKILL.md'
+  }
+
+  function handleEntry(entry: fs.Dirent, currentDir: string): void {
+    if (entry.isDirectory()) {
+      if (!shouldSkipDirectory(entry.name)) {
+        recurse(path.resolve(currentDir, entry.name))
+      }
+    } else if (shouldIncludeFile(entry.name)) {
+      files.push(path.resolve(currentDir, entry.name))
+    }
+  }
+
+  function recurse(currentDir: string): void {
+    if (files.length >= limit) return
+
+    try {
+      const entries = fs.readdirSync(currentDir, { withFileTypes: true })
+
+      for (const entry of entries) {
+        if (files.length >= limit) break
+        handleEntry(entry, currentDir)
+      }
+    } catch {
+      // Silently ignore read errors
+    }
+  }
+
+  recurse(dir)
+  return files.map((file) => `  <file>${file}</file>`).join('\n')
+}

--- a/src/lib/skill-tool.ts
+++ b/src/lib/skill-tool.ts
@@ -1,20 +1,17 @@
-import fs from 'node:fs'
-import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import type { ToolDefinition } from '@opencode-ai/plugin'
 import { tool } from '@opencode-ai/plugin/tool'
+import { escapeXml } from './skill-catalog.js'
+import { formatSkillCommandName } from './skill-loader.js'
 import {
-  buildCatalogEntries,
-  escapeXml,
-  renderCatalogCompact,
-} from './skill-catalog.js'
-import {
-  extractSkillBody,
-  formatSkillCommandName,
-  type LoadedSkill,
-  loadSkill,
-} from './skill-loader.js'
-import { findSkillsInDir, type SkillInfo } from './skills.js'
+  buildSkillContentOutput,
+  buildSkillToolDescription,
+  buildSkillToolParameterHint,
+  resolveSkill,
+} from './skill-resolver.js'
+import type { SkillInfo } from './skills.js'
+
+export { discoverSkillFiles } from './skill-resolver.js'
 
 export interface SkillToolOptions {
   bundledSkillsDir: string
@@ -41,88 +38,13 @@ export function formatSkillsXml(skills: SkillInfo[]): string {
   return ['<available_skills>', ...skillLines, '</available_skills>'].join(' ')
 }
 
-/**
- * Discovers skill files in a directory and formats them as XML tags.
- * Recursively searches subdirectories, includes hidden files, excludes .git and SKILL.md.
- * Matches OpenCode v1.1.50 behavior exactly.
- *
- * @param dir - Directory path to search for skill files
- * @param limit - Maximum number of files to return (default: 10)
- * @returns String with absolute file paths formatted as XML tags, one per line
- */
-export function discoverSkillFiles(dir: string, limit = 10): string {
-  const files: string[] = []
-
-  function shouldSkipDirectory(name: string): boolean {
-    return name === '.git'
-  }
-
-  function shouldIncludeFile(name: string): boolean {
-    return name !== 'SKILL.md'
-  }
-
-  function handleEntry(entry: fs.Dirent, currentDir: string): void {
-    if (entry.isDirectory()) {
-      if (!shouldSkipDirectory(entry.name)) {
-        recurse(path.resolve(currentDir, entry.name))
-      }
-    } else if (shouldIncludeFile(entry.name)) {
-      files.push(path.resolve(currentDir, entry.name))
-    }
-  }
-
-  function recurse(currentDir: string): void {
-    if (files.length >= limit) return
-
-    try {
-      const entries = fs.readdirSync(currentDir, { withFileTypes: true })
-
-      for (const entry of entries) {
-        if (files.length >= limit) break
-        handleEntry(entry, currentDir)
-      }
-    } catch {
-      // Silently ignore read errors
-    }
-  }
-
-  recurse(dir)
-  return files.map((file) => `  <file>${file}</file>`).join('\n')
-}
-
 export function createSkillTool(options: SkillToolOptions): ToolDefinition {
   const { bundledSkillsDir, disabledSkills } = options
-  const getAllSkills = (): LoadedSkill[] => {
-    return findSkillsInDir(bundledSkillsDir)
-      .filter((s) => !disabledSkills.includes(s.name))
-      .map((skillInfo) => loadSkill(skillInfo))
-      .filter((s): s is LoadedSkill => s !== null)
-      .sort((a, b) => a.name.localeCompare(b.name))
-  }
+  const buildDescription = (): string =>
+    buildSkillToolDescription({ bundledSkillsDir, disabledSkills })
 
-  const buildDescription = (): string => {
-    const catalog = renderCatalogCompact({ bundledSkillsDir, disabledSkills })
-
-    return `Load a specialized skill that provides domain-specific instructions and workflows.
-
-When you recognize that a task matches one of the available skills listed below, use this tool to load the full skill instructions.
-
-The skill will inject detailed instructions, workflows, and access to bundled resources (scripts, references, templates) into the conversation context.
-
-Tool output includes a \`<skill_content name="...">\` block with the loaded content.
-
-${catalog}`
-  }
-
-  const buildParameterHint = (): string => {
-    const entries = buildCatalogEntries({ bundledSkillsDir, disabledSkills })
-    const examples = entries
-      .slice(0, 3)
-      .map((s) => `'${s.prefixedName}'`)
-      .join(', ')
-    const hint = examples.length > 0 ? ` (e.g., ${examples}, ...)` : ''
-    return `The name of the skill from available_skills${hint}`
-  }
+  const buildParameterHint = (): string =>
+    buildSkillToolParameterHint({ bundledSkillsDir, disabledSkills })
 
   let cachedDescription: string | null = null
   let cachedParameterHint: string | null = null
@@ -147,27 +69,12 @@ ${catalog}`
     async execute(args: { name: string }, context): Promise<string> {
       const requestedName = args.name
 
-      const normalizedName = requestedName.startsWith('systematic:')
-        ? requestedName.slice('systematic:'.length)
-        : requestedName
+      const matchedSkill = resolveSkill(
+        { bundledSkillsDir, disabledSkills },
+        requestedName,
+      )
 
-      const skills = getAllSkills()
-      const matchedSkill = skills.find((s) => s.name === normalizedName)
-
-      if (!matchedSkill) {
-        const availableSystematic = buildCatalogEntries({
-          bundledSkillsDir,
-          disabledSkills,
-        }).map((s) => s.prefixedName)
-        throw new Error(
-          `Skill "${requestedName}" not found. Available systematic skills: ${availableSystematic.join(', ')}`,
-        )
-      }
-
-      const body = extractSkillBody(matchedSkill.wrappedTemplate)
-      const dir = path.dirname(matchedSkill.skillFile)
-      const base = pathToFileURL(dir).href
-      const files = discoverSkillFiles(dir)
+      const { output, dir } = buildSkillContentOutput(matchedSkill)
 
       await context.ask({
         permission: 'skill',
@@ -184,23 +91,7 @@ ${catalog}`
         },
       })
 
-      const output = [
-        `<skill_content name="${matchedSkill.prefixedName}">`,
-        `# Skill: ${matchedSkill.prefixedName}`,
-        '',
-        body.trim(),
-        '',
-        `Base directory for this skill: ${base}`,
-        'Relative paths in this skill (e.g., scripts/, reference/) are relative to this base directory.',
-        'Note: file list is sampled.',
-      ]
-
-      if (files) {
-        output.push('', '<skill_files>', files, '</skill_files>')
-      }
-
-      output.push('</skill_content>')
-      return output.join('\n')
+      return output
     },
   })
 }

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -1,4 +1,42 @@
 // Pi coding-agent extension entry point (built to dist/pi.js via pi.extensions manifest).
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
+import { Type } from 'typebox'
+import {
+  buildSkillContentOutput,
+  buildSkillToolDescription,
+  buildSkillToolParameterHint,
+  resolveSkill,
+} from './lib/skill-resolver.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const packageRoot = path.resolve(__dirname, '..')
+const bundledSkillsDir = path.join(packageRoot, 'skills')
+
 export default async function systematicPiExtension(
-  _pi: unknown,
-): Promise<void> {}
+  pi: ExtensionAPI,
+): Promise<void> {
+  const disabledSkills: string[] = []
+  const resolverOptions = { bundledSkillsDir, disabledSkills }
+
+  pi.registerTool({
+    name: 'systematic_skill',
+    label: 'Systematic Skill',
+    description: buildSkillToolDescription(resolverOptions),
+    parameters: Type.Object({
+      name: Type.String({
+        description: buildSkillToolParameterHint(resolverOptions),
+      }),
+    }),
+    async execute(_toolCallId, params) {
+      const matchedSkill = resolveSkill(resolverOptions, params.name)
+      const { output, dir } = buildSkillContentOutput(matchedSkill)
+
+      return {
+        content: [{ type: 'text', text: output }],
+        details: { skillDir: dir },
+      }
+    },
+  })
+}

--- a/tests/unit/pi.test.ts
+++ b/tests/unit/pi.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from 'bun:test'
+import { fileURLToPath } from 'node:url'
+import type {
+  AgentToolResult,
+  ExtensionAPI,
+  ToolDefinition,
+} from '@earendil-works/pi-coding-agent'
+import {
+  buildSkillContentOutput,
+  buildSkillToolDescription,
+  buildSkillToolParameterHint,
+  resolveSkill,
+} from '../../src/lib/skill-resolver.ts'
+import piExtension from '../../src/pi.ts'
+
+const bundledSkillsDir = fileURLToPath(new URL('../../skills', import.meta.url))
+const resolverOptions = { bundledSkillsDir, disabledSkills: [] }
+
+interface RegisterToolSpy {
+  registeredTools: ToolDefinition[]
+}
+
+/** Captures registerTool() calls; other ExtensionAPI members are unused. */
+function createFakeExtensionApi(): ExtensionAPI & RegisterToolSpy {
+  const registeredTools: ToolDefinition[] = []
+  const fake = {
+    registeredTools,
+    registerTool(tool: ToolDefinition) {
+      registeredTools.push(tool)
+    },
+  }
+  return fake as unknown as ExtensionAPI & RegisterToolSpy
+}
+
+describe('src/pi.ts systematic_skill tool registration', () => {
+  test('registers exactly one tool named systematic_skill with expected label and catalog-derived description', async () => {
+    const api = createFakeExtensionApi()
+
+    await piExtension(api)
+
+    expect(api.registeredTools).toHaveLength(1)
+    const [registered] = api.registeredTools
+    expect(registered.name).toBe('systematic_skill')
+    expect(registered.label).toBe('Systematic Skill')
+    expect(registered.description).toBe(
+      buildSkillToolDescription(resolverOptions),
+    )
+  })
+
+  test('parameters schema exposes the exact shared parameter hint on the name property', async () => {
+    const api = createFakeExtensionApi()
+
+    await piExtension(api)
+
+    const [registered] = api.registeredTools
+    const schema = registered.parameters as unknown as {
+      type: string
+      required: string[]
+      properties: { name: { type: string; description: string } }
+    }
+
+    expect(schema.type).toBe('object')
+    expect(schema.required).toEqual(['name'])
+    expect(schema.properties.name.type).toBe('string')
+    expect(schema.properties.name.description).toBe(
+      buildSkillToolParameterHint(resolverOptions),
+    )
+  })
+
+  test('execute returns Pi text content byte-identical to the shared skill content output', async () => {
+    const api = createFakeExtensionApi()
+    await piExtension(api)
+    const [registered] = api.registeredTools
+
+    const expectedSkill = resolveSkill(resolverOptions, 'ce:plan')
+    const expected = buildSkillContentOutput(expectedSkill)
+
+    const result = (await registered.execute(
+      'test-tool-call-id',
+      { name: 'ce:plan' },
+      undefined,
+      undefined,
+      {} as unknown as Parameters<ToolDefinition['execute']>[4],
+    )) as AgentToolResult<{ skillDir: string }>
+
+    expect(result.content).toEqual([{ type: 'text', text: expected.output }])
+    expect(result.details.skillDir).toBe(expected.dir)
+  })
+
+  test('execute throws the exact shared not-found error text for an unknown skill name', async () => {
+    const api = createFakeExtensionApi()
+    await piExtension(api)
+    const [registered] = api.registeredTools
+
+    let thrown: unknown
+    try {
+      await registered.execute(
+        'test-tool-call-id',
+        { name: 'nonexistent' },
+        undefined,
+        undefined,
+        {} as unknown as Parameters<ToolDefinition['execute']>[4],
+      )
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect((thrown as Error).message).toBe(
+      (() => {
+        try {
+          resolveSkill(resolverOptions, 'nonexistent')
+          throw new Error('resolveSkill unexpectedly succeeded')
+        } catch (error) {
+          return (error as Error).message
+        }
+      })(),
+    )
+  })
+})

--- a/tests/unit/pi.test.ts
+++ b/tests/unit/pi.test.ts
@@ -11,6 +11,7 @@ import {
   buildSkillToolParameterHint,
   resolveSkill,
 } from '../../src/lib/skill-resolver.ts'
+import { createSkillTool } from '../../src/lib/skill-tool.ts'
 import piExtension from '../../src/pi.ts'
 
 const bundledSkillsDir = fileURLToPath(new URL('../../skills', import.meta.url))
@@ -116,5 +117,80 @@ describe('src/pi.ts systematic_skill tool registration', () => {
         }
       })(),
     )
+  })
+
+  test('Pi and OpenCode adapters return the same wrapped success content and not-found error text for the same real skill fixture', async () => {
+    const api = createFakeExtensionApi()
+    await piExtension(api)
+    const [piTool] = api.registeredTools
+    const openCodeTool = createSkillTool({
+      bundledSkillsDir,
+      disabledSkills: [],
+    })
+
+    const metadataCalls: Array<{
+      title: string
+      metadata: { name: string; dir: string }
+    }> = []
+    const openCodeContext = {
+      ask: async () => {},
+      metadata: (payload: {
+        title: string
+        metadata: { name: string; dir: string }
+      }) => {
+        metadataCalls.push(payload)
+      },
+    } as never
+
+    const skillName = 'ce:plan'
+    const openCodeResult = await openCodeTool.execute(
+      { name: skillName },
+      openCodeContext,
+    )
+    const piResult = (await piTool.execute(
+      'test-tool-call-id',
+      { name: skillName },
+      undefined,
+      undefined,
+      {} as unknown as Parameters<ToolDefinition['execute']>[4],
+    )) as AgentToolResult<{ skillDir: string }>
+
+    expect(piResult.content).toEqual([{ type: 'text', text: openCodeResult }])
+    expect(metadataCalls).toEqual([
+      {
+        title: 'Loaded skill: ce:plan',
+        metadata: {
+          name: 'ce:plan',
+          dir: expect.any(String),
+        },
+      },
+    ])
+    expect(piResult.details.skillDir).toBe(metadataCalls[0]?.metadata.dir)
+
+    const unknownName = '__missing_skill__'
+    const openCodeError = await (async () => {
+      try {
+        await openCodeTool.execute({ name: unknownName }, openCodeContext)
+        throw new Error('openCodeTool.execute unexpectedly succeeded')
+      } catch (error) {
+        return (error as Error).message
+      }
+    })()
+    const piError = await (async () => {
+      try {
+        await piTool.execute(
+          'test-tool-call-id',
+          { name: unknownName },
+          undefined,
+          undefined,
+          {} as unknown as Parameters<ToolDefinition['execute']>[4],
+        )
+        throw new Error('piTool.execute unexpectedly succeeded')
+      } catch (error) {
+        return (error as Error).message
+      }
+    })()
+
+    expect(piError).toBe(openCodeError)
   })
 })

--- a/tests/unit/skill-resolver.test.ts
+++ b/tests/unit/skill-resolver.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  buildSkillContentOutput,
+  buildSkillToolDescription,
+  buildSkillToolParameterHint,
+  resolveSkill,
+} from '../../src/lib/skill-resolver.ts'
+
+function makeSkillsDir(): string {
+  const testDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'systematic-skill-resolver-test-'),
+  )
+  const skillDir = path.join(testDir, 'load-test')
+  fs.mkdirSync(skillDir)
+  fs.writeFileSync(
+    path.join(skillDir, 'SKILL.md'),
+    `---
+name: load-test
+description: Skill for loading test
+---
+# Load Test Skill
+
+This is the skill content.`,
+  )
+  return testDir
+}
+
+describe('skill-resolver (harness-neutral core)', () => {
+  test('resolveSkill returns the matched skill for a prefixed name', () => {
+    const testDir = makeSkillsDir()
+    try {
+      const skill = resolveSkill(
+        { bundledSkillsDir: testDir, disabledSkills: [] },
+        'systematic:load-test',
+      )
+      expect(skill.name).toBe('load-test')
+      expect(skill.prefixedName).toBe('systematic:load-test')
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  test('resolveSkill throws byte-identical not-found error text', () => {
+    const testDir = makeSkillsDir()
+    try {
+      expect(() =>
+        resolveSkill(
+          { bundledSkillsDir: testDir, disabledSkills: [] },
+          'nonexistent',
+        ),
+      ).toThrow(
+        'Skill "nonexistent" not found. Available systematic skills: systematic:load-test',
+      )
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  test('buildSkillToolDescription matches catalog-derived description', () => {
+    const testDir = makeSkillsDir()
+    try {
+      const description = buildSkillToolDescription({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+      expect(description).toContain('systematic:load-test')
+      expect(description).toContain('Skill for loading test')
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  test('buildSkillToolParameterHint includes example skill names', () => {
+    const testDir = makeSkillsDir()
+    try {
+      const hint = buildSkillToolParameterHint({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+      expect(hint).toContain('The name of the skill from available_skills')
+      expect(hint).toContain("'systematic:load-test'")
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  test('buildSkillContentOutput wraps skill content and reports skillDir', () => {
+    const testDir = makeSkillsDir()
+    try {
+      const skill = resolveSkill(
+        { bundledSkillsDir: testDir, disabledSkills: [] },
+        'load-test',
+      )
+      const { output, dir } = buildSkillContentOutput(skill)
+
+      expect(dir).toBe(path.join(testDir, 'load-test'))
+      expect(output).toStartWith('<skill_content name="systematic:load-test">')
+      expect(output).toContain('# Skill: systematic:load-test')
+      expect(output).toContain('# Load Test Skill')
+      expect(output).toContain('This is the skill content.')
+      expect(output).toContain(`Base directory for this skill: file://${dir}`)
+      expect(output).toEndWith('</skill_content>')
+      // No extra files beyond SKILL.md in this fixture: no <skill_files> block.
+      expect(output).not.toContain('<skill_files>')
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/unit/skill-tool.test.ts
+++ b/tests/unit/skill-tool.test.ts
@@ -373,11 +373,39 @@ description: Test CE skill
         disabledSkills: [],
       })
 
-      const result = await tool.execute({ name: 'ce:plan' }, mockContext)
+      const askCalls: unknown[] = []
+      const metadataCalls: unknown[] = []
+      const context = {
+        ask: async (payload: unknown) => {
+          askCalls.push(payload)
+        },
+        metadata: (payload: unknown) => {
+          metadataCalls.push(payload)
+        },
+      } as never
+
+      const result = await tool.execute({ name: 'ce:plan' }, context)
 
       expect(result).toContain('ce:plan')
       expect(result).toContain('# CE Plan Content')
       expect(result).not.toContain('systematic:ce:plan')
+      expect(askCalls).toEqual([
+        {
+          permission: 'skill',
+          patterns: ['ce:plan'],
+          always: ['ce:plan'],
+          metadata: {},
+        },
+      ])
+      expect(metadataCalls).toEqual([
+        {
+          title: 'Loaded skill: ce:plan',
+          metadata: {
+            name: 'ce:plan',
+            dir: skillDir,
+          },
+        },
+      ])
     })
 
     test('throws error when skill not found', async () => {
@@ -389,6 +417,31 @@ description: Test CE skill
       await expect(
         tool.execute({ name: 'nonexistent' }, mockContext),
       ).rejects.toThrow('Skill "nonexistent" not found')
+    })
+
+    test('does not call ask or metadata when skill not found', async () => {
+      const tool = createSkillTool({
+        bundledSkillsDir: testDir,
+        disabledSkills: [],
+      })
+
+      const askCalls: unknown[] = []
+      const metadataCalls: unknown[] = []
+      const context = {
+        ask: async (payload: unknown) => {
+          askCalls.push(payload)
+        },
+        metadata: (payload: unknown) => {
+          metadataCalls.push(payload)
+        },
+      } as never
+
+      await expect(
+        tool.execute({ name: 'nonexistent' }, context),
+      ).rejects.toThrow('Skill "nonexistent" not found')
+
+      expect(askCalls).toEqual([])
+      expect(metadataCalls).toEqual([])
     })
 
     test('strips frontmatter from loaded skill content', async () => {


### PR DESCRIPTION
## Summary

- extract harness-neutral skill catalog, resolution, description, and content helpers
- register `systematic_skill` from the Pi extension with TypeBox-native parameters and Pi result envelopes
- preserve OpenCode permission and metadata behavior while pinning direct adapter output/error parity
- document the boundary-contract testing pattern separately from subprocess/package integration

## Verification

- `bun test tests/unit/pi.test.ts tests/unit/skill-tool.test.ts`
- `bun test tests/unit/skill-resolver.test.ts tests/unit/skill-tool.test.ts tests/unit/skill-catalog.test.ts tests/unit/pi.test.ts tests/unit/package-exports.test.ts`
- `bun run typecheck`
- `bunx biome check src/pi.ts src/lib/skill-resolver.ts src/lib/skill-tool.ts tests/unit/pi.test.ts tests/unit/skill-resolver.test.ts tests/unit/skill-tool.test.ts package.json`
- `bun scripts/content-integrity.ts`
- `bun run docs:build`