### PR TITLE
fix(docs): use OpenCode's singular `plugin` config key, not `plugins`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Systematic is an [OpenCode](https://opencode.ai/) plugin — and, from v3, a [Pi
 **OpenCode plugin** — full integration (slash commands, `systematic_skill` tool, agent registration):
 
 ```json
-{ "plugins": ["@fro.bot/systematic@latest"] }
+{ "plugin": ["@fro.bot/systematic@latest"] }
 ```
 
 Add that to `~/.config/opencode/opencode.json` and restart OpenCode.

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -20,11 +20,11 @@ The OpenCode plugin is the recommended installation path. It provides the full e
 <Steps>
 1. **Add the plugin to your OpenCode config**
 
-   Open your global OpenCode config (typically `~/.config/opencode/opencode.json`) and add Systematic to the `plugins` array:
+   Open your global OpenCode config (typically `~/.config/opencode/opencode.json`) and add Systematic to the `plugin` array:
 
    ```json
    {
-     "plugins": ["@fro.bot/systematic@latest"]
+     "plugin": ["@fro.bot/systematic@latest"]
    }
    ```
 

--- a/docs/src/content/docs/guides/agent-install.mdx
+++ b/docs/src/content/docs/guides/agent-install.mdx
@@ -22,11 +22,11 @@ Follow these steps to enable Systematic in your environment:
 
 <Steps>
 1. **Add plugin to configuration**
-   Append `@fro.bot/systematic@latest` to the `plugins` array in `~/.config/opencode/opencode.json`.
+   Append `@fro.bot/systematic@latest` to the `plugin` array in `~/.config/opencode/opencode.json`.
 
    ```json
    {
-     "plugins": ["@fro.bot/systematic@latest"]
+     "plugin": ["@fro.bot/systematic@latest"]
    }
    ```
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -110,7 +110,7 @@ import StatsBanner from '../../components/StatsBanner.astro'
     
     ```json
     {
-      "plugins": ["@fro.bot/systematic@latest"]
+      "plugin": ["@fro.bot/systematic@latest"]
     }
     ```
     

--- a/registry/files/profiles/omo/opencode.jsonc
+++ b/registry/files/profiles/omo/opencode.jsonc
@@ -2,5 +2,5 @@
   "$schema": "https://opencode.ai/config.json",
   // OMO + Systematic Profile
   // Combines Oh My OpenCode's powerful agents with Systematic's structured workflows
-  "plugins": ["oh-my-opencode@latest", "@fro.bot/systematic@latest"]
+  "plugin": ["oh-my-opencode@latest", "@fro.bot/systematic@latest"]
 }

--- a/registry/files/profiles/standalone/opencode.jsonc
+++ b/registry/files/profiles/standalone/opencode.jsonc
@@ -2,5 +2,5 @@
   "$schema": "https://opencode.ai/config.json",
   // Standalone Systematic Profile
   // Use only Systematic's structured workflows and agents
-  "plugins": ["@fro.bot/systematic@latest"]
+  "plugin": ["@fro.bot/systematic@latest"]
 }


### PR DESCRIPTION
## What

Correct the OpenCode config key in all install instructions and shipped registry profiles from the plural `plugins` to the singular `plugin`.

## Why

OpenCode's config schema defines a singular `plugin` array. The plural `plugins` key is silently ignored — so users following these instructions get a config that never loads Systematic, with no error.

This is a pre-existing bug that predates the current docs work. It spans user-facing install docs **and** the shipped registry profile configs users install directly.

Ground truth confirming the singular form:
- OpenCode's own schema and docs use `"plugin": [...]`
- Systematic's `src/lib/setup.ts` explicitly rejects the plural key: *"`plugins` (plural) is not supported by OpenCode's schema; use singular `plugin`"*
- Systematic's OpenCode integration tests and the repo's own `opencode.json` use the singular form

So the docs and registry config were the only places still teaching the broken key.

## Changes

- `README.md` — install snippet
- `docs/src/content/docs/getting-started/installation.mdx` — prose + JSON
- `docs/src/content/docs/guides/agent-install.mdx` — prose + JSON
- `docs/src/content/docs/index.mdx` — install snippet
- `registry/files/profiles/standalone/opencode.jsonc` — shipped profile config
- `registry/files/profiles/omo/opencode.jsonc` — shipped profile config

## Verification

- Repo-wide grep: zero remaining plural `plugins` plugin-array keys (excluding historical plan docs and vendored dependency source)
- `bun run registry:drift` clean (73 components)
- `bun test tests/unit` — 1213 pass
- `bun run docs:build` — 85 pages, clean