### PR TITLE
docs: surface Pi harness support on the homepage and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You want AI that follows your process, not just your prompts. You want repeatabl
 
 ## What You Get
 
-Systematic is an [OpenCode](https://opencode.ai/) plugin that ships 40+ bundled skills covering brainstorming, planning, implementation, review, and knowledge capture. It includes 50+ specialized agents for architecture, security, performance, design, and code review. Installation is zero-configuration — the plugin registers everything via OpenCode's config hooks and works immediately on restart. OCX registry support is available for component-level installs when you only want specific pieces.
+Systematic is an [OpenCode](https://opencode.ai/) plugin — and, from v3, a [Pi coding agent](https://github.com/earendil-works/pi-coding-agent) extension in the same package — that ships 31 bundled skills covering brainstorming, planning, implementation, review, and knowledge capture. It includes 37 specialized agents for architecture, security, performance, design, and code review. Installation is zero-configuration — the plugin registers everything via OpenCode's config hooks and works immediately on restart. OCX registry support is available for component-level installs when you only want specific pieces.
 
 ## Quick Install
 
@@ -41,13 +41,21 @@ Systematic is an [OpenCode](https://opencode.ai/) plugin that ships 40+ bundled 
 
 Add that to `~/.config/opencode/opencode.json` and restart OpenCode.
 
+**Pi coding agent** — same package, second harness (bundled skills, `systematic_skill`, persona delegation via `systematic_delegate`):
+
+```bash
+npx @fro.bot/systematic setup --harness pi
+```
+
+See the [Pi harness guide](https://fro.bot/systematic/guides/pi-harness/) for what carries over and where parity honestly ends.
+
 **`npx skills`** — portable skill content for any AI harness (Claude Code, Cursor, Copilot, …):
 
 ```bash
 npx skills add marcusrbrown/systematic
 ```
 
-Use the plugin if you're on OpenCode and want the complete experience. Use `npx skills` if you want the skill Markdown files dropped into whatever harness you're running.
+Use the plugin if you're on OpenCode and want the complete experience, the Pi setup command if you're on Pi, or `npx skills` if you want the skill Markdown files dropped into whatever harness you're running.
 
 ## First Workflow
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Structured Engineering Workflows for OpenCode
-description: "Systematic adds structured engineering workflows to OpenCode: brainstorm, plan, work, and review with bundled skills and specialized agents."
+title: Structured Engineering Workflows for OpenCode and Pi
+description: "Systematic adds structured engineering workflows to OpenCode and the Pi coding agent: brainstorm, plan, work, and review with bundled skills and specialized agents."
 template: splash
 ---
 
@@ -11,7 +11,7 @@ import StatsBanner from '../../components/StatsBanner.astro'
   <div class="hero-overlay-inner">
     <p class="hero-eyebrow">@fro.bot/systematic</p>
     <h1 class="hero-title">Your AI writes code.<br />Systematic adds engineering discipline.</h1>
-    <p class="hero-subtagline">Systematic brings structured workflows to OpenCode. Brainstorm, plan, implement, and review with bundled skills and agents.</p>
+    <p class="hero-subtagline">Systematic brings structured workflows to OpenCode and the Pi coding agent. Brainstorm, plan, implement, and review with bundled skills and agents.</p>
     <div class="hero-actions">
       <a href="/systematic/getting-started/installation/" class="sl-link-button primary" data-umami-event="click_install_cta">
         <span>Install the Plugin</span>
@@ -123,6 +123,20 @@ import StatsBanner from '../../components/StatsBanner.astro'
 
   <div class="install-path secondary">
     <div class="install-header">
+      <h3 class="install-title">Pi Extension</h3>
+      <span class="install-cue">Pi coding agent, same package</span>
+    </div>
+    <p>Register Systematic in a Pi project:</p>
+    
+    ```bash
+    npx @fro.bot/systematic setup --harness pi
+    ```
+    
+    <p>Skills, the skill loader, and persona delegation load as a native Pi extension. See <a href="/systematic/guides/pi-harness/">Pi Harness Support</a> for what carries over and where parity ends.</p>
+  </div>
+
+  <div class="install-path secondary">
+    <div class="install-header">
       <h3 class="install-title">CLI Installer</h3>
       <span class="install-cue">Any harness, skills only</span>
     </div>
@@ -143,7 +157,7 @@ import StatsBanner from '../../components/StatsBanner.astro'
     <strong>Not a model wrapper or prompt pack.</strong> Systematic doesn't touch your model selection or inject hidden system prompts into every message. It registers structured skills you invoke explicitly.
   </li>
   <li class="not-item">
-    <strong>Not another chat UI.</strong> It runs inside OpenCode. You keep your existing setup.
+    <strong>Not another chat UI.</strong> It runs inside OpenCode or the Pi coding agent. You keep your existing setup.
   </li>
   <li class="not-item">
     <strong>Not SaaS or telemetry.</strong> Everything is local-first markdown assets bundled with the npm package. Nothing phones home.


### PR DESCRIPTION
## What

v3.0.0 shipped the Pi coding-agent extension, but the two highest-traffic surfaces still presented Systematic as OpenCode-only:

- **Docs homepage** (`docs/src/content/docs/index.mdx`): title, description, and hero now name both harnesses; Quick Start gains a **Pi Extension** install path (`npx @fro.bot/systematic setup --harness pi`) linking the [Pi harness guide](https://fro.bot/systematic/guides/pi-harness/); the "not another chat UI" bullet names both runtimes.
- **README**: "What You Get" names the second harness and corrects stale catalog counts (40+/50+ → 31/37 post-curation); Quick Install adds the Pi setup command between the plugin and `npx skills` paths.

## Verification

- `bun run docs:build` green (84 pages; homepage emits the Pi content)
- `bun scripts/content-integrity.ts` clean
- Docs-only diff (2 files); no source/test changes

After merge, a `workflow_dispatch` docs deploy publishes the updated homepage.