### PR TITLE
feat(skills): harness-portable skills — capability profiles, neutral spine, identifier gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Systematic is an OpenCode plugin providing structured engineering workflows for 
 | Where do I put new code? | [`STRUCTURE.md`](STRUCTURE.md) |
 | What does each directory contain? | [`STRUCTURE.md`](STRUCTURE.md) |
 | What are the naming conventions? | [`STRUCTURE.md`](STRUCTURE.md) |
+| What harnesses and compatibility evidence are verified? | [`HARNESSES.md`](HARNESSES.md) |
 | What conventions apply to my code? | This file (Conventions section below) |
 | What patterns should I follow? | This file (Conventions + Anti-Patterns below) |
 

--- a/HARNESSES.md
+++ b/HARNESSES.md
@@ -1,0 +1,97 @@
+# Harnesses
+
+This is the evidence registry for Systematic's harness-portability work. **Every tool or mechanism named here is backed by an in-repo path with line numbers, installed or cloned source, or an authoritative URL.** If the supplied research did not verify a capability, it is explicitly marked **UNVERIFIED**; absence of evidence is not evidence of absence.
+
+**Tiers.** Tier 1 means Systematic ships a controlled adapter: OpenCode and Pi. Tier 2 means the harness is documented for portability but has no Systematic adapter: Claude Code, Codex CLI, Gemini CLI, and GitHub Copilot.
+
+## Capability matrix
+
+The four capability rows use the vocabulary in the [OpenCode profile](skills/using-systematic/references/opencode-profile.md#L3-L8) and [Pi profile](skills/using-systematic/references/pi-profile.md#L3-L8).
+
+| Capability | OpenCode (Tier 1) | Pi (Tier 1) | Claude Code (Tier 2) | Codex CLI (Tier 2) | Gemini CLI (Tier 2) | GitHub Copilot (Tier 2) |
+|---|---|---|---|---|---|---|
+| Subagent delegation | `task`, including `subagent_type`, resume, and background execution [OC-1] | `systematic_delegate({agent, task})`; sequential, capped at 20 turns [PI-1] | `context: fork` for skills; `subagent_type` is **UNVERIFIED** [CC-1] | **UNVERIFIED** [U] | **UNVERIFIED** [U] | Built-in/custom agents [GH-1][GH-2] |
+| Blocking user interaction | `question` [OC-2] | No native blocking tool; numbered-chat fallback [PI-2] | `AskUserQuestion` [CC-2] | `request_user_input`; blocking and root-thread-only [CX-1][CX-2] | `ask_user`; pauses until answers [GE-1][GE-2] | No dedicated tool name verified; plan-mode clarification and `--no-ask-user` are documented [GH-3][GH-4] |
+| Task tracking | `todowrite` [OC-3] | No native mechanism; visible list fallback [PI-2] | `TodoWrite` is deprecated/disabled by default; `TaskCreate`/`TaskGet`/`TaskList`/`TaskUpdate` replace it [CC-3][CC-4] | **UNVERIFIED** [U] | **UNVERIFIED** [U] | No `TodoWrite` equivalent verified; cloud-agent tasks/sessions API is documented [GH-5] |
+| Skill loading | Skills become commands and `systematic_skill` is registered [OC-4][OC-5] | `systematic_skill` adapter and Pi-native activation [PI-3][PI-4] | Skill tool, `SKILL.md`, and `.claude/skills/` [CC-5][CC-6] | **UNVERIFIED** [U] | **UNVERIFIED** [U] | `SKILL.md` skills [GH-6] |
+| Skills-file support | `SKILL.md` is loaded by the Systematic skill path [OC-4] | `pi.skills` ships `./skills`, including `SKILL.md` discovery [PI-4][PI-5] | `SKILL.md` and `.claude/skills/` [CC-5][CC-6] | **UNVERIFIED** [U] | **UNVERIFIED** [U] | `SKILL.md` [GH-6] |
+
+`[U]` means the capability was not checked in the supplied research pack. It is not a claim that the capability does not exist.
+
+## OpenCode — Tier 1 shipped adapter
+
+OpenCode is the primary controlled integration. Its profile defines delegation, blocking interaction, task tracking, and skill loading [OC-P]. The underlying source registers `task` with specialized-agent, resume, and background fields [OC-1], `question` as a user-facing tool [OC-2], and `todowrite` as a built-in tool [OC-3]. Systematic converts bundled skills into commands in `src/lib/config-handler.ts:467-485` and registers the skill tool in `src/lib/skill-tool.ts:41-101` [OC-4][OC-5]. Bundled agent markdown omits a model field by invariant [OC-6]; runtime configuration may still supply source-owned defaults [OC-7].
+
+Compatibility is direct: OpenCode consumes the concrete invocation language in the profile. The adapter is not a generic claim about other harnesses.
+
+## Pi — Tier 1 shipped adapter
+
+Pi's profile records degraded or unavailable native capabilities and explicit fallbacks [PI-P]. The adapter registers `systematic_skill` in `src/pi.ts:85-103` and `systematic_delegate` in `src/pi.ts:106-113` [PI-3]. Delegation is explicitly sequential (`executionMode: 'sequential'`), capped at `MAX_DELEGATE_TURNS = 20`, and guarded against re-entry in `src/lib/pi-delegate-tool.ts:14-18,245-249` [PI-1].
+
+The package manifest exposes the extension and skills at `package.json:17-23`, with tests verifying both manifest entries and their packaged paths `tests/unit/package-exports.test.ts:42-66,241-267` [PI-4]. Pi's RPC/JSONL test fixture isolates its environment (`tests/integration/pi.test.ts:349-388`), and the installed runtime exposes environment-specific agent/session directories `node_modules/@earendil-works/pi-coding-agent/dist/config.js:396-398` [PI-5].
+
+Pi does not consume `disabled_skills` or Systematic's OpenCode configuration, and its skill loading has no OpenCode-style permission gate `docs/src/content/docs/guides/pi-harness.mdx:39-47` [PI-6]. Those are deliberate honesty boundaries, not implied parity.
+
+## Claude Code — Tier 2 documented portability target
+
+Claude Code documents `AskUserQuestion` [CC-2], current task tracking through `TaskCreate`/`TaskGet`/`TaskList`/`TaskUpdate`, and the deprecated `TodoWrite` [CC-3][CC-4]. Its skill model includes the skill tool, `SKILL.md`, `~/.claude/skills/`, and `.claude/skills/` [CC-5][CC-6]. Skills may run with `context: fork`; a public-docs verification of a `subagent_type` parameter was not found, so that name remains **UNVERIFIED** [CC-1]. Systematic ships no Claude Code adapter or profile.
+
+## Codex CLI — Tier 2 documented portability target
+
+The supplied evidence verifies only `request_user_input`: its definition names the tool [CX-1], and its handler blocks while restricting use to the root thread, rejecting subagents [CX-2]. Delegation, task tracking, skill loading, and skills-file support were not checked and remain **UNVERIFIED**. Systematic ships no Codex adapter or profile.
+
+## Gemini CLI — Tier 2 documented portability target
+
+The supplied evidence verifies `ask_user`: the official documentation says it pauses execution until answers arrive [GE-1], and the implementation defines `ASK_USER_TOOL_NAME` [GE-2]. Other capabilities, including delegation, task tracking, and skill-file support, were not checked and remain **UNVERIFIED**. Systematic ships no Gemini adapter or profile.
+
+## GitHub Copilot — Tier 2 documented portability target
+
+Copilot documents built-in agents and custom-agent invocation [GH-1][GH-2]. Its documented blocking behavior is plan-mode clarification, with `--no-ask-user` disabling asks; no dedicated blocking-tool name was verified [GH-3][GH-4]. The cloud-agent tasks/sessions API is documented, but no `TodoWrite` equivalent was verified [GH-5]. `SKILL.md` skills are documented [GH-6], as are instruction files including `AGENTS.md`, `.github/copilot-instructions.md`, and `.github/instructions/**/*.instructions.md` [GH-7][GH-8]. Systematic ships no Copilot adapter or profile.
+
+## Similarities and differences
+
+`SKILL.md` is the clearest cross-harness convergence: it is documented for Claude Code and Copilot, consumed by OpenCode's Systematic skill path, and shipped through Systematic-on-Pi [OC-4][PI-4][CC-5][GH-6]. `AGENTS.md` is also converging as an instruction-file convention: this repository uses it (`AGENTS.md:1-7`), and Copilot documents it [GH-7][GH-8].
+
+Delegation semantics diverge materially: OpenCode supports parallel/background dispatch [OC-1], Pi's adapter is sequential-only [PI-1], Claude's `context: fork` is skill-scoped [CC-1], and the remaining Tier 2 delegation claims are **UNVERIFIED**. Blocking input likewise ranges from native tools (`question`, `request_user_input`, `ask_user`, `AskUserQuestion`) to Pi's numbered-chat fallback and Copilot's plan-mode clarification [OC-2][PI-2][CC-2][CX-1][GE-1][GH-3].
+
+## Maintenance
+
+Update this file evidence-first: verify the implementation path and line range, installed/cloned source, or authoritative URL before adding a tool name. Re-check URLs when their pinned revision or behavior matters. Preserve **UNVERIFIED** when a capability has not been checked; do not fill gaps from intuition. Tier 1 changes require updating the corresponding profile and this registry together.
+
+Migrated-skill discipline is enforced by the [content-integrity gate](scripts/content-integrity.ts); keep exact harness identifiers in the designated profile/evidence surfaces and follow the gate's allowlist policy rather than weakening the gate.
+
+## Evidence registry
+
+- **OC-P** — [OpenCode profile](skills/using-systematic/references/opencode-profile.md#L3-L8).
+- **OC-1** — cloned OpenCode source, `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/src/tool/task.ts:24-62`.
+- **OC-2** — cloned OpenCode source, `.slim/clonedeps/repos/anomalyco__opencode/packages/core/src/tool/question.ts:10-25`.
+- **OC-3** — cloned OpenCode source, `.slim/clonedeps/repos/anomalyco__opencode/packages/core/src/tool/todowrite.ts:1-10`.
+- **OC-4** — `src/lib/config-handler.ts:467-485`.
+- **OC-5** — `src/lib/skill-tool.ts:41-101`.
+- **OC-6** — `ARCHITECTURE.md:75-85` and `agents/`.
+- **OC-7** — `src/lib/config-handler.ts:276-289`.
+- **PI-P** — [Pi profile](skills/using-systematic/references/pi-profile.md#L3-L8).
+- **PI-1** — `src/lib/pi-delegate-tool.ts:14-18,245-249,279-291`.
+- **PI-2** — [Pi profile](skills/using-systematic/references/pi-profile.md#L5-L8).
+- **PI-3** — `src/pi.ts:85-113`.
+- **PI-4** — `package.json:17-23`; `tests/unit/package-exports.test.ts:42-66,241-267`.
+- **PI-5** — `tests/integration/pi.test.ts:349-388`; installed Pi source `node_modules/@earendil-works/pi-coding-agent/dist/config.js:396-398`.
+- **PI-6** — `docs/src/content/docs/guides/pi-harness.mdx:39-47`.
+- **CC-1** — [Claude Code skills](https://code.claude.com/docs/en/skills) (`context: fork`); public-docs `subagent_type` verification is **UNVERIFIED**.
+- **CC-2** — [Claude Code tools reference](https://code.claude.com/docs/en/tools-reference).
+- **CC-3** — [Claude Code tools reference](https://code.claude.com/docs/en/tools-reference).
+- **CC-4** — [Claude Code todo tracking](https://code.claude.com/docs/en/agent-sdk/todo-tracking.md).
+- **CC-5** — [Claude Code skills](https://code.claude.com/docs/en/skills).
+- **CC-6** — [Claude Code Agent SDK skills](https://code.claude.com/docs/en/agent-sdk/skills.md).
+- **CX-1** — [Codex request_user_input definition](https://github.com/openai/codex/blob/35aaa5d9/codex-rs/tools/src/request_user_input_tool.rs).
+- **CX-2** — [Codex request_user_input handler](https://github.com/openai/codex/blob/d47b755a/codex-rs/core/src/tools/handlers/request_user_input.rs).
+- **GE-1** — [Gemini ask-user documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/ask-user.md).
+- **GE-2** — [Gemini ask-user implementation](https://github.com/google-gemini/gemini-cli/blob/d2cd12a7/packages/core/src/tools/ask-user.ts).
+- **GH-1** — [Copilot CLI built-in agents](https://docs.github.com/en/copilot/concepts/agents/copilot-cli/about-custom-agents).
+- **GH-2** — [Copilot CLI custom agents](https://docs.github.com/en/copilot/how-tos/copilot-cli/use-copilot-cli/invoke-custom-agents).
+- **GH-3** — [Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli).
+- **GH-4** — [Copilot CLI automation](https://docs.github.com/en/copilot/how-tos/copilot-cli/automate-copilot-cli/run-cli-programmatically).
+- **GH-5** — [Copilot cloud-agent tasks/sessions API](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent/use-cloud-agent-via-the-api).
+- **GH-6** — [Copilot CLI skills](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-skills).
+- **GH-7** — [Copilot best-practices instructions](https://docs.github.com/en/copilot/get-started/best-practices).
+- **GH-8** — [Copilot `AGENTS.md` support](https://github.blog/changelog/2025-08-28-copilot-coding-agent-now-supports-agents-md-custom-instructions/).

--- a/docs/plans/2026-07-16-001-feat-harness-portable-skills-plan.md
+++ b/docs/plans/2026-07-16-001-feat-harness-portable-skills-plan.md
@@ -1,0 +1,273 @@
+---
+title: 'feat: Harness-portable bundled skills (B′-thin)'
+type: feat
+status: active
+date: 2026-07-16
+origin: docs/brainstorms/2026-07-16-harness-portable-skills-requirements.md
+---
+
+# feat: Harness-Portable Bundled Skills (B′-thin)
+
+## Overview
+
+Pi sessions activating bundled skills today receive instructions naming OpenCode tools that do not exist in Pi. This plan rewrites the four divergent capability instructions (subagent delegation, blocking user interaction, task tracking, skill loading) as neutral operations in a six-skill migrated set, ships two capability profiles (OpenCode, Pi) inlined through both controlled bootstraps, adds Pi's binding to the multi-harness interaction idiom at every site catalog-wide, enforces a zero-tolerance identifier ban on the migrated set in the content-integrity gate, and proves the discipline with a Pi subprocess-harness scenario.
+
+## Problem Frame
+
+v3.0.0 made Pi a first-class consumer of `skills/` (`pi.skills` manifest — native discovery of every SKILL.md). The prose was written for OpenCode: `orchestrating-subagents` titles OpenCode's `task()` "The Portable Primitive" in a harness whose delegation is sequential-only and persona-bound; the interaction idiom ("`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini") appears across 17 skills with zero Pi mentions. Document-review of the fuller B′ shape converged on staging thin: prove the discipline on the shipped, verifiable harness before minting more profiles. (see origin: docs/brainstorms/2026-07-16-harness-portable-skills-requirements.md)
+
+## Requirements Trace
+
+- R1. Four divergent capabilities defined as the neutral vocabulary; near-universal operations stay concrete (origin R1).
+- R2. Migrated set: `orchestrating-subagents` (structural rewrite), `using-systematic` (additive routing), Pi binding added to the interaction idiom in `ce-brainstorm`, `ce-plan`, `ce-review` (3 sites), `ce-ideate` (origin R2). Per user confirmation, the same one-line Pi binding also lands at the 13 idiom sites in unmigrated skills (no gate marking implied).
+- R3. Neutral operations with inline fallbacks; workflow invariants capability-independent; body says *what*, profile says *how to call it here* (origin R3).
+- R4/R5. Two plain-markdown profiles under `skills/using-systematic/references/`; Pi profile encodes sequential-only `systematic_delegate`, optional blocking-input extension with numbered-chat fallback, skill loading via `systematic_skill` or native activation (origin R4, R5).
+- R6. Both bootstraps inline their compact profile (origin R6).
+- R7. Zero-tolerance bounded-identifier ban on the migrated set, fence-aware, profile files exempt-in-fences (origin R7).
+- R8. Pi harness scenario: payload-scan proof of no absent-tool instructions (origin R8).
+- R9/R10. Honesty posture in docs; `gh`/`git` stay; accidental `bun` prose in the migrated set generalized (origin R9, R10).
+
+## Scope Boundaries
+
+- No profiles for Claude Code / Codex / Copilot / Gemini this increment.
+- No migration or gate-marking of the remaining catalog beyond the idiom one-liners.
+- No runtime prose rewriting; no build-time variants.
+- `INTERNAL_AGENT_SIGNATURES` untouched (OpenCode-only mechanism, irrelevant to Pi path).
+- ce-review's `@./references/...` include-syntax portability: unresolved, deferred with the raw-consumer scope.
+
+### Deferred to Separate Tasks
+
+- Additional harness profiles + remaining-catalog classification: future increment, gated on the proof loop's evidence plus an explicit go decision.
+- New solution docs for the two novel patterns (inlined capability profiles; metadata-marked gate subset): post-merge `ce:compound`.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/lib/bootstrap.ts:175-217` `getBootstrapContent` — string concatenation; the `usageTemplate` field of `BootstrapDeps` (108-111) is the existing per-harness seam; insertion point for the profile block is between usage template and catalog (line 206), inside the `<SYSTEMATIC_WORKFLOWS>` zone (inherits marker idempotency).
+- `src/pi.ts:28-30, 62-68` — `PI_BOOTSTRAP_USAGE_TEMPLATE` override + load-time bootstrap snapshot; `before_agent_start` composes via `composeSystemPromptWithBootstrap` (`src/lib/bootstrap.ts:143-159`).
+- `scripts/content-integrity.ts` — 12 free-function checks dispatched in `checkContentIntegrity` (1261-1333); `stripFencedCodeBlocks` (1065-1071) is the fence primitive (used by `checkArgumentHint`); `isSkillEntryFile` (1175-1184) is the per-file scoping precedent; wiring requires `CheckResult` field + printer + `totalViolations` term.
+- `src/lib/skills.ts:64-76` `parseMetadata` — `metadata` is an allowlisted top-level field, free-form string-string map, gate-opaque inside. Marker: `metadata: { harness-portability: neutral-v1 }`.
+- `tests/integration/pi.test.ts:692-737` (bootstrap marker in payload, plain prompt), `824-871` (`systematic_skill` scripted tool call) — templates for the proof scenario.
+- `tests/unit/bootstrap.test.ts:79-100` — proves `usageTemplate` override; extend for `profileBlock`.
+- Idiom sites (19 total): ce-brainstorm:33, ce-plan:19, ce-review:62+314+637 (314 drifted to 2 harnesses), ce-ideate:21, deepen-plan:25, resolve-pr-feedback:330, frontend-design:56, git-commit-push-pr:10, git-commit:59+83, git-clean-gone-branches:40, ce-compound:35+266+416, ce-compound-refresh:36+398+678, reproduce-bug:17+114, onboarding:388, test-browser:51.
+- `skills/orchestrating-subagents/SKILL.md` — 12 `task(` occurrences: 2 framing (8, 12), 7 fenced examples (15-87), 3 instruction/table (121, 122, 133).
+- `skills/using-systematic/SKILL.md` — zero divergent identifiers in body; OpenCode-specific routing at lines 30 and 111 (duplicated by the bootstrap usage template); rest is harness-neutral discipline.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/undecidable-detection-honest-ban-rule-2026-06-04.md` — lexical ban, stated scope limits, one-action remediation.
+- `docs/solutions/logic-errors/pi-chained-bootstrap-composition-2026-07-14.md` — do not reuse OpenCode's scrubber in Pi; pin OpenCode bootstrap bytes with a snapshot test; add a double-run idempotency test; assert Pi output excludes OpenCode-only tool language.
+- `docs/solutions/best-practices/content-integrity-has-no-warning-channel-2026-06-06.md` — violation-or-nothing wiring; fence-strip before body scans + dedicated fence tests.
+- `docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md` — the gate's `metadata` read must mirror `parseMetadata`'s drop rules (non-string value drops the whole map).
+- `docs/solutions/best-practices/pi-real-runtime-integration-harness-2026-07-16.md` — payload scan is the settled assertion mechanism; hard-fail on missing Pi; positive markers over absence-of-error.
+- `docs/solutions/best-practices/third-party-bundled-skills-light-adaptation-2026-05-17.md` — empirical token count before AND after prose rewrites.
+- `docs/solutions/workflow-issues/registry-drift-on-skill-description-change-2026-05-20.md` — registry drift-check after any description edit.
+- `docs/solutions/workflow-issues/risks-table-rows-must-enforce-as-spec-checks-2026-05-18.md` — resolutions echoed into unit specs below, not left in tables.
+
+## Key Technical Decisions
+
+- Profile block rides inside `<SYSTEMATIC_WORKFLOWS>` via a new `BootstrapDeps.profileBlock` field (default absent → OpenCode path unchanged shape): inherits existing marker idempotency; mirrors the proven `usageTemplate` seam. Rejected: a second sentinel zone (new coordination point, new rules).
+- Profiles are pure markdown read from disk, inlined verbatim (no stitching/templating). Owned-by-one-file coupling comment in both consumers.
+- Migration marker is `metadata: { harness-portability: neutral-v1 }` — allowlisted field, string-map, semantically a structural declaration (not a `compatibility` caveat).
+- Gate mechanism is fence-strip + per-scope rule (strict on migrated `SKILL.md` bodies including fences; profile files exempt inside fences, banned in prose). Rejected: drift-allowlist entries (that file's schema keys on known `BannedPattern`s; a parallel mechanism inside the new check is simpler and self-contained).
+- Banned-identifier list (bounded, honest): `task(`, `subagent_type`, `todowrite`, `TodoWrite`, `` `question` `` tool references, `request_user_input`, `ask_user`, `AskUserQuestion`, `update_plan` — exact tokens, scope limit documented in the check. `systematic_skill`/`systematic_delegate` are NOT banned (they are Systematic's own cross-harness surface).
+- The 13 unmigrated idiom sites get the Pi binding line only — no `metadata` marker, no gate coverage (user-confirmed inclusion).
+
+## Open Questions
+
+### Resolved During Planning
+
+- Profile inlining point: inside `<SYSTEMATIC_WORKFLOWS>`, between usage template and catalog.
+- AE4 assertion form: mock-model payload scan (system/developer roles), not tool-call observation.
+- `metadata` viability: verified allowlisted + string-map semantics (`src/lib/skills.ts:48-76`).
+- ce-ideate "Pi line": does not exist; all four ce-* skills get the same addition.
+- Profile token budget: profiles are capability tables ~30-45 lines each; compact block target ≤ ~600 tokens per harness. Measured in Unit 2's snapshot test; if the OpenCode block pushes bootstrap growth past ~15%, trim the OpenCode profile to divergent-capability rows only (OpenCode names are already the prose default elsewhere).
+
+### Deferred to Implementation
+
+- Exact neutral phrasing per rewritten section (prose authoring is execution work).
+- Whether orchestrating-subagents' background-task guidance has any Pi expression: profile declares it unavailable (inline work fallback); the rewrite words the body accordingly.
+
+## Implementation Units
+
+- [ ] **Unit 1: Capability profiles + using-systematic migration**
+
+**Goal:** The two profile files exist; using-systematic's body becomes harness-neutral discipline that routes the four capabilities through "the active harness profile."
+
+**Requirements:** R1, R2 (using-systematic), R3, R4, R5
+
+**Dependencies:** None
+
+**Files:**
+- Create: `skills/using-systematic/references/opencode-profile.md`, `skills/using-systematic/references/pi-profile.md`
+- Modify: `skills/using-systematic/SKILL.md`
+- Test: `tests/unit/skills.test.ts` (frontmatter/marker parse), `scripts/content-integrity.ts` run (subfile refs resolve)
+
+**Approach:**
+- Each profile: one table over the four capabilities — mechanism, status (supported/degraded/unavailable), fallback — plus fenced invocation examples. Pi rows per R5: delegation = sequential-only `systematic_delegate({agent, task})`, bundled personas only, parallel unavailable → run sequentially; blocking input = optional extension, fallback numbered chat; task tracking = no native mechanism → maintain a visible list in responses; skill loading = `systematic_skill` or native activation.
+- using-systematic: remove OpenCode-specific routing lines 30 and 111 (the bootstrap usage template already carries the binding); add a short "Capability resolution" section: neutral statement of the four operations + "the bootstrap inlines the active harness profile; consult it for exact mechanisms" + inline no-mechanism fallbacks.
+- Add `metadata: { harness-portability: neutral-v1 }` to using-systematic frontmatter.
+- SKILL.md must reference both profile files by relative path (subfile-reference check enforces resolution).
+
+**Test scenarios:**
+- Happy path: `findSkillsInDir` surfaces using-systematic with `metadata['harness-portability'] === 'neutral-v1'`.
+- Edge case: profile files carry no frontmatter → confirm they are not picked up as skills and pass the gate's markdown scan.
+- Integration: content-integrity passes with the new references present; fails if a profile path referenced in SKILL.md is missing (existing check, verified by temporary-removal spot check during development, not a committed test).
+
+**Verification:** content-integrity clean; unit suite green; both profiles readable as standalone markdown.
+
+- [ ] **Unit 2: Bootstrap profile inlining (both harnesses)**
+
+**Goal:** Every OpenCode and Pi session's system prompt carries its harness's compact profile block inside `<SYSTEMATIC_WORKFLOWS>`.
+
+**Requirements:** R6; AE5
+
+**Dependencies:** Unit 1 (profiles exist)
+
+**Files:**
+- Modify: `src/lib/bootstrap.ts`, `src/index.ts`, `src/pi.ts`
+- Test: `tests/unit/bootstrap.test.ts`, `tests/unit/pi.test.ts`
+
+**Approach:**
+- Add `profileBlock?: string` to `BootstrapDeps`; concatenate between usage template and catalog. Absent → byte-identical current output.
+- `src/index.ts` passes the OpenCode profile; `src/pi.ts` passes the Pi profile (both read from the packaged `skills/using-systematic/references/` at load time, same directory-resolution pattern as the SKILL.md read; ownership coupling comment at both call sites).
+- Do NOT touch `applyBootstrapContent` or Pi's composition helper — the block rides inside the existing content string.
+
+**Execution note:** Snapshot-pin current OpenCode bootstrap output BEFORE the change (chained-bootstrap learning); the pinned test then documents the exact delta.
+
+**Test scenarios:**
+- Happy path: `getBootstrapContent` with `profileBlock` emits it inside the sentinel zone, after usage template, before catalog.
+- Edge case: absent `profileBlock` → output byte-identical to pre-change snapshot.
+- Edge case: profile block containing marker-shaped text round-trips composition without corruption (regression per chained-bootstrap incident).
+- Integration: double-run of Pi's `before_agent_start` handler composes the profile block exactly once (idempotency at the registered-handler level).
+- Integration: OpenCode path — `applyBootstrapContent` re-run does not duplicate the block (existing marker strip-and-replace covers it; assert explicitly).
+
+**Verification:** bootstrap + pi unit suites green; measured block sizes recorded in the test (budget guard: warn-comment if OpenCode bootstrap grew >15%).
+
+- [ ] **Unit 3: orchestrating-subagents structural rewrite**
+
+**Goal:** The skill teaches delegation discipline in neutral operations; zero banned identifiers in its body; OpenCode invocation syntax lives only in the OpenCode profile.
+
+**Requirements:** R1, R2, R3, R10
+
+**Dependencies:** Unit 1 (profile exists to reference)
+
+**Files:**
+- Modify: `skills/orchestrating-subagents/SKILL.md`
+- Test: gate check (Unit 5) + registry drift check
+
+**Approach:**
+- Rewrite framing (lines 8, 12): delegation as a capability ("dispatch bounded work to a subagent using the harness's delegation mechanism"), with parallel-vs-sequential expressed as profile-dependent ("run concurrently where the harness supports it; otherwise dispatch sequentially in dependency order").
+- Replace the 7 fenced `task(` examples with neutral dispatch descriptions (structured prompts, scope, expected returns) — concrete syntax moves to the OpenCode profile's fenced examples.
+- Rewrite retry/resume prose (121, 122, 133) neutrally ("re-dispatch with a corrected brief, or resume the prior specialist session where the harness supports session reuse").
+- Empirical token count before and after (light-adaptation learning): post-count of banned identifiers in body = 0.
+- Add `metadata: { harness-portability: neutral-v1 }`.
+- Preserve the skill's workflow substance (failure handling, synthesis, anti-patterns) — this is a re-voicing, not a content redesign.
+
+**Test scenarios:**
+- Test expectation: none beyond gate coverage — prose-only change; Unit 5's gate fixture and Unit 6's harness scenario are the mechanical proof.
+
+**Verification:** zero banned identifiers in body (counted); registry drift clean if description changed; content-integrity clean.
+
+- [ ] **Unit 4: Interaction idiom Pi binding — all 19 sites**
+
+**Goal:** Every occurrence of the multi-harness question-tool idiom names Pi's binding; ce-review's internally-drifted site (line 314) is normalized.
+
+**Requirements:** R2, R5; user-confirmed catalog-wide inclusion
+
+**Dependencies:** None (parallel-safe with Units 1-3; disjoint files except the four ce-* skills shared with nothing else)
+
+**Files:**
+- Modify: the 17 skills listed in Context (19 sites).
+- Test: none (prose one-liners); content-integrity + registry drift as gates.
+
+**Approach:**
+- Canonical line: "(`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait)". Adapt surrounding grammar per site; normalize ce-review:314 to the full form.
+- The four ce-* skills additionally get `metadata: { harness-portability: neutral-v1 }` (they are part of the migrated set; their remaining bodies already express the invariants capability-independently per AE2 — verify ce-review:62/637 wording stays tool-name-free outside the idiom parenthetical).
+
+**Test scenarios:**
+- Test expectation: none — mechanical prose edits; gate (Unit 5) covers the migrated four; grep-audit (19/19 sites carry the Pi binding) recorded in the PR body.
+
+**Verification:** 19/19 sites updated (counted); content-integrity + registry drift clean.
+
+- [ ] **Unit 5: Content-integrity gate — migrated-set identifier ban**
+
+**Goal:** CI fails any PR reintroducing a banned identifier into a migrated skill body; profile files may quote identifiers inside fences only.
+
+**Requirements:** R7; AE3
+
+**Dependencies:** Units 1, 3, 4 (migrated set exists and is clean — gate lands green, never red)
+
+**Files:**
+- Modify: `scripts/content-integrity.ts`
+- Test: `tests/unit/content-integrity.test.ts` (or the script's existing test home — follow current wiring)
+
+**Approach:**
+- New check `checkMigratedSkillIdentifiers(rootDir, scanFiles)`: for each `skills/*/SKILL.md` (existing `isSkillEntryFile` scope) with `metadata['harness-portability'] === 'neutral-v1'` (read via `parseFrontmatter` + the same drop-rule as `parseMetadata` — mirror-runtime learning), scan the full body INCLUDING fences for the banned list. For `skills/using-systematic/references/*-profile.md`: scan prose only (`stripFencedCodeBlocks` first), identifiers allowed inside fences.
+- Wire as check #13: `CheckResult` field, printer, `totalViolations` term, header list — violation-or-nothing (no warning channel).
+- Remediation message: name the identifier, the file, and the one action ("rephrase as a neutral operation; exact syntax belongs in the harness profile"). Document the scope limit in a comment (lexical tokens only, per honest-ban rule).
+
+**Test scenarios:**
+- Happy path: current repo state passes.
+- Error path: fixture migrated skill with `todowrite` in prose → violation (AE3).
+- Error path: fixture migrated skill with `task(` inside a fence → violation (strict scope).
+- Happy path: profile file with `task(` inside a fence → clean.
+- Error path: profile file with `todowrite` in prose → violation.
+- Edge case: skill with malformed `metadata` (non-string value) → treated as unmigrated (mirrors runtime drop), no violation.
+- Edge case: unmigrated skill with `task(` → no violation.
+
+**Verification:** gate green on the repo; all seven fixtures pass; `bun scripts/content-integrity.ts` output lists the new check.
+
+- [ ] **Unit 6: Pi harness proof scenario**
+
+**Goal:** Mechanical evidence: a Pi session with the migrated set active receives no instruction naming absent tools.
+
+**Requirements:** R8; AE1, AE4, AE5
+
+**Dependencies:** Units 1-3 (profiles inlined, orchestrating-subagents rewritten)
+
+**Files:**
+- Modify: `tests/integration/pi.test.ts`
+- Test: itself
+
+**Approach:**
+- Extend the existing describe block (fixture/mock-model/tarball infra as-is; hard-fail guard already present).
+- Scenario A (AE5): extend the existing bootstrap test — assert the composed system prompt contains the Pi profile marker on a plain prompt.
+- Scenario B (AE1/AE4): script the model to call `systematic_skill` for `systematic:orchestrating-subagents`; after `tool_execution_end`, assert (a) the returned skill body contains zero banned identifiers, (b) the full model-visible text (system/developer payload + tool result) contains no `task(`, `todowrite`, or OpenCode `question`-tool instruction, (c) the payload DOES contain the Pi profile's sequential-delegation guidance (positive marker, not absence-only).
+
+**Execution note:** Payload scan per the Pi-harness learning — the system prompt is not exposed by RPC; the mock model's captured requests are ground truth.
+
+**Test scenarios:** (the unit IS the tests — scenarios A and B above)
+
+**Verification:** `bun test tests/integration/pi.test.ts` green (7 scenarios total); runtime stays within the suite's existing budget (~15s).
+
+## System-Wide Impact
+
+- **Interaction graph:** bootstrap composition feeds every OpenCode session (plugin transform hook) and every Pi session (`before_agent_start`); profile block lands inside the existing sentinel — idempotency inherited, pinned by tests.
+- **API surface parity:** `BootstrapDeps` gains an optional field — additive, no consumer breaks. `bun run build` type surface unchanged externally (no new exports from `src/index.ts` — loader constraint).
+- **Unchanged invariants:** `INTERNAL_AGENT_SIGNATURES`, `applyBootstrapContent`, Pi composition helper, `systematic_skill`/`systematic_delegate` registration, discovered-skills-as-commands emission — all untouched.
+- **Integration coverage:** the Pi harness scenario is the only cross-layer proof; OpenCode-side behavior is covered by unit snapshot + idempotency tests (no OpenCode subprocess scenario needed — the profile is inert prose there).
+- **Error propagation:** missing profile file at load → same failure mode as missing using-systematic SKILL.md today (bootstrap returns degraded content); Unit 2 must not introduce a new throw path.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Neutral prose reduces OpenCode instruction-following on delegation | OpenCode profile carries the concrete `task(` syntax in the same system prompt; spine skills outside the migrated set keep concrete names |
+| Bootstrap growth degrades every session | Size measured in Unit 2 tests; ≤~600 tokens/harness budget; trim rule pre-agreed |
+| Gate false-positives on future legitimate prose | Bounded lexical list + per-scope fence rule + documented scope limit; remediation names the one action |
+| Registry/docs drift from description edits | `registry:drift` + `docs:generate` in the verification gates |
+| orchestrating-subagents rewrite loses workflow substance | Re-voicing constraint in Unit 3; ce:review autofix pass before PR |
+
+## Documentation / Operational Notes
+
+- R9 honesty note lands in `docs/src/content/docs/guides/pi-harness.mdx` (one paragraph: skill prose targets OpenCode and Pi; other harnesses consume at their own risk this increment) — fold into Unit 4's PR.
+- Release: ships as a v3.x minor (`feat:`); no breaking surface.
+
+## Sources & References
+
+- **Origin document:** docs/brainstorms/2026-07-16-harness-portable-skills-requirements.md
+- Oracle assessment + five-persona document-review (2026-07-16, session records)
+- Related code: `src/lib/bootstrap.ts`, `src/pi.ts`, `scripts/content-integrity.ts`, `tests/integration/pi.test.ts`
+- Prior art: obra/superpowers@v5.1.0 translation tables (deferred-harness shape)

--- a/docs/plans/2026-07-16-001-feat-harness-portable-skills-plan.md
+++ b/docs/plans/2026-07-16-001-feat-harness-portable-skills-plan.md
@@ -39,6 +39,7 @@ v3.0.0 made Pi a first-class consumer of `skills/` (`pi.skills` manifest — nat
 
 - Additional harness profiles + remaining-catalog classification: future increment, gated on the proof loop's evidence plus an explicit go decision.
 - New solution docs for the two novel patterns (inlined capability profiles; metadata-marked gate subset): post-merge `ce:compound`.
+- HARNESSES.md maintenance cadence beyond this increment (update when a profile ships or a harness contract changes).
 
 ## Context & Research
 
@@ -70,7 +71,7 @@ v3.0.0 made Pi a first-class consumer of `skills/` (`pi.skills` manifest — nat
 - Profile block rides inside `<SYSTEMATIC_WORKFLOWS>` via a new `BootstrapDeps.profileBlock` field (default absent → OpenCode path unchanged shape): inherits existing marker idempotency; mirrors the proven `usageTemplate` seam. Rejected: a second sentinel zone (new coordination point, new rules).
 - Profiles are pure markdown read from disk, inlined verbatim (no stitching/templating). Owned-by-one-file coupling comment in both consumers.
 - Migration marker is `metadata: { harness-portability: neutral-v1 }` — allowlisted field, string-map, semantically a structural declaration (not a `compatibility` caveat).
-- Gate mechanism is fence-strip + per-scope rule (strict on migrated `SKILL.md` bodies including fences; profile files exempt inside fences, banned in prose). Rejected: drift-allowlist entries (that file's schema keys on known `BannedPattern`s; a parallel mechanism inside the new check is simpler and self-contained).
+- Gate mechanism: strict scan on migrated `SKILL.md` bodies (including fences); profile files under `using-systematic/references/` are FULLY EXEMPT — they are the designated home for harness identifiers (capability tables name tools in prose by design; execution finding 2026-07-17 corrected the earlier fences-only exemption). Rejected: drift-allowlist entries (that file's schema keys on known `BannedPattern`s; a parallel mechanism inside the new check is simpler and self-contained).
 - Banned-identifier list (bounded, honest): `task(`, `subagent_type`, `todowrite`, `TodoWrite`, `` `question` `` tool references, `request_user_input`, `ask_user`, `AskUserQuestion`, `update_plan` — exact tokens, scope limit documented in the check. `systematic_skill`/`systematic_delegate` are NOT banned (they are Systematic's own cross-harness surface).
 - The 13 unmigrated idiom sites get the Pi binding line only — no `metadata` marker, no gate coverage (user-confirmed inclusion).
 
@@ -204,7 +205,7 @@ v3.0.0 made Pi a first-class consumer of `skills/` (`pi.skills` manifest — nat
 - Test: `tests/unit/content-integrity.test.ts` (or the script's existing test home — follow current wiring)
 
 **Approach:**
-- New check `checkMigratedSkillIdentifiers(rootDir, scanFiles)`: for each `skills/*/SKILL.md` (existing `isSkillEntryFile` scope) with `metadata['harness-portability'] === 'neutral-v1'` (read via `parseFrontmatter` + the same drop-rule as `parseMetadata` — mirror-runtime learning), scan the full body INCLUDING fences for the banned list. For `skills/using-systematic/references/*-profile.md`: scan prose only (`stripFencedCodeBlocks` first), identifiers allowed inside fences.
+- New check `checkMigratedSkillIdentifiers(rootDir, scanFiles)`: for each `skills/*/SKILL.md` (existing `isSkillEntryFile` scope) with `metadata['harness-portability'] === 'neutral-v1'` (read via `parseFrontmatter` + the same drop-rule as `parseMetadata` — mirror-runtime learning), scan the full body INCLUDING fences for the banned list. `skills/using-systematic/references/*-profile.md` are fully exempt (designated identifier home). Interaction-idiom lines (containing both `in OpenCode` and `in Pi`) are exempt — the sanctioned multi-harness binding.
 - Wire as check #13: `CheckResult` field, printer, `totalViolations` term, header list — violation-or-nothing (no warning channel).
 - Remediation message: name the identifier, the file, and the one action ("rephrase as a neutral operation; exact syntax belongs in the harness profile"). Document the scope limit in a comment (lexical tokens only, per honest-ban rule).
 
@@ -218,6 +219,28 @@ v3.0.0 made Pi a first-class consumer of `skills/` (`pi.skills` manifest — nat
 - Edge case: unmigrated skill with `task(` → no violation.
 
 **Verification:** gate green on the repo; all seven fixtures pass; `bun scripts/content-integrity.ts` output lists the new check.
+
+- [x] **Unit 7: HARNESSES.md — evidence-backed harness compatibility reference**
+
+**Goal:** A root-level `HARNESSES.md` documents similarities, differences, compatibility, and tools across every harness this feature touches (OpenCode, Pi, Claude Code, Codex, Copilot, Gemini), with EVERY tool mention mapping to verifiable evidence.
+
+**Requirements:** User directive 2026-07-17; extends R9's honesty posture into a standing reference.
+
+**Dependencies:** Units 1, 4 (profiles + idiom bindings are the in-repo ground truth it cites)
+
+**Files:**
+- Create: `HARNESSES.md`
+- Modify: `skills/using-systematic/references/opencode-profile.md`, `skills/using-systematic/references/pi-profile.md`, `AGENTS.md`; root markdown is outside gate skill scope
+
+**Approach:**
+- Structure: per-harness section (role: controlled vs deferred) + a cross-harness capability matrix (the four divergent capabilities × six harnesses) + compatibility notes (what Systematic ships/verifies per harness).
+- Evidence rule (non-negotiable): every named tool carries a citation — in-repo source (`src/pi.ts`, `src/lib/pi-delegate-tool.ts`, profile files, `tests/integration/pi.test.ts`), local installed/cloned source (`node_modules/@earendil-works/pi-coding-agent/`, `.slim/clonedeps/repos/anomalyco__opencode/`), or an external authoritative URL (official docs/repo) gathered by research. Tool names with no verifiable source are listed as UNVERIFIED with the strongest available provenance (e.g., "named in obra/superpowers translation tables") or omitted.
+- Deferred-harness sections state explicitly: prose-level binding only, no Systematic-shipped profile, consume-at-own-risk (mirrors the pi-harness.mdx honesty note).
+
+**Test scenarios:**
+- Test expectation: none automated — documentation; the evidence audit (every tool → citation) is recorded in the PR body as a checklist.
+
+**Verification:** every tool mention has a citation; content-integrity clean (root file outside skill scans, but run anyway); no session/process taxonomy in the text.
 
 - [ ] **Unit 6: Pi harness proof scenario**
 

--- a/docs/scripts/generate-config-reference.ts
+++ b/docs/scripts/generate-config-reference.ts
@@ -608,13 +608,16 @@ export function injectSourceDefaultsTable(mdxPath: string): string {
  * Run the generator and return an exit code (0 = success, 1 = error).
  * Replaces `process.exit(1)` with a return value for testability.
  */
-export async function execMain(version?: string): Promise<number> {
+export async function execMain(
+  version?: string,
+  mdxPath: string = CONFIG_MDX_PATH,
+): Promise<number> {
   try {
     const fieldRef = generateConfigReference(version)
-    const withFieldRef = injectFieldReference(CONFIG_MDX_PATH, fieldRef)
-    fs.writeFileSync(CONFIG_MDX_PATH, withFieldRef, 'utf-8')
-    const withDefaults = injectSourceDefaultsTable(CONFIG_MDX_PATH)
-    fs.writeFileSync(CONFIG_MDX_PATH, withDefaults, 'utf-8')
+    const withFieldRef = injectFieldReference(mdxPath, fieldRef)
+    fs.writeFileSync(mdxPath, withFieldRef, 'utf-8')
+    const withDefaults = injectSourceDefaultsTable(mdxPath)
+    fs.writeFileSync(mdxPath, withDefaults, 'utf-8')
     return 0
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)

--- a/docs/src/content/docs/guides/pi-harness.mdx
+++ b/docs/src/content/docs/guides/pi-harness.mdx
@@ -40,6 +40,8 @@ Once loaded, Systematic's Pi extension registers the same underlying capabilitie
 
 Pi support is real and runtime-tested, but it is not a byte-for-byte clone of the OpenCode integration. Two differences are worth knowing before you rely on it:
 
+Bundled skill prose targets OpenCode and Pi this release; other harnesses (Claude Code, Codex, Copilot, Gemini) consume the markdown at their own risk pending dedicated profiles.
+
 1. **Pi does not read `disabled_skills` (or any `systematic.json` config) today.** `src/pi.ts` constructs its skill resolver with a hardcoded empty disabled-skills list — the Pi extension does not load or consult OpenCode's `systematic.json` at all. Every bundled skill is available through `systematic_skill` in Pi regardless of what you have disabled for OpenCode. A Pi-native config namespace is a separate, not-yet-built decision — do not assume `.opencode` config applies to Pi sessions.
 
 2. **`systematic_skill` loads are not permission-gated in Pi.** OpenCode's `skill-tool.ts` calls `context.ask({ permission: 'skill', ... })` before returning skill content, so OpenCode's `permission.skill` config can prompt or block a load. Pi 0.80.6's extension API has no equivalent permission-gate hook, and Systematic's Pi tool implementation does not call one. `permission.skill` settings you rely on in OpenCode do not carry over — treat any skill reachable through `systematic_skill` in Pi as always-loadable.

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -330,7 +330,7 @@ JSON Schema URL for IDE autocomplete. The value is informational only — the lo
 **Examples:**
 
 ```json
-"$schema": "https://fro.bot/systematic/schemas/v3/systematic-config.schema.json"
+"$schema": "https://fro.bot/systematic/schemas/v2/systematic-config.schema.json"
 ```
 
 ## agents

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -330,7 +330,7 @@ JSON Schema URL for IDE autocomplete. The value is informational only — the lo
 **Examples:**
 
 ```json
-"$schema": "https://fro.bot/systematic/schemas/v2/systematic-config.schema.json"
+"$schema": "https://fro.bot/systematic/schemas/v3/systematic-config.schema.json"
 ```
 
 ## agents

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "dist",
     "skills",
     "agents",
-    "ATTRIBUTIONS.md"
+    "ATTRIBUTIONS.md",
+    "HARNESSES.md"
   ],
   "workspaces": [
     "docs"

--- a/registry/registry.jsonc
+++ b/registry/registry.jsonc
@@ -457,7 +457,7 @@
     {
       "name": "orchestrating-subagents",
       "type": "skill",
-      "description": "Use when dispatching parallel or serial subagents in OpenCode, coordinating multi-unit plan execution, synthesizing results from independent subagent runs, or handling subagent failure and retry. Triggers on requests to run tasks in parallel, divide work across subagents, orchestrate a pipeline of dependent steps, or coordinate multiple agents without shared-file conflicts.",
+      "description": "Use when dispatching parallel or serial subagents in OpenCode, coordinating multi-unit plan execution, synthesizing results from independent subagent runs, or handling subagent failure and retry. Triggers on requests to run tasks in parallel, divide work, orchestrate a pipeline of dependent steps, or coordinate multiple agents without shared-file conflicts.",
       "files": ["skills/orchestrating-subagents/SKILL.md"]
     },
     {
@@ -515,7 +515,11 @@
       "name": "using-systematic",
       "type": "skill",
       "description": "Use when starting any conversation - establishes how to find and use skills, requiring skill tool invocation before ANY response including clarifying questions",
-      "files": ["skills/using-systematic/SKILL.md"]
+      "files": [
+        "skills/using-systematic/SKILL.md",
+        "skills/using-systematic/references/opencode-profile.md",
+        "skills/using-systematic/references/pi-profile.md"
+      ]
     },
     {
       "name": "writing-skills",

--- a/registry/registry.jsonc
+++ b/registry/registry.jsonc
@@ -457,7 +457,7 @@
     {
       "name": "orchestrating-subagents",
       "type": "skill",
-      "description": "Use when dispatching parallel or serial subagents in OpenCode, coordinating multi-unit plan execution, synthesizing results from independent subagent runs, or handling subagent failure and retry. Triggers on requests to run tasks in parallel, divide work, orchestrate a pipeline of dependent steps, or coordinate multiple agents without shared-file conflicts.",
+      "description": "Use when dispatching parallel or serial subagents, coordinating multi-unit plan execution, synthesizing results from independent subagent runs, or handling subagent failure and retry. Triggers on requests to run tasks in parallel, divide work, orchestrate a pipeline of dependent steps, or coordinate multiple agents without shared-file conflicts.",
       "files": ["skills/orchestrating-subagents/SKILL.md"]
     },
     {

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -40,6 +40,10 @@
  *    `argument-hint` field in frontmatter. Fenced code blocks are stripped before
  *    scanning so skills that only document the placeholder are not flagged.
  *
+ * 13. **Migrated skill identifiers** — skills marked
+ *     `metadata['harness-portability'] === 'neutral-v1'` must use neutral
+ *     lexical vocabulary; exact harness syntax belongs in the harness profiles.
+ *
  * Scope is narrow by design: `skills/**\/*.md`, `agents/**\/*.md`, and
  * `src/**\/*.ts` for the full invariant suite. Additionally, `docs/solutions/**\/*.md`
  * is scanned for frontmatter parse-safety only (flags any unquoted inline comment —
@@ -218,6 +222,24 @@ export interface ArgumentHintViolation {
   message: string
 }
 
+export interface MigratedSkillIdentifierViolation {
+  file: string
+  line: number
+  identifier: MigratedSkillIdentifier
+  lineContent: string
+  message: string
+}
+
+type MigratedSkillIdentifier =
+  | 'task('
+  | 'subagent_type'
+  | 'todowrite'
+  | 'TodoWrite'
+  | 'request_user_input'
+  | 'ask_user'
+  | 'AskUserQuestion'
+  | 'update_plan'
+
 export interface RemovedNamesOverlapViolation {
   kind: 'skill' | 'agent'
   name: string
@@ -239,6 +261,7 @@ export interface CheckResult {
   agentStemViolations: AgentStemViolation[]
   agentTemperatureViolations: AgentTemperatureViolation[]
   argumentHintViolations: ArgumentHintViolation[]
+  migratedSkillIdentifierViolations: MigratedSkillIdentifierViolation[]
   removedNamesOverlapViolations: RemovedNamesOverlapViolation[]
   exemptHits: ExemptHit[]
   scanStats: {
@@ -1106,6 +1129,110 @@ export function checkArgumentHint(
   return violations
 }
 
+// These are deliberately lexical tokens only; the gate does not attempt to
+// detect paraphrases of harness-specific instructions.
+const MIGRATED_SKILL_IDENTIFIER_PATTERNS: ReadonlyArray<{
+  identifier: MigratedSkillIdentifier
+  pattern: RegExp
+}> = [
+  { identifier: 'task(', pattern: /(?:^|[^A-Za-z0-9_])task\(/ },
+  {
+    identifier: 'subagent_type',
+    pattern: /(?:^|[^A-Za-z0-9_])subagent_type(?:$|[^A-Za-z0-9_])/,
+  },
+  {
+    identifier: 'todowrite',
+    pattern: /(?:^|[^A-Za-z0-9_])todowrite(?:$|[^A-Za-z0-9_])/,
+  },
+  {
+    identifier: 'TodoWrite',
+    pattern: /(?:^|[^A-Za-z0-9_])TodoWrite(?:$|[^A-Za-z0-9_])/,
+  },
+  {
+    identifier: 'request_user_input',
+    pattern: /(?:^|[^A-Za-z0-9_])request_user_input(?:$|[^A-Za-z0-9_])/,
+  },
+  {
+    identifier: 'ask_user',
+    pattern: /(?:^|[^A-Za-z0-9_])ask_user(?:$|[^A-Za-z0-9_])/,
+  },
+  {
+    identifier: 'AskUserQuestion',
+    pattern: /(?:^|[^A-Za-z0-9_])AskUserQuestion(?:$|[^A-Za-z0-9_])/,
+  },
+  {
+    identifier: 'update_plan',
+    pattern: /(?:^|[^A-Za-z0-9_])update_plan(?:$|[^A-Za-z0-9_])/,
+  },
+]
+
+const MIGRATED_IDENTIFIER_REMEDIATION =
+  'rephrase as a neutral operation; exact syntax belongs in the harness profile (skills/using-systematic/references/)'
+
+/**
+ * Scan migrated skill bodies strictly, including fenced code. Harness profile
+ * files are the designated home for these identifiers and are fully exempt;
+ * this gate protects migrated skill bodies only. A line containing both
+ * `in OpenCode` and `in Pi` is the sanctioned interaction idiom and is exempt.
+ * The scope is intentionally lexical: paraphrases are not detected.
+ */
+export function checkMigratedSkillIdentifiers(
+  rootDir: string,
+  scanFiles: readonly string[],
+): MigratedSkillIdentifierViolation[] {
+  const violations: MigratedSkillIdentifierViolation[] = []
+
+  for (const relPath of scanFiles) {
+    if (isHarnessProfileFile(relPath)) continue
+    const content = readFileSafe(path.join(rootDir, relPath))
+    if (content === null) continue
+
+    if (!isSkillEntryFile(relPath)) continue
+    const parsed = parseFrontmatter(content)
+    if (!isMigratedSkill(parsed.data)) continue
+    scanMigratedIdentifierBody(relPath, parsed.body, violations)
+  }
+
+  return violations
+}
+
+function isHarnessProfileFile(relPath: string): boolean {
+  return /^skills\/using-systematic\/references\/[^/]+-profile\.md$/.test(
+    relPath,
+  )
+}
+
+function isMigratedSkill(data: Record<string, unknown>): boolean {
+  const metadata = data.metadata
+  if (!isRecord(metadata)) return false
+  const entries = Object.entries(metadata)
+  if (!entries.every(([, value]) => typeof value === 'string')) return false
+  return metadata['harness-portability'] === 'neutral-v1'
+}
+
+function scanMigratedIdentifierBody(
+  relPath: string,
+  body: string,
+  violations: MigratedSkillIdentifierViolation[],
+): void {
+  for (const [index, line] of body.split('\n').entries()) {
+    // The interaction idiom explicitly binds both harnesses on one line; its
+    // harness-specific identifiers are sanctioned and must not be reported.
+    if (line.includes('in OpenCode') && line.includes('in Pi')) continue
+
+    for (const { identifier, pattern } of MIGRATED_SKILL_IDENTIFIER_PATTERNS) {
+      if (!pattern.test(line)) continue
+      violations.push({
+        file: relPath,
+        line: index + 1,
+        identifier,
+        lineContent: line.trim(),
+        message: `Migrated skill identifier \`${identifier}\` found in ${relPath}: ${MIGRATED_IDENTIFIER_REMEDIATION}`,
+      })
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Removed-names overlap gate
 // ---------------------------------------------------------------------------
@@ -1294,6 +1421,10 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     targets.markdown,
   )
   const argumentHintViolations = checkArgumentHint(rootDir, targets.markdown)
+  const migratedSkillIdentifierViolations = checkMigratedSkillIdentifiers(
+    rootDir,
+    targets.markdown,
+  )
   const removedNamesOverlapViolations = checkRemovedNamesOverlap(
     REMOVED_BUNDLED_SKILL_NAMES,
     REMOVED_BUNDLED_AGENT_NAMES,
@@ -1322,6 +1453,7 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     agentStemViolations,
     agentTemperatureViolations,
     argumentHintViolations,
+    migratedSkillIdentifierViolations,
     removedNamesOverlapViolations,
     exemptHits,
     scanStats: {
@@ -1372,6 +1504,9 @@ function printResult(result: CheckResult, verbose: boolean): void {
   printAgentStemViolations(result.agentStemViolations)
   printAgentTemperatureViolations(result.agentTemperatureViolations)
   printArgumentHintViolations(result.argumentHintViolations)
+  printMigratedSkillIdentifierViolations(
+    result.migratedSkillIdentifierViolations,
+  )
   printRemovedNamesOverlapViolations(result.removedNamesOverlapViolations)
 
   if (totalViolations(result) === 0) {
@@ -1511,6 +1646,20 @@ function printArgumentHintViolations(
   }
 }
 
+function printMigratedSkillIdentifierViolations(
+  violations: readonly MigratedSkillIdentifierViolation[],
+): void {
+  if (violations.length === 0) return
+  process.stderr.write(
+    `\nMigrated skill identifier violations (${violations.length}):\n`,
+  )
+  for (const v of violations) {
+    process.stderr.write(
+      `  ${v.file}:${v.line}  ${v.identifier}  ${v.message}\n`,
+    )
+  }
+}
+
 function printRemovedNamesOverlapViolations(
   violations: readonly RemovedNamesOverlapViolation[],
 ): void {
@@ -1536,6 +1685,7 @@ function totalViolations(result: CheckResult): number {
     result.agentStemViolations.length +
     result.agentTemperatureViolations.length +
     result.argumentHintViolations.length +
+    result.migratedSkillIdentifierViolations.length +
     result.removedNamesOverlapViolations.length
   )
 }

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -239,6 +239,7 @@ type MigratedSkillIdentifier =
   | 'ask_user'
   | 'AskUserQuestion'
   | 'update_plan'
+  | 'question'
 
 export interface RemovedNamesOverlapViolation {
   kind: 'skill' | 'agent'
@@ -1164,6 +1165,7 @@ const MIGRATED_SKILL_IDENTIFIER_PATTERNS: ReadonlyArray<{
     identifier: 'update_plan',
     pattern: /(?:^|[^A-Za-z0-9_])update_plan(?:$|[^A-Za-z0-9_])/,
   },
+  { identifier: 'question', pattern: /`question`/ },
 ]
 
 const MIGRATED_IDENTIFIER_REMEDIATION =
@@ -1190,7 +1192,8 @@ export function checkMigratedSkillIdentifiers(
     if (!isSkillEntryFile(relPath)) continue
     const parsed = parseFrontmatter(content)
     if (!isMigratedSkill(parsed.data)) continue
-    scanMigratedIdentifierBody(relPath, parsed.body, violations)
+    scanMigratedIdentifierFrontmatter(relPath, content, parsed.data, violations)
+    scanMigratedIdentifierBody(relPath, content, parsed.body, violations)
   }
 
   return violations
@@ -1205,31 +1208,74 @@ function isHarnessProfileFile(relPath: string): boolean {
 function isMigratedSkill(data: Record<string, unknown>): boolean {
   const metadata = data.metadata
   if (!isRecord(metadata)) return false
-  const entries = Object.entries(metadata)
-  if (!entries.every(([, value]) => typeof value === 'string')) return false
+  // This marker is consumed only by this gate; there is no runtime protection to mirror.
   return metadata['harness-portability'] === 'neutral-v1'
+}
+
+const SANCTIONED_IDIOM_IDENTIFIERS = new Set<MigratedSkillIdentifier>([
+  'question',
+  'request_user_input',
+  'ask_user',
+  'AskUserQuestion',
+])
+
+function scanMigratedIdentifierFrontmatter(
+  relPath: string,
+  content: string,
+  data: Record<string, unknown>,
+  violations: MigratedSkillIdentifierViolation[],
+): void {
+  const rawBlock = extractFrontmatterBlock(content)
+  if (rawBlock === null) return
+  const rawLines = rawBlock.split('\n')
+
+  for (const field of ['description', 'argument-hint'] as const) {
+    const value = data[field]
+    if (typeof value !== 'string') continue
+    const rawLineIndex = rawLines.findIndex((line) =>
+      new RegExp(`^${escapeRegex(field)}:`).test(line),
+    )
+    const lineNumber = rawLineIndex >= 0 ? rawLineIndex + 2 : 2
+    scanMigratedIdentifierLine(relPath, value, lineNumber, violations)
+  }
 }
 
 function scanMigratedIdentifierBody(
   relPath: string,
+  content: string,
   body: string,
   violations: MigratedSkillIdentifierViolation[],
 ): void {
+  const bodyStart = content.length - body.length
+  const lineOffset = content.slice(0, bodyStart).split('\n').length - 1
   for (const [index, line] of body.split('\n').entries()) {
-    // The interaction idiom explicitly binds both harnesses on one line; its
-    // harness-specific identifiers are sanctioned and must not be reported.
-    if (line.includes('in OpenCode') && line.includes('in Pi')) continue
+    scanMigratedIdentifierLine(
+      relPath,
+      line,
+      lineOffset + index + 1,
+      violations,
+    )
+  }
+}
 
-    for (const { identifier, pattern } of MIGRATED_SKILL_IDENTIFIER_PATTERNS) {
-      if (!pattern.test(line)) continue
-      violations.push({
-        file: relPath,
-        line: index + 1,
-        identifier,
-        lineContent: line.trim(),
-        message: `Migrated skill identifier \`${identifier}\` found in ${relPath}: ${MIGRATED_IDENTIFIER_REMEDIATION}`,
-      })
-    }
+function scanMigratedIdentifierLine(
+  relPath: string,
+  line: string,
+  lineNumber: number,
+  violations: MigratedSkillIdentifierViolation[],
+): void {
+  const sanctionedIdiom = line.includes('in OpenCode') && line.includes('in Pi')
+  for (const { identifier, pattern } of MIGRATED_SKILL_IDENTIFIER_PATTERNS) {
+    if (sanctionedIdiom && SANCTIONED_IDIOM_IDENTIFIERS.has(identifier))
+      continue
+    if (!pattern.test(line)) continue
+    violations.push({
+      file: relPath,
+      line: lineNumber,
+      identifier,
+      lineContent: line.trim(),
+      message: `Migrated skill identifier \`${identifier}\` found in ${relPath}: ${MIGRATED_IDENTIFIER_REMEDIATION}`,
+    })
   }
 }
 

--- a/skills/ce-brainstorm/SKILL.md
+++ b/skills/ce-brainstorm/SKILL.md
@@ -2,6 +2,8 @@
 name: ce:brainstorm
 description: 'Explore requirements and approaches through collaborative dialogue before writing a right-sized requirements document and planning implementation. Use for feature ideas, problem framing, when the user says ''let''s brainstorm'', or when they want to think through options before deciding what to build. Also use when a user describes a vague or ambitious feature request, asks ''what should we build'', ''help me think through X'', presents a problem with multiple valid solutions, or seems unsure about scope or direction — even if they don''t explicitly ask to brainstorm.'
 argument-hint: "[feature idea or problem to explore]"
+metadata:
+  harness-portability: neutral-v1
 ---
 
 # Brainstorm a Feature or Improvement
@@ -30,7 +32,7 @@ This skill does not implement code. It explores, clarifies, and documents decisi
 1. **Ask one question at a time** - Do not batch several unrelated questions into one message.
 2. **Prefer single-select multiple choice** - Use single-select when choosing one direction, one priority, or one next step.
 3. **Use multi-select rarely and intentionally** - Use it only for compatible sets such as goals, constraints, non-goals, or success criteria that can all coexist. If prioritization matters, follow up by asking which selected item is primary.
-4. **Use the platform's question tool when available** - When asking the user a question, prefer the platform's blocking question tool if one exists (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini). Otherwise, present numbered options in chat and wait for the user's reply before proceeding.
+4. **Use the platform's question tool when available** - When asking the user a question, prefer the platform's blocking question tool if one exists (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait). Otherwise, present numbered options in chat and wait for the user's reply before proceeding.
 
 ## Output Guidance
 

--- a/skills/ce-compound-refresh/SKILL.md
+++ b/skills/ce-compound-refresh/SKILL.md
@@ -33,7 +33,7 @@ Check if `$ARGUMENTS` contains `mode:autofix`. If present, strip it from argumen
 
 Follow the same interaction style as `ce:brainstorm`:
 
-- Ask questions **one at a time** — use the platform's blocking question tool when available (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini). Otherwise, present numbered options in plain text and wait for the user's reply before continuing
+- Ask questions **one at a time** — use the platform's blocking question tool when available (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait). Otherwise, present numbered options in plain text and wait for the user's reply before continuing
 - Prefer **multiple choice** when natural options exist
 - Start with **scope and intent**, then narrow only when needed
 - Do **not** ask the user to make decisions before you have evidence
@@ -395,7 +395,7 @@ Do **not** ask questions about whether code changes were intentional, whether th
 
 #### Question Style
 
-Always present choices using the platform's blocking question tool when available (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini). Otherwise, present numbered options in plain text and wait for the user's reply before proceeding.
+Always present choices using the platform's blocking question tool when available (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait). Otherwise, present numbered options in plain text and wait for the user's reply before proceeding.
 
 Question rules:
 
@@ -675,6 +675,6 @@ After the refresh report is generated, check whether the project's instruction f
 
       `docs/solutions/` — documented solutions to past problems (bugs, best practices, workflow patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in documented areas.
       ```
-   c. In interactive mode, explain to the user why this matters — agents working in this repo (including fresh sessions, other tools, or collaborators without the plugin) won't know to check `docs/solutions/` unless the instruction file surfaces it. Show the proposed change and where it would go, then use the platform's blocking question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini) to get consent before making the edit. If no question tool is available, present the proposal and wait for the user's reply. In autofix mode, include it as a "Discoverability recommendation" line in the report — do not attempt to edit instruction files (autofix scope is doc maintenance, not project config).
+   c. In interactive mode, explain to the user why this matters — agents working in this repo (including fresh sessions, other tools, or collaborators without the plugin) won't know to check `docs/solutions/` unless the instruction file surfaces it. Show the proposed change and where it would go, then use the platform's blocking question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait) to get consent before making the edit. If no question tool is available, present the proposal and wait for the user's reply. In autofix mode, include it as a "Discoverability recommendation" line in the report — do not attempt to edit instruction files (autofix scope is doc maintenance, not project config).
 
 5. **Amend or create a follow-up commit when the check produces edits.** If step 4 resulted in an edit to an instruction file and Phase 5 already committed the refresh changes, stage the newly edited file and either amend the existing commit (if still on the same branch and no push has occurred) or create a small follow-up commit (e.g., `docs: add docs/solutions/ discoverability to AGENTS.md`). If Phase 5 already pushed the branch to a remote (e.g., the branch+PR path), push the follow-up commit as well so the open PR includes the discoverability change. This keeps the working tree clean and the remote in sync at the end of the run. If the user chose "Don't commit" in Phase 5, leave the instruction-file edit unstaged alongside the other uncommitted refresh changes — no separate commit logic needed.

--- a/skills/ce-compound/SKILL.md
+++ b/skills/ce-compound/SKILL.md
@@ -32,7 +32,7 @@ When spawning subagents, pass the relevant file contents into the task prompt so
 
 ## Execution Strategy
 
-Present the user with two options before proceeding, using the platform's blocking question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini). If no question tool is available, present the options and wait for the user's reply.
+Present the user with two options before proceeding, using the platform's blocking question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait). If no question tool is available, present the options and wait for the user's reply.
 
 ```
 1. Full (recommended) — the complete compound workflow. Researches,
@@ -263,7 +263,7 @@ After the learning is written and the refresh decision is made, check whether th
 
       `docs/solutions/` — documented solutions to past problems (bugs, best practices, workflow patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in documented areas.
       ```
-   c. In full mode, explain to the user why this matters — agents working in this repo (including fresh sessions, other tools, or collaborators without the plugin) won't know to check `docs/solutions/` unless the instruction file surfaces it. Show the proposed change and where it would go, then use the platform's blocking question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini) to get consent before making the edit. If no question tool is available, present the proposal and wait for the user's reply. In lightweight mode, output a one-liner note and move on
+   c. In full mode, explain to the user why this matters — agents working in this repo (including fresh sessions, other tools, or collaborators without the plugin) won't know to check `docs/solutions/` unless the instruction file surfaces it. Show the proposed change and where it would go, then use the platform's blocking question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait) to get consent before making the edit. If no question tool is available, present the proposal and wait for the user's reply. In lightweight mode, output a one-liner note and move on
 
 ### Phase 3: Optional Enhancement
 
@@ -413,7 +413,7 @@ What's next?
 5. Other
 ```
 
-**After displaying the success output, present the "What's next?" options using the platform's blocking question tool** (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini). If no question tool is available, present the numbered options and wait for the user's reply before proceeding. Do not continue the workflow or end the turn without the user's selection.
+**After displaying the success output, present the "What's next?" options using the platform's blocking question tool** (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait). If no question tool is available, present the numbered options and wait for the user's reply before proceeding. Do not continue the workflow or end the turn without the user's selection.
 
 **Alternate output (when updating an existing doc due to high overlap):**
 

--- a/skills/ce-ideate/SKILL.md
+++ b/skills/ce-ideate/SKILL.md
@@ -2,6 +2,8 @@
 name: ce:ideate
 description: "Generate and critically evaluate grounded improvement ideas for the current project. Use when asking what to improve, requesting idea generation, exploring surprising improvements, or wanting the AI to proactively suggest strong project directions before brainstorming one in depth. Triggers on phrases like 'what should I improve', 'give me ideas', 'ideate on this project', 'surprise me with improvements', 'what would you change', or any request for AI-generated project improvement suggestions rather than refining the user's own idea."
 argument-hint: "[feature, focus area, or constraint]"
+metadata:
+  harness-portability: neutral-v1
 ---
 
 # Generate Improvement Ideas
@@ -18,7 +20,7 @@ This workflow produces a ranked ideation artifact in `docs/ideation/`. It does *
 
 ## Interaction Method
 
-Use the platform's blocking question tool when available (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini). Otherwise, present numbered options in chat and wait for the user's reply before proceeding.
+Use the platform's blocking question tool when available (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait). Otherwise, present numbered options in chat and wait for the user's reply before proceeding.
 
 Ask one question at a time. Prefer concise single-select choices when natural options exist.
 

--- a/skills/ce-plan/SKILL.md
+++ b/skills/ce-plan/SKILL.md
@@ -2,6 +2,8 @@
 name: ce:plan
 description: "Create structured plans for any multi-step task -- software features, research workflows, events, study plans, or any goal that benefits from structured breakdown. Also deepen existing plans with interactive review of sub-agent findings. Use for plan creation when the user says 'plan this', 'create a plan', 'write a tech plan', 'plan the implementation', 'how should we build', 'what's the approach for', 'break this down', 'plan a trip', 'create a study plan', or when a brainstorm/requirements document is ready for planning. Use for plan deepening when the user says 'deepen the plan', 'deepen my plan', 'deepening pass', or uses 'deepen' in reference to a plan."
 argument-hint: "[optional: feature description, requirements doc path, plan path to deepen, or any task to plan]"
+metadata:
+  harness-portability: neutral-v1
 ---
 
 # Create Technical Plan
@@ -16,7 +18,7 @@ This workflow produces a durable implementation plan. It does **not** implement 
 
 ## Interaction Method
 
-Use the platform's question tool when available. When asking the user a question, prefer the platform's blocking question tool if one exists (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini). Otherwise, present numbered options in chat and wait for the user's reply before proceeding.
+Use the platform's question tool when available. When asking the user a question, prefer the platform's blocking question tool if one exists (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait). Otherwise, present numbered options in chat and wait for the user's reply before proceeding.
 
 Ask one question at a time. Prefer a concise single-select choice when natural options exist.
 

--- a/skills/ce-review/SKILL.md
+++ b/skills/ce-review/SKILL.md
@@ -2,6 +2,8 @@
 name: ce:review
 description: "Structured code review using tiered persona agents, confidence-gated findings, and a merge/dedup pipeline. Use when reviewing code changes before creating a PR."
 argument-hint: "[blank to review current branch, or provide PR link]"
+metadata:
+  harness-portability: neutral-v1
 ---
 
 # Code Review
@@ -59,7 +61,7 @@ All tokens are optional. Each one present means one less thing to infer. When ab
 
 ### Headless mode rules
 
-- **Skip all user questions.** Never use the platform question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini) or other interactive prompts. Infer intent conservatively if the diff metadata is thin.
+- **Skip all user questions.** Never use the platform question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait) or other interactive prompts. Infer intent conservatively if the diff metadata is thin.
 - **Require a determinable diff scope.** If headless mode cannot determine a diff scope (no branch, PR, or `base:` ref determinable without user interaction), emit `Review failed (headless mode). Reason: no diff scope detected. Re-invoke with a branch name, PR number, or base:<ref>.` and stop without dispatching agents.
 - **Apply only `safe_auto -> review-fixer` findings in a single pass.** No bounded re-review rounds. Leave `gated_auto`, `manual`, `human`, and `release` work unresolved and return them in the structured output.
 - **Return all non-auto findings as structured text output.** Use the headless output envelope format (see Stage 6 below) preserving severity, autofix_class, owner, requires_verification, confidence, pre_existing, and suggested_fix per finding. Enrich with detail-tier fields (why_it_matters, evidence[]) from the per-agent artifact files on disk (see Detail enrichment in Stage 6).
@@ -311,7 +313,7 @@ Pass this to every reviewer in their spawn prompt. Intent shapes *how hard each 
 
 **When intent is ambiguous:**
 
-- **Interactive mode:** Ask one question using the platform's interactive question tool (question in OpenCode, request_user_input in Codex): "What is the primary goal of these changes?" Do not spawn reviewers until intent is established.
+- **Interactive mode:** Ask one question using the platform's interactive question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait): "What is the primary goal of these changes?" Do not spawn reviewers until intent is established.
 - **Autofix/report-only/headless modes:** Infer intent conservatively from the branch name, diff, PR metadata, and caller context. Note the uncertainty in Coverage or Verdict reasoning instead of blocking.
 
 ### Stage 2b: Plan discovery (requirements verification)
@@ -634,7 +636,7 @@ After presenting findings and verdict (Stage 6), route the next steps by mode. R
 **Interactive mode**
 
 - Apply `safe_auto -> review-fixer` findings automatically without asking. These are safe by definition.
-- Ask a policy question **using the platform's blocking question tool** (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini) only when `gated_auto` or `manual` findings remain after safe fixes. Do not replace with a conversational open-ended question. Adapt the options to match what actually remains:
+- Ask a policy question **using the platform's blocking question tool** (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait) only when `gated_auto` or `manual` findings remain after safe fixes. Do not replace with a conversational open-ended question. Adapt the options to match what actually remains:
 
   **When `gated_auto` findings are present** (with or without `manual`):
   ```

--- a/skills/deepen-plan/SKILL.md
+++ b/skills/deepen-plan/SKILL.md
@@ -22,7 +22,7 @@ This skill does **not** turn plans into implementation scripts. It identifies we
 
 ## Interaction Method
 
-Use the platform's question tool when available. When asking the user a question, prefer the platform's blocking question tool if one exists (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini). Otherwise, present numbered options in chat and wait for the user's reply before proceeding.
+Use the platform's question tool when available. When asking the user a question, prefer the platform's blocking question tool if one exists (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait). Otherwise, present numbered options in chat and wait for the user's reply before proceeding.
 
 Ask one question at a time. Prefer a concise single-select choice when natural options exist.
 

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -53,7 +53,7 @@ Based on detected signals, choose a mode:
 
 ### Asking the User
 
-When context is ambiguous, use the platform's blocking question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini). If no question tool is available, assume "partial" mode and proceed conservatively.
+When context is ambiguous, use the platform's blocking question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait). If no question tool is available, assume "partial" mode and proceed conservatively.
 
 Example question: "I found [detected signals]. Should I follow your existing design patterns or create something distinctive?"
 

--- a/skills/git-clean-gone-branches/SKILL.md
+++ b/skills/git-clean-gone-branches/SKILL.md
@@ -37,7 +37,7 @@ These local branches have been deleted from the remote:
 Delete all of them? (y/n)
 ```
 
-Wait for the user's answer using the platform's question tool (e.g., `question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini). If no question tool is available, present the list and wait for the user's reply before proceeding.
+Wait for the user's answer using the platform's question tool (e.g., `question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait). If no question tool is available, present the list and wait for the user's reply before proceeding.
 
 This is a yes-or-no decision on the entire list -- do not offer multi-selection or per-branch choices.
 

--- a/skills/git-commit-push-pr/SKILL.md
+++ b/skills/git-commit-push-pr/SKILL.md
@@ -7,7 +7,7 @@ description: Commit, push, and open a PR with an adaptive, value-first descripti
 
 Go from working changes to an open pull request, or rewrite an existing PR description.
 
-**Asking the user:** When this skill says "ask the user", use the platform's blocking question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini). If unavailable, present the question and wait for a reply.
+**Asking the user:** When this skill says "ask the user", use the platform's blocking question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait). If unavailable, present the question and wait for a reply.
 
 ## Mode detection
 

--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -56,7 +56,7 @@ If both fail, fall back to `main`.
 
 If the git status from the context above shows a clean working tree (no staged, modified, or untracked files), report that there is nothing to commit and stop.
 
-If the current branch from the context above is empty, the repository is in detached HEAD state. Explain that a branch is required before committing if the user wants this work attached to a branch. Ask whether to create a feature branch now. Use the platform's blocking question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini). If no question tool is available, present the options and wait for the user's reply before proceeding.
+If the current branch from the context above is empty, the repository is in detached HEAD state. Explain that a branch is required before committing if the user wants this work attached to a branch. Ask whether to create a feature branch now. Use the platform's blocking question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait). If no question tool is available, present the options and wait for the user's reply before proceeding.
 
 - If the user chooses to create a branch, derive the name from the change content, create it with `git checkout -b <branch-name>`, then run `git branch --show-current` again and use that result as the current branch name for the rest of the workflow.
 - If the user declines, continue with the detached HEAD commit.
@@ -80,7 +80,7 @@ Keep this lightweight:
 
 ### Step 4: Stage and commit
 
-If the current branch from the context above is `main`, `master`, or the resolved default branch from Step 1, warn the user and ask whether to continue committing here or create a feature branch first. Use the platform's blocking question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini). If no question tool is available, present the options and wait for the user's reply before proceeding. If the user chooses to create a branch, derive the name from the change content, create it with `git checkout -b <branch-name>`, then continue.
+If the current branch from the context above is `main`, `master`, or the resolved default branch from Step 1, warn the user and ask whether to continue committing here or create a feature branch first. Use the platform's blocking question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait). If no question tool is available, present the options and wait for the user's reply before proceeding. If the user chooses to create a branch, derive the name from the change content, create it with `git checkout -b <branch-name>`, then continue.
 
 Write the commit message:
 - **Subject line**: Concise, imperative mood, focused on *why* not *what*. Follow the convention determined in Step 2.

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -385,7 +385,7 @@ Write the file to the repo root as `ONBOARDING.md`.
 
 ### Phase 5: Present Result
 
-After writing, inform the user that `ONBOARDING.md` has been generated. Offer next steps using the platform's blocking question tool when available (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini). Otherwise, present numbered options in chat.
+After writing, inform the user that `ONBOARDING.md` has been generated. Offer next steps using the platform's blocking question tool when available (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait). Otherwise, present numbered options in chat.
 
 Options:
 1. Open the file for review

--- a/skills/orchestrating-subagents/SKILL.md
+++ b/skills/orchestrating-subagents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orchestrating-subagents
-description: Use when dispatching parallel or serial subagents in OpenCode, coordinating multi-unit plan execution, synthesizing results from independent subagent runs, or handling subagent failure and retry. Triggers on requests to run tasks in parallel, divide work, orchestrate a pipeline of dependent steps, or coordinate multiple agents without shared-file conflicts.
+description: Use when dispatching parallel or serial subagents, coordinating multi-unit plan execution, synthesizing results from independent subagent runs, or handling subagent failure and retry. Triggers on requests to run tasks in parallel, divide work, orchestrate a pipeline of dependent steps, or coordinate multiple agents without shared-file conflicts.
 metadata:
   harness-portability: neutral-v1
 ---

--- a/skills/orchestrating-subagents/SKILL.md
+++ b/skills/orchestrating-subagents/SKILL.md
@@ -1,125 +1,131 @@
 ---
 name: orchestrating-subagents
-description: Use when dispatching parallel or serial subagents in OpenCode, coordinating multi-unit plan execution, synthesizing results from independent subagent runs, or handling subagent failure and retry. Triggers on requests to run tasks in parallel, divide work across subagents, orchestrate a pipeline of dependent steps, or coordinate multiple agents without shared-file conflicts.
+description: Use when dispatching parallel or serial subagents in OpenCode, coordinating multi-unit plan execution, synthesizing results from independent subagent runs, or handling subagent failure and retry. Triggers on requests to run tasks in parallel, divide work, orchestrate a pipeline of dependent steps, or coordinate multiple agents without shared-file conflicts.
+metadata:
+  harness-portability: neutral-v1
 ---
 
 # Orchestrating Subagents
 
-Dispatch, coordinate, and synthesize results from OpenCode subagents using the `task()` primitive.
+Dispatch, coordinate, and synthesize results from subagents using the harness's delegation mechanism (see the active harness profile).
 
 ## The Portable Primitive
 
-Every subagent dispatch goes through `task()`:
+Every subagent dispatch should carry the same bounded brief, expressed through the active harness's delegation mechanism:
 
-```typescript
-task({
-  subagent_type: "systematic-implementer",
-  description: "Implement auth module",
-  prompt: "...",
-})
+```text
+Specialist: systematic-implementer
+Objective: Implement the auth module
+Scope: Make only the changes needed for the auth module.
+Return: List the changed files and summarize the implementation.
 ```
 
-**Required parameters:**
-- `subagent_type` — the registered agent name (e.g., `systematic-implementer`, `best-practices-researcher`)
-- `description` — 3–5 word label shown in the UI
-- `prompt` — full instructions for the subagent
+**Required brief elements:**
+- **Specialist** — the registered agent or persona best suited to the work (for example, an implementer or researcher)
+- **Objective** — a concise statement of the outcome
+- **Scope** — full instructions, boundaries, dependencies, and files in scope
+- **Return** — the result format expected from the specialist
 
-**Optional:**
-- `task_id` — resume a prior subagent session instead of creating a new one
-- `command` — the slash command that triggered this task
+**Optional brief elements:**
+- **Session reference** — resume a prior specialist session instead of creating a new one, where the harness supports session reuse
+- **Trigger context** — the command or workflow that initiated the dispatch
 
-Foreground dispatch (no `background` parameter) blocks until the subagent returns its result. **This is the default and works on all OpenCode versions.**
+A foreground dispatch blocks until the specialist returns its result. Use the active harness profile to determine whether foreground, background, or other dispatch modes are available. Run independent dispatches concurrently where the harness supports it; otherwise dispatch sequentially in dependency order.
 
-## Background Dispatch (Experimental)
+## Background Dispatch (When Available)
 
-Background dispatch is gated by a runtime flag. It is **not available by default**.
+Background dispatch may be gated by a runtime capability or feature flag. Check the active harness profile and rely on whether the mechanism accepts background work.
 
-```typescript
-// Only use when the runtime exposes background support
-task({
-  subagent_type: "systematic-implementer",
-  description: "Implement auth module",
-  prompt: "...",
-  background: true,   // experimental — see below
-})
-```
+When background dispatch is available, it runs asynchronously and the harness reports the result to the parent session when the specialist completes. Do not poll or sleep.
 
-**When background is available:** `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true` (or the umbrella `OPENCODE_EXPERIMENTAL=true`) must be set. When enabled, `background: true` runs the subagent asynchronously. OpenCode automatically injects the result into the parent session as a synthetic message when the subagent completes. You are notified; you do not poll.
-
-**When background is unavailable:** Passing `background: true` returns an error. Fall back to foreground dispatch — dispatch subagents serially or in small foreground batches instead.
-
-**Check before assuming:** Rely on whether `background: true` is accepted (i.e., the env flag is set). If it returns an error, use foreground dispatch only.
+When background dispatch is unavailable, fall back to foreground dispatch—serially or in small foreground batches.
 
 ## Serial vs Parallel Dispatch
 
 ### Serial (default, always safe)
 
-Dispatch one subagent, wait for its result, then dispatch the next. Use when:
+Dispatch one specialist, wait for its result, then dispatch the next. Use when:
 - Units have dependencies (unit B needs unit A's output)
 - Units touch overlapping files
 - You need to verify each result before proceeding
 
-```typescript
-const researchResult = task({
-  subagent_type: "best-practices-researcher",
-  description: "Research caching patterns",
-  prompt: "Research Redis caching best practices for Rails APIs...",
-})
+```text
+First dispatch:
+  Specialist: best-practices-researcher
+  Objective: Research caching patterns
+  Scope: Research Redis caching best practices for Rails APIs.
+  Return: Summarize recommendations and constraints.
 
-// Use research output to guide implementation
-task({
-  subagent_type: "systematic-implementer",
-  description: "Implement caching",
-  prompt: `Implement caching based on this research:\n\n${researchResult}`,
-})
+After the first result, dispatch:
+  Specialist: systematic-implementer
+  Objective: Implement caching
+  Scope: Implement caching based on the research result below.
+  Input: Include the first specialist's returned research.
+  Return: List changed files and summarize the implementation.
 ```
 
-### Parallel (foreground batches)
+Use the first specialist's returned research to guide the dependent implementation dispatch.
 
-Dispatch multiple foreground subagents in the same turn. OpenCode runs them concurrently when dispatched together. Use when:
+### Parallel (independent dispatches)
+
+Dispatch multiple independent specialists concurrently where the harness supports it. Use when:
 - Units are fully independent (no shared files, no dependency on each other's output)
 - You have passed the Parallel Safety Check (see below)
 
-```typescript
-// Dispatch independent review subagents together
-task({ subagent_type: "security-reviewer", description: "Security review", prompt: "..." })
-task({ subagent_type: "performance-reviewer", description: "Performance review", prompt: "..." })
-task({ subagent_type: "correctness-reviewer", description: "Correctness review", prompt: "..." })
-// All three run; orchestrator synthesizes results after all complete
+```text
+Concurrent dispatch 1:
+  Specialist: security-reviewer
+  Objective: Perform a security review
+  Scope: Review the proposed changes for security issues.
+  Return: Findings with severity and file references.
+
+Concurrent dispatch 2:
+  Specialist: performance-reviewer
+  Objective: Perform a performance review
+  Scope: Review the proposed changes for performance issues.
+  Return: Findings with severity and file references.
+
+Concurrent dispatch 3:
+  Specialist: correctness-reviewer
+  Objective: Perform a correctness review
+  Scope: Review the proposed changes for functional issues.
+  Return: Findings with severity and file references.
 ```
+
+All three review dispatches run independently; the orchestrator synthesizes their results after all complete.
 
 ## Parallel Safety Check
 
 Before dispatching units in parallel, verify:
 
 1. **No file overlap** — build a file-to-unit map from each unit's declared files. Any file appearing in 2+ units means overlap → use serial dispatch instead.
-2. **No git index contention** — parallel subagents must not stage files (`git add`), create commits, or run the full test suite. If the current workflow owns git operations, the orchestrator handles staging and committing after all parallel units complete; otherwise, synthesize results and file lists and leave staging/committing to the caller or user.
-3. **No test interference** — concurrent test runs pick up each other's in-progress changes. Instruct parallel subagents not to run the project test suite.
+2. **No git index contention** — parallel specialists must not stage files (`git add`), create commits, or run the full test suite. If the current workflow owns git operations, the orchestrator handles staging and committing after all parallel units complete; otherwise, synthesize results and file lists and leave staging/committing to the caller or user.
+3. **No test interference** — concurrent test runs pick up each other's in-progress changes. Instruct parallel specialists not to run the project test suite.
 
-If any check fails, downgrade to serial dispatch. Log the reason (e.g., "Units 2 and 4 share `config/routes.rb` — using serial dispatch").
+If any check fails, downgrade to serial dispatch. Log the reason (for example, "Units 2 and 4 share `config/routes.rb` — using serial dispatch").
 
 ## Subagent Constraints for Parallel Work
 
-When dispatching units in parallel, include these instructions in each subagent's prompt:
+When dispatching units in parallel, include these instructions in each specialist's brief:
 
 > Do not stage files (`git add`), create commits, or run the project test suite. Leave staging and committing to the orchestrator or caller.
 
 ## Result Synthesis
 
-After subagents complete, the orchestrator synthesizes results:
+After specialists complete, the orchestrator synthesizes results:
 
-1. **Wait for all** — in a parallel batch, wait for every subagent to finish before acting on any result.
-2. **Check for file collisions** — compare actual files modified by all subagents in the batch (not just declared files). If 2+ subagents modified the same file, only the last writer's version survives. If the workflow owns git operations, resolve by staging non-colliding files first, then re-running the affected units serially; otherwise, report the collision list to the caller.
+1. **Wait for all** — in a parallel batch, wait for every specialist to finish before acting on any result.
+2. **Check for file collisions** — compare actual files modified by all specialists in the batch (not just declared files). If 2+ specialists modified the same file, only the last writer's version survives. If the workflow owns git operations, resolve by staging non-colliding files first, then re-running the affected units serially; otherwise, report the collision list to the caller.
 3. **Review each diff** — verify changes match the unit's declared scope.
 4. **Run targeted tests** — run the narrowest test command relevant to the changed files.
 5. **Stage and commit per unit (if the workflow owns git operations)** — in dependency order, stage only that unit's files and commit with a conventional message. If git operations belong to the caller or user, synthesize the result list and file inventory instead.
 
 ## Failure and Retry
 
-- If a subagent returns an error or its output is incomplete, diagnose before dispatching dependent units.
+- If a specialist returns an error or its output is incomplete, diagnose before dispatching dependent units.
 - Do not dispatch dependent units on a broken tree.
-- Retry a failed unit by dispatching a new `task()` call with a corrected prompt, or resume the prior session with `task_id`.
-- For background tasks (when available): wait for the automatic completion notification (the result is injected into the parent session). Do not poll or sleep. Retry by dispatching a new `task()` with a corrected prompt, or resume with `task_id`.
+- Retry a failed unit by re-dispatching with a corrected brief, or resume the prior specialist session where the harness supports session reuse.
+- For background work (when available): wait for the automatic completion notification (the result is delivered into the parent session). Do not poll or sleep. Retry by re-dispatching with a corrected brief, or resume the prior specialist session where the harness supports session reuse.
 
 ## Quick Reference
 
@@ -127,18 +133,18 @@ After subagents complete, the orchestrator synthesizes results:
 |---|---|
 | Units have dependencies | Serial foreground dispatch |
 | Units share files | Serial foreground dispatch |
-| Units are independent, no file overlap | Parallel foreground dispatch |
-| Background available + long-running work | Parallel background dispatch; results are pushed back to the parent on completion (no polling) |
+| Units are independent, no file overlap | Concurrent dispatch where supported; otherwise batched foreground dispatch |
+| Background available + long-running work | Concurrent background dispatch; results are pushed back to the parent on completion (no polling) |
 | Background unavailable | Foreground only — serial or batched |
-| Subagent fails | Diagnose, fix prompt, retry with new `task()` or resume with `task_id` |
+| Specialist fails | Diagnose, correct the brief, then re-dispatch or resume the prior session where supported |
 | File collision detected post-parallel | Stage non-colliding files (if workflow owns git ops), re-run colliding units serially |
 
 ## Common Mistakes
 
 | Mistake | Fix |
 |---|---|
-| Polling or sleeping to wait for a background subagent | Background results are pushed into the parent session automatically; never poll or sleep |
-| Parallel subagents staging or committing | Instruct subagents not to stage/commit; the current workflow owner handles git ops when applicable, otherwise synthesize file inventory and results for the caller or user |
+| Polling or sleeping to wait for background work | Background results are pushed into the parent session automatically; never poll or sleep |
+| Parallel specialists staging or committing | Instruct specialists not to stage/commit; the current workflow owner handles git ops when applicable, otherwise synthesize file inventory and results for the caller or user |
 | Dispatching dependent units without waiting | Always wait for prerequisites to complete and verify their output |
 | Ignoring file overlap in parallel batches | Run the Parallel Safety Check before every parallel dispatch |
-| Using `background: true` without the experimental flag enabled | Only use background when `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true`; otherwise dispatch foreground |
+| Assuming background support without checking the active profile | Use background dispatch only when the active harness profile declares it available; otherwise dispatch in the foreground |

--- a/skills/report-bug-ce/SKILL.md
+++ b/skills/report-bug-ce/SKILL.md
@@ -11,7 +11,7 @@ Report bugs encountered while using the Systematic plugin. This skill gathers st
 
 ## Step 1: Gather Bug Information
 
-Ask the user the following questions (using the platform's blocking question tool — e.g., `question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini — or present numbered options and wait for a reply):
+Ask the user the following questions (using the platform's blocking question tool — e.g., `question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait — or present numbered options and wait for a reply):
 
 **Question 1: Bug Category**
 - What type of issue are you experiencing?

--- a/skills/reproduce-bug/SKILL.md
+++ b/skills/reproduce-bug/SKILL.md
@@ -14,7 +14,7 @@ Fetch and analyze the bug report to extract structured information before touchi
 
 ### Fetch the issue
 
-If no issue number or URL was provided as an argument, ask the user for one before proceeding (using the platform's question tool -- e.g., `question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini -- or present a prompt and wait for a reply).
+If no issue number or URL was provided as an argument, ask the user for one before proceeding (using the platform's question tool -- e.g., `question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait -- or present a prompt and wait for a reply).
 
 ```bash
 gh issue view $ARGUMENTS --json title,body,comments,labels,assignees
@@ -111,7 +111,7 @@ When the bug is reproduced:
 For bugs that require specific data conditions, user roles, external service state, or cannot be automated:
 
 1. Document what conditions are needed
-2. Ask the user (using the platform's question tool -- e.g., `question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini -- or present options and wait for a reply) whether they can set up the required conditions
+2. Ask the user (using the platform's question tool -- e.g., `question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait -- or present options and wait for a reply) whether they can set up the required conditions
 3. Guide them through manual reproduction steps if needed
 
 ### If reproduction fails

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -327,7 +327,7 @@ Still pending from a previous run (count):
 
 If a blocking question tool is available, use it to ask about all pending decisions (both new `needs-human` and previous-run pending) together. If there are only pending decisions and no new work was done, the summary is just the pending items.
 
-If a blocking question tool is available (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini), use it to present the decisions and wait for the user's response. After they decide, process the remaining items: fix the code, compose the reply, post it, and resolve the thread.
+If a blocking question tool is available (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait), use it to present the decisions and wait for the user's response. After they decide, process the remaining items: fix the code, compose the reply, post it, and resolve the thread.
 
 If no question tool is available, present the decisions in the summary output and wait for the user to respond in conversation. If they don't respond, the items remain open on the PR for later handling.
 

--- a/skills/test-browser/SKILL.md
+++ b/skills/test-browser/SKILL.md
@@ -48,7 +48,7 @@ If not installed, inform the user: "`agent-browser` is not installed. Install it
 
 ### 2. Ask Browser Mode
 
-Ask the user whether to run headed or headless (using the platform's question tool — e.g., `question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini — or present options and wait for a reply):
+Ask the user whether to run headed or headless (using the platform's question tool — e.g., `question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait — or present options and wait for a reply):
 
 ```
 Do you want to watch the browser tests run?

--- a/skills/using-systematic/SKILL.md
+++ b/skills/using-systematic/SKILL.md
@@ -110,6 +110,6 @@ Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.
 
 The four capabilities are subagent delegation, blocking user interaction, task tracking, and skill loading.
 
-The bootstrap inlines the active harness profile naming the exact mechanisms—consult it. See [the OpenCode profile](references/opencode-profile.md) and [the Pi profile](references/pi-profile.md).
+The bootstrap inlines the active harness profile naming the exact mechanisms—consult it. See `references/opencode-profile.md` and `references/pi-profile.md`.
 
 When a mechanism is unavailable, present numbered options in chat and wait for questions, maintain a visible list for task tracking, and dispatch delegation sequentially or do the work inline.

--- a/skills/using-systematic/SKILL.md
+++ b/skills/using-systematic/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: using-systematic
 description: Use when starting any conversation - establishes how to find and use skills, requiring skill tool invocation before ANY response including clarifying questions
+metadata:
+  harness-portability: neutral-v1
 ---
 
 <SUBAGENT-STOP>
@@ -26,8 +28,6 @@ Systematic skills override default system prompt behavior, but **user instructio
 If CLAUDE.md, GEMINI.md, or AGENTS.md says "don't use TDD" and a skill says "always use TDD," follow the user's instructions. The user is in control.
 
 ## How to Access Skills
-
-Use the `systematic_skill` tool for Systematic bundled skills. Use the `skill` tool for non-Systematic skills. When you invoke a skill, its content is loaded and presented to you—follow it directly.
 
 # Using Skills
 
@@ -106,6 +106,10 @@ The skill itself tells you which.
 
 Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.
 
-## Skill Resolution
+## Capability Resolution
 
-Systematic bundled skills are listed in the `systematic_skill` tool description. Use the `skill` tool for skills outside the Systematic plugin.
+The four capabilities are subagent delegation, blocking user interaction, task tracking, and skill loading.
+
+The bootstrap inlines the active harness profile naming the exact mechanisms—consult it. See [the OpenCode profile](references/opencode-profile.md) and [the Pi profile](references/pi-profile.md).
+
+When a mechanism is unavailable, present numbered options in chat and wait for questions, maintain a visible list for task tracking, and dispatch delegation sequentially or do the work inline.

--- a/skills/using-systematic/references/opencode-profile.md
+++ b/skills/using-systematic/references/opencode-profile.md
@@ -1,0 +1,57 @@
+# OpenCode Capability Profile
+
+Evidence registry: see [`HARNESSES.md`](../../../HARNESSES.md).
+
+| Capability | Mechanism | Status | Fallback |
+|---|---|---|---|
+| Subagent delegation | `task()` tool; `subagent_type` selects a specialist, `task_id` resumes a session | supported; parallel and background dispatch may be available | Dispatch in the foreground, serially or in small batches |
+| Blocking user interaction | `question` tool | supported | Present numbered options in chat and wait |
+| Task tracking | `todowrite` | supported | Maintain a visible task list in responses |
+| Skill loading | `systematic_skill` for bundled skills; `skill` tool for non-Systematic skills | supported | Read the skill instructions listed by the active harness |
+
+## Invocation examples
+
+### Subagent delegation
+
+```typescript
+task({
+  subagent_type: "systematic-implementer",
+  description: "Implement auth module",
+  prompt: "Implement the auth module and return the changed files.",
+})
+
+// Background dispatch (run independent work concurrently; reconcile on completion):
+task({
+  subagent_type: "explorer",
+  description: "Map fixture patterns",
+  prompt: "…",
+  background: true,
+})
+
+// Resume a prior specialist session:
+task({ subagent_type: "fixer", task_id: "<prior-session-id>", prompt: "…" })
+```
+
+### Blocking user interaction
+
+```typescript
+question({
+  questions: [{ question: "Which deployment target should I use?", header: "Deployment target",
+    options: [{ label: "Staging", description: "Deploy to staging" }] }],
+})
+```
+
+### Task tracking
+
+```typescript
+todowrite({
+  todos: [{ content: "Run validation", status: "pending", priority: "high" }],
+})
+```
+
+### Skill loading
+
+```typescript
+systematic_skill({ name: "systematic:using-systematic" })
+skill({ name: "external-skill" })
+```

--- a/skills/using-systematic/references/opencode-profile.md
+++ b/skills/using-systematic/references/opencode-profile.md
@@ -29,7 +29,7 @@ task({
 })
 
 // Resume a prior specialist session:
-task({ subagent_type: "fixer", task_id: "<prior-session-id>", prompt: "…" })
+task({ subagent_type: "fixer", task_id: "<prior-session-id>", description: "Resume fixer task", prompt: "…" })
 ```
 
 ### Blocking user interaction

--- a/skills/using-systematic/references/pi-profile.md
+++ b/skills/using-systematic/references/pi-profile.md
@@ -1,0 +1,44 @@
+# Pi Capability Profile
+
+Evidence registry: see [`HARNESSES.md`](../../../HARNESSES.md).
+
+| Capability | Mechanism | Status | Fallback |
+|---|---|---|---|
+| Subagent delegation | `systematic_delegate({agent, task})` with bundled personas | degraded; execution is sequential only | Dispatch sequentially in dependency order or do the work inline |
+| Blocking user interaction | No native blocking tool | degraded | Present numbered options in chat and wait |
+| Task tracking | No native task-tracking mechanism | unavailable | Maintain a visible task list in responses |
+| Skill loading | `systematic_skill` tool or Pi-native skill activation | supported | Read the skill instructions listed by the active harness |
+
+## Invocation examples
+
+### Subagent delegation
+
+```typescript
+systematic_delegate({
+  agent: "systematic-implementer",
+  task: "Implement the auth module and return the changed files.",
+})
+```
+
+### Blocking user interaction
+
+```text
+1. Deploy to staging
+2. Deploy to production
+
+Reply with the number of your choice.
+```
+
+### Task tracking
+
+```text
+Task list:
+- [ ] Implement the auth module
+- [ ] Run validation
+```
+
+### Skill loading
+
+```typescript
+systematic_skill({ name: "systematic:using-systematic" })
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   applyBootstrapContent,
   getBootstrapContent,
   INTERNAL_AGENT_SIGNATURES,
+  readHarnessProfile,
 } from './lib/bootstrap.js'
 import { loadConfig } from './lib/config.js'
 import { createConfigHandler } from './lib/config-handler.js'
@@ -35,7 +36,11 @@ const initializePlugin = async ({ client, directory }: PluginInput) => {
   const config = loadConfig(directory)
   // Snapshot bootstrap once per plugin init so the cached system prefix stays
   // stable across requests. Custom bootstrap file edits take effect on restart.
-  const bootstrapContent = getBootstrapContent(config, { bundledSkillsDir })
+  // Profile files owned by skills/using-systematic/references/ — Unit 2 of 2026-07-16-001 plan.
+  const bootstrapContent = getBootstrapContent(config, {
+    bundledSkillsDir,
+    profileBlock: readHarnessProfile(bundledSkillsDir, 'opencode') ?? undefined,
+  })
 
   const configHandler = createConfigHandler({
     directory,

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -108,6 +108,25 @@ export const applyBootstrapContent = (
 export interface BootstrapDeps {
   bundledSkillsDir: string
   usageTemplate?: string
+  profileBlock?: string
+}
+
+/** Reads a harness capability profile from the packaged using-systematic references. */
+export function readHarnessProfile(
+  bundledSkillsDir: string,
+  name: string,
+): string | null {
+  const profilePath = path.join(
+    bundledSkillsDir,
+    'using-systematic/references',
+    `${name}-profile.md`,
+  )
+  try {
+    if (!fs.existsSync(profilePath)) return null
+    return fs.readFileSync(profilePath, 'utf8')
+  } catch {
+    return null
+  }
 }
 
 type BootstrapContentConfig = Pick<
@@ -176,7 +195,7 @@ export function getBootstrapContent(
   config: BootstrapContentConfig,
   deps: BootstrapDeps,
 ): string | null {
-  const { bundledSkillsDir, usageTemplate } = deps
+  const { bundledSkillsDir, usageTemplate, profileBlock } = deps
 
   if (!config.bootstrap.enabled) return null
 
@@ -205,6 +224,8 @@ export function getBootstrapContent(
   })
   const catalogSection = catalog.length > 0 ? `\n\n${catalog}` : ''
 
+  const profileSection = profileBlock === undefined ? '' : `\n\n${profileBlock}`
+
   return `<SYSTEMATIC_WORKFLOWS>
 You have access to structured engineering workflows via the Systematic plugin.
 
@@ -212,6 +233,6 @@ You have access to structured engineering workflows via the Systematic plugin.
 
 ${content}
 
-${skillUsage}${catalogSection}
+${skillUsage}${profileSection}${catalogSection}
 </SYSTEMATIC_WORKFLOWS>`
 }

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -122,9 +122,11 @@ export function readHarnessProfile(
     `${name}-profile.md`,
   )
   try {
-    if (!fs.existsSync(profilePath)) return null
     return fs.readFileSync(profilePath, 'utf8')
-  } catch {
+  } catch (error) {
+    console.error(
+      `Failed to read harness profile ${profilePath}: ${error instanceof Error ? error.message : String(error)}`,
+    )
     return null
   }
 }

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -11,6 +11,7 @@ import { buildAgentCatalog } from './lib/agent-resolver.js'
 import {
   composeSystemPromptWithBootstrap,
   computeBootstrapContentSafe,
+  readHarnessProfile,
 } from './lib/bootstrap.js'
 import { createRealPiDelegateSession } from './lib/pi-delegate-session.js'
 import { createPiDelegateTool } from './lib/pi-delegate-tool.js'
@@ -63,6 +64,8 @@ export default async function systematicPiExtension(
     {
       bundledSkillsDir,
       usageTemplate: PI_BOOTSTRAP_USAGE_TEMPLATE,
+      // Profile files owned by skills/using-systematic/references/ — Unit 2 of 2026-07-16-001 plan.
+      profileBlock: readHarnessProfile(bundledSkillsDir, 'pi') ?? undefined,
     },
     reportPiBootstrapFailure,
   )

--- a/tests/integration/pi.test.ts
+++ b/tests/integration/pi.test.ts
@@ -732,6 +732,8 @@ describe('Pi subprocess integration', () => {
         )
         .join('\n')
       expect(systemText).toContain('<SYSTEMATIC_WORKFLOWS>')
+      expect(systemText).toContain('# Pi Capability Profile')
+      expect(systemText).not.toContain('# OpenCode Capability Profile')
     },
     TIMEOUT_MS,
   )
@@ -866,6 +868,74 @@ describe('Pi subprocess integration', () => {
       expect(text).toContain(
         '<skill_content name="systematic:test-driven-development">',
       )
+    },
+    TIMEOUT_MS,
+  )
+
+  test(
+    'Pi skill payloads contain neutral orchestrating-subagents instructions',
+    async () => {
+      client = spawnPiRpc({ fixture })
+
+      await client.send({
+        type: 'set_model',
+        provider: MOCK_PROVIDER_ID,
+        modelId: MOCK_MODEL_ID,
+      })
+
+      mockModel.push({
+        toolCalls: [
+          {
+            id: 'call_orchestrating_subagents_1',
+            name: 'systematic_skill',
+            arguments: { name: 'systematic:orchestrating-subagents' },
+          },
+        ],
+      })
+      mockModel.push({ text: 'loaded the skill' })
+
+      const promptResponse = await client.send({
+        type: 'prompt',
+        message:
+          'Use systematic_skill to load systematic:orchestrating-subagents',
+      })
+      expect(promptResponse.success).toBe(true)
+
+      const toolEnd = await client.waitFor(
+        (msg) =>
+          msg.type === 'tool_execution_end' &&
+          (msg as { toolName?: string }).toolName === 'systematic_skill',
+      )
+      await client.waitFor((msg) => msg.type === 'agent_settled')
+
+      const result = (toolEnd as { result?: unknown }).result as
+        | { content?: { type: string; text?: string }[] }
+        | undefined
+      const skillText = result?.content?.[0]?.text ?? ''
+      expect(skillText).toContain(
+        '<skill_content name="systematic:orchestrating-subagents">',
+      )
+
+      for (const bannedToken of [
+        'task(',
+        'subagent_type',
+        'todowrite',
+        'TodoWrite',
+        'request_user_input',
+        'ask_user',
+        'AskUserQuestion',
+        'update_plan',
+      ]) {
+        expect(skillText).not.toContain(bannedToken)
+      }
+
+      const payloadStream = mockModel.requests
+        .map((request) => JSON.stringify(request))
+        .join('\n')
+      expect(payloadStream).not.toContain('task(')
+      expect(payloadStream).not.toContain('todowrite')
+      expect(payloadStream).not.toContain('subagent_type')
+      expect(payloadStream).toContain('execution is sequential only')
     },
     TIMEOUT_MS,
   )

--- a/tests/unit/__snapshots__/bootstrap.test.ts.snap
+++ b/tests/unit/__snapshots__/bootstrap.test.ts.snap
@@ -1,0 +1,307 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`getBootstrapContent pins the production-shaped OpenCode bootstrap with its profile inlined 1`] = `
+"<SYSTEMATIC_WORKFLOWS>
+You have access to structured engineering workflows via the Systematic plugin.
+
+**IMPORTANT: The using-systematic skill content is included below. It is ALREADY LOADED - you are currently following it. Do NOT use the systematic_skill tool to load "using-systematic" again - that would be redundant.**
+
+<SUBAGENT-STOP>
+If you were dispatched as a subagent to execute a specific task, skip this skill.
+</SUBAGENT-STOP>
+
+<EXTREMELY-IMPORTANT>
+If you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.
+
+IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
+
+This is not negotiable. This is not optional. You cannot rationalize your way out of this.
+</EXTREMELY-IMPORTANT>
+
+## Instruction Priority
+
+Systematic skills override default system prompt behavior, but **user instructions always take precedence**:
+
+1. **User's explicit instructions** (CLAUDE.md, GEMINI.md, AGENTS.md, direct requests) — highest priority
+2. **Systematic skills** — override default system behavior where they conflict
+3. **Default system prompt** — lowest priority
+
+If CLAUDE.md, GEMINI.md, or AGENTS.md says "don't use TDD" and a skill says "always use TDD," follow the user's instructions. The user is in control.
+
+## How to Access Skills
+
+# Using Skills
+
+## The Rule
+
+**Invoke relevant or requested skills BEFORE any response or action.** Even a 1% chance a skill might apply means that you should invoke the skill to check. If an invoked skill turns out to be wrong for the situation, you don't need to use it.
+
+\`\`\`dot
+digraph skill_flow {
+    "User message received" [shape=doublecircle];
+    "About to enter Plan mode?" [shape=doublecircle];
+    "Already brainstormed?" [shape=diamond];
+    "Invoke brainstorming skill" [shape=box];
+    "Might any skill apply?" [shape=diamond];
+    "Invoke \`systematic_skill\` tool" [shape=box];
+    "Announce: 'Using [skill] to [purpose]'" [shape=box];
+    "Has checklist?" [shape=diamond];
+    "Create todo per item" [shape=box];
+    "Follow skill exactly" [shape=box];
+    "Respond (including clarifications)" [shape=doublecircle];
+
+    "About to enter Plan mode?" -> "Already brainstormed?";
+    "Already brainstormed?" -> "Invoke brainstorming skill" [label="no"];
+    "Already brainstormed?" -> "Might any skill apply?" [label="yes"];
+    "Invoke brainstorming skill" -> "Might any skill apply?";
+
+    "User message received" -> "Might any skill apply?";
+    "Might any skill apply?" -> "Invoke \`systematic_skill\` tool" [label="yes, even 1%"];
+    "Might any skill apply?" -> "Respond (including clarifications)" [label="definitely not"];
+    "Invoke \`systematic_skill\` tool" -> "Announce: 'Using [skill] to [purpose]'";
+    "Announce: 'Using [skill] to [purpose]'" -> "Has checklist?";
+    "Has checklist?" -> "Create todo per item" [label="yes"];
+    "Has checklist?" -> "Follow skill exactly" [label="no"];
+    "Create todo per item" -> "Follow skill exactly";
+}
+\`\`\`
+
+## Red Flags
+
+These thoughts mean STOP—you're rationalizing:
+
+| Thought | Reality |
+|---------|---------|
+| "This is just a simple question" | Questions are tasks. Check for skills. |
+| "I need more context first" | Skill check comes BEFORE clarifying questions. |
+| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
+| "I can check git/files quickly" | Files lack conversation context. Check for skills. |
+| "Let me gather information first" | Skills tell you HOW to gather information. |
+| "This doesn't need a formal skill" | If a skill exists, use it. |
+| "I remember this skill" | Skills evolve. Read current version. |
+| "This doesn't count as a task" | Action = task. Check for skills. |
+| "The skill is overkill" | Simple things become complex. Use it. |
+| "I'll just do this one thing first" | Check BEFORE doing anything. |
+| "This feels productive" | Undisciplined action wastes time. Skills prevent this. |
+| "I know what that means" | Knowing the concept != using the skill. Invoke it. |
+
+## Skill Priority
+
+When multiple skills could apply, use this order:
+
+1. **Process skills first** (brainstorming, debugging) - these determine HOW to approach the task
+2. **Implementation skills second** (frontend-design, mcp-builder) - these guide execution
+
+"Let's build X" -> brainstorming first, then implementation skills.
+"Fix this bug" -> debugging first, then domain-specific skills.
+
+## Skill Types
+
+**Rigid** (TDD, debugging): Follow exactly. Don't adapt away discipline. The canonical bundled Rigid skill is \`test-driven-development\` — load it when implementing any feature or bugfix that requires test-first discipline.
+
+**Flexible** (patterns): Adapt principles to context.
+
+The skill itself tells you which.
+
+## User Instructions
+
+Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.
+
+## Capability Resolution
+
+The four capabilities are subagent delegation, blocking user interaction, task tracking, and skill loading.
+
+The bootstrap inlines the active harness profile naming the exact mechanisms—consult it. See \`references/opencode-profile.md\` and \`references/pi-profile.md\`.
+
+When a mechanism is unavailable, present numbered options in chat and wait for questions, maintain a visible list for task tracking, and dispatch delegation sequentially or do the work inline.
+
+**Skills naming:**
+- Systematic bundled skills use the \`systematic:\` prefix (e.g., \`systematic:onboarding\`)
+- Workflow skills with their own namespace keep it (e.g., \`ce:brainstorm\`)
+- Skills can also be invoked without prefix if unambiguous
+
+**Skills usage:**
+- Use \`systematic_skill\` to load Systematic bundled skills
+- Use the \`skill\` tool for non-Systematic skills
+
+**Skills location:**
+Bundled skills ship with the Systematic plugin and are discoverable via \`systematic_skill\`.
+
+# OpenCode Capability Profile
+
+Evidence registry: see [\`HARNESSES.md\`](../../../HARNESSES.md).
+
+| Capability | Mechanism | Status | Fallback |
+|---|---|---|---|
+| Subagent delegation | \`task()\` tool; \`subagent_type\` selects a specialist, \`task_id\` resumes a session | supported; parallel and background dispatch may be available | Dispatch in the foreground, serially or in small batches |
+| Blocking user interaction | \`question\` tool | supported | Present numbered options in chat and wait |
+| Task tracking | \`todowrite\` | supported | Maintain a visible task list in responses |
+| Skill loading | \`systematic_skill\` for bundled skills; \`skill\` tool for non-Systematic skills | supported | Read the skill instructions listed by the active harness |
+
+## Invocation examples
+
+### Subagent delegation
+
+\`\`\`typescript
+task({
+  subagent_type: "systematic-implementer",
+  description: "Implement auth module",
+  prompt: "Implement the auth module and return the changed files.",
+})
+
+// Background dispatch (run independent work concurrently; reconcile on completion):
+task({
+  subagent_type: "explorer",
+  description: "Map fixture patterns",
+  prompt: "…",
+  background: true,
+})
+
+// Resume a prior specialist session:
+task({ subagent_type: "fixer", task_id: "<prior-session-id>", description: "Resume fixer task", prompt: "…" })
+\`\`\`
+
+### Blocking user interaction
+
+\`\`\`typescript
+question({
+  questions: [{ question: "Which deployment target should I use?", header: "Deployment target",
+    options: [{ label: "Staging", description: "Deploy to staging" }] }],
+})
+\`\`\`
+
+### Task tracking
+
+\`\`\`typescript
+todowrite({
+  todos: [{ content: "Run validation", status: "pending", priority: "high" }],
+})
+\`\`\`
+
+### Skill loading
+
+\`\`\`typescript
+systematic_skill({ name: "systematic:using-systematic" })
+skill({ name: "external-skill" })
+\`\`\`
+
+
+<available_skills>
+  <skill>
+    <name>systematic:agent-browser</name>
+    <description>Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, or automating any browser task. Triggers include requests to "open a website", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction.</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/agent-browser</location>
+  </skill>
+  <skill>
+    <name>systematic:agent-native-architecture</name>
+    <description>Build applications where agents are first-class citizens. Use this skill when designing autonomous agents, creating MCP tools, implementing self-modifying systems, or building apps where features are outcomes achieved by agents operating in a loop.</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/agent-native-architecture</location>
+  </skill>
+  <skill>
+    <name>ce:brainstorm</name>
+    <description>Explore requirements and approaches through collaborative dialogue before writing a right-sized requirements document and planning implementation. Use for feature ideas, problem framing, when the user says 'let's brainstorm', or when they want to think through options before deciding what to build. Also use when a user describes a vague or ambitious feature request, asks 'what should we build', 'help me think through X', presents a problem with multiple valid solutions, or seems unsure about scope or direction — even if they don't explicitly ask to brainstorm.</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-brainstorm</location>
+  </skill>
+  <skill>
+    <name>ce:compound</name>
+    <description>Document a recently solved problem to compound your team's knowledge</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-compound</location>
+  </skill>
+  <skill>
+    <name>ce:ideate</name>
+    <description>Generate and critically evaluate grounded improvement ideas for the current project. Use when asking what to improve, requesting idea generation, exploring surprising improvements, or wanting the AI to proactively suggest strong project directions before brainstorming one in depth. Triggers on phrases like 'what should I improve', 'give me ideas', 'ideate on this project', 'surprise me with improvements', 'what would you change', or any request for AI-generated project improvement suggestions rather than refining the user's own idea.</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-ideate</location>
+  </skill>
+  <skill>
+    <name>ce:plan</name>
+    <description>Create structured plans for any multi-step task -- software features, research workflows, events, study plans, or any goal that benefits from structured breakdown. Also deepen existing plans with interactive review of sub-agent findings. Use for plan creation when the user says 'plan this', 'create a plan', 'write a tech plan', 'plan the implementation', 'how should we build', 'what's the approach for', 'break this down', 'plan a trip', 'create a study plan', or when a brainstorm/requirements document is ready for planning. Use for plan deepening when the user says 'deepen the plan', 'deepen my plan', 'deepening pass', or uses 'deepen' in reference to a plan.</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-plan</location>
+  </skill>
+  <skill>
+    <name>ce:review</name>
+    <description>Structured code review using tiered persona agents, confidence-gated findings, and a merge/dedup pipeline. Use when reviewing code changes before creating a PR.</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-review</location>
+  </skill>
+  <skill>
+    <name>ce:work</name>
+    <description>Execute work efficiently while maintaining quality and finishing features</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-work</location>
+  </skill>
+  <skill>
+    <name>systematic:deepen-plan</name>
+    <description>Stress-test an existing implementation plan and selectively strengthen weak sections with targeted research. Use when a plan needs more confidence around decisions, sequencing, system-wide impact, risks, or verification. Best for Standard or Deep plans, or high-risk topics such as auth, payments, migrations, external APIs, and security. For structural or clarity improvements, prefer document-review instead.</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/deepen-plan</location>
+  </skill>
+  <skill>
+    <name>systematic:document-review</name>
+    <description>Review requirements or plan documents using parallel persona agents that surface role-specific issues. Use when a requirements document or plan document exists and the user wants to improve it.</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/document-review</location>
+  </skill>
+  <skill>
+    <name>systematic:frontend-design</name>
+    <description>Use when building or reviewing any frontend interface. Covers the full design lifecycle: context detection, pre-build planning, design laws (OKLCH color, theme forcing function, layout rhythm, absolute bans on AI-slop patterns), implementation guidance, and visual verification. Use for landing pages, dashboards, components, or any web UI where design quality matters.</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/frontend-design</location>
+  </skill>
+  <skill>
+    <name>systematic:git-clean-gone-branches</name>
+    <description>Clean up local branches whose remote tracking branch is gone. Use when the user says "clean up branches", "delete gone branches", "prune local branches", "clean gone", or wants to remove stale local branches that no longer exist on the remote. Also handles removing associated worktrees for branches that have them.</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/git-clean-gone-branches</location>
+  </skill>
+  <skill>
+    <name>systematic:git-commit</name>
+    <description>Create a git commit with a clear, value-communicating message. Use when the user says "commit", "commit this", "save my changes", "create a commit", or wants to commit staged or unstaged work. Produces well-structured commit messages that follow repo conventions when they exist, and defaults to conventional commit format otherwise.</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/git-commit</location>
+  </skill>
+  <skill>
+    <name>systematic:git-commit-push-pr</name>
+    <description>Commit, push, and open a PR with an adaptive, value-first description. Use when the user says "commit and PR", "push and open a PR", "ship this", "create a PR", "open a pull request", "commit push PR", or wants to go from working changes to an open pull request in one step. Also use when the user says "update the PR description", "refresh the PR description", "freshen the PR", or wants to rewrite an existing PR description. Produces PR descriptions that scale in depth with the complexity of the change, avoiding cookie-cutter templates.</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/git-commit-push-pr</location>
+  </skill>
+  <skill>
+    <name>systematic:git-worktree</name>
+    <description>This skill manages Git worktrees for isolated parallel development. It handles creating, listing, switching, and cleaning up worktrees with a simple interactive interface, following KISS principles.</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/git-worktree</location>
+  </skill>
+  <skill>
+    <name>systematic:onboarding</name>
+    <description>Generate or regenerate ONBOARDING.md to help new contributors understand a codebase. Use when the user asks to 'create onboarding docs', 'generate ONBOARDING.md', 'document this project for new developers', 'write onboarding documentation', 'vonboard', 'vonboarding', 'prepare this repo for a new contributor', 'refresh the onboarding doc', or 'update ONBOARDING.md'. Also use when someone needs to onboard a new team member and wants a written artifact, or when a codebase lacks onboarding documentation and the user wants to generate one.</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/onboarding</location>
+  </skill>
+  <skill>
+    <name>systematic:orchestrating-subagents</name>
+    <description>Use when dispatching parallel or serial subagents, coordinating multi-unit plan execution, synthesizing results from independent subagent runs, or handling subagent failure and retry. Triggers on requests to run tasks in parallel, divide work, orchestrate a pipeline of dependent steps, or coordinate multiple agents without shared-file conflicts.</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/orchestrating-subagents</location>
+  </skill>
+  <skill>
+    <name>systematic:reproduce-bug</name>
+    <description>Systematically reproduce and investigate a bug from a GitHub issue. Use when the user provides a GitHub issue number or URL for a bug they want reproduced or investigated.</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/reproduce-bug</location>
+  </skill>
+  <skill>
+    <name>systematic:resolve-pr-feedback</name>
+    <description>Resolve PR review feedback by evaluating validity and fixing issues in parallel. Use when addressing PR review comments, resolving review threads, or fixing code review feedback.</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/resolve-pr-feedback</location>
+  </skill>
+  <skill>
+    <name>systematic:test-browser</name>
+    <description>Run browser tests on pages affected by current PR or branch</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/test-browser</location>
+  </skill>
+  <skill>
+    <name>systematic:test-driven-development</name>
+    <description>Use when implementing any feature or bugfix, before writing implementation code</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/test-driven-development</location>
+  </skill>
+  <skill>
+    <name>systematic:using-systematic</name>
+    <description>Use when starting any conversation - establishes how to find and use skills, requiring skill tool invocation before ANY response including clarifying questions</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/using-systematic</location>
+  </skill>
+  <skill>
+    <name>systematic:writing-skills</name>
+    <description>Use when creating new skills, editing existing skills, or verifying skills work before deployment</description>
+    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/writing-skills</location>
+  </skill>
+</available_skills>
+</SYSTEMATIC_WORKFLOWS>"
+`;

--- a/tests/unit/__snapshots__/bootstrap.test.ts.snap
+++ b/tests/unit/__snapshots__/bootstrap.test.ts.snap
@@ -190,117 +190,117 @@ skill({ name: "external-skill" })
   <skill>
     <name>systematic:agent-browser</name>
     <description>Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, or automating any browser task. Triggers include requests to "open a website", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction.</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/agent-browser</location>
+    <location>file://<SKILLS_DIR>/agent-browser</location>
   </skill>
   <skill>
     <name>systematic:agent-native-architecture</name>
     <description>Build applications where agents are first-class citizens. Use this skill when designing autonomous agents, creating MCP tools, implementing self-modifying systems, or building apps where features are outcomes achieved by agents operating in a loop.</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/agent-native-architecture</location>
+    <location>file://<SKILLS_DIR>/agent-native-architecture</location>
   </skill>
   <skill>
     <name>ce:brainstorm</name>
     <description>Explore requirements and approaches through collaborative dialogue before writing a right-sized requirements document and planning implementation. Use for feature ideas, problem framing, when the user says 'let's brainstorm', or when they want to think through options before deciding what to build. Also use when a user describes a vague or ambitious feature request, asks 'what should we build', 'help me think through X', presents a problem with multiple valid solutions, or seems unsure about scope or direction — even if they don't explicitly ask to brainstorm.</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-brainstorm</location>
+    <location>file://<SKILLS_DIR>/ce-brainstorm</location>
   </skill>
   <skill>
     <name>ce:compound</name>
     <description>Document a recently solved problem to compound your team's knowledge</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-compound</location>
+    <location>file://<SKILLS_DIR>/ce-compound</location>
   </skill>
   <skill>
     <name>ce:ideate</name>
     <description>Generate and critically evaluate grounded improvement ideas for the current project. Use when asking what to improve, requesting idea generation, exploring surprising improvements, or wanting the AI to proactively suggest strong project directions before brainstorming one in depth. Triggers on phrases like 'what should I improve', 'give me ideas', 'ideate on this project', 'surprise me with improvements', 'what would you change', or any request for AI-generated project improvement suggestions rather than refining the user's own idea.</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-ideate</location>
+    <location>file://<SKILLS_DIR>/ce-ideate</location>
   </skill>
   <skill>
     <name>ce:plan</name>
     <description>Create structured plans for any multi-step task -- software features, research workflows, events, study plans, or any goal that benefits from structured breakdown. Also deepen existing plans with interactive review of sub-agent findings. Use for plan creation when the user says 'plan this', 'create a plan', 'write a tech plan', 'plan the implementation', 'how should we build', 'what's the approach for', 'break this down', 'plan a trip', 'create a study plan', or when a brainstorm/requirements document is ready for planning. Use for plan deepening when the user says 'deepen the plan', 'deepen my plan', 'deepening pass', or uses 'deepen' in reference to a plan.</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-plan</location>
+    <location>file://<SKILLS_DIR>/ce-plan</location>
   </skill>
   <skill>
     <name>ce:review</name>
     <description>Structured code review using tiered persona agents, confidence-gated findings, and a merge/dedup pipeline. Use when reviewing code changes before creating a PR.</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-review</location>
+    <location>file://<SKILLS_DIR>/ce-review</location>
   </skill>
   <skill>
     <name>ce:work</name>
     <description>Execute work efficiently while maintaining quality and finishing features</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-work</location>
+    <location>file://<SKILLS_DIR>/ce-work</location>
   </skill>
   <skill>
     <name>systematic:deepen-plan</name>
     <description>Stress-test an existing implementation plan and selectively strengthen weak sections with targeted research. Use when a plan needs more confidence around decisions, sequencing, system-wide impact, risks, or verification. Best for Standard or Deep plans, or high-risk topics such as auth, payments, migrations, external APIs, and security. For structural or clarity improvements, prefer document-review instead.</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/deepen-plan</location>
+    <location>file://<SKILLS_DIR>/deepen-plan</location>
   </skill>
   <skill>
     <name>systematic:document-review</name>
     <description>Review requirements or plan documents using parallel persona agents that surface role-specific issues. Use when a requirements document or plan document exists and the user wants to improve it.</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/document-review</location>
+    <location>file://<SKILLS_DIR>/document-review</location>
   </skill>
   <skill>
     <name>systematic:frontend-design</name>
     <description>Use when building or reviewing any frontend interface. Covers the full design lifecycle: context detection, pre-build planning, design laws (OKLCH color, theme forcing function, layout rhythm, absolute bans on AI-slop patterns), implementation guidance, and visual verification. Use for landing pages, dashboards, components, or any web UI where design quality matters.</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/frontend-design</location>
+    <location>file://<SKILLS_DIR>/frontend-design</location>
   </skill>
   <skill>
     <name>systematic:git-clean-gone-branches</name>
     <description>Clean up local branches whose remote tracking branch is gone. Use when the user says "clean up branches", "delete gone branches", "prune local branches", "clean gone", or wants to remove stale local branches that no longer exist on the remote. Also handles removing associated worktrees for branches that have them.</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/git-clean-gone-branches</location>
+    <location>file://<SKILLS_DIR>/git-clean-gone-branches</location>
   </skill>
   <skill>
     <name>systematic:git-commit</name>
     <description>Create a git commit with a clear, value-communicating message. Use when the user says "commit", "commit this", "save my changes", "create a commit", or wants to commit staged or unstaged work. Produces well-structured commit messages that follow repo conventions when they exist, and defaults to conventional commit format otherwise.</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/git-commit</location>
+    <location>file://<SKILLS_DIR>/git-commit</location>
   </skill>
   <skill>
     <name>systematic:git-commit-push-pr</name>
     <description>Commit, push, and open a PR with an adaptive, value-first description. Use when the user says "commit and PR", "push and open a PR", "ship this", "create a PR", "open a pull request", "commit push PR", or wants to go from working changes to an open pull request in one step. Also use when the user says "update the PR description", "refresh the PR description", "freshen the PR", or wants to rewrite an existing PR description. Produces PR descriptions that scale in depth with the complexity of the change, avoiding cookie-cutter templates.</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/git-commit-push-pr</location>
+    <location>file://<SKILLS_DIR>/git-commit-push-pr</location>
   </skill>
   <skill>
     <name>systematic:git-worktree</name>
     <description>This skill manages Git worktrees for isolated parallel development. It handles creating, listing, switching, and cleaning up worktrees with a simple interactive interface, following KISS principles.</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/git-worktree</location>
+    <location>file://<SKILLS_DIR>/git-worktree</location>
   </skill>
   <skill>
     <name>systematic:onboarding</name>
     <description>Generate or regenerate ONBOARDING.md to help new contributors understand a codebase. Use when the user asks to 'create onboarding docs', 'generate ONBOARDING.md', 'document this project for new developers', 'write onboarding documentation', 'vonboard', 'vonboarding', 'prepare this repo for a new contributor', 'refresh the onboarding doc', or 'update ONBOARDING.md'. Also use when someone needs to onboard a new team member and wants a written artifact, or when a codebase lacks onboarding documentation and the user wants to generate one.</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/onboarding</location>
+    <location>file://<SKILLS_DIR>/onboarding</location>
   </skill>
   <skill>
     <name>systematic:orchestrating-subagents</name>
     <description>Use when dispatching parallel or serial subagents, coordinating multi-unit plan execution, synthesizing results from independent subagent runs, or handling subagent failure and retry. Triggers on requests to run tasks in parallel, divide work, orchestrate a pipeline of dependent steps, or coordinate multiple agents without shared-file conflicts.</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/orchestrating-subagents</location>
+    <location>file://<SKILLS_DIR>/orchestrating-subagents</location>
   </skill>
   <skill>
     <name>systematic:reproduce-bug</name>
     <description>Systematically reproduce and investigate a bug from a GitHub issue. Use when the user provides a GitHub issue number or URL for a bug they want reproduced or investigated.</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/reproduce-bug</location>
+    <location>file://<SKILLS_DIR>/reproduce-bug</location>
   </skill>
   <skill>
     <name>systematic:resolve-pr-feedback</name>
     <description>Resolve PR review feedback by evaluating validity and fixing issues in parallel. Use when addressing PR review comments, resolving review threads, or fixing code review feedback.</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/resolve-pr-feedback</location>
+    <location>file://<SKILLS_DIR>/resolve-pr-feedback</location>
   </skill>
   <skill>
     <name>systematic:test-browser</name>
     <description>Run browser tests on pages affected by current PR or branch</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/test-browser</location>
+    <location>file://<SKILLS_DIR>/test-browser</location>
   </skill>
   <skill>
     <name>systematic:test-driven-development</name>
     <description>Use when implementing any feature or bugfix, before writing implementation code</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/test-driven-development</location>
+    <location>file://<SKILLS_DIR>/test-driven-development</location>
   </skill>
   <skill>
     <name>systematic:using-systematic</name>
     <description>Use when starting any conversation - establishes how to find and use skills, requiring skill tool invocation before ANY response including clarifying questions</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/using-systematic</location>
+    <location>file://<SKILLS_DIR>/using-systematic</location>
   </skill>
   <skill>
     <name>systematic:writing-skills</name>
     <description>Use when creating new skills, editing existing skills, or verifying skills work before deployment</description>
-    <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/writing-skills</location>
+    <location>file://<SKILLS_DIR>/writing-skills</location>
   </skill>
 </available_skills>
 </SYSTEMATIC_WORKFLOWS>"

--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -27,6 +27,16 @@ function shouldSkipBootstrap(system: readonly string[]): boolean {
   )
 }
 
+function normalizeBootstrapSnapshot(
+  content: string,
+  skillsDir: string,
+): string {
+  const normalized = content.replaceAll(skillsDir, '<SKILLS_DIR>')
+  expect(normalized).toContain('<SKILLS_DIR>')
+  expect(normalized).not.toContain(skillsDir)
+  return normalized
+}
+
 // ---------------------------------------------------------------------------
 // getBootstrapContent
 // ---------------------------------------------------------------------------
@@ -56,15 +66,18 @@ describe('getBootstrapContent', () => {
   }
 
   test('pins the default bootstrap bytes before profile inlining', () => {
+    const skillsDir = path.resolve(process.cwd(), 'skills')
     const content = getBootstrapContent(
       {
         bootstrap: { enabled: true },
         disabled_skills: [],
       },
-      { bundledSkillsDir: path.resolve(process.cwd(), 'skills') },
+      { bundledSkillsDir: skillsDir },
     )
 
-    expect(content).toMatchInlineSnapshot(`
+    expect(
+      normalizeBootstrapSnapshot(content as string, skillsDir),
+    ).toMatchInlineSnapshot(`
       "<SYSTEMATIC_WORKFLOWS>
       You have access to structured engineering workflows via the Systematic plugin.
 
@@ -195,117 +208,117 @@ describe('getBootstrapContent', () => {
         <skill>
           <name>systematic:agent-browser</name>
           <description>Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, or automating any browser task. Triggers include requests to "open a website", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction.</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/agent-browser</location>
+          <location>file://<SKILLS_DIR>/agent-browser</location>
         </skill>
         <skill>
           <name>systematic:agent-native-architecture</name>
           <description>Build applications where agents are first-class citizens. Use this skill when designing autonomous agents, creating MCP tools, implementing self-modifying systems, or building apps where features are outcomes achieved by agents operating in a loop.</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/agent-native-architecture</location>
+          <location>file://<SKILLS_DIR>/agent-native-architecture</location>
         </skill>
         <skill>
           <name>ce:brainstorm</name>
           <description>Explore requirements and approaches through collaborative dialogue before writing a right-sized requirements document and planning implementation. Use for feature ideas, problem framing, when the user says 'let's brainstorm', or when they want to think through options before deciding what to build. Also use when a user describes a vague or ambitious feature request, asks 'what should we build', 'help me think through X', presents a problem with multiple valid solutions, or seems unsure about scope or direction — even if they don't explicitly ask to brainstorm.</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-brainstorm</location>
+          <location>file://<SKILLS_DIR>/ce-brainstorm</location>
         </skill>
         <skill>
           <name>ce:compound</name>
           <description>Document a recently solved problem to compound your team's knowledge</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-compound</location>
+          <location>file://<SKILLS_DIR>/ce-compound</location>
         </skill>
         <skill>
           <name>ce:ideate</name>
           <description>Generate and critically evaluate grounded improvement ideas for the current project. Use when asking what to improve, requesting idea generation, exploring surprising improvements, or wanting the AI to proactively suggest strong project directions before brainstorming one in depth. Triggers on phrases like 'what should I improve', 'give me ideas', 'ideate on this project', 'surprise me with improvements', 'what would you change', or any request for AI-generated project improvement suggestions rather than refining the user's own idea.</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-ideate</location>
+          <location>file://<SKILLS_DIR>/ce-ideate</location>
         </skill>
         <skill>
           <name>ce:plan</name>
           <description>Create structured plans for any multi-step task -- software features, research workflows, events, study plans, or any goal that benefits from structured breakdown. Also deepen existing plans with interactive review of sub-agent findings. Use for plan creation when the user says 'plan this', 'create a plan', 'write a tech plan', 'plan the implementation', 'how should we build', 'what's the approach for', 'break this down', 'plan a trip', 'create a study plan', or when a brainstorm/requirements document is ready for planning. Use for plan deepening when the user says 'deepen the plan', 'deepen my plan', 'deepening pass', or uses 'deepen' in reference to a plan.</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-plan</location>
+          <location>file://<SKILLS_DIR>/ce-plan</location>
         </skill>
         <skill>
           <name>ce:review</name>
           <description>Structured code review using tiered persona agents, confidence-gated findings, and a merge/dedup pipeline. Use when reviewing code changes before creating a PR.</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-review</location>
+          <location>file://<SKILLS_DIR>/ce-review</location>
         </skill>
         <skill>
           <name>ce:work</name>
           <description>Execute work efficiently while maintaining quality and finishing features</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-work</location>
+          <location>file://<SKILLS_DIR>/ce-work</location>
         </skill>
         <skill>
           <name>systematic:deepen-plan</name>
           <description>Stress-test an existing implementation plan and selectively strengthen weak sections with targeted research. Use when a plan needs more confidence around decisions, sequencing, system-wide impact, risks, or verification. Best for Standard or Deep plans, or high-risk topics such as auth, payments, migrations, external APIs, and security. For structural or clarity improvements, prefer document-review instead.</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/deepen-plan</location>
+          <location>file://<SKILLS_DIR>/deepen-plan</location>
         </skill>
         <skill>
           <name>systematic:document-review</name>
           <description>Review requirements or plan documents using parallel persona agents that surface role-specific issues. Use when a requirements document or plan document exists and the user wants to improve it.</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/document-review</location>
+          <location>file://<SKILLS_DIR>/document-review</location>
         </skill>
         <skill>
           <name>systematic:frontend-design</name>
           <description>Use when building or reviewing any frontend interface. Covers the full design lifecycle: context detection, pre-build planning, design laws (OKLCH color, theme forcing function, layout rhythm, absolute bans on AI-slop patterns), implementation guidance, and visual verification. Use for landing pages, dashboards, components, or any web UI where design quality matters.</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/frontend-design</location>
+          <location>file://<SKILLS_DIR>/frontend-design</location>
         </skill>
         <skill>
           <name>systematic:git-clean-gone-branches</name>
           <description>Clean up local branches whose remote tracking branch is gone. Use when the user says "clean up branches", "delete gone branches", "prune local branches", "clean gone", or wants to remove stale local branches that no longer exist on the remote. Also handles removing associated worktrees for branches that have them.</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/git-clean-gone-branches</location>
+          <location>file://<SKILLS_DIR>/git-clean-gone-branches</location>
         </skill>
         <skill>
           <name>systematic:git-commit</name>
           <description>Create a git commit with a clear, value-communicating message. Use when the user says "commit", "commit this", "save my changes", "create a commit", or wants to commit staged or unstaged work. Produces well-structured commit messages that follow repo conventions when they exist, and defaults to conventional commit format otherwise.</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/git-commit</location>
+          <location>file://<SKILLS_DIR>/git-commit</location>
         </skill>
         <skill>
           <name>systematic:git-commit-push-pr</name>
           <description>Commit, push, and open a PR with an adaptive, value-first description. Use when the user says "commit and PR", "push and open a PR", "ship this", "create a PR", "open a pull request", "commit push PR", or wants to go from working changes to an open pull request in one step. Also use when the user says "update the PR description", "refresh the PR description", "freshen the PR", or wants to rewrite an existing PR description. Produces PR descriptions that scale in depth with the complexity of the change, avoiding cookie-cutter templates.</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/git-commit-push-pr</location>
+          <location>file://<SKILLS_DIR>/git-commit-push-pr</location>
         </skill>
         <skill>
           <name>systematic:git-worktree</name>
           <description>This skill manages Git worktrees for isolated parallel development. It handles creating, listing, switching, and cleaning up worktrees with a simple interactive interface, following KISS principles.</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/git-worktree</location>
+          <location>file://<SKILLS_DIR>/git-worktree</location>
         </skill>
         <skill>
           <name>systematic:onboarding</name>
           <description>Generate or regenerate ONBOARDING.md to help new contributors understand a codebase. Use when the user asks to 'create onboarding docs', 'generate ONBOARDING.md', 'document this project for new developers', 'write onboarding documentation', 'vonboard', 'vonboarding', 'prepare this repo for a new contributor', 'refresh the onboarding doc', or 'update ONBOARDING.md'. Also use when someone needs to onboard a new team member and wants a written artifact, or when a codebase lacks onboarding documentation and the user wants to generate one.</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/onboarding</location>
+          <location>file://<SKILLS_DIR>/onboarding</location>
         </skill>
         <skill>
           <name>systematic:orchestrating-subagents</name>
           <description>Use when dispatching parallel or serial subagents, coordinating multi-unit plan execution, synthesizing results from independent subagent runs, or handling subagent failure and retry. Triggers on requests to run tasks in parallel, divide work, orchestrate a pipeline of dependent steps, or coordinate multiple agents without shared-file conflicts.</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/orchestrating-subagents</location>
+          <location>file://<SKILLS_DIR>/orchestrating-subagents</location>
         </skill>
         <skill>
           <name>systematic:reproduce-bug</name>
           <description>Systematically reproduce and investigate a bug from a GitHub issue. Use when the user provides a GitHub issue number or URL for a bug they want reproduced or investigated.</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/reproduce-bug</location>
+          <location>file://<SKILLS_DIR>/reproduce-bug</location>
         </skill>
         <skill>
           <name>systematic:resolve-pr-feedback</name>
           <description>Resolve PR review feedback by evaluating validity and fixing issues in parallel. Use when addressing PR review comments, resolving review threads, or fixing code review feedback.</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/resolve-pr-feedback</location>
+          <location>file://<SKILLS_DIR>/resolve-pr-feedback</location>
         </skill>
         <skill>
           <name>systematic:test-browser</name>
           <description>Run browser tests on pages affected by current PR or branch</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/test-browser</location>
+          <location>file://<SKILLS_DIR>/test-browser</location>
         </skill>
         <skill>
           <name>systematic:test-driven-development</name>
           <description>Use when implementing any feature or bugfix, before writing implementation code</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/test-driven-development</location>
+          <location>file://<SKILLS_DIR>/test-driven-development</location>
         </skill>
         <skill>
           <name>systematic:using-systematic</name>
           <description>Use when starting any conversation - establishes how to find and use skills, requiring skill tool invocation before ANY response including clarifying questions</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/using-systematic</location>
+          <location>file://<SKILLS_DIR>/using-systematic</location>
         </skill>
         <skill>
           <name>systematic:writing-skills</name>
           <description>Use when creating new skills, editing existing skills, or verifying skills work before deployment</description>
-          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/writing-skills</location>
+          <location>file://<SKILLS_DIR>/writing-skills</location>
         </skill>
       </available_skills>
       </SYSTEMATIC_WORKFLOWS>"
@@ -459,7 +472,9 @@ describe('getBootstrapContent', () => {
       },
     )
     expect(content).not.toBeNull()
-    expect(content).toMatchSnapshot()
+    expect(
+      normalizeBootstrapSnapshot(content as string, bundledSkillsDir),
+    ).toMatchSnapshot()
   })
 
   test('preserves marker-shaped profile text during Pi-style composition', () => {

--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -175,7 +175,7 @@ describe('getBootstrapContent', () => {
 
       The four capabilities are subagent delegation, blocking user interaction, task tracking, and skill loading.
 
-      The bootstrap inlines the active harness profile naming the exact mechanisms—consult it. See [the OpenCode profile](references/opencode-profile.md) and [the Pi profile](references/pi-profile.md).
+      The bootstrap inlines the active harness profile naming the exact mechanisms—consult it. See \`references/opencode-profile.md\` and \`references/pi-profile.md\`.
 
       When a mechanism is unavailable, present numbered options in chat and wait for questions, maintain a visible list for task tracking, and dispatch delegation sequentially or do the work inline.
 
@@ -274,7 +274,7 @@ describe('getBootstrapContent', () => {
         </skill>
         <skill>
           <name>systematic:orchestrating-subagents</name>
-          <description>Use when dispatching parallel or serial subagents in OpenCode, coordinating multi-unit plan execution, synthesizing results from independent subagent runs, or handling subagent failure and retry. Triggers on requests to run tasks in parallel, divide work, orchestrate a pipeline of dependent steps, or coordinate multiple agents without shared-file conflicts.</description>
+          <description>Use when dispatching parallel or serial subagents, coordinating multi-unit plan execution, synthesizing results from independent subagent runs, or handling subagent failure and retry. Triggers on requests to run tasks in parallel, divide work, orchestrate a pipeline of dependent steps, or coordinate multiple agents without shared-file conflicts.</description>
           <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/orchestrating-subagents</location>
         </skill>
         <skill>
@@ -389,9 +389,77 @@ describe('getBootstrapContent', () => {
     )
   })
 
-  test('reads missing harness profiles as null without throwing', () => {
+  test('reports missing harness profiles to stderr and returns null', () => {
     const bundledSkillsDir = makeBundledSkillsDir()
-    expect(readHarnessProfile(bundledSkillsDir, 'missing')).toBeNull()
+    const errors: unknown[][] = []
+    const originalError = console.error
+    console.error = (...args: unknown[]) => errors.push(args)
+    try {
+      expect(readHarnessProfile(bundledSkillsDir, 'missing')).toBeNull()
+      expect(errors).toHaveLength(1)
+      expect(errors[0]?.join(' ')).toContain('missing-profile.md')
+      expect(errors[0]?.join(' ')).toContain('ENOENT')
+    } finally {
+      console.error = originalError
+    }
+  })
+
+  test('reports profile read failures to stderr and still returns null', () => {
+    const bundledSkillsDir = makeBundledSkillsDir(
+      '---\nname: using-systematic\n---\nBundled body',
+    )
+    const profileDir = path.join(
+      bundledSkillsDir,
+      'using-systematic/references/opencode-profile.md',
+    )
+    fs.mkdirSync(profileDir, { recursive: true })
+    const errors: unknown[][] = []
+    const originalError = console.error
+    console.error = (...args: unknown[]) => errors.push(args)
+    try {
+      expect(readHarnessProfile(bundledSkillsDir, 'opencode')).toBeNull()
+      expect(errors).toHaveLength(1)
+      expect(errors[0]?.join(' ')).toContain(profileDir)
+      expect(errors[0]?.join(' ')).toContain('EISDIR')
+
+      const content = getBootstrapContent(
+        { bootstrap: { enabled: true }, disabled_skills: [] },
+        { bundledSkillsDir },
+      )
+      expect(content).not.toBeNull()
+      expect(content).not.toContain('PROFILE BLOCK')
+    } finally {
+      console.error = originalError
+    }
+  })
+
+  test('real harness profiles do not contain bootstrap replacement sentinels', () => {
+    const profilesDir = path.resolve(
+      process.cwd(),
+      'skills/using-systematic/references',
+    )
+    for (const name of ['opencode', 'pi']) {
+      const profile = fs.readFileSync(
+        path.join(profilesDir, `${name}-profile.md`),
+        'utf8',
+      )
+      expect(profile).not.toContain('<SYSTEMATIC_WORKFLOWS>')
+      expect(profile).not.toContain('</SYSTEMATIC_WORKFLOWS>')
+    }
+  })
+
+  test('pins the production-shaped OpenCode bootstrap with its profile inlined', () => {
+    const bundledSkillsDir = path.resolve(process.cwd(), 'skills')
+    const content = getBootstrapContent(
+      { bootstrap: { enabled: true }, disabled_skills: [] },
+      {
+        bundledSkillsDir,
+        profileBlock:
+          readHarnessProfile(bundledSkillsDir, 'opencode') ?? undefined,
+      },
+    )
+    expect(content).not.toBeNull()
+    expect(content).toMatchSnapshot()
   })
 
   test('preserves marker-shaped profile text during Pi-style composition', () => {

--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -8,6 +8,7 @@ import {
   computeBootstrapContentSafe,
   getBootstrapContent,
   INTERNAL_AGENT_SIGNATURES,
+  readHarnessProfile,
 } from '../../src/lib/bootstrap.ts'
 
 /**
@@ -54,6 +55,263 @@ describe('getBootstrapContent', () => {
     return bundledSkillsDir
   }
 
+  test('pins the default bootstrap bytes before profile inlining', () => {
+    const content = getBootstrapContent(
+      {
+        bootstrap: { enabled: true },
+        disabled_skills: [],
+      },
+      { bundledSkillsDir: path.resolve(process.cwd(), 'skills') },
+    )
+
+    expect(content).toMatchInlineSnapshot(`
+      "<SYSTEMATIC_WORKFLOWS>
+      You have access to structured engineering workflows via the Systematic plugin.
+
+      **IMPORTANT: The using-systematic skill content is included below. It is ALREADY LOADED - you are currently following it. Do NOT use the systematic_skill tool to load "using-systematic" again - that would be redundant.**
+
+      <SUBAGENT-STOP>
+      If you were dispatched as a subagent to execute a specific task, skip this skill.
+      </SUBAGENT-STOP>
+
+      <EXTREMELY-IMPORTANT>
+      If you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.
+
+      IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
+
+      This is not negotiable. This is not optional. You cannot rationalize your way out of this.
+      </EXTREMELY-IMPORTANT>
+
+      ## Instruction Priority
+
+      Systematic skills override default system prompt behavior, but **user instructions always take precedence**:
+
+      1. **User's explicit instructions** (CLAUDE.md, GEMINI.md, AGENTS.md, direct requests) — highest priority
+      2. **Systematic skills** — override default system behavior where they conflict
+      3. **Default system prompt** — lowest priority
+
+      If CLAUDE.md, GEMINI.md, or AGENTS.md says "don't use TDD" and a skill says "always use TDD," follow the user's instructions. The user is in control.
+
+      ## How to Access Skills
+
+      # Using Skills
+
+      ## The Rule
+
+      **Invoke relevant or requested skills BEFORE any response or action.** Even a 1% chance a skill might apply means that you should invoke the skill to check. If an invoked skill turns out to be wrong for the situation, you don't need to use it.
+
+      \`\`\`dot
+      digraph skill_flow {
+          "User message received" [shape=doublecircle];
+          "About to enter Plan mode?" [shape=doublecircle];
+          "Already brainstormed?" [shape=diamond];
+          "Invoke brainstorming skill" [shape=box];
+          "Might any skill apply?" [shape=diamond];
+          "Invoke \`systematic_skill\` tool" [shape=box];
+          "Announce: 'Using [skill] to [purpose]'" [shape=box];
+          "Has checklist?" [shape=diamond];
+          "Create todo per item" [shape=box];
+          "Follow skill exactly" [shape=box];
+          "Respond (including clarifications)" [shape=doublecircle];
+
+          "About to enter Plan mode?" -> "Already brainstormed?";
+          "Already brainstormed?" -> "Invoke brainstorming skill" [label="no"];
+          "Already brainstormed?" -> "Might any skill apply?" [label="yes"];
+          "Invoke brainstorming skill" -> "Might any skill apply?";
+
+          "User message received" -> "Might any skill apply?";
+          "Might any skill apply?" -> "Invoke \`systematic_skill\` tool" [label="yes, even 1%"];
+          "Might any skill apply?" -> "Respond (including clarifications)" [label="definitely not"];
+          "Invoke \`systematic_skill\` tool" -> "Announce: 'Using [skill] to [purpose]'";
+          "Announce: 'Using [skill] to [purpose]'" -> "Has checklist?";
+          "Has checklist?" -> "Create todo per item" [label="yes"];
+          "Has checklist?" -> "Follow skill exactly" [label="no"];
+          "Create todo per item" -> "Follow skill exactly";
+      }
+      \`\`\`
+
+      ## Red Flags
+
+      These thoughts mean STOP—you're rationalizing:
+
+      | Thought | Reality |
+      |---------|---------|
+      | "This is just a simple question" | Questions are tasks. Check for skills. |
+      | "I need more context first" | Skill check comes BEFORE clarifying questions. |
+      | "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
+      | "I can check git/files quickly" | Files lack conversation context. Check for skills. |
+      | "Let me gather information first" | Skills tell you HOW to gather information. |
+      | "This doesn't need a formal skill" | If a skill exists, use it. |
+      | "I remember this skill" | Skills evolve. Read current version. |
+      | "This doesn't count as a task" | Action = task. Check for skills. |
+      | "The skill is overkill" | Simple things become complex. Use it. |
+      | "I'll just do this one thing first" | Check BEFORE doing anything. |
+      | "This feels productive" | Undisciplined action wastes time. Skills prevent this. |
+      | "I know what that means" | Knowing the concept != using the skill. Invoke it. |
+
+      ## Skill Priority
+
+      When multiple skills could apply, use this order:
+
+      1. **Process skills first** (brainstorming, debugging) - these determine HOW to approach the task
+      2. **Implementation skills second** (frontend-design, mcp-builder) - these guide execution
+
+      "Let's build X" -> brainstorming first, then implementation skills.
+      "Fix this bug" -> debugging first, then domain-specific skills.
+
+      ## Skill Types
+
+      **Rigid** (TDD, debugging): Follow exactly. Don't adapt away discipline. The canonical bundled Rigid skill is \`test-driven-development\` — load it when implementing any feature or bugfix that requires test-first discipline.
+
+      **Flexible** (patterns): Adapt principles to context.
+
+      The skill itself tells you which.
+
+      ## User Instructions
+
+      Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.
+
+      ## Capability Resolution
+
+      The four capabilities are subagent delegation, blocking user interaction, task tracking, and skill loading.
+
+      The bootstrap inlines the active harness profile naming the exact mechanisms—consult it. See [the OpenCode profile](references/opencode-profile.md) and [the Pi profile](references/pi-profile.md).
+
+      When a mechanism is unavailable, present numbered options in chat and wait for questions, maintain a visible list for task tracking, and dispatch delegation sequentially or do the work inline.
+
+      **Skills naming:**
+      - Systematic bundled skills use the \`systematic:\` prefix (e.g., \`systematic:onboarding\`)
+      - Workflow skills with their own namespace keep it (e.g., \`ce:brainstorm\`)
+      - Skills can also be invoked without prefix if unambiguous
+
+      **Skills usage:**
+      - Use \`systematic_skill\` to load Systematic bundled skills
+      - Use the \`skill\` tool for non-Systematic skills
+
+      **Skills location:**
+      Bundled skills ship with the Systematic plugin and are discoverable via \`systematic_skill\`.
+
+      <available_skills>
+        <skill>
+          <name>systematic:agent-browser</name>
+          <description>Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, or automating any browser task. Triggers include requests to "open a website", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction.</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/agent-browser</location>
+        </skill>
+        <skill>
+          <name>systematic:agent-native-architecture</name>
+          <description>Build applications where agents are first-class citizens. Use this skill when designing autonomous agents, creating MCP tools, implementing self-modifying systems, or building apps where features are outcomes achieved by agents operating in a loop.</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/agent-native-architecture</location>
+        </skill>
+        <skill>
+          <name>ce:brainstorm</name>
+          <description>Explore requirements and approaches through collaborative dialogue before writing a right-sized requirements document and planning implementation. Use for feature ideas, problem framing, when the user says 'let's brainstorm', or when they want to think through options before deciding what to build. Also use when a user describes a vague or ambitious feature request, asks 'what should we build', 'help me think through X', presents a problem with multiple valid solutions, or seems unsure about scope or direction — even if they don't explicitly ask to brainstorm.</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-brainstorm</location>
+        </skill>
+        <skill>
+          <name>ce:compound</name>
+          <description>Document a recently solved problem to compound your team's knowledge</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-compound</location>
+        </skill>
+        <skill>
+          <name>ce:ideate</name>
+          <description>Generate and critically evaluate grounded improvement ideas for the current project. Use when asking what to improve, requesting idea generation, exploring surprising improvements, or wanting the AI to proactively suggest strong project directions before brainstorming one in depth. Triggers on phrases like 'what should I improve', 'give me ideas', 'ideate on this project', 'surprise me with improvements', 'what would you change', or any request for AI-generated project improvement suggestions rather than refining the user's own idea.</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-ideate</location>
+        </skill>
+        <skill>
+          <name>ce:plan</name>
+          <description>Create structured plans for any multi-step task -- software features, research workflows, events, study plans, or any goal that benefits from structured breakdown. Also deepen existing plans with interactive review of sub-agent findings. Use for plan creation when the user says 'plan this', 'create a plan', 'write a tech plan', 'plan the implementation', 'how should we build', 'what's the approach for', 'break this down', 'plan a trip', 'create a study plan', or when a brainstorm/requirements document is ready for planning. Use for plan deepening when the user says 'deepen the plan', 'deepen my plan', 'deepening pass', or uses 'deepen' in reference to a plan.</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-plan</location>
+        </skill>
+        <skill>
+          <name>ce:review</name>
+          <description>Structured code review using tiered persona agents, confidence-gated findings, and a merge/dedup pipeline. Use when reviewing code changes before creating a PR.</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-review</location>
+        </skill>
+        <skill>
+          <name>ce:work</name>
+          <description>Execute work efficiently while maintaining quality and finishing features</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/ce-work</location>
+        </skill>
+        <skill>
+          <name>systematic:deepen-plan</name>
+          <description>Stress-test an existing implementation plan and selectively strengthen weak sections with targeted research. Use when a plan needs more confidence around decisions, sequencing, system-wide impact, risks, or verification. Best for Standard or Deep plans, or high-risk topics such as auth, payments, migrations, external APIs, and security. For structural or clarity improvements, prefer document-review instead.</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/deepen-plan</location>
+        </skill>
+        <skill>
+          <name>systematic:document-review</name>
+          <description>Review requirements or plan documents using parallel persona agents that surface role-specific issues. Use when a requirements document or plan document exists and the user wants to improve it.</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/document-review</location>
+        </skill>
+        <skill>
+          <name>systematic:frontend-design</name>
+          <description>Use when building or reviewing any frontend interface. Covers the full design lifecycle: context detection, pre-build planning, design laws (OKLCH color, theme forcing function, layout rhythm, absolute bans on AI-slop patterns), implementation guidance, and visual verification. Use for landing pages, dashboards, components, or any web UI where design quality matters.</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/frontend-design</location>
+        </skill>
+        <skill>
+          <name>systematic:git-clean-gone-branches</name>
+          <description>Clean up local branches whose remote tracking branch is gone. Use when the user says "clean up branches", "delete gone branches", "prune local branches", "clean gone", or wants to remove stale local branches that no longer exist on the remote. Also handles removing associated worktrees for branches that have them.</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/git-clean-gone-branches</location>
+        </skill>
+        <skill>
+          <name>systematic:git-commit</name>
+          <description>Create a git commit with a clear, value-communicating message. Use when the user says "commit", "commit this", "save my changes", "create a commit", or wants to commit staged or unstaged work. Produces well-structured commit messages that follow repo conventions when they exist, and defaults to conventional commit format otherwise.</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/git-commit</location>
+        </skill>
+        <skill>
+          <name>systematic:git-commit-push-pr</name>
+          <description>Commit, push, and open a PR with an adaptive, value-first description. Use when the user says "commit and PR", "push and open a PR", "ship this", "create a PR", "open a pull request", "commit push PR", or wants to go from working changes to an open pull request in one step. Also use when the user says "update the PR description", "refresh the PR description", "freshen the PR", or wants to rewrite an existing PR description. Produces PR descriptions that scale in depth with the complexity of the change, avoiding cookie-cutter templates.</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/git-commit-push-pr</location>
+        </skill>
+        <skill>
+          <name>systematic:git-worktree</name>
+          <description>This skill manages Git worktrees for isolated parallel development. It handles creating, listing, switching, and cleaning up worktrees with a simple interactive interface, following KISS principles.</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/git-worktree</location>
+        </skill>
+        <skill>
+          <name>systematic:onboarding</name>
+          <description>Generate or regenerate ONBOARDING.md to help new contributors understand a codebase. Use when the user asks to 'create onboarding docs', 'generate ONBOARDING.md', 'document this project for new developers', 'write onboarding documentation', 'vonboard', 'vonboarding', 'prepare this repo for a new contributor', 'refresh the onboarding doc', or 'update ONBOARDING.md'. Also use when someone needs to onboard a new team member and wants a written artifact, or when a codebase lacks onboarding documentation and the user wants to generate one.</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/onboarding</location>
+        </skill>
+        <skill>
+          <name>systematic:orchestrating-subagents</name>
+          <description>Use when dispatching parallel or serial subagents in OpenCode, coordinating multi-unit plan execution, synthesizing results from independent subagent runs, or handling subagent failure and retry. Triggers on requests to run tasks in parallel, divide work, orchestrate a pipeline of dependent steps, or coordinate multiple agents without shared-file conflicts.</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/orchestrating-subagents</location>
+        </skill>
+        <skill>
+          <name>systematic:reproduce-bug</name>
+          <description>Systematically reproduce and investigate a bug from a GitHub issue. Use when the user provides a GitHub issue number or URL for a bug they want reproduced or investigated.</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/reproduce-bug</location>
+        </skill>
+        <skill>
+          <name>systematic:resolve-pr-feedback</name>
+          <description>Resolve PR review feedback by evaluating validity and fixing issues in parallel. Use when addressing PR review comments, resolving review threads, or fixing code review feedback.</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/resolve-pr-feedback</location>
+        </skill>
+        <skill>
+          <name>systematic:test-browser</name>
+          <description>Run browser tests on pages affected by current PR or branch</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/test-browser</location>
+        </skill>
+        <skill>
+          <name>systematic:test-driven-development</name>
+          <description>Use when implementing any feature or bugfix, before writing implementation code</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/test-driven-development</location>
+        </skill>
+        <skill>
+          <name>systematic:using-systematic</name>
+          <description>Use when starting any conversation - establishes how to find and use skills, requiring skill tool invocation before ANY response including clarifying questions</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/using-systematic</location>
+        </skill>
+        <skill>
+          <name>systematic:writing-skills</name>
+          <description>Use when creating new skills, editing existing skills, or verifying skills work before deployment</description>
+          <location>file:///Users/mrbrown/src/github.com/marcusrbrown/systematic/skills/writing-skills</location>
+        </skill>
+      </available_skills>
+      </SYSTEMATIC_WORKFLOWS>"
+    `)
+  })
+
   test('default config returns content with SYSTEMATIC_WORKFLOWS wrapper', () => {
     const bundledSkillsDir = makeBundledSkillsDir(
       '---\nname: using-systematic\n---\nBootstrap body content here.',
@@ -97,6 +355,81 @@ describe('getBootstrapContent', () => {
     expect(content).not.toContain(
       'Use the `skill` tool for non-Systematic skills',
     )
+  })
+
+  test('inlines a profile after usage guidance and before the catalog', () => {
+    const bundledSkillsDir = makeBundledSkillsDir(
+      '---\nname: using-systematic\n---\nBootstrap body content here.',
+    )
+    fs.mkdirSync(path.join(bundledSkillsDir, 'catalog-skill'))
+    fs.writeFileSync(
+      path.join(bundledSkillsDir, 'catalog-skill', 'SKILL.md'),
+      '---\nname: catalog-skill\ndescription: Catalog entry\n---\nBody.',
+    )
+    const profile = 'PROFILE BLOCK'
+    const content = getBootstrapContent(
+      { bootstrap: { enabled: true }, disabled_skills: [] },
+      {
+        bundledSkillsDir,
+        usageTemplate: 'USAGE TEMPLATE',
+        profileBlock: profile,
+      },
+    )
+
+    expect(content).not.toBeNull()
+    const output = content as string
+    expect(output.indexOf('USAGE TEMPLATE')).toBeLessThan(
+      output.indexOf(profile),
+    )
+    expect(output.indexOf(profile)).toBeLessThan(
+      output.indexOf('<available_skills>'),
+    )
+    expect(output.indexOf(profile)).toBeLessThan(
+      output.indexOf('</SYSTEMATIC_WORKFLOWS>'),
+    )
+  })
+
+  test('reads missing harness profiles as null without throwing', () => {
+    const bundledSkillsDir = makeBundledSkillsDir()
+    expect(readHarnessProfile(bundledSkillsDir, 'missing')).toBeNull()
+  })
+
+  test('preserves marker-shaped profile text during Pi-style composition', () => {
+    const bundledSkillsDir = makeBundledSkillsDir(
+      '---\nname: using-systematic\n---\nBootstrap body content here.',
+    )
+    const profile = 'literal <SYSTEMATIC_WORKFLOWS> marker text'
+    const bootstrap = getBootstrapContent(
+      { bootstrap: { enabled: true }, disabled_skills: [] },
+      { bundledSkillsDir, profileBlock: profile },
+    ) as string
+
+    const composed = composeSystemPromptWithBootstrap(
+      'Earlier prompt',
+      bootstrap,
+    )
+    expect(composed).toContain(profile)
+    expect(
+      composeSystemPromptWithBootstrap(composed as string, bootstrap),
+    ).toBe(composed)
+  })
+
+  test('applyBootstrapContent does not duplicate an inlined profile on rerun', () => {
+    const bundledSkillsDir = makeBundledSkillsDir(
+      '---\nname: using-systematic\n---\nBootstrap body content here.',
+    )
+    const profile = 'PROFILE BLOCK'
+    const bootstrap = getBootstrapContent(
+      { bootstrap: { enabled: true }, disabled_skills: [] },
+      { bundledSkillsDir, profileBlock: profile },
+    ) as string
+    const output = { system: ['Earlier prompt'] }
+
+    applyBootstrapContent(output, bootstrap)
+    applyBootstrapContent(output, bootstrap)
+
+    expect(output.system[0].split(profile)).toHaveLength(2)
+    expect(output.system[0].split('<SYSTEMATIC_WORKFLOWS>')).toHaveLength(2)
   })
 
   test('config.bootstrap.enabled = false returns null', () => {
@@ -227,6 +560,28 @@ describe('getBootstrapContent', () => {
     expect(content).toContain(
       'Bundled skills ship with the Systematic plugin and are discoverable via `systematic_skill`.',
     )
+  })
+})
+
+describe('harness profile size budget', () => {
+  test('keeps both inlined profiles below the compact bootstrap budget', () => {
+    const profilesDir = path.resolve(
+      process.cwd(),
+      'skills/using-systematic/references',
+    )
+    const sizes = ['opencode', 'pi'].map((name) => {
+      const contents = fs.readFileSync(
+        path.join(profilesDir, `${name}-profile.md`),
+        'utf8',
+      )
+      return { name, size: contents.length }
+    })
+
+    // Keep each profile under ~600 tokens so every session gets capability
+    // routing without making the bootstrap disproportionately large.
+    for (const { name, size } of sizes) {
+      expect(size, `${name} profile size`).toBeLessThan(4000)
+    }
   })
 })
 

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -92,7 +92,7 @@ function writeMigratedSkill(root: string, name: string, body: string): void {
 // ---------------------------------------------------------------------------
 
 describe('BANNED_PATTERNS', () => {
-  test('exposes the 8 patterns documented in the plan', () => {
+  test('exposes the 8 global banned patterns documented in the plan', () => {
     expect(BANNED_PATTERNS).toEqual([
       'Claude Code',
       'TaskCreate',
@@ -891,38 +891,45 @@ describe('checkFrontmatter — deprecated block surfaces via unknown-field rule'
 })
 
 describe('checkMigratedSkillIdentifiers', () => {
-  test('flags todowrite in migrated skill prose', () => {
+  test.each([
+    'task(',
+    'subagent_type',
+    'todowrite',
+    'TodoWrite',
+    'request_user_input',
+    'ask_user',
+    'AskUserQuestion',
+    'update_plan',
+    'question',
+  ] as const)('flags %s in migrated skill prose', (identifier) => {
     const root = makeFixtureRepo()
     try {
-      writeMigratedSkill(
-        root,
-        'migrated',
-        'Do not use todowrite in this prose.\n',
-      )
+      const token = identifier === 'question' ? '`question`' : identifier
+      writeMigratedSkill(root, 'migrated', `Use ${token} here.\n`)
       const violations = checkMigratedSkillIdentifiers(
         root,
         collectScanTargets(root).markdown,
       )
-      expect(violations).toHaveLength(1)
-      expect(violations[0]).toMatchObject({
-        file: 'skills/migrated/SKILL.md',
-        identifier: 'todowrite',
-        line: 1,
-      })
+      expect(violations.map((v) => v.identifier)).toEqual([identifier])
+      expect(violations[0]?.line).toBe(7)
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }
   })
 
-  test('flags task( inside a migrated skill fence', () => {
+  test('flags the backtick-delimited question token but not plain prose', () => {
     const root = makeFixtureRepo()
     try {
-      writeMigratedSkill(root, 'migrated', '```text\ntask(\n```\n')
+      writeMigratedSkill(
+        root,
+        'migrated',
+        'Use `question` here.\nUse question here.\n',
+      )
       const violations = checkMigratedSkillIdentifiers(
         root,
         collectScanTargets(root).markdown,
       )
-      expect(violations.map((v) => v.identifier)).toEqual(['task('])
+      expect(violations.map((v) => v.identifier)).toEqual(['question'])
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }
@@ -960,7 +967,7 @@ describe('checkMigratedSkillIdentifiers', () => {
     }
   })
 
-  test('treats metadata with a non-string value as unmigrated', () => {
+  test('honors the marker when metadata has a boolean sibling value', () => {
     const root = makeFixtureRepo()
     try {
       writeSkill(
@@ -970,7 +977,23 @@ describe('checkMigratedSkillIdentifiers', () => {
       )
       expect(
         checkMigratedSkillIdentifiers(root, collectScanTargets(root).markdown),
-      ).toEqual([])
+      ).toHaveLength(1)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('honors the marker when metadata has an array sibling value', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'array-metadata',
+        '---\nname: array-metadata\ndescription: Test skill\nmetadata:\n  harness-portability: neutral-v1\n  tags: [one, two]\n---\nUse task( here.\n',
+      )
+      expect(
+        checkMigratedSkillIdentifiers(root, collectScanTargets(root).markdown),
+      ).toHaveLength(1)
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }
@@ -999,6 +1022,77 @@ describe('checkMigratedSkillIdentifiers', () => {
       expect(
         checkMigratedSkillIdentifiers(root, collectScanTargets(root).markdown),
       ).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('does not exempt non-question identifiers on the sanctioned idiom line', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeMigratedSkill(
+        root,
+        'idiom-with-todo',
+        'Use question in OpenCode and todowrite in Pi.\n',
+      )
+      expect(
+        checkMigratedSkillIdentifiers(
+          root,
+          collectScanTargets(root).markdown,
+        ).map((v) => v.identifier),
+      ).toEqual(['todowrite'])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('exempts backtick-delimited question on the sanctioned idiom line', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeMigratedSkill(
+        root,
+        'idiom-question',
+        'Use `question` in OpenCode and `question` in Pi.\n',
+      )
+      expect(
+        checkMigratedSkillIdentifiers(root, collectScanTargets(root).markdown),
+      ).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags banned identifiers in description frontmatter', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'frontmatter-description',
+        '---\nname: frontmatter-description\ndescription: Use task( here\nmetadata:\n  harness-portability: neutral-v1\n---\nBody\n',
+      )
+      const violations = checkMigratedSkillIdentifiers(
+        root,
+        collectScanTargets(root).markdown,
+      )
+      expect(violations).toMatchObject([{ identifier: 'task(', line: 3 }])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags banned identifiers in argument-hint frontmatter', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'frontmatter-hint',
+        '---\nname: frontmatter-hint\ndescription: Test\nargument-hint: task( input\nmetadata:\n  harness-portability: neutral-v1\n---\nBody\n',
+      )
+      const violations = checkMigratedSkillIdentifiers(
+        root,
+        collectScanTargets(root).markdown,
+      )
+      expect(violations).toMatchObject([{ identifier: 'task(', line: 4 }])
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -16,6 +16,7 @@ import {
   checkContentIntegrity,
   checkFrontmatter,
   checkFrontmatterParseSafety,
+  checkMigratedSkillIdentifiers,
   checkReferenceIntegrity,
   checkRemovedNamesOverlap,
   checkSubfileReferences,
@@ -77,6 +78,14 @@ function writeCompliantSkill(root: string, name: string, body: string): void {
     root,
     name,
     `---\nname: ${name}\ndescription: Test skill\n---\n${body}`,
+  )
+}
+
+function writeMigratedSkill(root: string, name: string, body: string): void {
+  writeSkill(
+    root,
+    name,
+    `---\nname: ${name}\ndescription: Test skill\nmetadata:\n  harness-portability: neutral-v1\n---\n${body}`,
   )
 }
 
@@ -875,6 +884,121 @@ describe('checkFrontmatter — deprecated block surfaces via unknown-field rule'
       )
       expect(match).toHaveLength(1)
       expect(match[0]?.file).toBe('skills/my-skill/SKILL.md')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('checkMigratedSkillIdentifiers', () => {
+  test('flags todowrite in migrated skill prose', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeMigratedSkill(
+        root,
+        'migrated',
+        'Do not use todowrite in this prose.\n',
+      )
+      const violations = checkMigratedSkillIdentifiers(
+        root,
+        collectScanTargets(root).markdown,
+      )
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({
+        file: 'skills/migrated/SKILL.md',
+        identifier: 'todowrite',
+        line: 1,
+      })
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags task( inside a migrated skill fence', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeMigratedSkill(root, 'migrated', '```text\ntask(\n```\n')
+      const violations = checkMigratedSkillIdentifiers(
+        root,
+        collectScanTargets(root).markdown,
+      )
+      expect(violations.map((v) => v.identifier)).toEqual(['task('])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('allows task( inside a profile fence', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'skills/using-systematic/references/opencode-profile.md',
+        '```text\ntask(\n```\n',
+      )
+      expect(
+        checkMigratedSkillIdentifiers(root, collectScanTargets(root).markdown),
+      ).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('allows identifiers in profile prose', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'skills/using-systematic/references/pi-profile.md',
+        'Do not mention todowrite in prose.\n',
+      )
+      expect(
+        checkMigratedSkillIdentifiers(root, collectScanTargets(root).markdown),
+      ).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('treats metadata with a non-string value as unmigrated', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'malformed-metadata',
+        '---\nname: malformed-metadata\ndescription: Test skill\nmetadata:\n  harness-portability: neutral-v1\n  enabled: true\n---\nUse task( here.\n',
+      )
+      expect(
+        checkMigratedSkillIdentifiers(root, collectScanTargets(root).markdown),
+      ).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('does not scan unmigrated skills', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeCompliantSkill(root, 'unmigrated', 'Use task( here.\n')
+      expect(
+        checkMigratedSkillIdentifiers(root, collectScanTargets(root).markdown),
+      ).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('exempts the sanctioned interaction idiom line', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeMigratedSkill(
+        root,
+        'idiom',
+        'Use request_user_input in OpenCode and ask_user in Pi.\n',
+      )
+      expect(
+        checkMigratedSkillIdentifiers(root, collectScanTargets(root).markdown),
+      ).toEqual([])
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }

--- a/tests/unit/generate-config-reference.test.ts
+++ b/tests/unit/generate-config-reference.test.ts
@@ -1,5 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 
 const TEMP_ROOTS: string[] = []
 
@@ -375,9 +377,28 @@ describe('error handling', () => {
     const mod = await import('../../docs/scripts/generate-config-reference.js')
     expect(typeof mod.execMain).toBe('function')
 
+    // Run against an isolated copy of the real MDX — execMain writes the
+    // target file, and running it against the repo's configuration.mdx
+    // would silently rewrite the committed $schema example URL to this
+    // test's pinned major version on every unit-suite run.
+    const realMdxPath = path.resolve(
+      import.meta.dir,
+      '../../docs/src/content/docs/reference/configuration.mdx',
+    )
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exec-main-'))
+    TEMP_ROOTS.push(tmpDir)
+    const tmpMdxPath = path.join(tmpDir, 'configuration.mdx')
+    fs.copyFileSync(realMdxPath, tmpMdxPath)
+
     // execMain should return an exit code (0 for success, non-zero for error)
-    const exitCode = await mod.execMain('2.11.0')
+    const exitCode = await mod.execMain('2.11.0', tmpMdxPath)
     expect(exitCode).toBe(0)
+
+    // The repo file must be untouched; only the temp copy changes.
+    const repoMdx = fs.readFileSync(realMdxPath, 'utf-8')
+    expect(repoMdx).not.toContain('schemas/v2/systematic-config.schema.json')
+    const tmpMdx = fs.readFileSync(tmpMdxPath, 'utf-8')
+    expect(tmpMdx).toContain('schemas/v2/systematic-config.schema.json')
   })
 
   test('generator with real schema: all fields have examples', async () => {

--- a/tests/unit/package-exports.test.ts
+++ b/tests/unit/package-exports.test.ts
@@ -63,6 +63,7 @@ describe('package.json Pi manifest', () => {
     expect(pkg.files).toContain('skills')
     expect(pkg.files).toContain('agents')
     expect(pkg.files).toContain('dist')
+    expect(pkg.files).toContain('HARNESSES.md')
   })
 
   test('declares @earendil-works/pi-coding-agent and typebox as optional peer deps', () => {

--- a/tests/unit/pi.test.ts
+++ b/tests/unit/pi.test.ts
@@ -242,13 +242,15 @@ describe('src/pi.ts before_agent_start bootstrap injection', () => {
       () => true,
     )
     const originalReadFileSync = fs.readFileSync
-    const readFileSyncSpy = spyOn(fs, 'readFileSync')
-      .mockImplementationOnce(() => {
-        throw new Error('bootstrap failure')
-      })
-      .mockImplementation((...args) => {
+    const readFileSyncSpy = spyOn(fs, 'readFileSync').mockImplementation(
+      (...args) => {
+        const filePath = String(args[0])
+        if (filePath.endsWith('using-systematic/SKILL.md')) {
+          throw new Error('bootstrap failure')
+        }
         return originalReadFileSync(...args)
-      })
+      },
+    )
 
     await expect(piExtension(api)).resolves.toBeUndefined()
 
@@ -359,6 +361,31 @@ describe('src/pi.ts before_agent_start bootstrap injection', () => {
     expect(systemPrompt).not.toContain(
       'Use the skill tool for non-Systematic skills',
     )
+  })
+
+  test('Pi handler composes the capability profile exactly once across double-run', async () => {
+    const api = createFakeExtensionApi()
+    await piExtension(api)
+    const handler = api.handlers.before_agent_start as ExtensionHandler<
+      BeforeAgentStartEvent,
+      BeforeAgentStartEventResult
+    >
+    const event: BeforeAgentStartEvent = {
+      type: 'before_agent_start',
+      prompt: 'do the thing',
+      systemPrompt: 'Earlier extension prompt contribution.',
+      systemPromptOptions: {} as BeforeAgentStartEvent['systemPromptOptions'],
+    }
+
+    const first = (await handler(event, fakeExtensionContext))
+      ?.systemPrompt as string
+    const second = (
+      await handler({ ...event, systemPrompt: first }, fakeExtensionContext)
+    )?.systemPrompt as string
+    const profileMarker = '# Pi Capability Profile'
+
+    expect(second.split(profileMarker)).toHaveLength(2)
+    expect(second).toBe(first)
   })
 })
 


### PR DESCRIPTION
Makes the bundled skill catalog honest across harnesses. Skill bodies stop teaching OpenCode tool syntax as if it were universal; each harness's bootstrap now declares its own capability bindings, and a new content-integrity check keeps migrated skills neutral.

## What changed

- **Two capability profiles** under `skills/using-systematic/references/` (OpenCode, Pi) covering the four divergent capabilities: subagent delegation, blocking user interaction, task tracking, skill loading. Both bootstraps inline their active profile inside the existing `<SYSTEMATIC_WORKFLOWS>` zone — snapshot-pinned, double-run idempotent, sentinel-collision guarded.
- **`using-systematic`** migrated to neutral capability routing; its OpenCode-specific routing lines moved to the bootstrap layer.
- **`orchestrating-subagents`** structurally rewritten to neutral delegation language (12 `task(` + 8 `subagent_type` occurrences → 0) with workflow substance preserved.
- **Blocking-question idiom** now names Pi's binding at 24 sites across 16 skills (previously zero Pi mentions; ce-review's internally drifted site normalized).
- **Content-integrity check #13**: bans 9 harness identifiers in migrated skill bodies and frontmatter (`metadata: harness-portability: neutral-v1`), identifier-aware idiom exemption, profile files exempt, real file line numbers.
- **Pi proof scenarios** in the integration harness: active-profile presence + cross-profile absence in the system payload, migrated-skill activation payload scans, sequential-delegation marker.
- **`HARNESSES.md`**: evidence registry for every harness/tool claim — in-repo paths with line numbers, cloned/installed source, or authoritative URLs; unchecked capabilities are marked UNVERIFIED rather than guessed. Shipped in the npm package (profiles reference it).

## Review

8-persona ce:review (correctness, testing, maintainability, project-standards, kieran-typescript, adversarial, agent-native, learnings): 15 findings, 14 fixed in `e9c48d1` — including a 4-reviewer P1 (metadata predicate could be silently disabled), an identifier-aware rework of the gate's idiom exemption, and an invalid `task()` example in the OpenCode profile.

## Deferred (named next increment)

`ce-plan`/`ce-ideate`/`ce-review`/`ce-brainstorm` bodies still contain dispatch prose that isn't directly executable in Pi (qualified persona IDs, orchestration pseudo-syntax). The `neutral-v1` marker is deliberately lexical (the 9-identifier ban, documented in-gate); full dispatch-prose neutrality for the ce:* workflow set is the next portability increment.

## Verification

- 1181 unit tests, Pi integration 6/6, typecheck, lint (no new warnings), content-integrity clean, registry drift clean, build green
- Bootstrap bytes pinned pre- and post-profile; Pi double-run idempotency test; packaged-tarball isolated-install regression from #648 still green