### PR TITLE
feat(pi): inject Systematic bootstrap prompt

### DIFF
--- a/docs/solutions/logic-errors/pi-chained-bootstrap-composition-2026-07-14.md
+++ b/docs/solutions/logic-errors/pi-chained-bootstrap-composition-2026-07-14.md
@@ -1,0 +1,120 @@
+---
+title: Preserve foreign content when composing a chained bootstrap prompt
+date: 2026-07-14
+category: logic-errors
+module: pi-harness-bootstrap
+problem_type: logic_error
+component: tooling
+symptoms:
+  - Earlier extension text containing a Systematic marker example is silently deleted
+  - The Pi prompt tells agents to call an OpenCode-only skill tool
+  - Bootstrap loading failure disables injection without an operator-visible diagnostic
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags: [pi-harness, bootstrap-injection, prompt-composition, idempotency, adapter-parity, graceful-degradation]
+---
+
+# Preserve foreign content when composing a chained bootstrap prompt
+
+## Problem
+
+Pi's `before_agent_start` hook receives one system-prompt string containing contributions from earlier extensions. Reusing OpenCode's marker-scrubbing mutator against that string treated foreign text as Systematic-owned content, while also carrying OpenCode-specific tool instructions and silent failure behavior into Pi.
+
+## Symptoms
+
+- An earlier contribution containing a literal `<SYSTEMATIC_WORKFLOWS>...</SYSTEMATIC_WORKFLOWS>` example disappears.
+- The injected prompt tells Pi agents to use a generic `skill` tool that Pi does not register; Pi exposes skills through its native prompt/read workflow instead.
+- Unreadable or malformed bootstrap content can disable injection without telling the operator why.
+
+## What Didn't Work
+
+The first composition helper wrapped Pi's chained string in a synthetic OpenCode-shaped array and called `applyBootstrapContent`:
+
+```typescript
+const output = { system: [existingSystemPrompt] }
+applyBootstrapContent(output, bootstrapContent)
+return output.system[0]
+```
+
+`applyBootstrapContent` removes every complete Systematic marker block before appending the current snapshot. That is useful for reconciling Systematic's prior OpenCode registrations, but it is too broad for a string that already contains arbitrary text from other Pi extensions.
+
+## Solution
+
+### Deduplicate only the exact owned snapshot
+
+Pi composition now compares against the bootstrap content computed by this extension. It never scans or removes marker-shaped text from earlier contributions:
+
+```typescript
+export function composeSystemPromptWithBootstrap(
+  existingSystemPrompt: string,
+  bootstrapContent: string | null,
+): string | null {
+  if (bootstrapContent === null) return null
+
+  if (
+    existingSystemPrompt === bootstrapContent ||
+    existingSystemPrompt.endsWith(`\n\n${bootstrapContent}`)
+  ) {
+    return existingSystemPrompt
+  }
+
+  return existingSystemPrompt.length > 0
+    ? `${existingSystemPrompt}\n\n${bootstrapContent}`
+    : bootstrapContent
+}
+```
+
+OpenCode continues using `applyBootstrapContent`; the adapters intentionally use different composition strategies because their host ownership models differ.
+
+### Inject harness-specific usage text
+
+`BootstrapDeps` accepts an optional `usageTemplate`. OpenCode omits it and retains the existing bytes; Pi supplies instructions matching Pi's native skill workflow:
+
+```typescript
+const PI_BOOTSTRAP_USAGE_TEMPLATE = `**Skills usage:**
+- Use \`systematic_skill\` for Systematic skills.
+- For non-Systematic skills, follow Pi's native skill instructions and read the listed SKILL.md path.`
+```
+
+This keeps the shared bootstrap loader while moving harness vocabulary to the adapter that owns it.
+
+### Separate safe computation from diagnostics
+
+`computeBootstrapContentSafe` returns `null` when bootstrap computation fails and accepts a best-effort reporter for thrown errors. Reporter failure is also caught, so diagnostics cannot turn graceful degradation into startup failure. Pi writes one constant line to stderr for thrown computation failures rather than putting operator-facing errors into the model's prompt.
+
+The Pi handler translates `null` to `undefined`:
+
+```typescript
+pi.on('before_agent_start', (event) => {
+  const systemPrompt = composeSystemPromptWithBootstrap(
+    event.systemPrompt,
+    bootstrapContent,
+  )
+  if (systemPrompt === null) return undefined
+  return { systemPrompt }
+})
+```
+
+Pi only replaces the current prompt when a handler result includes `systemPrompt`; returning `undefined` leaves the prompt produced by earlier handlers unchanged.
+
+## Why This Works
+
+A sentinel pattern identifies syntax, not authorship; foreign content can legitimately contain the same bytes. Exact comparison against the adapter's own snapshot provides idempotency without claiming ownership of the rest of the chain. Injected harness vocabulary keeps shared content loading without pretending host tools are portable, while the guarded reporter separates operator diagnostics from agent instructions.
+
+## Prevention
+
+- Derive idempotency from the host's composition and ownership model before reusing a mutator from another adapter.
+- Preserve an earlier marker example byte-for-byte in a regression test.
+- Assert idempotency at the composition-helper level, and add a real registered-handler double-run test if handler-level chaining semantics change.
+- Assert Pi output contains Pi-native skill instructions and excludes OpenCode-only tool language.
+- Force bootstrap loading to throw; assert one stderr diagnostic and successful extension registration.
+- Keep OpenCode bootstrap output pinned so Pi dependency injection cannot drift its default text.
+
+## Related Issues
+
+- [Cross-harness adapter parity contract tests](../best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md)
+- [OpenCode plugin factory duplicate registration](../integration-issues/opencode-plugin-factory-duplicate-registration-2026-05-04.md)
+- [OpenCode plugin hook silent defect swallowing](../integration-issues/opencode-plugin-hook-silent-defect-swallow-2026-05-19.md)
+
+Pi currently computes this bootstrap from Systematic's default configuration. A Pi-native config namespace and precedence policy remain a separate architecture decision; do not read `.opencode` configuration implicitly from Pi.

--- a/src/lib/AGENTS.md
+++ b/src/lib/AGENTS.md
@@ -46,7 +46,7 @@ All discovery follows same pattern: `dir → walkDir() → find files → parseF
 | `agent-colors.ts` | `isValidAgentColor`, `OPENCODE_AGENT_COLOR_TOKENS` | Color validator (hex or named token) + accepted token enum |
 | `config-handler.ts` | `createConfigHandler`, `ConfigHandlerDeps`, `formatAgentDescription`, `toTitleCase` | OpenCode config hook (collects + emits all assets) |
 | `skill-tool.ts` | `createSkillTool`, `SkillToolOptions` | OpenCode `systematic_skill` adapter (tool wiring, permission/metadata side effects, execution bridging) |
