### PR TITLE
docs(solutions): compound Claude Code plugin arc learnings

### DIFF
--- a/docs/solutions/best-practices/claude-code-plugin-build-and-publish-architecture-2026-07-18.md
+++ b/docs/solutions/best-practices/claude-code-plugin-build-and-publish-architecture-2026-07-18.md
@@ -1,0 +1,100 @@
+---
+title: Build and publish a harness plugin from CI instead of committing it
+date: 2026-07-18
+category: best-practices
+module: claude-code-harness
+problem_type: architecture_pattern
+component: tooling
+severity: high
+tags:
+  - claude-code
+  - plugin-packaging
+  - orphan-branch
+  - build-from-ci
+  - identifier-translation
+  - release-gating
+  - sha-versioning
+applies_when:
+  - Distributing a plugin/extension for a host that installs by copying the whole plugin directory
+  - The host namespaces skills/agents differently than your canonical source
+  - You want a single source of truth with no committed generated duplication
+  - Publishing a build artifact that must stay in lockstep with an npm release
+---
+
+# Build and publish a harness plugin from CI instead of committing it
+
+## Context
+
+Systematic ships the same skills and agents to three harnesses. OpenCode and Pi load them through a runtime plugin, but Claude Code consumes a **plugin bundle**: a directory (`.claude-plugin/plugin.json` + `skills/` + `agents/` + `output-styles/` + `hooks/`) that the host copies to a cache on install. Two forces collide:
+
+1. Claude Code namespaces plugin skills as `systematic:<skill-dir>` and subagents as `systematic:<agent-stem>` — different from Systematic's canonical `ce:<name>` and `systematic:<category>:<name>` reference forms.
+2. The plugin files must exist at an install source (a git ref the marketplace points at), but committing 148 copied skill/agent files into `main` duplicates the source of truth and rots.
+
+The first implementation committed the generated bundle plus a drift check. That was the wrong instinct — it put copies in `main`. The shipped pattern removes them entirely.
+
+## Guidance
+
+**Build to gitignored staging; never commit the bundle.** `scripts/build-claude-code-plugin.ts` generates the bundle into `claude-code/`, which is gitignored build-only staging (`.gitignore`; assert `git ls-files claude-code/` is 0 in CI/tests). There is no committed artifact, so there is no drift check — the build *is* the source of truth.
+
+**Translate identifiers on generated output only; keep source canonical.** The build rewrites references in the *generated* bodies to the host's namespace, leaving source untouched (source stays phantom-validated by `checkReferenceIntegrity`). Rules, inventory-driven and boundary-aware:
+
+- `ce:<x>` → `systematic:ce-<x>` when `skills/ce-<x>/` exists
+- `systematic:<category>:<name>` → `systematic:<name>` when the flattened agent stem exists
+- bare `systematic:<name>` kept only if it resolves to a bundled skill dir or agent stem
+
+Candidate matching uses a boundary-aware regex (`\b(?:ce:[a-z0-9-]+|systematic:[a-z0-9-]+(?::[a-z0-9-]+)?)\b`), and each candidate is looked up in an inventory built from the real discovered components — unknown tokens are never fabricated. A generated-namespace integrity gate (`checkGeneratedNamespace`) fails the build if any untranslated `ce:` form, leftover qualified ref, or unresolvable bare id survives. This is the build-output analogue of the source reference-integrity gate.
+
+**Don't emit facts the build can't state truthfully.** `package.json` version is a `0.0.0-semantic-release` placeholder, so the plugin manifest omits `version` entirely (Claude Code versions the plugin by the source commit SHA of the published branch), and the `SessionStart` hook emits declarative counts only — no version, no name list.
+
+**Publish from CI to an orphan branch, gated on release.** On push to `main`, a `publish-claude-code-plugin` job builds the bundle and fast-forwards it to the orphan `claude-code-plugin` branch (bundle at the branch root) with the built-in `GITHUB_TOKEN` (`permissions: contents: write` job-scoped; no App token or PAT — and `GITHUB_TOKEN` pushes do not recursively retrigger workflows). Publication is gated so the plugin never diverges from npm:
+
+```yaml
+if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.release.outputs.new-release-published == 'true'
+needs: [build, typecheck, lint, test, release]
+```
+
+The `release` job exposes `new-release-published` / `new-release-version` (from the `semantic-release-export-data` plugin) as job outputs. First run creates the branch (`git worktree add --orphan -b claude-code-plugin`); later runs replace the tree and fast-forward — never `--force`, and a guard refuses to publish an incomplete bundle.
+
+**Point a marketplace catalog at the branch.** `.claude-plugin/marketplace.json` on `main` (tracked, not gitignored) declares the plugin with `source: { source: github, repo: marcusrbrown/systematic, ref: claude-code-plugin }`. Users install with `claude plugin marketplace add marcusrbrown/systematic` then `claude plugin install systematic@systematic`.
+
+## Why This Matters
+
+- **Single source of truth.** No committed duplication of 148 files; the bundle is derived, not stored.
+- **npm ↔ plugin lockstep.** Gating publish on an actually-cut release means the plugin never ships a non-release commit or a release-failed state. (Verified live: a `ci:` commit cut no release, so the publish job correctly *skipped* and the plugin branch stayed unchanged.)
+- **Least-privilege, non-recursive publishing.** `GITHUB_TOKEN` scoped to one job, and its push to the orphan branch doesn't retrigger CI or Renovate.
+- **No fake versioning channel.** SHA-based versioning avoids injecting npm's semantic version into a second distribution channel with its own cadence.
+
+## When to Apply
+
+Any time you distribute a build artifact for a plugin/extension host that (a) installs by copying the whole plugin directory, and (b) namespaces identifiers differently than your source. Build it, translate the generated output, gate the generated namespace, and publish from CI to a dedicated ref — rather than committing copies.
+
+## Examples
+
+Translation (generated output only):
+
+```
+source body:   see `ce:brainstorm`, then dispatch `systematic:research:repo-research-analyst`
+built body:    see `systematic:ce-brainstorm`, then dispatch `systematic:repo-research-analyst`
+```
+
+Release-gated publish (`.github/workflows/main.yaml`) and first-run orphan creation:
+
+```yaml
+- name: Publish bundle to claude-code-plugin branch
+  run: |
+    if git show-ref --verify --quiet refs/remotes/origin/claude-code-plugin; then
+      git worktree add "$WORKTREE_DIR" claude-code-plugin
+    else
+      git worktree add --orphan -b claude-code-plugin "$WORKTREE_DIR"
+    fi
+    # replace tree, git add -A, commit only if changed, push (never --force)
+```
+
+## Related
+
+- [neutral-v1 marker + migrated-set identifier gate](./neutral-v1-marker-migrated-set-identifier-gate-2026-07-17.md) — sibling gate concept. Boundary: that gate operates on source marked `neutral-v1`; this translation operates only on *generated* output. Do not extend either to rewrite canonical source IDs.
+- [Qualified persona IDs are canonical validated references](./qualified-persona-ids-are-canonical-validated-references-2026-07-17.md) — the canonical complement: source keeps qualified IDs (phantom-validated); the CC build translates them only in generated output, preserving validation coverage on both sides.
+- [reconciliation-sync reference integrity](../workflow-issues/reconciliation-sync-reference-integrity-20260417.md) — origin of the reference-integrity checks; the source-side skill-ref gate added in this arc is its descendant.
+- [OpenCode plugin named exports break the loader](../integration-issues/opencode-plugin-named-exports-break-loader-2026-05-11.md) — published-artifact shape gate; packaging precedent.
+- [Typed config validation via build-time codegen](./typed-config-validation-build-time-codegen-2026-05-16.md) and [Registry drift on skill description change](../workflow-issues/registry-drift-on-skill-description-change-2026-05-20.md) — generated-artifact precedents.
+- [Verify installed artifacts, not just build gates](../workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md) — the verification lesson from the same arc.

