### PR TITLE
chore(schema): canonicalize v3 schema path post-release

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -50,28 +50,6 @@ jobs:
       - name: Generate reference content
         run: bun run docs:generate
 
-      # Transition cleanup: the v2 -> v3 schema path migration (deleting
-      # docs/public/schemas/v2/, committing v3/) is gated to land only once a
-      # real v3.0.0+ tag exists. Until that release, v2/ must keep deploying
-      # so IDE $schema URLs pointing at /v2/ keep resolving. This step is a
-      # release-time-only removal of the *workspace copy* (the Astro build
-      # input), gated on the checked-out release tag being v3.0.0 or a higher
-      # major — never on branch/PR/main builds. Safe to delete this step
-      # entirely once the v2 -> v3 directory cut lands for real.
-      - name: Remove legacy v2 schema mirror for v3+ releases
-        if: github.event_name == 'release'
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: |
-          tag="${RELEASE_TAG#v}"
-          major="${tag%%.*}"
-          if [ "$major" -ge 3 ] 2>/dev/null; then
-            echo "Release tag ${RELEASE_TAG} is v${major}+ — removing docs/public/schemas/v2/"
-            rm -rf docs/public/schemas/v2
-          else
-            echo "Release tag ${RELEASE_TAG} is pre-v3 — keeping docs/public/schemas/v2/"
-          fi
-
       - name: Resolve registry version
         id: registry-version
         env:

--- a/docs/public/schemas/v3/systematic-config.schema.json
+++ b/docs/public/schemas/v3/systematic-config.schema.json
@@ -37,7 +37,7 @@
       }
     }
   ],
-  "$id": "https://fro.bot/systematic/schemas/v2/systematic-config.schema.json",
+  "$id": "https://fro.bot/systematic/schemas/v3/systematic-config.schema.json",
   "definitions": {
     "__schema0": {
       "description": "JSON Schema URL for IDE autocomplete. The value is informational only — the loader does not fetch or validate against it. Add this to enable IDE schema activation and field-level autocomplete in editors that support JSON Schema (VSCode, Zed, IntelliJ).",

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -99,7 +99,7 @@ Add a `$schema` field to your `systematic.json` to enable per-key autocomplete i
 
 ```jsonc
 {
-  "$schema": "https://fro.bot/systematic/schemas/v2/systematic-config.schema.json",
+  "$schema": "https://fro.bot/systematic/schemas/v3/systematic-config.schema.json",
 
   "disabled_skills": ["git-worktree"],
   "agents": {
@@ -330,7 +330,7 @@ JSON Schema URL for IDE autocomplete. The value is informational only — the lo
 **Examples:**
 
 ```json
-"$schema": "https://fro.bot/systematic/schemas/v2/systematic-config.schema.json"
+"$schema": "https://fro.bot/systematic/schemas/v3/systematic-config.schema.json"
 ```
 
 ## agents


### PR DESCRIPTION
## What

The post-v3.0.0-tag half of the schema transition (deferred from #615 by design — CI resolves the schema major from git tags, so this could only land after the tag existed):

- Regenerate the published schema as `docs/public/schemas/v3/` (byte-identical to `latest/`; `$id` now points at the v3 URL) and delete the tracked `v2/` bridge copy
- Remove the release-gated v2-mirror cleanup step from `docs.yaml` — the real directory deletion supersedes the transition hack
- Regenerate the configuration reference (`$schema` examples now cite v3) and fix the one hand-written v2 URL in the Schema and Autocomplete section

## Verified

- `schema:drift` reports "up to date (v3)"; 85/85 schema tests; typecheck/lint/content-integrity clean
- `docs:build` green — dist ships `schemas/latest` + `schemas/v3`
- Live site checked post-release: the release-triggered deploy already dropped `schemas/v2/` (404) via the transition step doing its job once; `latest/` 200. The live configuration page still shows two v2 refs from the release build — after this merges, a `workflow_dispatch` docs deploy publishes the corrected page.

Note: `chore:` — no version bump, no release.