### PR TITLE
ci: update Fro Bot for response delivery fix

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -578,7 +578,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run Fro Bot
-        uses: fro-bot/agent@90a10fbc74137b9def94438ba6866e8832a15a77 # v0.86.0
+        uses: fro-bot/agent@18a64ba81f2258441d5c03d55147577848577a95 # v0.92.0
         env:
           OPENCODE_PROMPT_ARTIFACT: 'true'
           # IS_SUNDAY_UTC is set by the "Detect Sunday UTC" step only on schedule


### PR DESCRIPTION
## Summary

- update `fro-bot/agent` from v0.86.0 to v0.92.0 using the immutable release SHA
- pick up [fro-bot/agent#1193](https://github.com/fro-bot/agent/pull/1193), which permits only the action-owned response-file directory through the build agent's external-directory deny rule
- restore file-convention review delivery; the previous pin let the review complete but blocked the final response write, causing an `ENOENT` failure

## Verification

- v0.92.0 tag `18a64ba81f2258441d5c03d55147577848577a95` contains fix commit `047c1cdde28379e657227c821720651a03f67887`
- `.github/workflows/fro-bot.yaml` remains SHA-pinned
- `git diff --check`

Reproduced on [workflow run 29404742765](https://github.com/marcusrbrown/systematic/actions/runs/29404742765): the model produced a PASS review, but OpenCode denied writes to `$RUNNER_TEMP/fro-bot-response/...` and the action failed reading the missing file.