### PR TITLE
fix(config): warn-and-ignore removed agent categories instead of failing config hook

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -16,6 +16,7 @@ import {
   SECURITY_OVERLAY_FIELDS as SCHEMA_SECURITY_OVERLAY_FIELDS,
   SystematicConfigSchema,
 } from './config-schema.js'
+import { REMOVED_BUNDLED_AGENT_CATEGORIES } from './removed-names.js'
 
 export interface BootstrapConfig {
   enabled: boolean
@@ -96,6 +97,10 @@ const CURRENT_AGENT_NAMES_SET: ReadonlySet<string> = new Set([
   ...BUNDLED_AGENT_QUALIFIED_IDS,
 ])
 
+const REMOVED_AGENT_CATEGORIES_SET: ReadonlySet<string> = new Set(
+  REMOVED_BUNDLED_AGENT_CATEGORIES,
+)
+
 /**
  * Return the subset of `names` that are absent from `allowedSet`. These are
  * names that parsed successfully (they are in the removed-names list so the
@@ -121,12 +126,17 @@ export function warnDroppedNames(
   dropped: string[],
   field: string,
   warned: Set<string>,
+  removalVersion?: string,
 ): void {
   for (const name of dropped) {
     if (warned.has(name)) continue
     warned.add(name)
+    const displayName = field === 'categories' ? `${field}.${name}` : name
+    const removalNote = removalVersion
+      ? ` It was removed in ${removalVersion}.`
+      : ''
     console.warn(
-      `[systematic] "${name}" in \`${field}\` is no longer a bundled name and will be ignored. Remove it from your config to silence this warning. See ${MIGRATION_DOCS_URL} for migration guidance.`,
+      `[systematic] "${displayName}" in \`${field}\` is no longer a bundled name and will be ignored.${removalNote} Remove it from your config to silence this warning. See ${MIGRATION_DOCS_URL} for migration guidance.`,
     )
   }
 }
@@ -390,7 +400,24 @@ export function loadConfigWithSources(
     (source): source is ConfigSource => source !== null,
   )
 
-  const overlays = mergeOverlaySources(sources)
+  const mergedOverlays = mergeOverlaySources(sources)
+  const droppedCategories = Object.keys(mergedOverlays.categories).filter(
+    (name) => REMOVED_AGENT_CATEGORIES_SET.has(name),
+  )
+  const warned = new Set<string>()
+  warnDroppedNames(droppedCategories, 'categories', warned, 'v3.0.0')
+  const droppedCategorySet = new Set(droppedCategories)
+  const overlays: SourcedOverlayConfigMap =
+    droppedCategorySet.size === 0
+      ? mergedOverlays
+      : {
+          ...mergedOverlays,
+          categories: Object.fromEntries(
+            Object.entries(mergedOverlays.categories).filter(
+              ([key]) => !droppedCategorySet.has(key),
+            ),
+          ),
+        }
   const userConfig = userSource?.config
   const projectConfig = projectSource?.config
   const customConfig = customSource?.config
@@ -446,7 +473,6 @@ export function loadConfigWithSources(
   // precedence and raw-config preservation are both unaffected. A local Set
   // deduplicates warnings within this single load invocation without any
   // sticky module-global state that could suppress unrelated later warnings.
-  const warned = new Set<string>()
   const droppedSkills = computeDroppedNames(
     result.disabled_skills,
     CURRENT_SKILL_NAMES_SET,

--- a/src/lib/removed-names.ts
+++ b/src/lib/removed-names.ts
@@ -63,3 +63,7 @@ export const REMOVED_BUNDLED_AGENT_NAMES: readonly string[] = [
   'security-sentinel',
   'workflow/lint',
 ] as const
+
+export const REMOVED_BUNDLED_AGENT_CATEGORIES: readonly string[] = [
+  'docs',
+] as const

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -1630,6 +1630,81 @@ model: gpt-4
       )
       await expect(handler(config)).rejects.toThrow(expectedConfigPath)
       await expect(handler(config)).rejects.toThrow('disabled_skills')
+    })
+
+    test('removed docs category does not prevent all bundled agents from being emitted', async () => {
+      createCategorizedAgent('review', 'review-agent', {
+        name: 'review-agent',
+        description: 'Review agent',
+      })
+      createCategorizedAgent('workflow', 'workflow-agent', {
+        name: 'workflow-agent',
+        description: 'Workflow agent',
+      })
+      writeCustomSystematicConfig({
+        categories: { docs: { model: 'openai/gpt-4' } },
+      })
+
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+      const config: Config = {}
+
+      await expect(handler(config)).resolves.toBeUndefined()
+      expect(config.agent).toHaveProperty('review-agent')
+      expect(config.agent).toHaveProperty('workflow-agent')
+      expect(warnSpy.mock.calls[0]?.[0]).toMatch(/categories\.docs/)
+      warnSpy.mockRestore()
+    })
+
+    test('never-existed category still fails validation', async () => {
+      createCategorizedAgent('review', 'review-agent', {
+        name: 'review-agent',
+        description: 'Review agent',
+      })
+      writeCustomSystematicConfig({
+        categories: { bogus: { model: 'openai/gpt-4' } },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+
+      await expect(handler({})).rejects.toThrow(
+        /categories\.bogus.*unknown bundled agent category.*Valid categories: review/,
+      )
+    })
+
+    test('valid category model defaults still apply alongside removed docs category', async () => {
+      createCategorizedAgent('review', 'review-agent', {
+        name: 'review-agent',
+        description: 'Review agent',
+      })
+      writeCustomSystematicConfig({
+        categories: {
+          docs: { model: 'openai/gpt-4' },
+          review: { model: 'openai/gpt-4' },
+        },
+      })
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+      const config: Config = {}
+
+      await handler(config)
+
+      expect(config.agent?.['review-agent']?.model).toBe('openai/gpt-4')
     })
 
     test('explicit frontmatter temperature is preserved', async () => {

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1393,6 +1393,39 @@ describe('config', () => {
     })
   })
 
+  describe('removed bundled agent categories (warn-and-ignore)', () => {
+    test('categories.docs is dropped and warns about its v3.0.0 removal', () => {
+      writeUserConfig({ categories: { docs: { model: 'openai/gpt-4' } } })
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+
+      const result = loadConfig(testDir)
+
+      expect(result.categories).not.toHaveProperty('docs')
+      expect(warnSpy.mock.calls[0]?.[0]).toMatch(
+        /categories\.docs.*removed in v3\.0\.0.*https:\/\/fro\.bot\/systematic\/guides\/v3-migration\//,
+      )
+      warnSpy.mockRestore()
+    })
+
+    test('valid categories remain after removing categories.docs', () => {
+      writeUserConfig({
+        categories: {
+          docs: { model: 'openai/gpt-4' },
+          review: { model: 'anthropic/claude-sonnet-4' },
+        },
+      })
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+
+      const result = loadConfig(testDir)
+
+      expect(result.categories).toEqual({
+        review: { model: 'anthropic/claude-sonnet-4' },
+      })
+      expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+  })
+
   describe('JSONC precedence', () => {
     test('only systematic.json exists -- loads it (backward compat)', () => {
       writeUserConfig({ disabled_skills: ['ce:plan'] })


### PR DESCRIPTION
## Problem

Upgrading to v3 with a v2-era `categories.docs` override in `systematic.jsonc` deregisters **all 37 bundled agents**. The `docs` agent category was removed by the v3 bundle curation, so config validation throws `categories.docs unknown bundled agent category` — and a Systematic config error fails OpenCode's entire plugin config hook (`plugin config hook failed` in logs). Tools keep working, agents silently vanish. Hit in production on 3.0.2.

## Fix

Mirror the existing removed-names safety net: `REMOVED_BUNDLED_AGENT_CATEGORIES = ['docs']` is stripped from merged overlays **before** strict category validation, with a warning naming `categories.docs`, the v3.0.0 removal, and the migration guide URL. Never-existed categories (e.g. `categories.bogus`) still fail validation loudly.

## Regression coverage

- `categories.docs` → validation succeeds, entry dropped, warning emitted
- **Incident test:** agents remain emitted through the config-handler path despite the stale key
- Never-existed category still throws
- Mixed configs: valid category overlays still apply their model defaults

## Verification

1151/1151 unit tests, typecheck, lint, content-integrity, schema drift all clean (no schema artifact changes — category keys are not enumerated in the published schema).