-| `bootstrap.ts` | `getBootstrapContent`, `INTERNAL_AGENT_SIGNATURES`, `BootstrapDeps` | System prompt injection (using-systematic skill) |
+| `bootstrap.ts` | `getBootstrapContent`, `applyBootstrapContent`, `computeBootstrapContentSafe`, `composeSystemPromptWithBootstrap`, `INTERNAL_AGENT_SIGNATURES`, `BootstrapDeps` | System prompt injection (using-systematic skill); harness-neutral safe-compute/compose helpers reused by Pi's `before_agent_start` |
 
 ## Key Types
 

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { DEFAULT_CONFIG, type SystematicConfig } from './config.js'
+import type { SystematicConfig } from './config.js'
 import { parseFrontmatter } from './frontmatter.js'
 import { renderCatalogVerbose } from './skill-catalog.js'
 
@@ -110,13 +110,23 @@ export interface BootstrapDeps {
   usageTemplate?: string
 }
 
+type BootstrapContentConfig = Pick<
+  SystematicConfig,
+  'bootstrap' | 'disabled_skills'
+>
+
+const DEFAULT_BOOTSTRAP_CONFIG: BootstrapContentConfig = {
+  bootstrap: { enabled: true },
+  disabled_skills: [],
+}
+
 /** Safely computes default bootstrap content, returning null instead of throwing. */
 export function computeBootstrapContentSafe(
   deps: BootstrapDeps,
   reportError?: (error: unknown) => void,
 ): string | null {
   try {
-    return getBootstrapContent(DEFAULT_CONFIG, deps)
+    return getBootstrapContent(DEFAULT_BOOTSTRAP_CONFIG, deps)
   } catch (error) {
     if (reportError !== undefined) {
       try {
@@ -163,7 +173,7 @@ Bundled skills ship with the Systematic plugin and are discoverable via \`system
 }
 
 export function getBootstrapContent(
-  config: SystematicConfig,
+  config: BootstrapContentConfig,
   deps: BootstrapDeps,
 ): string | null {
   const { bundledSkillsDir, usageTemplate } = deps

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import type { SystematicConfig } from './config.js'
+import { DEFAULT_CONFIG, type SystematicConfig } from './config.js'
 import { parseFrontmatter } from './frontmatter.js'
 import { renderCatalogVerbose } from './skill-catalog.js'
 
@@ -107,6 +107,29 @@ export const applyBootstrapContent = (
 
 export interface BootstrapDeps {
   bundledSkillsDir: string
+}
+
+/** Safely computes default bootstrap content, returning null instead of throwing. */
+export function computeBootstrapContentSafe(
+  deps: BootstrapDeps,
+): string | null {
+  try {
+    return getBootstrapContent(DEFAULT_CONFIG, deps)
+  } catch {
+    return null
+  }
+}
+
+/** Composes an existing system prompt with nullable bootstrap content; returns null when bootstrapContent is null. */
+export function composeSystemPromptWithBootstrap(
+  existingSystemPrompt: string,
+  bootstrapContent: string | null,
+): string | null {
+  if (bootstrapContent === null) return null
+
+  const output = { system: [existingSystemPrompt] }
+  applyBootstrapContent(output, bootstrapContent)
+  return output.system[0]
 }
 
 function getSkillUsageTemplate(): string {

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -107,15 +107,24 @@ export const applyBootstrapContent = (
 
 export interface BootstrapDeps {
   bundledSkillsDir: string
+  usageTemplate?: string
 }
 
 /** Safely computes default bootstrap content, returning null instead of throwing. */
 export function computeBootstrapContentSafe(
   deps: BootstrapDeps,
+  reportError?: (error: unknown) => void,
 ): string | null {
   try {
     return getBootstrapContent(DEFAULT_CONFIG, deps)
-  } catch {
+  } catch (error) {
+    if (reportError !== undefined) {
+      try {
+        reportError(error)
+      } catch {
+        // Ignore reporter failures so startup stays non-blocking.
+      }
+    }
     return null
   }
 }
@@ -127,9 +136,16 @@ export function composeSystemPromptWithBootstrap(
 ): string | null {
   if (bootstrapContent === null) return null
 
-  const output = { system: [existingSystemPrompt] }
-  applyBootstrapContent(output, bootstrapContent)
-  return output.system[0]
+  if (
+    existingSystemPrompt === bootstrapContent ||
+    existingSystemPrompt.endsWith(`\n\n${bootstrapContent}`)
+  ) {
+    return existingSystemPrompt
+  }
+
+  return existingSystemPrompt.length > 0
+    ? `${existingSystemPrompt}\n\n${bootstrapContent}`
+    : bootstrapContent
 }
 
 function getSkillUsageTemplate(): string {
@@ -150,7 +166,7 @@ export function getBootstrapContent(
   config: SystematicConfig,
   deps: BootstrapDeps,
 ): string | null {
-  const { bundledSkillsDir } = deps
+  const { bundledSkillsDir, usageTemplate } = deps
 
   if (!config.bootstrap.enabled) return null
 
@@ -172,7 +188,7 @@ export function getBootstrapContent(
   const fullContent = fs.readFileSync(usingSystematicPath, 'utf8')
   const { body } = parseFrontmatter(fullContent)
   const content = body.trim()
-  const skillUsage = getSkillUsageTemplate()
+  const skillUsage = usageTemplate ?? getSkillUsageTemplate()
   const catalog = renderCatalogVerbose({
     bundledSkillsDir,
     disabledSkills: config.disabled_skills,

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -1,8 +1,16 @@
 // Pi coding-agent extension entry point (built to dist/pi.js via pi.extensions manifest).
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
+import type {
+  BeforeAgentStartEvent,
+  BeforeAgentStartEventResult,
+  ExtensionAPI,
+} from '@earendil-works/pi-coding-agent'
 import { Type } from 'typebox'
+import {
+  composeSystemPromptWithBootstrap,
+  computeBootstrapContentSafe,
+} from './lib/bootstrap.js'
 import {
   buildSkillContentOutput,
   buildSkillToolDescription,
@@ -19,6 +27,21 @@ export default async function systematicPiExtension(
 ): Promise<void> {
   const disabledSkills: string[] = []
   const resolverOptions = { bundledSkillsDir, disabledSkills }
+
+  // Match OpenCode's process-lifetime bootstrap snapshot.
+  const bootstrapContent = computeBootstrapContentSafe({ bundledSkillsDir })
+
+  pi.on(
+    'before_agent_start',
+    (event: BeforeAgentStartEvent): BeforeAgentStartEventResult | undefined => {
+      const systemPrompt = composeSystemPromptWithBootstrap(
+        event.systemPrompt,
+        bootstrapContent,
+      )
+      if (systemPrompt === null) return undefined
+      return { systemPrompt }
+    },
+  )
 
   pi.registerTool({
     name: 'systematic_skill',

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -21,6 +21,15 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const packageRoot = path.resolve(__dirname, '..')
 const bundledSkillsDir = path.join(packageRoot, 'skills')
+const PI_BOOTSTRAP_USAGE_TEMPLATE = `**Skills usage:**
+- Use \`systematic_skill\` for Systematic skills.
+- For non-Systematic skills, follow Pi's native skill instructions and read the listed SKILL.md path.`
+
+const reportPiBootstrapFailure = (): void => {
+  process.stderr.write(
+    '[systematic] Failed to compute Pi bootstrap; continuing without injection.\n',
+  )
+}
 
 export default async function systematicPiExtension(
   pi: ExtensionAPI,
@@ -29,7 +38,13 @@ export default async function systematicPiExtension(
   const resolverOptions = { bundledSkillsDir, disabledSkills }
 
   // Match OpenCode's process-lifetime bootstrap snapshot.
-  const bootstrapContent = computeBootstrapContentSafe({ bundledSkillsDir })
+  const bootstrapContent = computeBootstrapContentSafe(
+    {
+      bundledSkillsDir,
+      usageTemplate: PI_BOOTSTRAP_USAGE_TEMPLATE,
+    },
+    reportPiBootstrapFailure,
+  )
 
   pi.on(
     'before_agent_start',

--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -4,6 +4,8 @@ import os from 'node:os'
 import path from 'node:path'
 import {
   applyBootstrapContent,
+  composeSystemPromptWithBootstrap,
+  computeBootstrapContentSafe,
   getBootstrapContent,
   INTERNAL_AGENT_SIGNATURES,
 } from '../../src/lib/bootstrap.ts'
@@ -529,5 +531,119 @@ describe('INTERNAL_AGENT_SIGNATURES skip heuristic', () => {
       'Generate layout recommendations.',
     ]
     expect(shouldSkipBootstrap(legitimate)).toBe(true)
+  })
+})
+
+describe('computeBootstrapContentSafe', () => {
+  let testDir: string
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'systematic-bootstrap-safe-'),
+    )
+  })
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true })
+  })
+
+  function makeBundledSkillsDir(usingSystematicBody?: string): string {
+    const bundledSkillsDir = path.join(testDir, 'skills')
+    fs.mkdirSync(bundledSkillsDir, { recursive: true })
+    if (usingSystematicBody !== undefined) {
+      fs.mkdirSync(path.join(bundledSkillsDir, 'using-systematic'))
+      fs.writeFileSync(
+        path.join(bundledSkillsDir, 'using-systematic', 'SKILL.md'),
+        usingSystematicBody,
+      )
+    }
+    return bundledSkillsDir
+  }
+
+  test('returns bootstrap content string for a valid bundled skills dir', () => {
+    const bundledSkillsDir = makeBundledSkillsDir(
+      '---\nname: using-systematic\n---\nBody content.',
+    )
+    const content = computeBootstrapContentSafe({ bundledSkillsDir })
+    expect(content).not.toBeNull()
+    expect(content).toContain('<SYSTEMATIC_WORKFLOWS>')
+    expect(content).toContain('Body content.')
+  })
+
+  test('returns null (not throws) when using-systematic/SKILL.md is missing', () => {
+    const bundledSkillsDir = makeBundledSkillsDir() // no SKILL.md
+    expect(() =>
+      computeBootstrapContentSafe({ bundledSkillsDir }),
+    ).not.toThrow()
+    expect(computeBootstrapContentSafe({ bundledSkillsDir })).toBeNull()
+  })
+
+  test('returns null (not throws) when bundledSkillsDir itself does not exist', () => {
+    const missingDir = path.join(testDir, 'does-not-exist')
+    expect(() =>
+      computeBootstrapContentSafe({ bundledSkillsDir: missingDir }),
+    ).not.toThrow()
+    expect(
+      computeBootstrapContentSafe({ bundledSkillsDir: missingDir }),
+    ).toBeNull()
+  })
+
+  test('returns null (not throws) for a malformed/unreadable using-systematic SKILL.md fixture', () => {
+    // Real temp-dir fixture: create using-systematic as a directory named
+    // SKILL.md instead of a file, so fs.readFileSync throws EISDIR.
+    const bundledSkillsDir = path.join(testDir, 'skills')
+    fs.mkdirSync(path.join(bundledSkillsDir, 'using-systematic'), {
+      recursive: true,
+    })
+    fs.mkdirSync(path.join(bundledSkillsDir, 'using-systematic', 'SKILL.md'), {
+      recursive: true,
+    })
+    expect(() =>
+      computeBootstrapContentSafe({ bundledSkillsDir }),
+    ).not.toThrow()
+    expect(computeBootstrapContentSafe({ bundledSkillsDir })).toBeNull()
+  })
+})
+
+describe('composeSystemPromptWithBootstrap', () => {
+  test('appends bootstrap content after an existing system prompt contribution', () => {
+    const existing = 'You are a primary agent. Earlier extension contribution.'
+    const bootstrap = '<SYSTEMATIC_WORKFLOWS>\nContent\n</SYSTEMATIC_WORKFLOWS>'
+
+    const result = composeSystemPromptWithBootstrap(existing, bootstrap)
+
+    expect(result).not.toBeNull()
+    const resultStr = result as string
+    expect(resultStr.indexOf(existing)).toBe(0)
+    expect(resultStr.indexOf('<SYSTEMATIC_WORKFLOWS>')).toBeGreaterThan(
+      resultStr.indexOf(existing),
+    )
+  })
+
+  test('handles an empty existing prompt by using bootstrap content alone', () => {
+    const bootstrap = '<SYSTEMATIC_WORKFLOWS>\nContent\n</SYSTEMATIC_WORKFLOWS>'
+    const result = composeSystemPromptWithBootstrap('', bootstrap)
+    expect(result).toBe(bootstrap)
+  })
+
+  test('avoids duplicate <SYSTEMATIC_WORKFLOWS> blocks when the prompt already has one', () => {
+    const existing =
+      'Earlier.\n\n<SYSTEMATIC_WORKFLOWS>\nOld\n</SYSTEMATIC_WORKFLOWS>'
+    const bootstrap = '<SYSTEMATIC_WORKFLOWS>\nNew\n</SYSTEMATIC_WORKFLOWS>'
+
+    const result = composeSystemPromptWithBootstrap(existing, bootstrap)
+
+    expect(result).not.toBeNull()
+    const resultStr = result as string
+    const occurrences = resultStr.split('<SYSTEMATIC_WORKFLOWS>').length - 1
+    expect(occurrences).toBe(1)
+    expect(resultStr).toContain('New')
+    expect(resultStr).not.toContain('Old')
+  })
+
+  test('returns the existing prompt unchanged when bootstrap content is null', () => {
+    const existing = 'You are a primary agent. Earlier extension contribution.'
+    const result = composeSystemPromptWithBootstrap(existing, null)
+    expect(result).toBeNull()
   })
 })

