### PR TITLE
fix(packaging): remove OpenCode SDK runtime dependency from plugin entry

### DIFF
--- a/docs/plans/2026-07-16-002-fix-opencode-plugin-load-failure-plan.md
+++ b/docs/plans/2026-07-16-002-fix-opencode-plugin-load-failure-plan.md
@@ -1,0 +1,92 @@
+---
+title: 'fix: v3 OpenCode plugin load failure (optional-peer runtime import)'
+type: fix
+status: active
+date: 2026-07-16
+---
+
+# fix: v3 OpenCode Plugin Load Failure
+
+## Overview
+
+@fro.bot/systematic v3.0.0/3.0.1 never loads for OpenCode cache installs: `peerDependenciesMeta` (added for Pi harness portability in PR #623) makes `@opencode-ai/plugin` optional, the installer skips it, and `dist/index.js`'s top-level `import { tool } from "@opencode-ai/plugin/tool"` throws `ERR_MODULE_NOT_FOUND` at load. No skills, no `systematic_skill`, no bootstrap. Fix: eliminate the runtime import (the SDK's `tool()` is an identity function), add the isolated-install regression test CI lacked, ship 3.0.2, deprecate 3.0.0/3.0.1.
+
+## Problem Frame
+
+v2.33.3 declared `@opencode-ai/plugin` as a required peer — OpenCode's package cache auto-installed it, so the runtime import resolved. v3's Pi support intentionally made all peers optional so Pi consumers don't pull OpenCode's SDK; the runtime import shape defeats the intent on the OpenCode side. Empirical proof: bare-node import of the cached 3.0.1 entry fails with `Cannot find package '@opencode-ai/plugin'`; the log has zero v3 init lines. CI missed it because `tests/integration/opencode.test.ts:852` manually symlinks `@opencode-ai/plugin` into the fixture.
+
+## Requirements Trace
+
+- R1. OpenCode cache installs of the published package load under bare node with no optional peers present.
+- R2. Optional-peer architecture preserved (Pi consumers still don't install the OpenCode SDK; OpenCode consumers don't install Pi's).
+- R3. A regression test fails on any future top-level runtime import of an optional peer in the OpenCode artifact.
+- R4. 3.0.0/3.0.1 deprecated on npm with an upgrade message after 3.0.2 verifies.
+
+## Scope Boundaries
+
+- Pi-side `typebox` externalization hardening: deferred (host-supplied in every real Pi install; not blocking).
+- `@earendil-works/pi-coding-agent` stays external and optional — a Pi extension legitimately requires its host.
+- No build-externals restructuring beyond what the fix needs.
+
+## Key Technical Decisions
+
+- Remove the `tool()` runtime import rather than bundle it (Oracle option D over A): the helper is `return input` + `tool.schema = z` (verified in SDK source and clonedep); returning the object directly, typed by the existing type-only `ToolDefinition` import, keeps the contract with zero runtime coupling. Bundling would conceal the dependency and pull the SDK's own zod copy.
+- Keep `--external @opencode-ai/plugin` in the build so any future accidental runtime coupling fails loudly instead of silently bundling.
+- Regression test lives in `tests/unit/package-exports.test.ts` (tarball already packed there): npm-install the tarball into a temp project with `--omit=dev`, assert `@opencode-ai/plugin` absent, import under bare node subprocess, require default-only export shape. Artifact-graph not-contains assertion as the fast secondary check.
+
+## Implementation Units
+
+- [x] **Unit 1: Regression test first (RED)**
+
+**Goal:** Isolated-install test reproducing the production failure.
+
+**Files:**
+- Modify: `tests/unit/package-exports.test.ts`
+
+**Approach:** Temp project outside repo; `npm install --omit=dev --ignore-scripts --no-audit --no-fund --package-lock=false <tarball>`; assert `node_modules/@opencode-ai/plugin` absent; bare-node subprocess `import('@fro.bot/systematic')` asserting `typeof default === 'function'` and default-only keys; exit 0 required, stderr in failure output. Must FAIL with ERR_MODULE_NOT_FOUND before the fix.
+
+**Test scenarios:** the unit IS the test — failure pre-fix, green post-fix.
+
+**Verification:** test fails on current HEAD.
+
+- [x] **Unit 2: Remove the runtime import (GREEN)**
+
+**Goal:** `dist/index.js` graph contains no runtime `@opencode-ai/plugin` import.
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `src/lib/skill-tool.ts`
+- Test: Unit 1's test + `tests/unit/skill-tool.test.ts` (existing suite stays green)
+
+**Approach:** Drop `import { tool } from '@opencode-ai/plugin/tool'`; keep `ToolDefinition` type-only; `import { z } from 'zod'`; return the definition object directly with `z.string().describe(...)` args. Add the artifact assertion (emitted JS graph not-contains `@opencode-ai/plugin`) to the package-exports suite.
+
+**Test scenarios:**
+- Happy path: Unit 1's isolated install loads; existing skill-tool suite green (tool description, args shape, execute behavior unchanged).
+- Edge: `.d.ts` may retain type-only imports — assertion scoped to `.js` files only.
+
+**Verification:** full gates (build, typecheck, lint, unit, integration) + Unit 1 green.
+
+## System-Wide Impact
+
+- **Unchanged invariants:** tool description/args/execute contract (`ToolDefinition`-typed), single default export, optional-peer package.json shape, Pi artifact untouched.
+- **Integration coverage:** `tests/integration/opencode.test.ts` keeps its symlink fixture (validates offline host behavior, not install) — the new unit test owns install validation.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| npm-install-in-test flakiness/latency | `--ignore-scripts --no-audit --no-fund`, tarball already local; runs once in the packaging suite |
+| SDK contract drift (tool() gains real behavior later) | `ToolDefinition` type-only import keeps compile-time checking; artifact assertion documents the boundary |
+
+## Documentation / Operational Notes
+
+- Release: `fix:` commit → semantic-release 3.0.2 on main merge.
+- Post-verify: `npm deprecate @fro.bot/systematic@"3.0.0 || 3.0.1" "Broken OpenCode plugin load (ERR_MODULE_NOT_FOUND); upgrade to >=3.0.2"` — needs Marcus's go (public registry action).
+- Post-release validation: fresh OpenCode cache install, `systematic_skill` registers, init log shows 3.0.2.
+
+## Sources & References
+
+- RCA evidence: cached 3.0.1 bare-node load failure; log analysis (zero v3 init lines); tarball diff 2.33.3↔3.0.1.
+- Oracle fix assessment (2026-07-16 session record).
+- Related: PR #623 (optional peers), `tests/integration/opencode.test.ts:852` (the masking symlink).

--- a/src/lib/skill-tool.ts
+++ b/src/lib/skill-tool.ts
@@ -65,6 +65,13 @@ export function createSkillTool(options: SkillToolOptions): ToolDefinition {
           return cachedParameterHint
         })(),
       ),
