### PR TITLE
fix(skills): replace release-notes length gate with structural verification

### DIFF
--- a/.agents/skills/release-notes-narrative/SKILL.md
+++ b/.agents/skills/release-notes-narrative/SKILL.md
@@ -191,17 +191,24 @@ rm -f "${TMPFILE}"
 
 ### Step 13 — Verify and roll back on failure
 
+Re-read the published body and verify it structurally:
+
 ```bash
-NEW_LEN=$(gh release view "${TARGET}" --json body --jq '.body|length')
-PRE_LEN=$(jq -Rs 'length' < ".context/pr-evidence/release-notes-narrative/${TARGET}-before.md")
+PUB=$(gh release view "${TARGET}" --json body --jq .body)
 ```
 
-Both sides measure UTF-8 character count (not byte count). The `jq -Rs 'length'` form reads the snapshot file as a single raw string and reports its character length, matching the units `gh release view --jq '.body|length'` produces on the live body. Using `wc -c` here would compare bytes against characters, producing false-positive failures on bodies containing multibyte characters.
-
 Assert:
-- `NEW_LEN` is greater than `PRE_LEN`
+- The body starts with `## What's new`
 - The body contains at least one expected bucket heading
 - The Compare link is present in the published body
+- The body is non-empty and differs from the pre-edit snapshot (the edit actually applied)
+
+Do NOT compare lengths. A narrative rewrite is routinely SHORTER than the
+auto-generated body it replaces — semantic-release inflates major-release
+bodies by embedding entire squash-commit prose under BREAKING CHANGES
+(v3.0.0: 11,048 chars raw vs 4,394 chars narrative), and a length gate
+rolls back exactly the rewrites that matter most. Structural presence of
+the render contract, not size, is the correctness signal.
 
 If any assertion fails, restore the pre-edit snapshot:
 
@@ -265,7 +272,7 @@ The normalized forms of two runs against the same range must be byte-identical.
 - [ ] The Compare link uses the correct `v<PREV>...v<TARGET>` format and points at `github.com/marcusrbrown/systematic`
 - [ ] No spurious `closes [URL-fragment]` autolinks remain after step 10
 - [ ] The pre-edit snapshot exists at `.context/pr-evidence/release-notes-narrative/${TARGET}-before.md` before `gh release edit` is called
-- [ ] Post-edit verification (step 13) ran and passed; if it failed, the snapshot was restored
+- [ ] Post-edit verification (step 13) ran and passed — structural checks, never length comparison; if it failed, the snapshot was restored
 
 ## Common Mistakes
 


### PR DESCRIPTION
## What

The release-notes-narrative automation ran correctly for v3.0.0 — drafted a proper narrative, applied it — then **rolled itself back**: the step-13 gate asserts `NEW_LEN > PRE_LEN`, and the raw semantic-release body (11,048 chars — the squash commit's full prose embedded under BREAKING CHANGES) dwarfed the correct 4,394-char narrative. The gate rejected exactly the rewrite it exists to protect. (Run 29549248068; the v3.0.0 body has since been fixed manually with the narrative the run drafted-and-reverted, adjusted for the release-mechanics framing.)

Step 13 now verifies the render contract structurally — body starts with `## What's new`, at least one bucket heading, Compare link present, body differs from the pre-edit snapshot — and explicitly forbids length comparison, with the incident recorded inline as the rationale.

## Verification

- content-integrity clean
- Docs-only (repo-local skill); no source/test changes
- The v3.0.0 release body is already corrected and passes every structural check the new gate specifies