### PR TITLE
docs(solutions): compound docs-reframe learnings

### DIFF
--- a/docs/solutions/best-practices/auto-generated-install-commands-mdx-pitfalls-2026-06-06.md
+++ b/docs/solutions/best-practices/auto-generated-install-commands-mdx-pitfalls-2026-06-06.md
@@ -139,3 +139,4 @@ npx skills add marcusrbrown/systematic --skill [name]
 - `docs/solutions/best-practices/verify-css-liveness-against-rendered-html-2026-06-04.md` — inspect built `docs/dist` HTML rather than trusting source markup.
 - `docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md` — adjacent build-time codegen pattern (generator self-reads, fresh-input boundaries).
 - `docs/solutions/test-failures/unit-suite-rewrites-repo-file-trap-2026-07-17.md` — the docs generator's test suite rewriting the committed configuration.mdx during verification; injectable write target + repo-file-untouched assertion.
+- `docs/solutions/ui-bugs/mdx-gfm-tables-render-as-raw-pipe-text-2026-07-18.md` — another MDX-pipeline gap: authored `.mdx` GFM tables rendered as raw pipe text until `remark-gfm` was wired into the markdown config; same "verify built HTML, not source" discipline.

--- a/docs/solutions/documentation-gaps/opencode-plugin-config-key-is-singular-plugin-not-plugins-2026-07-18.md
+++ b/docs/solutions/documentation-gaps/opencode-plugin-config-key-is-singular-plugin-not-plugins-2026-07-18.md
@@ -1,0 +1,70 @@
+---
+title: OpenCode plugin config key is singular plugin, not plugins
+date: 2026-07-18
+category: documentation-gaps
+module: opencode-plugin-config
+problem_type: documentation_gap
+component: documentation
+severity: medium
+applies_when:
+  - "Writing OpenCode install instructions in docs, README, or shipped config"
+  - "Defining the plugin array in an opencode.json / opencode.jsonc profile"
+  - "Documenting any third-party tool's config key from memory"
+tags:
+  - opencode
+  - config
+  - plugin
+  - install-docs
+  - registry
+---
+
+# OpenCode plugin config key is singular plugin, not plugins
+
+## Context
+
+Systematic's install docs and both shipped registry profiles told users to add the plugin under a plural `plugins` array in `opencode.json`. OpenCode's config schema only reads a **singular** `plugin` array, so the plural key is silently ignored — the plugin never loads, with no error. This shipped in the README, three docs pages, and the `standalone`/`omo` registry profiles that users install directly, so anyone following the instructions got a config that silently did nothing.
+
+## Guidance
+
+Use the singular `plugin` key for OpenCode plugin config, everywhere:
+
+```json
+{ "plugin": ["@fro.bot/systematic@latest"] }
+```
+
+Not `"plugins"`. The fix (PR #665) swept every user-facing occurrence to singular:
+
+- `README.md`
+- `docs/src/content/docs/getting-started/installation.mdx` (prose + JSON)
+- `docs/src/content/docs/index.mdx`
+- `docs/src/content/docs/guides/agent-install.mdx` (prose + JSON)
+- `registry/files/profiles/standalone/opencode.jsonc`
+- `registry/files/profiles/omo/opencode.jsonc`
+
+The repo's own `opencode.json` and the integration tests already used the singular form correctly — only the human-facing docs and registry profiles had drifted to the plural.
+
+## Why This Matters
+
+The failure is **silent**: OpenCode does not warn on an unknown `plugins` key, the docs build stays green, and tests pass (they exercise the correct singular form). A user following the docs sees no error — the plugin just isn't there. Broken install instructions in the README and shipped registry profiles are among the highest-blast-radius docs bugs, because they are the literal first thing a new user copies.
+
+## When to Apply
+
+- Any time you write or review OpenCode plugin install config.
+- Whenever documenting a third-party tool's config key — verify against that tool's actual schema/source, not memory or naming intuition. Plural "plugins" is the intuitive guess and it is wrong here.
+
+## Examples
+
+Ground truth confirming the singular key:
+
+- OpenCode runtime reads `config.plugin` — `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/src/config/config.ts:101-108`.
+- OpenCode's config schema: `plugin: Schema.optional(Schema.Array(PluginSpec))` — `.slim/clonedeps/repos/anomalyco__opencode/packages/tui/src/config/index.tsx:53-58`.
+- Systematic's own setup code **already rejects** the plural at runtime — `src/lib/setup.ts:296-316`: *"`plugins` (plural) is not supported by OpenCode's schema; use singular `plugin`."*
+- Systematic's OpenCode integration test uses `{ plugin: [pluginPath] }` — `tests/integration/opencode.test.ts:751-759`.
+
+The clinching signal: the project's own code enforced the singular key while its docs taught the plural. When your runtime already validates a shape, the docs must match the shape the code enforces.
+
+## Related
+
+- `docs/solutions/integration-issues/opencode-plugin-factory-duplicate-registration-2026-05-04.md` — plugin config/loader semantics (how OpenCode resolves the `plugin` array across sources).
+- `docs/solutions/developer-experience/local-systematic-overrides-global-2026-05-14.md` — OpenCode config source precedence.
+- `docs/solutions/integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md` — verifying real OpenCode loader behavior rather than assuming.

--- a/docs/solutions/integration-issues/opencode-plugin-factory-duplicate-registration-2026-05-04.md
+++ b/docs/solutions/integration-issues/opencode-plugin-factory-duplicate-registration-2026-05-04.md
@@ -215,6 +215,9 @@ node -e "import('./dist/index.js').then(m => console.log(Object.keys(m)))"
   orthogonal export-shape contract at the same plugin boundary
 - `docs/solutions/developer-experience/local-systematic-overrides-global-2026-05-14.md` — applies the
   per-load registration model to the project-overrides-user case
+- `docs/solutions/documentation-gaps/opencode-plugin-config-key-is-singular-plugin-not-plugins-2026-07-18.md` —
+  the config key that feeds this loader is singular `plugin`; docs/registry that used plural `plugins`
+  silently failed to load the plugin at all
 - `docs/brainstorms/2026-05-10-multi-load-plugin-registration-requirements.md` — design rationale
   (per-load registration; bootstrap idempotency via `<SYSTEMATIC_WORKFLOWS>` marker; system prompt array
   as coordination point; no global state)

--- a/docs/solutions/ui-bugs/mdx-gfm-tables-render-as-raw-pipe-text-2026-07-18.md
+++ b/docs/solutions/ui-bugs/mdx-gfm-tables-render-as-raw-pipe-text-2026-07-18.md
@@ -1,0 +1,84 @@
+---
+title: MDX GFM tables render as raw pipe text on the docs site
+date: 2026-07-18
+category: ui-bugs
+module: docs
+problem_type: ui_bug
+component: documentation
+symptoms:
+  - "Hand-authored pipe tables in `.mdx` pages rendered as literal `<p>| Col | Col |` text"
+  - "Built HTML contained zero `<table>` elements for authored `.mdx` tables"
+  - "Generated `.md` reference pages rendered real tables, masking the bug"
+root_cause: missing_include
+resolution_type: dependency_update
+severity: medium
+tags:
+  - mdx
+  - remark-gfm
+  - starlight
+  - astro
+  - tables
+  - docs-site
+---
+
+# MDX GFM tables render as raw pipe text on the docs site
+
+## Problem
+
+Hand-authored GitHub-Flavored-Markdown pipe tables in `.mdx` content pages rendered as literal pipe text inside a `<p>` element instead of real `<table>` elements — across the live site (`reference/configuration`, `guides/main-loop`, `guides/v3-migration`, and the new Installation compatibility aid). Generated `.md` reference pages were unaffected, which masked the bug.
+
+## Symptoms
+
+- Built HTML showed `<p>| Category | Chain | Rationale | When to Override |` for a table that should have rendered as `<table>` (verified on production and in local `docs/dist`).
+- `grep -c '<table' docs/dist/reference/configuration/index.html` returned `0`.
+- The same raw-pipe rendering appeared on every hand-authored `.mdx` table, but not on generated `.md` reference pages.
+
+## What Didn't Work
+
+Two hypotheses had to be disambiguated before touching config:
+
+- **"The content generator emits HTML tables."** Disproved: `docs/scripts/transform-content.ts:107-115` writes the source body through unchanged (`generatePage(..., body, ...)` returns `header + cleanedBody`), only normalizing whitespace. It does not convert markdown tables to HTML. So the `<table>` in generated `.md` pages was *not* evidence that the generator produced them.
+- **"It's a `.md` vs `.mdx` GFM split."** Confirmed: the fix lives in the Astro markdown pipeline, not the generator. Authored `.mdx` was not receiving Astro's default GFM table parsing, while `.md` was.
+
+Reading a generated reference page's source (plain pipe markdown, not HTML) plus `transform-content.ts` settled it in one check.
+
+## Solution
+
+Wire `remark-gfm` explicitly into the Astro markdown pipeline.
+
+`docs/astro.config.mjs` (before → after):
+
+```js
+// before: markdown had only a rehype plugin
+markdown: {
+  rehypePlugins: [[rehypeMermaid, { /* ... */ }]],
+}
+
+// after: add the remark-gfm import + remarkPlugins
+import remarkGfm from 'remark-gfm'
+// ...
+markdown: {
+  remarkPlugins: [remarkGfm],
+  rehypePlugins: [[rehypeMermaid, { /* ... */ }]],
+}
+```
+
+`docs/package.json` — added `remark-gfm` (`^4.0.1`) to `devDependencies`.
+
+Verified: `grep -c '<table' docs/dist/reference/configuration/index.html` went `0` → `1`; `guides/main-loop` `0` → `1`; `guides/v3-migration` → `2`; no raw `<p>|` tables remained; mermaid diagrams unaffected; 85 pages build clean. Shipped in PR #663.
+
+## Why This Works
+
+Astro enables GFM by default, but in this Astro 6 + Starlight + `@astrojs/mdx` setup that default was not reaching authored `.mdx` content (plain `.md` still got it). Declaring `remark-gfm` in `markdown.remarkPlugins` restores GFM table parsing for `.mdx` during the build. `remark-gfm` is the same plugin Astro uses internally, so there is no behavior surprise beyond the GFM features it enables (tables, strikethrough, autolinks, task lists).
+
+## Prevention
+
+- **Verify rendered tables against built HTML (`docs/dist/**/index.html`), not source.** A pipe table that looks correct in `.mdx` source can still render as raw text. Use `grep -c '<table' docs/dist/<page>/index.html` as the check.
+- **`docs:generate` alone does not parse MDX** — run `bun run docs:build` before pushing docs changes.
+- **Run `bun run lint` before pushing docs-config edits** — Biome formats `astro.config.mjs`, and a multi-line config value will fail the format gate in CI.
+
+## Related Issues
+
+- `docs/solutions/best-practices/auto-generated-install-commands-mdx-pitfalls-2026-06-06.md` — sibling MDX-pipeline pitfalls (`<name>` in table cells parses as JSX; copy buttons only attach to fenced blocks). Same "verify built HTML, not source" discipline.
+- `docs/solutions/build-errors/mdx-heading-anchor-crashes-astro-build-2026-05-22.md` — another Astro/MDX parse-behavior gap.
+- `docs/solutions/workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md` — "build passed" is not "artifact is correct."


### PR DESCRIPTION
## What

Capture two reusable learnings from the docs workflow-first reframe arc as `docs/solutions/` entries, with reciprocal cross-links to the strongest sibling docs.

## Learnings

- **`ui-bugs/mdx-gfm-tables-render-as-raw-pipe-text`** — authored `.mdx` GFM tables rendered as raw pipe text (zero `<table>` elements) while generated `.md` pages were fine. Root cause: authored `.mdx` wasn't receiving Astro's default GFM parsing; `remark-gfm` wasn't in the pipeline. Fix + the disambiguation method (generator emits pipe markdown, not HTML) + prevention (verify built HTML, not source).
- **`documentation-gaps/opencode-plugin-config-key-is-singular-plugin-not-plugins`** — OpenCode's config key is singular `plugin`; the plural `plugins` is silently ignored so the plugin never loads. Ground truth cited against OpenCode source and Systematic's own `setup.ts` (which already rejects the plural). Prevention: verify third-party config keys against the tool's schema.

## Cross-links

Reciprocal links added to `auto-generated-install-commands-mdx-pitfalls` (MDX-pipeline sibling) and `opencode-plugin-factory-duplicate-registration` (plugin-config-boundary sibling).

## Verification

- `content-integrity` clean (53 solution docs scanned); all cross-link targets resolve