### PR TITLE
ci: publish Claude Code plugin only on a cut release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -188,6 +188,9 @@ jobs:
       DRY_RUN: ${{ github.event_name == 'pull_request' || github.event.inputs.dry-run && 'true' || 'false' }}
     name: Release
     needs: [build, typecheck, lint, test]
+    outputs:
+      new-release-published: ${{ steps.semantic-release.outputs.new-release-published }}
+      new-release-version: ${{ steps.semantic-release.outputs.new-release-version }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -262,8 +265,11 @@ jobs:
 
   publish-claude-code-plugin:
     name: Publish Claude Code Plugin
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [build, typecheck, lint, test]
+    # Publish in lockstep with npm releases: only after the release job cuts a
+    # new version, so the plugin branch never ships a non-released or
+    # release-failed state. The plugin is still versioned by source commit SHA.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.release.outputs.new-release-published == 'true'
+    needs: [build, typecheck, lint, test, release]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

The \`publish-claude-code-plugin\` job (added in #660) ran independent of the release job — gated only on the test jobs, in parallel with \`release\`. That let the Claude Code plugin branch ship states npm never released:

- A non-release commit (e.g. \`refactor:\`/\`chore:\` touching a skill body) republishes the plugin while cutting no npm version.
- A release-job failure (npm/token) still lets the plugin publish, diverging the plugin from the package.

## Fix

Publish in lockstep with npm releases:

- Expose semantic-release's \`new-release-published\` / \`new-release-version\` (from the existing \`semantic-release-export-data\` plugin) as \`release\` job outputs.
- Add \`release\` to the publish job's \`needs\`.
- Only publish when \`needs.release.outputs.new-release-published == 'true'\`.

The plugin is still versioned by source commit SHA — this couples only its *publish timing* to npm releases, so it never ships a non-released or release-failed state. No npm version is injected into the plugin.

## Verification

- Workflow YAML parses; \`release\` outputs and the publish \`needs\`/\`if\` gate confirmed.
- Live-validated on the next release-cutting push to main after merge (the gate can only exercise on a real release).