--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it, test } from 'bun:test'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -72,7 +72,31 @@ describe('getBootstrapContent', () => {
     expect(content).toContain('</SYSTEMATIC_WORKFLOWS>')
     expect(content).toContain('Bootstrap body content here.')
     expect(content).toContain('**Skills naming:**')
+    expect(content).toContain('Use the `skill` tool for non-Systematic skills')
     expect(content).not.toContain('**Tool Mapping for OpenCode:**')
+  })
+
+  test('custom usage template is included when provided without changing the default OpenCode template', () => {
+    const bundledSkillsDir = makeBundledSkillsDir(
+      '---\nname: using-systematic\n---\nBootstrap body content here.',
+    )
+    const config = {
+      bootstrap: { enabled: true, file: undefined },
+      disabled_skills: [] as string[],
+      disabled_agents: [] as string[],
+      disabled_commands: [] as string[],
+    }
+
+    const content = getBootstrapContent(config, {
+      bundledSkillsDir,
+      usageTemplate: '**Pi-native guidance:**\n- use systematic_skill\n',
+    })
+
+    expect(content).not.toBeNull()
+    expect(content).toContain('**Pi-native guidance:**')
+    expect(content).not.toContain(
+      'Use the `skill` tool for non-Systematic skills',
+    )
   })
 
   test('config.bootstrap.enabled = false returns null', () => {
@@ -560,7 +584,7 @@ describe('computeBootstrapContentSafe', () => {
     return bundledSkillsDir
   }
 
-  test('returns bootstrap content string for a valid bundled skills dir', () => {
+  it('returns bootstrap content string for a valid bundled skills dir', () => {
     const bundledSkillsDir = makeBundledSkillsDir(
       '---\nname: using-systematic\n---\nBody content.',
     )
@@ -570,7 +594,7 @@ describe('computeBootstrapContentSafe', () => {
     expect(content).toContain('Body content.')
   })
 
-  test('returns null (not throws) when using-systematic/SKILL.md is missing', () => {
+  it('returns null (not throws) when using-systematic/SKILL.md is missing', () => {
     const bundledSkillsDir = makeBundledSkillsDir() // no SKILL.md
     expect(() =>
       computeBootstrapContentSafe({ bundledSkillsDir }),
@@ -578,7 +602,7 @@ describe('computeBootstrapContentSafe', () => {
     expect(computeBootstrapContentSafe({ bundledSkillsDir })).toBeNull()
   })
 
-  test('returns null (not throws) when bundledSkillsDir itself does not exist', () => {
+  it('returns null (not throws) when bundledSkillsDir itself does not exist', () => {
     const missingDir = path.join(testDir, 'does-not-exist')
     expect(() =>
       computeBootstrapContentSafe({ bundledSkillsDir: missingDir }),
@@ -588,7 +612,7 @@ describe('computeBootstrapContentSafe', () => {
     ).toBeNull()
   })
 
-  test('returns null (not throws) for a malformed/unreadable using-systematic SKILL.md fixture', () => {
+  it('returns null (not throws) for a malformed/unreadable using-systematic SKILL.md fixture', () => {
     // Real temp-dir fixture: create using-systematic as a directory named
     // SKILL.md instead of a file, so fs.readFileSync throws EISDIR.
     const bundledSkillsDir = path.join(testDir, 'skills')
@@ -603,45 +627,56 @@ describe('computeBootstrapContentSafe', () => {
     ).not.toThrow()
     expect(computeBootstrapContentSafe({ bundledSkillsDir })).toBeNull()
   })
+
+  it('reports failures once and still returns null when the reporter throws', () => {
+    const bundledSkillsDir = makeBundledSkillsDir()
+    fs.mkdirSync(path.join(bundledSkillsDir, 'using-systematic'), {
+      recursive: true,
+    })
+    fs.mkdirSync(path.join(bundledSkillsDir, 'using-systematic', 'SKILL.md'), {
+      recursive: true,
+    })
+
+    let reportCalls = 0
+
+    const result = computeBootstrapContentSafe({ bundledSkillsDir }, () => {
+      reportCalls++
+      throw new Error('reporter failure')
+    })
+
+    expect(reportCalls).toBe(1)
+    expect(result).toBeNull()
+  })
 })
 
 describe('composeSystemPromptWithBootstrap', () => {
-  test('appends bootstrap content after an existing system prompt contribution', () => {
-    const existing = 'You are a primary agent. Earlier extension contribution.'
+  it('preserves earlier extension marker bytes exactly when appending the Systematic snapshot', () => {
+    const existing =
+      'You are a primary agent. Earlier extension contribution: <SYSTEMATIC_WORKFLOWS>example</SYSTEMATIC_WORKFLOWS>'
     const bootstrap = '<SYSTEMATIC_WORKFLOWS>\nContent\n</SYSTEMATIC_WORKFLOWS>'
 
     const result = composeSystemPromptWithBootstrap(existing, bootstrap)
 
     expect(result).not.toBeNull()
-    const resultStr = result as string
-    expect(resultStr.indexOf(existing)).toBe(0)
-    expect(resultStr.indexOf('<SYSTEMATIC_WORKFLOWS>')).toBeGreaterThan(
-      resultStr.indexOf(existing),
-    )
+    expect(result).toBe(`${existing}\n\n${bootstrap}`)
   })
 
-  test('handles an empty existing prompt by using bootstrap content alone', () => {
+  it('returns the existing prompt unchanged when it already ends with the same snapshot', () => {
+    const bootstrap = '<SYSTEMATIC_WORKFLOWS>\nContent\n</SYSTEMATIC_WORKFLOWS>'
+    const existing = `Earlier.\n\n${bootstrap}`
+
+    const result = composeSystemPromptWithBootstrap(existing, bootstrap)
+
+    expect(result).toBe(existing)
+  })
+
+  it('handles an empty existing prompt by using bootstrap content alone', () => {
     const bootstrap = '<SYSTEMATIC_WORKFLOWS>\nContent\n</SYSTEMATIC_WORKFLOWS>'
     const result = composeSystemPromptWithBootstrap('', bootstrap)
     expect(result).toBe(bootstrap)
   })
 
-  test('avoids duplicate <SYSTEMATIC_WORKFLOWS> blocks when the prompt already has one', () => {
-    const existing =
-      'Earlier.\n\n<SYSTEMATIC_WORKFLOWS>\nOld\n</SYSTEMATIC_WORKFLOWS>'
-    const bootstrap = '<SYSTEMATIC_WORKFLOWS>\nNew\n</SYSTEMATIC_WORKFLOWS>'
-
-    const result = composeSystemPromptWithBootstrap(existing, bootstrap)
-
-    expect(result).not.toBeNull()
-    const resultStr = result as string
-    const occurrences = resultStr.split('<SYSTEMATIC_WORKFLOWS>').length - 1
-    expect(occurrences).toBe(1)
-    expect(resultStr).toContain('New')
-    expect(resultStr).not.toContain('Old')
-  })
-
-  test('returns the existing prompt unchanged when bootstrap content is null', () => {
+  it('returns the existing prompt unchanged when bootstrap content is null', () => {
     const existing = 'You are a primary agent. Earlier extension contribution.'
     const result = composeSystemPromptWithBootstrap(existing, null)
     expect(result).toBeNull()

--- a/tests/unit/pi.test.ts
+++ b/tests/unit/pi.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from 'bun:test'
+import { describe, expect, spyOn, test } from 'bun:test'
+import fs from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import type {
   AgentToolResult,
@@ -217,6 +218,33 @@ describe('src/pi.ts before_agent_start bootstrap injection', () => {
     expect(api.handlers.before_agent_start).toBeDefined()
   })
 
+  test('emits one constant stderr diagnostic and still initializes when bootstrap computation fails', async () => {
+    const api = createFakeExtensionApi()
+    const stderrSpy = spyOn(process.stderr, 'write').mockImplementation(
+      () => true,
+    )
+    const originalReadFileSync = fs.readFileSync
+    const readFileSyncSpy = spyOn(fs, 'readFileSync')
+      .mockImplementationOnce(() => {
+        throw new Error('bootstrap failure')
+      })
+      .mockImplementation((...args) => {
+        return originalReadFileSync(...args)
+      })
+
+    await expect(piExtension(api)).resolves.toBeUndefined()
+
+    expect(stderrSpy).toHaveBeenCalledTimes(1)
+    expect(stderrSpy).toHaveBeenCalledWith(
+      '[systematic] Failed to compute Pi bootstrap; continuing without injection.\n',
+    )
+    expect(api.handlers.before_agent_start).toBeDefined()
+    expect(api.registeredTools).toHaveLength(1)
+
+    readFileSyncSpy.mockRestore()
+    stderrSpy.mockRestore()
+  })
+
   test('an earlier extension contribution remains before exactly one real Systematic bootstrap block', async () => {
     const api = createFakeExtensionApi()
     await piExtension(api)
@@ -247,6 +275,36 @@ describe('src/pi.ts before_agent_start bootstrap injection', () => {
     expect(prompt).toContain('</SYSTEMATIC_WORKFLOWS>')
     expect(prompt.indexOf('<SYSTEMATIC_WORKFLOWS>')).toBeGreaterThan(
       prompt.indexOf(earlierContribution),
+    )
+  })
+
+  test('Pi bootstrap uses native skill guidance and omits the generic skill tool instruction', async () => {
+    const api = createFakeExtensionApi()
+    await piExtension(api)
+    const handler = api.handlers.before_agent_start as ExtensionHandler<
+      BeforeAgentStartEvent,
+      BeforeAgentStartEventResult
+    >
+    const event: BeforeAgentStartEvent = {
+      type: 'before_agent_start',
+      prompt: 'do the thing',
+      systemPrompt: 'Earlier extension prompt contribution.',
+      systemPromptOptions: {} as BeforeAgentStartEvent['systemPromptOptions'],
+    }
+
+    const result = await handler(event, fakeExtensionContext)
+
+    expect(result).toBeDefined()
+    const systemPrompt = (result as BeforeAgentStartEventResult)
+      .systemPrompt as string
+    expect(systemPrompt).toContain(
+      'Use `systematic_skill` for Systematic skills.',
+    )
+    expect(systemPrompt).toContain(
+      "For non-Systematic skills, follow Pi's native skill instructions and read the listed SKILL.md path.",
+    )
+    expect(systemPrompt).not.toContain(
+      'Use the skill tool for non-Systematic skills',
     )
   })
 })

--- a/tests/unit/pi.test.ts
+++ b/tests/unit/pi.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from 'bun:test'
 import { fileURLToPath } from 'node:url'
 import type {
   AgentToolResult,
+  BeforeAgentStartEvent,
+  BeforeAgentStartEventResult,
   ExtensionAPI,
+  ExtensionContext,
+  ExtensionHandler,
   ToolDefinition,
 } from '@earendil-works/pi-coding-agent'
 import {
@@ -21,17 +25,28 @@ interface RegisterToolSpy {
   registeredTools: ToolDefinition[]
 }
 
-/** Captures registerTool() calls; other ExtensionAPI members are unused. */
-function createFakeExtensionApi(): ExtensionAPI & RegisterToolSpy {
+interface OnSpy {
+  handlers: Record<string, ExtensionHandler<unknown, unknown>>
+}
+
+/** Captures registerTool() and on() calls; other ExtensionAPI members are unused. */
+function createFakeExtensionApi(): ExtensionAPI & RegisterToolSpy & OnSpy {
   const registeredTools: ToolDefinition[] = []
+  const handlers: Record<string, ExtensionHandler<unknown, unknown>> = {}
   const fake = {
     registeredTools,
+    handlers,
     registerTool(tool: ToolDefinition) {
       registeredTools.push(tool)
     },
+    on(event: string, handler: ExtensionHandler<unknown, unknown>) {
+      handlers[event] = handler
+    },
   }
-  return fake as unknown as ExtensionAPI & RegisterToolSpy
+  return fake as unknown as ExtensionAPI & RegisterToolSpy & OnSpy
 }
+
+const fakeExtensionContext = {} as ExtensionContext
 
 describe('src/pi.ts systematic_skill tool registration', () => {
   test('registers exactly one tool named systematic_skill with expected label and catalog-derived description', async () => {
@@ -192,5 +207,46 @@ describe('src/pi.ts systematic_skill tool registration', () => {
     })()
 
     expect(piError).toBe(openCodeError)
+  })
+})
+
+describe('src/pi.ts before_agent_start bootstrap injection', () => {
+  test('registers exactly one before_agent_start handler', async () => {
+    const api = createFakeExtensionApi()
+    await piExtension(api)
+    expect(api.handlers.before_agent_start).toBeDefined()
+  })
+
+  test('an earlier extension contribution remains before exactly one real Systematic bootstrap block', async () => {
+    const api = createFakeExtensionApi()
+    await piExtension(api)
+    const handler = api.handlers.before_agent_start as ExtensionHandler<
+      BeforeAgentStartEvent,
+      BeforeAgentStartEventResult
+    >
+    expect(handler).toBeDefined()
+
+    const earlierContribution = 'Earlier extension prompt contribution.'
+    const event: BeforeAgentStartEvent = {
+      type: 'before_agent_start',
+      prompt: 'do the thing',
+      systemPrompt: earlierContribution,
+      systemPromptOptions: {} as BeforeAgentStartEvent['systemPromptOptions'],
+    }
+
+    const result = await handler(event, fakeExtensionContext)
+
+    expect(result).toBeDefined()
+    const systemPrompt = (result as BeforeAgentStartEventResult).systemPrompt
+    expect(systemPrompt).toBeDefined()
+    const prompt = systemPrompt as string
+
+    expect(prompt.indexOf(earlierContribution)).toBe(0)
+    const occurrences = prompt.split('<SYSTEMATIC_WORKFLOWS>').length - 1
+    expect(occurrences).toBe(1)
+    expect(prompt).toContain('</SYSTEMATIC_WORKFLOWS>')
+    expect(prompt.indexOf('<SYSTEMATIC_WORKFLOWS>')).toBeGreaterThan(
+      prompt.indexOf(earlierContribution),
+    )
   })
 })


### PR DESCRIPTION
Pi extensions chain system prompts from multiple handlers. Reusing OpenCode’s broad marker scrub here could erase text contributed by another extension, so this adds a Pi-specific composition path instead.

## What changed

- registers `before_agent_start` and appends the Systematic bootstrap after earlier prompt contributions
- deduplicates only the exact Systematic-owned bootstrap snapshot
- keeps Pi skill instructions aligned with Pi’s native prompt/read workflow
- degrades to an unchanged prompt with one stderr diagnostic when bootstrap computation throws
- adds regression coverage for composition, fallback, hook registration, and OpenCode compatibility
- documents the chained-bootstrap ownership pattern for future harness adapters

## Verification

- `bun test tests/unit/bootstrap.test.ts tests/unit/pi.test.ts tests/unit/plugin.test.ts` — 90 pass
- `bun run typecheck`
- `bunx biome check src/lib/bootstrap.ts src/pi.ts tests/unit/bootstrap.test.ts tests/unit/pi.test.ts src/lib/AGENTS.md`
- `bun run docs:build`
- `bun scripts/content-integrity.ts`

## Scope

Pi currently uses Systematic’s package-default bootstrap configuration. This PR does not define a Pi-specific `systematic.json` location or precedence model.
