### PR TITLE
docs(guides): add Pi harness install and parity guide

### DIFF
--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -109,6 +109,14 @@ Use `npx skills` to install the skill Markdown files directly. This path works i
   </div>
 </div>
 
+## Install into a Pi coding-agent project
+
+Systematic also ships a [Pi coding-agent](https://github.com/earendil-works/pi-coding-agent) extension from the same package — same `systematic_skill` tool, same bootstrap injection, plus a `systematic_delegate` persona-delegation tool. See [Pi Harness Support](/systematic/guides/pi-harness/) for the full install steps and an honest list of where Pi parity with OpenCode currently ends (config support, permission gating).
+
+```bash
+npx @fro.bot/systematic setup --harness pi
+```
+
 ## Automatic asset discovery
 
 Systematic requires zero manual file copying. When the plugin loads, it automatically:

--- a/docs/src/content/docs/guides/pi-harness.mdx
+++ b/docs/src/content/docs/guides/pi-harness.mdx
@@ -1,0 +1,55 @@
+---
+title: Pi Harness Support
+description: Install Systematic into Pi coding-agent projects and understand exactly where Pi parity with OpenCode ends.
+sidebar:
+  order: 8
+---
+
+Systematic ships the same npm package for two harnesses: [OpenCode](https://opencode.ai) and [Pi coding-agent](https://github.com/earendil-works/pi-coding-agent). `package.json` carries a `pi` manifest (`extensions: ["./dist/pi.js"]`, `skills: ["./skills"]`) alongside the OpenCode `plugin` export. Installing the Pi extension does not touch `main`/`exports` or anything an OpenCode user already has configured — the two harness entries are additive and independent.
+
+## Install
+
+Run the setup command from your project root:
+
+```bash
+npx @fro.bot/systematic setup --harness pi
+```
+
+This writes a project-local `.pi/settings.json` with a `packages` entry pointing at `npm:@fro.bot/systematic`. The write is atomic (temp file + rename), backs up an existing `.pi/settings.json` to `.pi/settings.json.bak` before modifying it, and is idempotent — running it again against an already-configured project reports `already-configured` instead of duplicating the entry. There is no `--global` mode; setup is project-local only, for both harnesses.
+
+You can also add the entry by hand if you prefer:
+
+```json title=".pi/settings.json"
+{
+  "packages": ["npm:@fro.bot/systematic"]
+}
+```
+
+On first run against a fresh project, Pi prompts to trust project-local resources (packages, extensions) before loading them. That prompt is Pi's own trust gate, not something Systematic adds — non-interactive/CI usage needs Pi's `--approve` flag or equivalent, the same as any other project-local Pi package.
+
+## What you get
+
+Once loaded, Systematic's Pi extension registers the same underlying capabilities as the OpenCode plugin, adapted to Pi's extension API (`src/pi.ts`):
+
+- **Bundled skills as Pi skills** — the `skills` manifest entry points Pi at the same bundled skill directory OpenCode uses, so Pi's own skill discovery picks them up and surfaces each one as a native Pi skill command.
+- **The `systematic_skill` tool** — registered via `pi.registerTool`, it resolves a skill by name and returns its content through the same shared resolution logic the OpenCode plugin's `systematic_skill` tool uses.
+- **`using-systematic` bootstrap injection** — a `before_agent_start` handler composes Systematic's bootstrap content into Pi's system prompt, so every session starts with skill-usage instructions the same way OpenCode sessions do.
+- **Persona delegation via `systematic_delegate`** — a second registered tool spawns an in-process child Pi session running one of Systematic's bundled agent personas, sequentially, capped at 20 turns, with a fail-closed re-entry guard (the child's tool allowlist can never include `systematic_delegate` itself) and a least-privilege tool allowlist derived from the persona's own `tools` frontmatter. The child inherits the parent session's model and working directory; Pi's in-process delegation path has no separate model selection, so model-free bundled agent files simply run under whatever model the parent session is using.
+
+## Honest parity differences
+
+Pi support is real and runtime-tested, but it is not a byte-for-byte clone of the OpenCode integration. Two differences are worth knowing before you rely on it:
+
+1. **Pi does not read `disabled_skills` (or any `systematic.json` config) today.** `src/pi.ts` constructs its skill resolver with a hardcoded empty disabled-skills list — the Pi extension does not load or consult OpenCode's `systematic.json` at all. Every bundled skill is available through `systematic_skill` in Pi regardless of what you have disabled for OpenCode. A Pi-native config namespace is a separate, not-yet-built decision — do not assume `.opencode` config applies to Pi sessions.
+
+2. **`systematic_skill` loads are not permission-gated in Pi.** OpenCode's `skill-tool.ts` calls `context.ask({ permission: 'skill', ... })` before returning skill content, so OpenCode's `permission.skill` config can prompt or block a load. Pi 0.80.6's extension API has no equivalent permission-gate hook, and Systematic's Pi tool implementation does not call one. `permission.skill` settings you rely on in OpenCode do not carry over — treat any skill reachable through `systematic_skill` in Pi as always-loadable.
+
+A few other behaviors worth knowing, carried over from the delegation design:
+
+- Pi trust-gates project-local resources (including this package) at first use, as noted above — that gate is Pi's, not Systematic's.
+- `systematic_delegate` fails closed on turn budget: a child session that exceeds 20 turns is aborted rather than allowed to keep running.
+- Delegated personas never get a wider tool surface than their own frontmatter `tools` list declares.
+
+## Uninstall
+
+Remove the `npm:@fro.bot/systematic` entry from `.pi/settings.json`'s `packages` array. If setup left a `.pi/settings.json.bak` from its first run, that is the pre-install snapshot of your settings file — restore from it if you want to revert the whole file rather than hand-editing the array.


### PR DESCRIPTION
## What

Pi harness plan 003, Unit 8 (final unit) — committed docs for the second harness.

- **New guide: `guides/pi-harness`** — install via `setup --harness pi` (atomic, backed-up, idempotent, project-local only) or manual `.pi/settings.json` entry; Pi's own first-run trust prompt; the four capabilities proven by the Unit 7 subprocess harness (bundled skills, `systematic_skill`, `using-systematic` bootstrap, `systematic_delegate` with its 20-turn fail-closed cap, re-entry guard, and least-privilege persona tool allowlists); uninstall path including the `.bak` restore option.
- **Honest parity boundaries, verified against source:** the Pi extension reads no `systematic.json` config (`src/pi.ts` hardcodes an empty disabled-skills list — `disabled_skills` does not apply in Pi), and Pi 0.80.6 has no permission-gate hook (`context.ask` equivalent), so `permission.skill` semantics do not carry over. Documented plainly, no invented workarounds.
- **Installation page** gains a short Pi section linking the guide; OpenCode sections untouched.

Sidebar entry comes from the guides directory autogenerate config — no config change needed.

## Verification

- `bun run docs:build` green (84 pages; `guides/pi-harness/index.html` emitted)
- `bun scripts/content-integrity.ts` clean (every cited skill name is a real bundled skill)
- Docs-only diff — no source, test, or config changes; unit suite untouched-green (1144/1144)