--- a/docs/solutions/best-practices/neutral-v1-marker-migrated-set-identifier-gate-2026-07-17.md
+++ b/docs/solutions/best-practices/neutral-v1-marker-migrated-set-identifier-gate-2026-07-17.md
@@ -123,3 +123,8 @@ sanctioned idiom line passes while `todowrite` on the same line fails;
   no runtime consumer.
 - `docs/solutions/logic-errors/pi-chained-bootstrap-composition-2026-07-14.md`
   — the bootstrap/profile composition layer this gate protects.
+- `docs/solutions/best-practices/claude-code-plugin-build-and-publish-architecture-2026-07-18.md`
+  — a sibling generated-namespace gate (`checkGeneratedNamespace`). Boundary: it
+  operates on *generated* plugin output (translating source IDs to the host
+  namespace); this gate operates on source marked `neutral-v1`. Neither rewrites
+  canonical source IDs.

--- a/docs/solutions/best-practices/qualified-persona-ids-are-canonical-validated-references-2026-07-17.md
+++ b/docs/solutions/best-practices/qualified-persona-ids-are-canonical-validated-references-2026-07-17.md
@@ -135,3 +135,7 @@ Wrong change — strips phantom-validation coverage and breaks corpus convention
   ban-rule case.
 - `docs/solutions/logic-errors/pi-chained-bootstrap-composition-2026-07-14.md`
   — the harness-portability/profile context this increment grew out of.