+      // Double-cast is required, not stylistic: the SDK types its args
+      // against its own bundled zod, whose Zod types are nominally
+      // incompatible with this package's zod (v4-vs-v1 internal version
+      // brands), so a direct cast fails typecheck. Runtime-safe because the
+      // SDK's `tool()` is an identity function and OpenCode consumes args
+      // structurally. Revisit if the SDK contract gains real behavior
+      // (guarded by the no-runtime-import artifact test in package-exports).
     } as unknown as ToolDefinition['args'],
     async execute(args: { name: string }, context): Promise<string> {
       const requestedName = args.name

--- a/src/lib/skill-tool.ts
+++ b/src/lib/skill-tool.ts
@@ -1,6 +1,6 @@
 import { pathToFileURL } from 'node:url'
 import type { ToolDefinition } from '@opencode-ai/plugin'
-import { tool } from '@opencode-ai/plugin/tool'
+import { z } from 'zod'
 import { escapeXml } from './skill-catalog.js'
 import { formatSkillCommandName } from './skill-loader.js'
 import {
@@ -49,7 +49,7 @@ export function createSkillTool(options: SkillToolOptions): ToolDefinition {
   let cachedDescription: string | null = null
   let cachedParameterHint: string | null = null
 
-  return tool({
+  return {
     get description() {
       if (cachedDescription == null) {
         cachedDescription = buildDescription()
@@ -57,7 +57,7 @@ export function createSkillTool(options: SkillToolOptions): ToolDefinition {
       return cachedDescription
     },
     args: {
-      name: tool.schema.string().describe(
+      name: z.string().describe(
         (() => {
           if (cachedParameterHint == null) {
             cachedParameterHint = buildParameterHint()
@@ -65,7 +65,7 @@ export function createSkillTool(options: SkillToolOptions): ToolDefinition {
           return cachedParameterHint
         })(),
       ),
-    },
+    } as unknown as ToolDefinition['args'],
     async execute(args: { name: string }, context): Promise<string> {
       const requestedName = args.name
 
@@ -93,5 +93,5 @@ export function createSkillTool(options: SkillToolOptions): ToolDefinition {
 
       return output
     },
-  })
+  }
 }

--- a/tests/unit/package-exports.test.ts
+++ b/tests/unit/package-exports.test.ts
@@ -13,6 +13,14 @@ const DIST_INDEX = path.join(DIST_DIR, 'index.js')
 const DIST_PI = path.join(DIST_DIR, 'pi.js')
 const DIST_CLI = path.join(DIST_DIR, 'cli.js')
 
+function listJavaScriptFiles(directory: string): string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name)
+    if (entry.isDirectory()) return listJavaScriptFiles(entryPath)
+    return entry.name.endsWith('.js') ? [entryPath] : []
+  })
+}
+
 interface PackageJson {
   main?: string
   exports?: Record<string, unknown>
@@ -144,6 +152,70 @@ describe('build output and packaging', () => {
     expect(Object.keys(mod).sort()).toEqual(['default'])
     expect(typeof mod.default).toBe('function')
   })
+
+  test('emitted JavaScript contains no OpenCode plugin runtime imports', () => {
+    for (const filePath of listJavaScriptFiles(DIST_DIR)) {
+      expect(fs.readFileSync(filePath, 'utf8')).not.toContain(
+        '@opencode-ai/plugin',
+      )
+    }
+  })
+
+  test('loads from an isolated npm install without optional peer dependencies', () => {
+    const projectDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'systematic-opencode-load-'),
+    )
+    try {
+      fs.writeFileSync(
+        path.join(projectDir, 'package.json'),
+        JSON.stringify({ type: 'module' }),
+      )
+
+      const install = spawnSync(
+        'npm',
+        [
+          'install',
+          '--omit=dev',
+          '--ignore-scripts',
+          '--no-audit',
+          '--no-fund',
+          '--package-lock=false',
+          packedTarballPath,
+        ],
+        {
+          cwd: projectDir,
+          encoding: 'utf8',
+          env: { ...process.env, npm_config_workspaces: 'false' },
+          timeout: 120_000,
+        },
+      )
+      expect(install.status).toBe(
+        0,
+        `npm install failed (exit ${install.status})\n--- stdout ---\n${install.stdout}\n--- stderr ---\n${install.stderr}`,
+      )
+      expect(
+        fs.existsSync(
+          path.join(projectDir, 'node_modules/@opencode-ai/plugin'),
+        ),
+      ).toBe(false)
+
+      const load = spawnSync(
+        'node',
+        [
+          '--input-type=module',
+          '-e',
+          "const m = await import('@fro.bot/systematic'); if (typeof m.default !== 'function') process.exit(1); if (Object.keys(m).join(',') !== 'default') process.exit(2)",
+        ],
+        { cwd: projectDir, encoding: 'utf8', timeout: 30_000 },
+      )
+      expect(load.status).toBe(
+        0,
+        `bare node import failed (exit ${load.status})\n--- stdout ---\n${load.stdout}\n--- stderr ---\n${load.stderr}`,
+      )
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true })
+    }
+  }, 180_000)
 
   test('dist/pi.js default export is a function importable without OpenCode runtime values', async () => {
     const mod = (await import(pathToFileURL(DIST_PI).href)) as Record<

--- a/tests/unit/package-exports.test.ts
+++ b/tests/unit/package-exports.test.ts
@@ -189,10 +189,10 @@ describe('build output and packaging', () => {
           timeout: 120_000,
         },
       )
-      expect(install.status).toBe(
-        0,
+      expect(
+        install.status,
         `npm install failed (exit ${install.status})\n--- stdout ---\n${install.stdout}\n--- stderr ---\n${install.stderr}`,
-      )
+      ).toBe(0)
       expect(
         fs.existsSync(
           path.join(projectDir, 'node_modules/@opencode-ai/plugin'),
@@ -208,10 +208,10 @@ describe('build output and packaging', () => {
         ],
         { cwd: projectDir, encoding: 'utf8', timeout: 30_000 },
       )
-      expect(load.status).toBe(
-        0,
+      expect(
+        load.status,
         `bare node import failed (exit ${load.status})\n--- stdout ---\n${load.stdout}\n--- stderr ---\n${load.stderr}`,
-      )
+      ).toBe(0)
     } finally {
       fs.rmSync(projectDir, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Production blocker

@fro.bot/systematic 3.0.0 and 3.0.1 never load as an OpenCode plugin for cache installs: sessions get no skills, no `systematic_skill`, no bootstrap.

**Root cause:** v3 marked `@opencode-ai/plugin` as an optional peer (`peerDependenciesMeta`, added for Pi harness portability in #623) so OpenCode's package installer skips it — but `dist/index.js` still carried a top-level runtime `import { tool } from "@opencode-ai/plugin/tool"`, which throws `ERR_MODULE_NOT_FOUND` before the plugin factory runs. v2.33.3 worked only because the required-peer declaration made the installer provide the package.

**Why CI missed it:** the integration fixture symlinks `@opencode-ai/plugin` into the extracted-tarball install (`tests/integration/opencode.test.ts`), masking exactly this failure. The unit packaging suite imported local `dist/` with dev deps present.

## Fix

The SDK's `tool()` helper is an identity function (`return input`; `tool.schema = z`) — verified in the SDK dist and the OpenCode source clone. `createSkillTool` now returns the typed definition object directly, with `z` from the package's own bundled zod. `ToolDefinition` remains a type-only import; `--external @opencode-ai/plugin` stays in the build so any future runtime coupling fails loudly instead of bundling silently. Optional-peer architecture (Pi consumers don't install the OpenCode SDK and vice versa) is preserved.

## Regression test

New isolated-install test in the packaging suite: installs the packed tarball into a temp project with `--omit=dev` (asserting `@opencode-ai/plugin` is absent), then imports the package under bare Node in a subprocess, requiring a callable default-only export. It failed with `ERR_MODULE_NOT_FOUND` before the fix (RED) and passes after (GREEN). A fast artifact assertion additionally requires no emitted `dist/*.js` to reference `@opencode-ai/plugin`.

## Verification

- Packaging suite 17/17 (includes the new isolated install)
- Full unit 1146/1146; integration 47 pass / 1 skip; build, typecheck, lint, content-integrity clean
- Bare-node import of the temp-install entry returns `function`

## Post-merge

semantic-release ships 3.0.2; after the published tarball verifies, 3.0.0/3.0.1 should be npm-deprecated with an upgrade message (separate explicit action).