### PR TITLE
docs(solutions): compound harness-portability learnings + plan closeout

### DIFF
--- a/docs/plans/2026-07-16-001-feat-harness-portable-skills-plan.md
+++ b/docs/plans/2026-07-16-001-feat-harness-portable-skills-plan.md
@@ -1,8 +1,10 @@
 ---
 title: 'feat: Harness-portable bundled skills (B′-thin)'
 type: feat
-status: active
+status: completed
 date: 2026-07-16
+completed: 2026-07-17
+shipped: PR #653 / v3.1.0
 origin: docs/brainstorms/2026-07-16-harness-portable-skills-requirements.md
 ---
 
@@ -92,7 +94,7 @@ v3.0.0 made Pi a first-class consumer of `skills/` (`pi.skills` manifest — nat
 
 ## Implementation Units
 
-- [ ] **Unit 1: Capability profiles + using-systematic migration**
+- [x] **Unit 1: Capability profiles + using-systematic migration**
 
 **Goal:** The two profile files exist; using-systematic's body becomes harness-neutral discipline that routes the four capabilities through "the active harness profile."
 
@@ -118,7 +120,7 @@ v3.0.0 made Pi a first-class consumer of `skills/` (`pi.skills` manifest — nat
 
 **Verification:** content-integrity clean; unit suite green; both profiles readable as standalone markdown.
 
-- [ ] **Unit 2: Bootstrap profile inlining (both harnesses)**
+- [x] **Unit 2: Bootstrap profile inlining (both harnesses)**
 
 **Goal:** Every OpenCode and Pi session's system prompt carries its harness's compact profile block inside `<SYSTEMATIC_WORKFLOWS>`.
 
@@ -146,7 +148,7 @@ v3.0.0 made Pi a first-class consumer of `skills/` (`pi.skills` manifest — nat
 
 **Verification:** bootstrap + pi unit suites green; measured block sizes recorded in the test (budget guard: warn-comment if OpenCode bootstrap grew >15%).
 
-- [ ] **Unit 3: orchestrating-subagents structural rewrite**
+- [x] **Unit 3: orchestrating-subagents structural rewrite**
 
 **Goal:** The skill teaches delegation discipline in neutral operations; zero banned identifiers in its body; OpenCode invocation syntax lives only in the OpenCode profile.
 
@@ -171,7 +173,7 @@ v3.0.0 made Pi a first-class consumer of `skills/` (`pi.skills` manifest — nat
 
 **Verification:** zero banned identifiers in body (counted); registry drift clean if description changed; content-integrity clean.
 
-- [ ] **Unit 4: Interaction idiom Pi binding — all 19 sites**
+- [x] **Unit 4: Interaction idiom Pi binding — all 19 sites**
 
 **Goal:** Every occurrence of the multi-harness question-tool idiom names Pi's binding; ce-review's internally-drifted site (line 314) is normalized.
 
@@ -192,7 +194,7 @@ v3.0.0 made Pi a first-class consumer of `skills/` (`pi.skills` manifest — nat
 
 **Verification:** 19/19 sites updated (counted); content-integrity + registry drift clean.
 
-- [ ] **Unit 5: Content-integrity gate — migrated-set identifier ban**
+- [x] **Unit 5: Content-integrity gate — migrated-set identifier ban**
 
 **Goal:** CI fails any PR reintroducing a banned identifier into a migrated skill body; profile files may quote identifiers inside fences only.
 
@@ -242,7 +244,7 @@ v3.0.0 made Pi a first-class consumer of `skills/` (`pi.skills` manifest — nat
 
 **Verification:** every tool mention has a citation; content-integrity clean (root file outside skill scans, but run anyway); no session/process taxonomy in the text.
 
-- [ ] **Unit 6: Pi harness proof scenario**
+- [x] **Unit 6: Pi harness proof scenario**
 
 **Goal:** Mechanical evidence: a Pi session with the migrated set active receives no instruction naming absent tools.
 

--- a/docs/solutions/best-practices/auto-generated-install-commands-mdx-pitfalls-2026-06-06.md
+++ b/docs/solutions/best-practices/auto-generated-install-commands-mdx-pitfalls-2026-06-06.md
@@ -138,3 +138,4 @@ npx skills add marcusrbrown/systematic --skill [name]
 - `docs/solutions/best-practices/pre-push-live-server-screenshot-qa-2026-05-22.md` — `docs:build` is necessary but not sufficient; verify the rendered output.
 - `docs/solutions/best-practices/verify-css-liveness-against-rendered-html-2026-06-04.md` — inspect built `docs/dist` HTML rather than trusting source markup.
 - `docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md` — adjacent build-time codegen pattern (generator self-reads, fresh-input boundaries).
+- `docs/solutions/test-failures/unit-suite-rewrites-repo-file-trap-2026-07-17.md` — the docs generator's test suite rewriting the committed configuration.mdx during verification; injectable write target + repo-file-untouched assertion.

--- a/docs/solutions/best-practices/content-integrity-has-no-warning-channel-2026-06-06.md
+++ b/docs/solutions/best-practices/content-integrity-has-no-warning-channel-2026-06-06.md
@@ -76,3 +76,4 @@ primitive you intend to use actually exists before writing units around it.
 - `docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md` — a runtime drop-rule and its gate check must agree; this doc adds that the gate side has only one enforcement primitive.
 - `docs/solutions/best-practices/undecidable-detection-honest-ban-rule-2026-06-04.md` — another content-integrity check where the honest design was simpler than the first plan assumed.
 - `docs/solutions/best-practices/harden-converter-injected-agent-defaults-2026-06-06.md` — the sibling hardening arc whose gates this check pattern mirrors.
+- `docs/solutions/best-practices/neutral-v1-marker-migrated-set-identifier-gate-2026-07-17.md` — check #13 follows this doc's violation-or-nothing wiring for a metadata-marked subset gate.

--- a/docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md
+++ b/docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md
@@ -31,6 +31,18 @@ This created a silent disconnect: a bundled skill could be authored with `deprec
 
 Fro Bot's review on PR #401 caught the gap before merge.
 
+## Scope limit (2026-07-17)
+
+This rule applies when the gate protects a **runtime behavior** — the mirror
+exists so CI-green implies the runtime effect actually happens. It does NOT
+apply when a frontmatter marker's only consumer is the gate itself: check #13
+(`harness-portability: neutral-v1`, PR #653) deliberately keys off the single
+marker key instead of mirroring `parseMetadata`'s all-string drop rule,
+because mirroring would let one unrelated non-string metadata key silently
+disable the gate with no runtime signal to compensate. Derive the predicate
+from what the marker's consumer needs. See
+[neutral-v1 marker + migrated-set identifier gate](neutral-v1-marker-migrated-set-identifier-gate-2026-07-17.md).
+
 ## Guidance
 
 **When a content-integrity gate validates a field that the runtime parser handles permissively, the gate must enforce the same minimum field set that the runtime requires to NOT silently drop the value. Otherwise the gate gives false confidence — CI passes but the runtime behavior the gate is meant to protect (here: emitting a deprecation warning) doesn't actually happen.**

--- a/docs/solutions/best-practices/neutral-v1-marker-migrated-set-identifier-gate-2026-07-17.md
+++ b/docs/solutions/best-practices/neutral-v1-marker-migrated-set-identifier-gate-2026-07-17.md
@@ -1,0 +1,118 @@
+---
+title: neutral-v1 marker + migrated-set identifier gate
+date: 2026-07-17
+category: best-practices
+module: content-integrity
+problem_type: best_practice
+component: tooling
+severity: medium
+tags:
+  - content-integrity
+  - harness-portability
+  - bundled-skills
+  - gate-discipline
+  - lexical-ban
+applies_when:
+  - Migrating bundled skill prose to harness-neutral capability language
+  - Adding a CI gate over a subset of assets marked via frontmatter metadata
+  - Designing a lexical (non-semantic) ban with sanctioned exemption zones
+---
+
+# neutral-v1 marker + migrated-set identifier gate
+
+## Context
+
+The harness-portability increment (PR #653, v3.1.0) rewrote a migrated set of
+bundled skills to neutral capability language: skill bodies must not teach
+harness-specific tool syntax (that belongs to the capability profiles inlined
+by each harness's bootstrap). The gate enforcing this is content-integrity
+check #13 (`scripts/content-integrity.ts`), scoped to skills marked with:
+
+```yaml
+metadata:
+  harness-portability: neutral-v1
+```
+
+## Guidance
+
+- **Marker-only predicate.** A skill is migrated iff `metadata` is a record
+  and `metadata['harness-portability'] === 'neutral-v1'` — nothing else
+  (`scripts/content-integrity.ts:1208-1213`). This deliberately does NOT
+  mirror the runtime `parseMetadata` drop rules (which drop the whole map if
+  any value is non-string): the marker's only consumer is this gate, so there
+  is no runtime protection to mirror, and requiring all-string siblings would
+  let one unrelated `enabled: true` key silently disable the gate. The
+  divergence is commented in-gate. (A 4-reviewer P1 in the ce:review round
+  caught the original all-string predicate as a bypass.)
+- **Bounded lexical vocabulary.** Exactly nine identifier patterns:
+  `task(`, `subagent_type`, `todowrite`, `TodoWrite`, `request_user_input`,
+  `ask_user`, `AskUserQuestion`, `update_plan`, and backtick-wrapped
+  `` `question` `` (`scripts/content-integrity.ts:1135-1169`). Word-boundary
+  regexes prevent prose false positives ("task" as an English word passes;
+  `task(` fails). The scope is intentionally lexical — paraphrases are not
+  detected, and the gate says so in its doc comment (honest-ban rule).
+- **Zones, not blanket rules:**
+  - Harness profile files (`skills/using-systematic/references/*-profile.md`)
+    are fully exempt — they are the designated home for exact syntax.
+  - Migrated skill bodies are scanned INCLUDING fenced code blocks — a
+    migrated body has no legitimate use for harness syntax, even in examples.
+  - The sanctioned interaction idiom line (contains both `in OpenCode` and
+    `in Pi`) exempts only the blocking-question identifiers; every other
+    banned identifier is still scanned on that line
+    (`scripts/content-integrity.ts:1215-1279`). An earlier whole-line skip
+    was a bypass (3 reviewers converged on it).
+  - Frontmatter `description` and `argument-hint` are scanned too — they
+    render into the bootstrap catalog in every harness.
+- **Real file line numbers.** Violations add the frontmatter offset so
+  reported lines match the file, not the parsed body.
+
+## Why This Matters
+
+A subset-gate keyed off frontmatter is only as strong as its predicate and
+its exemptions. The review round demonstrated both failure classes on first
+implementation: an over-strict predicate that unrelated metadata could turn
+off, and an over-broad exemption that let any identifier ride a sanctioned
+line. Keying off the single marker and making exemptions identifier-aware
+closes both while keeping the gate honestly lexical.
+
+## When to Apply
+
+- Any future migrated-set expansion (marking more skills `neutral-v1`).
+- Any gate that applies stricter rules to a frontmatter-marked subset of
+  files: derive the predicate from what the marker's consumer needs, not
+  from unrelated parser semantics.
+- When adding exemption zones to a lexical ban: exempt the narrowest thing
+  (specific identifiers in a specific context), never whole lines or files
+  unless the file is the designated syntax home.
+
+## Examples
+
+```ts
+// scripts/content-integrity.ts:1208-1213 — marker-only predicate
+function isMigratedSkill(data: Record<string, unknown>): boolean {
+  const metadata = data.metadata
+  if (!isRecord(metadata)) return false
+  // This marker is consumed only by this gate; there is no runtime
+  // protection to mirror.
+  return metadata['harness-portability'] === 'neutral-v1'
+}
+```
+
+Regression fixtures cover: marker + boolean sibling still scans; every one
+of the nine identifiers has a positive body fixture; `` `question` `` on the
+sanctioned idiom line passes while `todowrite` on the same line fails;
+`task(` in a migrated fence fails; `task(` in a profile fence passes;
+`task(` in a migrated `description` fails.
+
+## Related
+
+- `docs/solutions/best-practices/content-integrity-has-no-warning-channel-2026-06-06.md`
+  — check #13 is wired violation-or-nothing per this doc's contract.
+- `docs/solutions/best-practices/undecidable-detection-honest-ban-rule-2026-06-04.md`
+  — the lexical-ban + honest-scope-statement discipline this gate follows.
+- `docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md`
+  — historical contrast: mirror runtime drop rules when the gate protects a
+  runtime behavior; this gate deliberately diverges because the marker has
+  no runtime consumer.
+- `docs/solutions/logic-errors/pi-chained-bootstrap-composition-2026-07-14.md`
+  — the bootstrap/profile composition layer this gate protects.

--- a/docs/solutions/best-practices/undecidable-detection-honest-ban-rule-2026-06-04.md
+++ b/docs/solutions/best-practices/undecidable-detection-honest-ban-rule-2026-06-04.md
@@ -121,3 +121,5 @@ The remediation is always available and unambiguous: quote the value, or remove 
 
 - `docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md`
   — companion content-integrity gate-design lesson (mirror runtime rules in the gate).
+- `docs/solutions/best-practices/neutral-v1-marker-migrated-set-identifier-gate-2026-07-17.md`
+  — check #13 applies this honest-ban discipline: nine bounded lexical identifiers, scope stated in-gate, paraphrases declared out of scope.

--- a/docs/solutions/integration-issues/workflow-command-prompt-dry-run-integration.md
+++ b/docs/solutions/integration-issues/workflow-command-prompt-dry-run-integration.md
@@ -93,3 +93,4 @@ agent:
 ## Related References
 - `docs/plans/2026-02-15-feat-automated-resync-workflow-plan.md`
 - `docs/solutions/integration-issues/converter-code-block-tool-name-capitalization-20260210.md`
+- `docs/solutions/test-failures/unit-suite-rewrites-repo-file-trap-2026-07-17.md` — sibling verification-side-effect trap: the unit suite itself mutating a committed file during a fix's verification run.

--- a/docs/solutions/logic-errors/pi-chained-bootstrap-composition-2026-07-14.md
+++ b/docs/solutions/logic-errors/pi-chained-bootstrap-composition-2026-07-14.md
@@ -12,7 +12,8 @@ symptoms:
 root_cause: logic_error
 resolution_type: code_fix
 severity: medium
-tags: [pi-harness, bootstrap-injection, prompt-composition, idempotency, adapter-parity, graceful-degradation]
+last_updated: 2026-07-17
+tags: [pi-harness, bootstrap-injection, prompt-composition, idempotency, adapter-parity, graceful-degradation, capability-profiles]
 ---
 
 # Preserve foreign content when composing a chained bootstrap prompt
@@ -110,6 +111,35 @@ A sentinel pattern identifies syntax, not authorship; foreign content can legiti
 - Assert Pi output contains Pi-native skill instructions and excludes OpenCode-only tool language.
 - Force bootstrap loading to throw; assert one stderr diagnostic and successful extension registration.
 - Keep OpenCode bootstrap output pinned so Pi dependency injection cannot drift its default text.
+
+## Pattern extension (2026-07-17): capability-profile inlining via BootstrapDeps
+
+The harness-portability increment (PR #653, v3.1.0) widened the same seam this
+doc established. `BootstrapDeps` now carries an optional `profileBlock`
+alongside `usageTemplate`; `getBootstrapContent` appends it inside the
+`<SYSTEMATIC_WORKFLOWS>` zone in fixed order: usage template → profile block →
+skill catalog (`src/lib/bootstrap.ts:108-239`).
+
+- Harness capability profiles are plain markdown under
+  `skills/using-systematic/references/{opencode,pi}-profile.md`, read by
+  `readHarnessProfile(dir, name)` (`src/lib/bootstrap.ts:114-131`).
+- Per-harness population at the entry points: OpenCode passes
+  `readHarnessProfile(..., 'opencode')` (`src/index.ts:40-43`); Pi passes the
+  `'pi'` profile through `computeBootstrapContentSafe` (`src/pi.ts:63-70`).
+- The seam is nullable and fail-soft: any read failure emits one stderr
+  diagnostic and returns `null`, so the bootstrap composes without the profile
+  rather than crashing plugin load — the diagnostic requirement from this
+  doc's Prevention list, applied at the narrower profile scope.
+- Regression guards extend this doc's list: a production-shaped snapshot pin
+  (profile inlined), double-run idempotency for profile injection, and a
+  sentinel-collision guard asserting neither real profile contains the
+  bootstrap markers (`tests/unit/bootstrap.test.ts:449-516`).
+
+When adding a new harness or new per-harness prose, extend `BootstrapDeps`
+with optional, nullable fields consumed inside the existing sentinel zone —
+do not fork the bootstrap or compose outside the markers. The neutral skill
+prose this layer serves is enforced by content-integrity check #13 (see
+[neutral-v1 marker + migrated-set identifier gate](../best-practices/neutral-v1-marker-migrated-set-identifier-gate-2026-07-17.md)).
 
 ## Related Issues
 

--- a/docs/solutions/test-failures/unit-suite-rewrites-repo-file-trap-2026-07-17.md
+++ b/docs/solutions/test-failures/unit-suite-rewrites-repo-file-trap-2026-07-17.md
@@ -1,0 +1,95 @@
+---
+title: Unit suite rewrites a committed repo file during verification
+date: 2026-07-17
+category: test-failures
+module: tests/unit/generate-config-reference.test.ts
+problem_type: test_failure
+component: testing_framework
+severity: high
+symptoms:
+  - A one-line docs fix keeps reverting between commits
+  - Reviewer flags the same finding twice; author claims "fixed" while the file shows the old value
+  - Committed generated-docs file flips content on every local `bun test tests/unit` run
+root_cause: test_isolation
+resolution_type: test_fix
+tags:
+  - test-isolation
+  - docs-generator
+  - side-effects
+  - verification-discipline
+---
+
+# Unit suite rewrites a committed repo file during verification
+
+## Problem
+
+The `execMain` error-handling test in
+`tests/unit/generate-config-reference.test.ts` invoked the real docs
+generator, which defaulted its write target to the repo's committed
+`docs/src/content/docs/reference/configuration.mdx` — with a pinned old
+version (`2.11.0`). Every unit-suite run silently rewrote the `$schema`
+example URL from `v3` back to `v2`.
+
+## Symptoms
+
+On PR #653 this produced a two-round review failure: Fro Bot flagged the
+stray `v2` URL; the fix was applied, then the verification suite run
+itself reverted it before commit; the "fixed" claim shipped with the
+regression intact; Fro Bot flagged it again with proof the commit never
+touched the file.
+
+## What Didn't Work
+
+- **Fix the file, then run the suite as verification.** The suite was the
+  mutator — verification undid the fix. Any "edit → test → commit" loop
+  where a test writes repo files can invert its own result.
+- **Trusting a subagent's completion claim.** The fixer reported the edit
+  done; the artifact on disk disagreed. Only checking the file caught it.
+
+## Solution
+
+`docs/scripts/generate-config-reference.ts` — `execMain` takes an
+injectable target (`execMain(version?, mdxPath = CONFIG_MDX_PATH)`), so
+the script path is unchanged while tests redirect the write. The test
+copies the real MDX to a temp dir, runs against the copy, and asserts
+BOTH directions: the temp copy contains the downgraded URL (generator ran)
+and the repo file does not (repo untouched).
+
+```ts
+const tmpMdxPath = path.join(tmpDir, 'configuration.mdx')
+fs.copyFileSync(realMdxPath, tmpMdxPath)
+const exitCode = await mod.execMain('2.11.0', tmpMdxPath)
+expect(exitCode).toBe(0)
+expect(fs.readFileSync(realMdxPath, 'utf-8')).not.toContain(
+  'schemas/v2/systematic-config.schema.json',
+)
+expect(fs.readFileSync(tmpMdxPath, 'utf-8')).toContain(
+  'schemas/v2/systematic-config.schema.json',
+)
+```
+
+## Why This Works
+
+Verification becomes non-destructive: the suite can run any number of
+times without mutating the committed source of truth, and the
+repo-file-untouched assertion turns any future regression of this trap
+into a test failure instead of a silent flip-flop.
+
+## Prevention
+
+- Tests must never write repo-committed files. Any test invoking a
+  generator/CLI main against real paths needs an injectable target plus a
+  repo-file-untouched assertion.
+- When a fix "doesn't stick," suspect the verification loop itself before
+  suspecting the edit — check `git status` after the suite runs.
+- Verify claimed fixes by reading the artifact on disk, not by trusting
+  the runner's (or a subagent's) completion report.
+
+## Related
+
+- `docs/solutions/integration-issues/workflow-command-prompt-dry-run-integration.md`
+  — sibling verification-side-effect trap (dry-run vs mutating runs).
+- `docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md`
+  — generator self-write / stale-read boundaries for build-time codegen.
+- `docs/solutions/best-practices/auto-generated-install-commands-mdx-pitfalls-2026-06-06.md`
+  — docs-generator + MDX unit-testability adjacency.


### PR DESCRIPTION
Post-merge ce:compound round for the harness-portability arc (#653, v3.1.0).

## New solution docs

- **neutral-v1 marker + migrated-set identifier gate** (best-practices) — the marker-only predicate rationale (deliberate divergence from mirror-runtime drop rules), the 9-identifier lexical vocabulary, and the zone model (profile exemption, fence-inclusive migrated bodies, identifier-aware idiom exemption).
- **Unit suite rewrites repo file trap** (test-failures) — the execMain/configuration.mdx verification loop behind #653's double CHANGES_REQUESTED: a test invoking the real docs generator against the committed MDX, reverting the fix during its own verification run. Prevention: injectable write targets + repo-file-untouched assertions.

## Refreshed

- **pi-chained-bootstrap-composition** — updated in place (high overlap per the compound workflow) with the capability-profile inlining pattern extension: the profileBlock seam, fail-soft reads, and the three regression guards.
- **mirror-runtime-drop-rules** — scope-limited: the mirror rule applies when the gate protects runtime behavior, not when a marker's only consumer is the gate itself.

## Housekeeping

Reciprocal cross-links in 4 sibling docs; plan 2026-07-16-001 closed out (status completed, shipped PR #653 / v3.1.0).