### PR TITLE
ci: retire v3 branch triggers post-release

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, v3]
+    branches: [main]
   schedule:
     - cron: '30 5 * * 1'
   workflow_dispatch:

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -11,7 +11,7 @@ on:
   issues:
     types: [opened, edited]
   pull_request:
-    branches: [main, v3]
+    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, review_requested]
   schedule:
     - cron: '0 9 * * 1'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, v3]
+    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## What

v3.0.0 shipped (#641) and the `v3` integration branch is deleted (remote and local). This drops `v3` from the `pull_request.branches` filters in `main.yaml`, `fro-bot.yaml`, and `codeql-analysis.yaml` — the triggers added in #584 solely to give v3 PRs full CI + Fro Bot review during the development window.

`push.branches` was always `[main]` and `.releaserc.yaml` never changed, so release behavior is untouched — this is pure trigger hygiene.

## Verification

- YAML validated (js-yaml) on all three files
- Diff is exactly three one-line filter changes