### PR TITLE
build(dev): render GFM tables on the docs site

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -50,6 +50,7 @@
       },
       "devDependencies": {
         "playwright": "1.61.1",
+        "remark-gfm": "^4.0.1",
       },
     },
   },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,6 +1,7 @@
 import starlight from '@astrojs/starlight'
 import { defineConfig } from 'astro/config'
 import rehypeMermaid from 'rehype-mermaid'
+import remarkGfm from 'remark-gfm'
 
 export default defineConfig({
   site: 'https://fro.bot',
@@ -14,6 +15,7 @@ export default defineConfig({
       '/systematic/getting-started/installation/',
   },
   markdown: {
+    remarkPlugins: [remarkGfm],
     rehypePlugins: [
       [
         rehypeMermaid,

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
     "sharp": "^0.34.0"
   },
   "devDependencies": {
-    "playwright": "1.61.1"
+    "playwright": "1.61.1",
+    "remark-gfm": "^4.0.1"
   }
 }


### PR DESCRIPTION
## What

Wire `remark-gfm` explicitly into the docs site's `markdown.remarkPlugins` so authored `.mdx` content pages get GitHub-Flavored-Markdown table parsing.

## Why

Hand-authored pipe tables in `.mdx` content pages were rendering as **raw pipe text** inside a `<p>` element across the live site — `reference/configuration`, `guides/main-loop`, `guides/v3-migration`, and more — with zero `<table>` elements. Plain generated `.md` reference pages were unaffected, which masked the bug.

Root cause: authored `.mdx` content was not receiving Astro's default GFM table parsing (the `.md` reference pages were). The content generator (`docs/scripts/transform-content.ts`) writes pipe markdown through unchanged, so this was purely a markdown-pipeline gap, not a generator issue. Making GFM explicit via `remark-gfm` restores table parsing for `.mdx`.

## Changes

- `docs/package.json` — add `remark-gfm` devDependency (`^4.0.1`)
- `docs/astro.config.mjs` — import `remarkGfm`, add `remarkPlugins: [remarkGfm]` (existing `rehypeMermaid` config untouched)
- `bun.lock` — workspace lockfile update

## Verification

Against built HTML (`docs/dist/**/index.html`):

| Page | `<table>` before | `<table>` after |
|---|---|---|
| reference/configuration | 0 | 1 |
| guides/main-loop | 0 | 1 |
| guides/v3-migration | — | 2 |

- No raw pipe-text tables remain (`<p>|` count → 0)
- Mermaid diagrams still render (6 pages)
- 85 pages build clean

Classified `build(dev)` — a docs-workspace tooling change, not shipped in the npm package; `release: false` per `.releaserc.yaml`, so no version is cut.