+- `docs/solutions/best-practices/claude-code-plugin-build-and-publish-architecture-2026-07-18.md`
+  — the Claude Code build translates the qualified form to `systematic:<name>` in
+  *generated output only*; source keeps the canonical, phantom-validated form, so
+  validation coverage is preserved on both sides.

--- a/docs/solutions/workflow-issues/reconciliation-sync-reference-integrity-20260417.md
+++ b/docs/solutions/workflow-issues/reconciliation-sync-reference-integrity-20260417.md
@@ -109,3 +109,5 @@ This logic is now implemented in `scripts/content-integrity.ts` (the `checkRefer
 Leaving a dangling reference and hoping runtime catches it is the failure mode this doc exists to prevent.
 
 **Corollary — the qualified form is the form to preserve.** Because `checkReferenceIntegrity` validates `systematic:<category>:<name>` against real agent files, that qualified form must not be "cleaned up" to bare names during unrelated refactors — doing so silently removes the validation coverage this doc established. See `docs/solutions/best-practices/qualified-persona-ids-are-canonical-validated-references-2026-07-17.md`.
+
+**Descendant — skill-reference integrity.** The same reference-integrity discipline was extended to skill references: `checkSkillReferenceIntegrity` asserts every `ce:<name>` reference resolves to a real `skills/ce-<name>/` directory, catching phantom refs (`ce:debug`, `ce:polish-beta`) that had dangled on every harness. See `docs/solutions/best-practices/claude-code-plugin-build-and-publish-architecture-2026-07-18.md` for the build that surfaced them.

--- a/docs/solutions/workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md
+++ b/docs/solutions/workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md
@@ -1,0 +1,82 @@
+---
+title: Verify installed artifacts, not just build gates
+date: 2026-07-18
+category: workflow-issues
+module: claude-code-harness
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+tags:
+  - verification
+  - installed-artifact
+  - build-gates
+  - claude-code
+  - empirical-probing
+  - generated-output
+applies_when:
+  - A build or codegen step emits an artifact consumed in a different context than the source repo
+  - A design rests on unverified external runtime/host behavior
+  - Mechanical gates (build, drift, tests, typecheck) pass but correctness-in-situ is unconfirmed
+---
+
+# Verify installed artifacts, not just build gates
+
+## Context
+
+The first Claude Code plugin implementation passed every mechanical gate — build, drift check, tests, typecheck, lint, and a full code review all green — yet the generated bundle shipped three defects that only surfaced when the artifact was read as it would appear installed:
+
+- a **fake version** (`0.0.1`) hardcoded as a fallback because `package.json` is a `0.0.0-semantic-release` placeholder that can never yield a real version at build time;
+- a **dangling repo-relative link** — `Evidence registry: see [HARNESSES.md](../../../HARNESSES.md)` — inlined verbatim from a source profile into the shipped output-style, where `HARNESSES.md` doesn't exist and `../../../` escapes the plugin root;
+- **wrong catalog identifiers** — the output-style listed skills as `ce:brainstorm` / `systematic:agent-browser` (source namespace) when Claude Code exposes them as `systematic:ce-brainstorm` (`plugin:dir-name`).
+
+Every one passed CI. The user caught all three by reading the generated file.
+
+## Guidance
+
+**Mechanical gates validate the pipeline, not the artifact in situ.** Build/drift/tests/typecheck confirm the build ran and matches itself — they say nothing about whether the emitted artifact is *correct once installed in its target context*. For any codegen or build that produces an artifact consumed elsewhere (an installed plugin, a published bundle, a rendered doc), verification must **read or execute the emitted artifact as it appears in that target context**, not merely confirm the build succeeded.
+
+Concretely, for a generated/published artifact:
+
+- Read the actual generated file end-to-end and check for **context-coupled content** that is valid in the repo but broken once relocated: absolute paths, repo-relative links, source-namespace identifiers, and values that can't be produced truthfully at build time (placeholder versions).
+- **Execute** the artifact where feasible (e.g., run the hook command to confirm shell escaping produces the intended text), rather than eyeballing it.
+- Add gates that model the *target* contract: an integrity check over the generated namespace, not just a build-succeeds check.
+
+**Probe unproven runtime channels empirically before designing around them.** Don't assume a host honors a mechanism. In this arc, probing the real Claude Desktop revealed that **imperative `SessionStart` hook content is refused as prompt injection**, while **declarative facts and the plugin output-style are honored** — which directly shaped the design (declarative hook, output-style enforcement). Verify the channel behaves as assumed before building on it.
+
+**Close the class with a source-side gate where you can.** The arc also added a lexical skill-reference integrity check (`checkSkillReferenceIntegrity`, `SKILL_REF_REGEX = /\bce:([a-z0-9-]+)\b/g`) that fails when a `ce:<name>` reference has no matching `skills/ce-<name>/` directory — catching phantom references (`ce:debug`, `ce:polish-beta`) that had dangled on every harness.
+
+## Why This Matters
+
+Context-coupled content passes every gate and still ships broken. A green pipeline is a necessary but wildly insufficient signal for artifact correctness when the artifact lives somewhere other than the repo. Treating "gates pass" as "artifact is correct" is how a fake version, a dead link, and wrong identifiers all shipped past a full review.
+
+## When to Apply
+
+- Any build/codegen that emits an artifact consumed in a different context than the source repo (installed plugins, published bundles, generated docs, marketplace artifacts).
+- Any design that rests on unverified host/runtime behavior — probe the real host first.
+- Whenever you're tempted to conclude "CI is green, so it's correct" for a generated output.
+
+## Examples
+
+Context-coupled defects that passed all gates:
+
+```
+# fake version — package.json is a semantic-release placeholder
+manifest.version = "0.1.0"   # fix: omit version; version by source commit SHA
+
+# dangling repo-relative link inlined into the shipped output-style
+Evidence registry: see [HARNESSES.md](../../../HARNESSES.md)   # fix: strip from shipped profile
+
+# wrong catalog identifiers (source namespace, not the host's)
+<name>ce:brainstorm</name>   # host exposes systematic:ce-brainstorm; fix: drop the catalog / translate
+```
+
+Empirical channel finding that shaped the design: imperative hook content refused as prompt injection; declarative facts + output-style honored — verified in the real host before committing to the enforcement model.
+
+## Related
+
+- [Pi real-runtime integration harness](../best-practices/pi-real-runtime-integration-harness-2026-07-16.md) — verify a packaged extension in the *real* host runtime, not against a fake SDK; same "installed artifact ≠ build output" spine.
+- [Cross-harness adapter parity contract tests](../best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md) — don't mistake boundary/helper tests for runtime proof.
+- [Pi chained bootstrap composition](../logic-errors/pi-chained-bootstrap-composition-2026-07-14.md) — host-specific prompt composition; the imperative-vs-declarative channel distinction.
+- [content-integrity should mirror runtime drop rules](../best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md) — gates should model the runtime contract they protect.
+- [OpenCode plugin hook silent-defect swallow](../integration-issues/opencode-plugin-hook-silent-defect-swallow-2026-05-19.md) — probe the real host; don't trust silent success.
+- [Build and publish a harness plugin from CI](../best-practices/claude-code-plugin-build-and-publish-architecture-2026-07-18.md) — the packaging pattern from the same arc.


### PR DESCRIPTION
Captures two durable learnings from the Claude Code harness work (v3.2.0, #660/#661) as solution docs, so the next person shipping a harness plugin doesn't re-derive them.

## Docs added

- **`best-practices/claude-code-plugin-build-and-publish-architecture`** — the packaging pattern: build the plugin to gitignored staging (never commit copies), translate identifiers to the host namespace on generated output only (source stays canonical/phantom-validated), gate the generated namespace with an integrity check, publish from CI to an orphan branch via `GITHUB_TOKEN`, gate the publish on an actually-cut release, version by source commit SHA, and point a marketplace catalog at the branch.
- **`workflow-issues/verify-installed-artifacts-not-just-build-gates`** — the verification lesson: mechanical gates (build/drift/tests/typecheck) validate the pipeline, not the artifact once installed. Context-coupled content (fake versions, repo-relative links, source-namespace identifiers) passes every gate and still ships broken. Read/execute the emitted artifact as it appears in its target context, and probe unproven host channels empirically before designing around them.

## Cross-links

Adds reciprocal links to the qualified-persona-ids, reconciliation-sync reference-integrity, and neutral-v1-gate sibling docs, with explicit boundary notes (translation happens on generated output only; canonical source IDs are never rewritten).

Content-integrity clean; all cross-link targets resolve.