### PR TITLE
docs: capture Pi real-runtime harness learnings and close out plan 003

### DIFF
--- a/docs/plans/2026-07-06-003-feat-pi-harness-support-plan.md
+++ b/docs/plans/2026-07-06-003-feat-pi-harness-support-plan.md
@@ -1,7 +1,9 @@
 ---
 title: "feat: Pi coding-agent harness support"
 type: feat
-status: active
+status: completed
+completed_at: 2026-07-16
+shipped: "Units 1-6: PRs #623, #624, #626, #627, #629, #633; Unit 7: PR #637; Unit 8: PR #638 (all merged into v3)"
 date: 2026-07-06
 origin: docs/brainstorms/2026-07-06-pi-harness-support-requirements.md
 target_branch: v3
@@ -365,7 +367,7 @@ Phase 3 — Install, docs, assurance
 
 **Verification (implemented):** `tests/integration/pi.test.ts` (931 lines, self-contained): real Pi 0.80.6 spawned via `dist/cli.js --mode rpc` against an in-test OpenAI-completions SSE mock (`Bun.serve`, port 0), packaged extension loaded from the `npm pack` tarball through a project-local `.pi/settings.json` relative-path package source (real `pi.extensions`/`pi.skills` manifest resolution, fully offline, `--approve` for non-interactive project trust). Model wiring via `models.json` in the agent dir (`PI_CODING_AGENT_DIR`; project-local `.pi/models.json` is not a Pi scope). All five scenarios green: extension load (no `extension_error` + bootstrap marker in the captured model payload), skill commands (`get_commands` `source: "skill"`), `systematic_skill` resolution (`tool_execution_end` carries `<skill_content>`), bootstrap injection incl. Pi-native usage text (asserted from the mock-model request payload — v0.80.6 RPC exposes no system-prompt command), and `systematic_delegate` child-session completion (`outcome === 'completed'`). Deliberate deviation from the planned skip guard: Pi is an exact devDependency, so the suite hard-fails with an actionable message when the CLI is missing instead of silently skipping (a `PI_AVAILABLE`-style guard could false-green CI). 5/5 integration, 1144/1144 unit, typecheck/lint/content-integrity clean.
 
-- [ ] **Unit 8: Committed Pi install + parity docs**
+- [x] **Unit 8: Committed Pi install + parity docs**
 
 **Goal:** Ship committed docs covering Pi installation and harness parity/differences, without changing the OpenCode path docs.
 
@@ -385,6 +387,8 @@ Phase 3 — Install, docs, assurance
 - Test expectation: none (docs content) — verified by `bun run docs:build` (MDX parses, links resolve).
 
 **Verification:** `bun run docs:build` green; Pi page reachable from active nav; OpenCode docs unchanged.
+
+**Verification (implemented):** PR #638 — `guides/pi-harness.mdx` (new, sidebar order 8) + a Pi section in `getting-started/installation.mdx` (OpenCode content untouched). Documents install (`setup --harness pi`, manual `.pi/settings.json`, Pi's first-run trust prompt), the four runtime-proven capabilities, and the honest parity boundaries verified against source: the Pi extension reads no `systematic.json` config (`disabled_skills` does not apply) and Pi 0.80.6 has no permission-gate hook (`permission.skill` does not carry over). `docs:build` green (84 pages); content-integrity clean; Fro Bot source-verified every factual claim (PASS, zero NBCs).
 
 ## System-Wide Impact
 

--- a/docs/solutions/best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md
+++ b/docs/solutions/best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md
@@ -131,6 +131,7 @@ OpenCode and Pi `systematic_skill` adapters in `tests/unit/pi.test.ts` and
 ## Related
 
 - [Isolate OpenCode subprocess fixtures from the real installation](../integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md)
+- [Test packaged harness extensions against the real Pi runtime](pi-real-runtime-integration-harness-2026-07-16.md) — the subprocess/package tier of this layer table, implemented for Pi
 - [OpenCode swallows plugin hook defects unless tests force invocation](../integration-issues/opencode-plugin-hook-silent-defect-swallow-2026-05-19.md)
 - [Pi harness support plan](../../plans/2026-07-06-003-feat-pi-harness-support-plan.md)
 - [Pi harness support requirements](../../brainstorms/2026-07-06-pi-harness-support-requirements.md)

--- a/docs/solutions/best-practices/pi-real-runtime-integration-harness-2026-07-16.md
+++ b/docs/solutions/best-practices/pi-real-runtime-integration-harness-2026-07-16.md
@@ -1,0 +1,182 @@
+---
+title: Test packaged harness extensions against the real Pi runtime
+date: 2026-07-16
+category: best-practices
+module: pi
+problem_type: best_practice
+component: testing_framework
+severity: medium
+applies_when:
+  - building integration tests against the real Pi runtime
+  - mocking Pi model responses without a built-in test provider
+  - validating packaged Pi extensions from the shipped npm artifact
+  - deciding between silent skip guards and hard failures for exact devDependencies
+tags: [pi, integration-testing, real-runtime, rpc, mock-server, env-isolation, fail-fast]
+related_components:
+  - tooling
+  - development_workflow
+---
+
+# Test packaged harness extensions against the real Pi runtime
+
+## Context
+
+Unit-level adapter parity tests only prove the shared core and adapter envelope agree. They do
+**not** prove the real harness can install, load, and wire the packaged extension in-process.
+
+`tests/integration/pi.test.ts` proves what fake-SDK tests miss:
+
+- real CLI boot (`node .../dist/cli.js --mode rpc`) with the **exact devDependency**; a missing CLI
+  is a hard failure, not a skip (`pi.test.ts:70-79`)
+- real packaged plugin loading from an **`npm pack` tarball**, not source (`pi.test.ts:234-298`)
+- real manifest-driven wiring of `pi.extensions` / `pi.skills`
+- real RPC/JSONL plumbing between subprocess and test harness (`pi.test.ts:485-657`)
+- real model-driven tool execution over SSE, so bootstrap and tool results are observed through the
+  same path the agent uses (`pi.test.ts:341-483`, `:692-930`)
+
+That is the boundary where packaged-runtime regressions actually live.
+
+## Guidance
+
+### 1) Isolate the fixture hard
+
+Mirror the OpenCode discipline: temp `HOME` + temp XDG roots + narrow env allowlist + agent/session
+dirs overridden. The Pi dir env names were verified against the installed source
+(`dist/config.js:397-398`, `ENV_AGENT_DIR` / `ENV_SESSION_DIR`).
+
+```ts
+const ENV_ALLOWLIST = new Set(['PATH', 'HOME', 'USER', 'LOGNAME', ...])
+
+return {
+  HOME: fixture.homeDir,
+  XDG_CONFIG_HOME: fixture.xdgConfigHome,
+  XDG_DATA_HOME: fixture.xdgDataHome,
+  XDG_CACHE_HOME: fixture.xdgCacheHome,
+  XDG_STATE_HOME: fixture.xdgStateHome,
+  PI_CODING_AGENT_DIR: fixture.agentDir,
+  PI_CODING_AGENT_SESSION_DIR: fixture.sessionDir,
+  PI_OFFLINE: '1',
+}
+```
+
+Refs: `pi.test.ts:103-193`, `:676-704`; shared OpenCode pattern: `opencode.test.ts:142-212`.
+
+### 2) Install packaged code offline
+
+Pack once, extract the tarball into the fixture, then point `.pi/settings.json` at it via a
+**relative local path** (Pi's package manager accepts local directory sources):
+
+```ts
+fs.writeFileSync(
+  path.join(piDir, 'settings.json'),
+  JSON.stringify({ packages: [relativePackagePath] }, null, 2),
+)
+```
+
+The key is an offline local source, not npm spec resolution. That exercises real manifest loading
+without network. Use Pi's `--approve` flag for non-interactive project trust. See
+`pi.test.ts:234-298`.
+
+### 3) Put mock model config in the agent dir
+
+Pi 0.80.6 has no built-in mock or test provider. The working mechanism is an in-test
+OpenAI-completions SSE server (`Bun.serve` on port 0) plus a `models.json` provider override — and
+that file must live in the agent dir (`PI_CODING_AGENT_DIR`), not the project:
+
+```ts
+fs.writeFileSync(path.join(fixture.agentDir, 'models.json'), JSON.stringify(...))
+```
+
+A project-local `.pi/models.json` is silently ignored (verified empirically — it is not a Pi config
+scope). Scripted multi-turn responses, including `tool_calls` chunks, drive real tool execution.
+Refs: `pi.test.ts:300-338`, `:371-483`.
+
+### 4) Drive RPC by id, and keep tails for failures
+
+The client writes JSONL requests, correlates responses by `id`, and waits with a timeout:
+
+```ts
+const responsePromise = waitFor((msg) => msg.type === 'response' && msg.id === id)
+stdin.write(`${JSON.stringify(withId)}\n`)
+```
+
+Timeout errors include stdout/stderr tails for diagnosis. Refs: `pi.test.ts:486-657`.
+
+### 5) Ground observability in what the runtime actually exposes
+
+Do not rely on a command that does not exist.
+
+- The system prompt is **not** exposed by RPC; assert the bootstrap marker in the mock model's
+  captured request payload instead (`pi.test.ts:792-820`).
+- Extension load is proven by **absence of `extension_error`** plus behavioral markers, not by
+  slash commands (`pi.test.ts:692-735`).
+- Tool success is proven via `tool_execution_end` frames (`pi.test.ts:855-869`).
+- Pi registers tools, not commands, so `get_commands` is the wrong load signal
+  (`pi.test.ts:697-704`).
+
+### 6) Hard-fail exact devDependencies
+
+If the CLI is missing, throw immediately:
+
+```ts
+if (!fs.existsSync(PI_CLI)) {
+  throw new Error(`Pi coding-agent CLI not found...`)
+}
+```
+
+Rule of thumb: **skip guards are for genuinely optional external deps**. If the repo declares an
+exact devDependency, a silent skip creates false-green CI.
+Ref: `pi.test.ts:70-79`.
+
+## Why This Matters
+
+This closes the false-green gap:
+
+- fake-SDK tests can drift from the real runtime
+- subprocess tests catch packaging, manifest resolution, bootstrap injection, and RPC wiring
+- the right contract is three-layered: shared-core unit tests, adapter contract tests, and
+  subprocess/package integration (see the layer table in
+  [cross-harness adapter parity contract tests](cross-harness-adapter-parity-contract-tests-2026-07-14.md))
+
+## When to Apply
+
+- Adding a harness/runtime integration suite.
+- A dependency becomes exact or vendored, and existing skip guards need revisiting.
+- Asserting on prompts or tooling the runtime does not expose directly through its API.
+
+## Examples
+
+**Don't**
+
+```ts
+if (!PI_AVAILABLE) test.skip(...)
+```
+
+**Do**
+
+```ts
+if (!fs.existsSync(PI_CLI)) throw new Error('...missing exact devDependency...')
+```
+
+**Don't**
+
+```ts
+fs.writeFileSync(path.join(projectDir, '.pi/models.json'), ...)
+```
+
+**Do**
+
+```ts
+fs.writeFileSync(path.join(fixture.agentDir, 'models.json'), ...)
+```
+
+## Related
+
+- [Isolate OpenCode subprocess fixtures from the real installation](../integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md)
+  — the OpenCode sibling of this recipe (server+SDK spawn; this doc covers Pi's RPC/JSONL spawn
+  with a mocked model)
+- [Pin cross-harness adapter contracts at the boundary](cross-harness-adapter-parity-contract-tests-2026-07-14.md)
+  — the layer contract this harness completes at the subprocess tier
+- [Preserve foreign content when composing a chained bootstrap prompt](../logic-errors/pi-chained-bootstrap-composition-2026-07-14.md)
+  — the bootstrap composition rules whose runtime proof lives in this harness
+- [Pi harness support plan](../../plans/2026-07-06-003-feat-pi-harness-support-plan.md)

--- a/docs/solutions/integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md
+++ b/docs/solutions/integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md
@@ -202,3 +202,4 @@ Pi splits install from load. A raw tarball can install successfully while persis
 - `docs/solutions/integration-issues/opencode-plugin-named-exports-break-loader-2026-05-11.md`
 - `tests/unit/package-exports.test.ts`
 - [PR #617: Validate the packaged v3 runtime](https://github.com/marcusrbrown/systematic/pull/617)
+- [Test packaged harness extensions against the real Pi runtime](../best-practices/pi-real-runtime-integration-harness-2026-07-16.md) — the Pi sibling of this recipe (RPC/JSONL spawn with a mocked model instead of the OpenCode server+SDK spawn)

--- a/docs/solutions/logic-errors/pi-chained-bootstrap-composition-2026-07-14.md
+++ b/docs/solutions/logic-errors/pi-chained-bootstrap-composition-2026-07-14.md
@@ -114,6 +114,7 @@ A sentinel pattern identifies syntax, not authorship; foreign content can legiti
 ## Related Issues
 
 - [Cross-harness adapter parity contract tests](../best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md)
+- [Test packaged harness extensions against the real Pi runtime](../best-practices/pi-real-runtime-integration-harness-2026-07-16.md) — runtime proof of these bootstrap-injection rules against the real spawned Pi
 - [OpenCode plugin factory duplicate registration](../integration-issues/opencode-plugin-factory-duplicate-registration-2026-05-04.md)
 - [OpenCode plugin hook silent defect swallowing](../integration-issues/opencode-plugin-hook-silent-defect-swallow-2026-05-19.md)
 


### PR DESCRIPTION
## What

Docs-only closeout for the Pi harness plan (003) — all 8 units now merged.

- **New solution doc** (`docs/solutions/best-practices/pi-real-runtime-integration-harness-2026-07-16.md`): the distilled Unit 7 recipe for testing packaged harness extensions against the real Pi runtime — hard fixture isolation (source-verified `PI_CODING_AGENT_DIR`/`SESSION_DIR` env names), offline packaged-tarball install through a `.pi/settings.json` local path, mock-model wiring (`models.json` must live in the agent dir; a project-local `.pi/models.json` is silently ignored), JSONL/RPC drive with diagnostic tails, runtime-grounded observability (the mock model's captured request payload as system-prompt ground truth; `extension_error` absence as the load signal), and the hard-fail-over-silent-skip rule for exact devDependencies.
- **Reciprocal cross-links** added to the three sibling docs (isolated-opencode-subprocess-fixtures, cross-harness-adapter-parity, pi-chained-bootstrap-composition) so the subprocess tier is discoverable from each. Targeted refresh found no other drift — their guidance still matches current code.
- **Plan 003 marked completed** with shipped provenance (Units 1–8: PRs #623, #624, #626, #627, #629, #633, #637, #638), Unit 8's implemented verification recorded, and the Unit 8 checkbox ticked.

## Verification

- `bun scripts/content-integrity.ts` clean (46 solution docs scanned, 0 warnings)
- Frontmatter validated against the ce:compound schema (knowledge track, `best_practice`, all enums exact)
- Docs-only diff; no source, test, or config changes