### PR TITLE
fix(build): harden Claude Code agent flattening and widen SessionStart hook

### DIFF
--- a/scripts/build-claude-code-plugin.ts
+++ b/scripts/build-claude-code-plugin.ts
@@ -172,7 +172,6 @@ function shellSingleQuote(value: string): string {
 export interface ClaudeHooksJson {
   hooks: {
     SessionStart: Array<{
-      matcher: string
       hooks: Array<{ type: 'command'; command: string }>
     }>
   }
@@ -181,6 +180,13 @@ export interface ClaudeHooksJson {
 /**
  * Declarative SessionStart command hook. Static `printf` of facts — no
  * runtime JS in the bundle, sidestepping the hook-throw-swallowing failure mode.
+ *
+ * The SessionStart entry omits `matcher` entirely — per Claude Code docs
+ * (code.claude.com/docs/en/hooks#sessionstart), the four source values
+ * (startup/resume/clear/compact) are exact-string matchers with no
+ * documented alternation form; omitting `matcher` is the canonical way to
+ * match all sources, so the hook fires on startup, resume, clear, and
+ * compact alike.
  */
 export function buildHooksJson(rootDir: string): ClaudeHooksJson {
   const facts = buildHookFacts(rootDir)
@@ -190,7 +196,6 @@ export function buildHooksJson(rootDir: string): ClaudeHooksJson {
     hooks: {
       SessionStart: [
         {
-          matcher: 'startup',
           hooks: [{ type: 'command', command }],
         },
       ],
@@ -392,42 +397,98 @@ export function checkGeneratedNamespace(
 }
 
 /**
+ * Canonicalizes an identity string (agent stem or frontmatter `name`) for
+ * collision detection: NFC-normalized + case-folded so two stems/names
+ * differing only by case or Unicode normalization form collide loudly here
+ * instead of silently overwriting each other on a case-insensitive output
+ * filesystem (macOS).
+ */
+function foldIdentity(value: string): string {
+  return value.normalize('NFC').toLowerCase()
+}
+
+/**
  * Flattens `agents/<category>/<name>.md` → a stem-keyed list, enforcing
- * global stem uniqueness (mirrors `checkAgentStemUniqueness` in
- * scripts/content-integrity.ts). Claude Code accepts Systematic's agent
- * frontmatter as-is, so this is a pure hierarchy move — no frontmatter
- * injection or stripping.
+ * global uniqueness on two independent identities (mirrors
+ * `checkAgentStemUniqueness` in scripts/content-integrity.ts, hardened
+ * beyond stems):
+ *
+ *   - file-stem identity (the flattened output filename)
+ *   - frontmatter `name` identity (what Claude Code actually dispatches by)
+ *
+ * Both identities are canonicalized via `foldIdentity` before comparison, so
+ * case-/Unicode-fold-only differences collide here rather than surviving to
+ * overwrite each other on disk. Missing/empty frontmatter `name` fails the
+ * build closed — an agent Claude Code cannot dispatch by identity is a build
+ * error, not a silent pass-through.
+ *
+ * Claude Code accepts Systematic's agent frontmatter as-is, so this is a
+ * pure hierarchy move — no frontmatter injection or stripping.
  */
 export function flattenAgents(rootDir: string): FlattenedAgent[] {
   const agentsDir = path.join(rootDir, 'agents')
   const agents = findAgentsInDir(agentsDir)
 
-  const byStem = new Map<string, string[]>()
-  for (const agent of agents) {
-    const files = byStem.get(agent.name) ?? []
-    files.push(agent.file)
-    byStem.set(agent.name, files)
+  const parsed = agents.map((agent) => {
+    const content = fs.readFileSync(agent.file)
+    const { data } = parseFrontmatter<Record<string, unknown>>(
+      content.toString('utf8'),
+    )
+    const rawName = data.name
+    const name = typeof rawName === 'string' ? rawName.trim() : ''
+    if (name === '') {
+      throw buildError(
+        `Agent "${path.relative(rootDir, agent.file)}" is missing a non-empty frontmatter "name" — Claude Code dispatches agents by this identity, so the build fails closed rather than shipping an undispatchable agent.`,
+      )
+    }
+    return { agent, content, name }
+  })
+
+  const byFoldedStem = new Map<string, string[]>()
+  const byFoldedName = new Map<string, string[]>()
+
+  for (const { agent, name } of parsed) {
+    const foldedStem = foldIdentity(agent.name)
+    const stemFiles = byFoldedStem.get(foldedStem) ?? []
+    stemFiles.push(agent.file)
+    byFoldedStem.set(foldedStem, stemFiles)
+
+    const foldedName = foldIdentity(name)
+    const nameFiles = byFoldedName.get(foldedName) ?? []
+    nameFiles.push(agent.file)
+    byFoldedName.set(foldedName, nameFiles)
   }
 
-  const collisions = [...byStem.entries()].filter(
-    ([, files]) => files.length > 1,
-  )
-  if (collisions.length > 0) {
-    const detail = collisions
+  const formatCollisions = (collisions: [string, string[]][]): string =>
+    collisions
       .map(
-        ([stem, files]) =>
-          `  - "${stem}": ${files.map((f) => path.relative(rootDir, f)).join(', ')}`,
+        ([key, files]) =>
+          `  - "${key}": ${files.map((f) => path.relative(rootDir, f)).join(', ')}`,
       )
       .join('\n')
+
+  const stemCollisions = [...byFoldedStem.entries()].filter(
+    ([, files]) => files.length > 1,
+  )
+  if (stemCollisions.length > 0) {
     throw buildError(
-      `Agent stem collision(s) detected — the flatten step requires globally unique stems:\n${detail}`,
+      `Agent stem collision(s) detected — the flatten step requires globally unique stems (case-/Unicode-fold aware):\n${formatCollisions(stemCollisions)}`,
     )
   }
 
-  return agents.map((agent) => ({
+  const nameCollisions = [...byFoldedName.entries()].filter(
+    ([, files]) => files.length > 1,
+  )
+  if (nameCollisions.length > 0) {
+    throw buildError(
+      `Agent frontmatter "name" collision(s) detected — Claude Code dispatches by frontmatter "name", so it must be globally unique (case-/Unicode-fold aware):\n${formatCollisions(nameCollisions)}`,
+    )
+  }
+
+  return parsed.map(({ agent, content }) => ({
     stem: agent.name,
     sourceFile: agent.file,
-    content: fs.readFileSync(agent.file),
+    content,
   }))
 }
 
@@ -469,18 +530,37 @@ export function generatePluginFiles(rootDir: string): Map<string, Buffer> {
   return translated
 }
 
-/** Writes a generated file map to `outDir`, clearing any prior contents first. */
+/**
+ * Writes a generated file map to `outDir` atomically: files are written to a
+ * temp sibling directory first, then the temp dir is renamed into `outDir`
+ * only after every file has been written successfully. `outDir`'s prior
+ * contents are replaced only at the final rename, so a build interrupted
+ * mid-write never leaves a partial `outDir` — either the old bundle stays
+ * intact or the new one lands whole. The temp dir is cleaned up on failure.
+ */
 export function writePluginFiles(
   files: Map<string, Buffer>,
   outDir: string,
 ): void {
-  if (fs.existsSync(outDir)) {
-    fs.rmSync(outDir, { recursive: true, force: true })
-  }
-  for (const [relPath, content] of files) {
-    const outPath = path.join(outDir, relPath)
-    fs.mkdirSync(path.dirname(outPath), { recursive: true })
-    fs.writeFileSync(outPath, content)
+  const parentDir = path.dirname(outDir)
+  const tempDir = fs.mkdtempSync(
+    path.join(parentDir, `.${path.basename(outDir)}-staging-`),
+  )
+
+  try {
+    for (const [relPath, content] of files) {
+      const outPath = path.join(tempDir, relPath)
+      fs.mkdirSync(path.dirname(outPath), { recursive: true })
+      fs.writeFileSync(outPath, content)
+    }
+
+    if (fs.existsSync(outDir)) {
+      fs.rmSync(outDir, { recursive: true, force: true })
+    }
+    fs.renameSync(tempDir, outDir)
+  } catch (err) {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+    throw err
   }
 }
 

--- a/scripts/build-claude-code-plugin.ts
+++ b/scripts/build-claude-code-plugin.ts
@@ -435,10 +435,18 @@ export function flattenAgents(rootDir: string): FlattenedAgent[] {
       content.toString('utf8'),
     )
     const rawName = data.name
+    const relFile = path.relative(rootDir, agent.file)
+
+    if (rawName !== undefined && typeof rawName !== 'string') {
+      throw buildError(
+        `Agent "${relFile}" has a frontmatter "name" of type ${typeof rawName} (expected a non-empty string) — Claude Code dispatches agents by this identity, so the build fails closed rather than shipping an undispatchable agent.`,
+      )
+    }
+
     const name = typeof rawName === 'string' ? rawName.trim() : ''
     if (name === '') {
       throw buildError(
-        `Agent "${path.relative(rootDir, agent.file)}" is missing a non-empty frontmatter "name" — Claude Code dispatches agents by this identity, so the build fails closed rather than shipping an undispatchable agent.`,
+        `Agent "${relFile}" is missing a non-empty frontmatter "name" — Claude Code dispatches agents by this identity, so the build fails closed rather than shipping an undispatchable agent.`,
       )
     }
     return { agent, content, name }
@@ -531,21 +539,35 @@ export function generatePluginFiles(rootDir: string): Map<string, Buffer> {
 }
 
 /**
- * Writes a generated file map to `outDir` atomically: files are written to a
- * temp sibling directory first, then the temp dir is renamed into `outDir`
- * only after every file has been written successfully. `outDir`'s prior
- * contents are replaced only at the final rename, so a build interrupted
- * mid-write never leaves a partial `outDir` — either the old bundle stays
- * intact or the new one lands whole. The temp dir is cleaned up on failure.
+ * Writes a generated file map to `outDir` via rename-aside, so the prior
+ * bundle is never destroyed before the new one is safely in place:
+ *
+ *   1. Write the new bundle to a temp sibling dir (all files must succeed).
+ *   2. If `outDir` already exists, rename it aside to a backup sibling path
+ *      (not deleted) — `renameSync` can't land the temp dir directly onto an
+ *      existing non-empty dir on POSIX, which is exactly why the aside step
+ *      exists.
+ *   3. Rename the temp dir into `outDir`.
+ *   4. On success, delete the aside backup.
+ *
+ * Guarantee this actually provides: the prior bundle is preserved until the
+ * moment the new one lands, so a crash during steps 1 leaves the old bundle
+ * (if any) completely untouched, and a crash during steps 2-3 is caught and
+ * rolled back (the aside backup is renamed back to `outDir`) so the old
+ * bundle is restored. There is no window where neither bundle exists except
+ * a crash the process cannot catch (e.g. SIGKILL) between the aside-rename
+ * and the swap-rename — an extremely narrow window, and even then the aside
+ * backup remains on disk for manual recovery. `outDir` is gitignored and
+ * fully rebuilt on the next run regardless, so recovery is also just
+ * "re-run the build."
  */
 export function writePluginFiles(
   files: Map<string, Buffer>,
   outDir: string,
 ): void {
   const parentDir = path.dirname(outDir)
-  const tempDir = fs.mkdtempSync(
-    path.join(parentDir, `.${path.basename(outDir)}-staging-`),
-  )
+  const baseName = path.basename(outDir)
+  const tempDir = fs.mkdtempSync(path.join(parentDir, `.${baseName}-staging-`))
 
   try {
     for (const [relPath, content] of files) {
@@ -553,14 +575,33 @@ export function writePluginFiles(
       fs.mkdirSync(path.dirname(outPath), { recursive: true })
       fs.writeFileSync(outPath, content)
     }
-
-    if (fs.existsSync(outDir)) {
-      fs.rmSync(outDir, { recursive: true, force: true })
-    }
-    fs.renameSync(tempDir, outDir)
   } catch (err) {
     fs.rmSync(tempDir, { recursive: true, force: true })
     throw err
+  }
+
+  const priorExisted = fs.existsSync(outDir)
+  let asideDir: string | undefined
+  if (priorExisted) {
+    asideDir = fs.mkdtempSync(path.join(parentDir, `.${baseName}-old-`))
+    fs.rmdirSync(asideDir) // renameSync requires the destination not exist
+    fs.renameSync(outDir, asideDir)
+  }
+
+  try {
+    fs.renameSync(tempDir, outDir)
+  } catch (err) {
+    // Swap failed after the prior bundle was moved aside — restore it so
+    // outDir never ends up empty/missing, then clean up the temp dir.
+    if (asideDir && !fs.existsSync(outDir) && fs.existsSync(asideDir)) {
+      fs.renameSync(asideDir, outDir)
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true })
+    throw err
+  }
+
+  if (asideDir) {
+    fs.rmSync(asideDir, { recursive: true, force: true })
   }
 }
 

--- a/scripts/build-claude-code-plugin.ts
+++ b/scripts/build-claude-code-plugin.ts
@@ -551,15 +551,18 @@ export function generatePluginFiles(rootDir: string): Map<string, Buffer> {
  *   4. On success, delete the aside backup.
  *
  * Guarantee this actually provides: the prior bundle is preserved until the
- * moment the new one lands, so a crash during steps 1 leaves the old bundle
- * (if any) completely untouched, and a crash during steps 2-3 is caught and
- * rolled back (the aside backup is renamed back to `outDir`) so the old
- * bundle is restored. There is no window where neither bundle exists except
- * a crash the process cannot catch (e.g. SIGKILL) between the aside-rename
- * and the swap-rename — an extremely narrow window, and even then the aside
- * backup remains on disk for manual recovery. `outDir` is gitignored and
- * fully rebuilt on the next run regardless, so recovery is also just
- * "re-run the build."
+ * moment the new one lands, so a crash while writing the new bundle (step 1)
+ * leaves the old bundle (if any) completely untouched, and a crash during
+ * the rename-aside setup or the final swap (steps 2-3) is caught and rolled
+ * back (the aside backup is renamed back to `outDir`) so the old bundle is
+ * restored. Every failure path — including a failure while setting up the
+ * rename-aside itself — also removes the temp staging dir, so no failure
+ * mode leaks a stray `.<outDir>-staging-*` directory. There is no window
+ * where neither bundle exists except a crash the process cannot catch (e.g.
+ * SIGKILL) between the aside-rename and the swap-rename — an extremely
+ * narrow window, and even then the aside backup remains on disk for manual
+ * recovery. `outDir` is gitignored and fully rebuilt on the next run
+ * regardless, so recovery is also just "re-run the build."
  */
 export function writePluginFiles(
   files: Map<string, Buffer>,
@@ -580,19 +583,22 @@ export function writePluginFiles(
     throw err
   }
 
-  const priorExisted = fs.existsSync(outDir)
+  // From here on, tempDir cleanup on any failure is guaranteed by this
+  // single try/catch — including a failure during the rename-aside setup
+  // itself, not just the final swap-rename.
   let asideDir: string | undefined
-  if (priorExisted) {
-    asideDir = fs.mkdtempSync(path.join(parentDir, `.${baseName}-old-`))
-    fs.rmdirSync(asideDir) // renameSync requires the destination not exist
-    fs.renameSync(outDir, asideDir)
-  }
-
   try {
+    const priorExisted = fs.existsSync(outDir)
+    if (priorExisted) {
+      asideDir = fs.mkdtempSync(path.join(parentDir, `.${baseName}-old-`))
+      fs.rmdirSync(asideDir) // renameSync requires the destination not exist
+      fs.renameSync(outDir, asideDir)
+    }
+
     fs.renameSync(tempDir, outDir)
   } catch (err) {
-    // Swap failed after the prior bundle was moved aside — restore it so
-    // outDir never ends up empty/missing, then clean up the temp dir.
+    // If the prior bundle was already moved aside, restore it so outDir
+    // never ends up empty/missing.
     if (asideDir && !fs.existsSync(outDir) && fs.existsSync(asideDir)) {
       fs.renameSync(asideDir, outDir)
     }

--- a/tests/unit/build-claude-code-plugin.test.ts
+++ b/tests/unit/build-claude-code-plugin.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test } from 'bun:test'
+import { afterAll, describe, expect, spyOn, test } from 'bun:test'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -324,6 +324,34 @@ describe('flattenAgents — hardened collision detection (frontmatter name, fold
     const flattened = flattenAgents(root)
     expect(flattened.map((a) => a.stem).sort()).toEqual(['bar', 'baz'])
   })
+
+  test('a numeric frontmatter name fails the build fail-closed with a wrong-type message (not "missing")', () => {
+    const root = makeFixtureRepo()
+    writeFile(
+      root,
+      'agents/review/numeric-name.md',
+      '---\nname: 123\ndescription: Numeric name agent.\nmode: subagent\ntemperature: 0.1\n---\nAgent body.\n',
+    )
+
+    expect(() => flattenAgents(root)).toThrow(
+      /frontmatter "name" of type number/i,
+    )
+    expect(() => flattenAgents(root)).not.toThrow(/missing a non-empty/i)
+  })
+
+  test('a boolean frontmatter name fails the build fail-closed with a wrong-type message (not "missing")', () => {
+    const root = makeFixtureRepo()
+    writeFile(
+      root,
+      'agents/review/boolean-name.md',
+      '---\nname: true\ndescription: Boolean name agent.\nmode: subagent\ntemperature: 0.1\n---\nAgent body.\n',
+    )
+
+    expect(() => flattenAgents(root)).toThrow(
+      /frontmatter "name" of type boolean/i,
+    )
+    expect(() => flattenAgents(root)).not.toThrow(/missing a non-empty/i)
+  })
 })
 
 describe('buildHooksJson — SessionStart matcher omission', () => {
@@ -574,7 +602,7 @@ describe('writePluginFiles — atomic staging write', () => {
     expect(fs.existsSync(path.join(outDir, 'agents/bar.md'))).toBe(true)
   })
 
-  test('leaves no stray staging temp dir behind after a successful write', () => {
+  test('leaves no stray staging temp dir or backup dir behind after a successful write', () => {
     const root = makeFixtureRepo()
     writeUsingSystematicAndProfile(root)
     writeSkill(root, 'foo', 'Foo skill.')
@@ -584,10 +612,32 @@ describe('writePluginFiles — atomic staging write', () => {
     writePluginFiles(files, outDir)
 
     const siblingEntries = fs.readdirSync(root)
-    const strayStagingDirs = siblingEntries.filter((name) =>
-      name.startsWith('.out-staging-'),
+    const strayDirs = siblingEntries.filter(
+      (name) =>
+        name.startsWith('.out-staging-') || name.startsWith('.out-old-'),
     )
-    expect(strayStagingDirs).toEqual([])
+    expect(strayDirs).toEqual([])
+  })
+
+  test('leaves no stray staging or backup dir after a second successful write over a prior bundle', () => {
+    const root = makeFixtureRepo()
+    writeUsingSystematicAndProfile(root)
+    writeSkill(root, 'foo', 'Foo skill.')
+
+    const outDir = path.join(root, 'out')
+    const files = generatePluginFiles(root)
+    writePluginFiles(files, outDir) // first write (outDir does not yet exist)
+    writePluginFiles(files, outDir) // second write (outDir exists — exercises rename-aside)
+
+    expect(fs.existsSync(path.join(outDir, '.claude-plugin/plugin.json'))).toBe(
+      true,
+    )
+    const siblingEntries = fs.readdirSync(root)
+    const strayDirs = siblingEntries.filter(
+      (name) =>
+        name.startsWith('.out-staging-') || name.startsWith('.out-old-'),
+    )
+    expect(strayDirs).toEqual([])
   })
 
   test('a pre-swap failure (simulated by an unwritable temp path) leaves the prior outDir untouched and cleans up the temp dir', () => {
@@ -612,18 +662,72 @@ describe('writePluginFiles — atomic staging write', () => {
     expect(() => writePluginFiles(badFiles, outDir)).toThrow()
 
     // outDir (the prior bundle) must still exist and be untouched — the
-    // rename never happened because the write loop failed first.
+    // rename never happened because the write loop failed first (before
+    // outDir was ever renamed aside).
     expect(fs.existsSync(path.join(outDir, 'sentinel.txt'))).toBe(true)
     expect(fs.readFileSync(path.join(outDir, 'sentinel.txt'), 'utf8')).toBe(
       'prior bundle\n',
     )
 
-    // No leftover staging temp dir.
+    // No leftover staging temp dir or aside backup.
     const siblingEntries = fs.readdirSync(root)
-    const strayStagingDirs = siblingEntries.filter((name) =>
-      name.startsWith('.out-staging-'),
+    const strayDirs = siblingEntries.filter(
+      (name) =>
+        name.startsWith('.out-staging-') || name.startsWith('.out-old-'),
     )
-    expect(strayStagingDirs).toEqual([])
+    expect(strayDirs).toEqual([])
+  })
+
+  test('a swap-rename failure (renameSync(tempDir, outDir) throws) restores the prior bundle and leaves no stray dirs', () => {
+    const root = makeFixtureRepo()
+    const outDir = path.join(root, 'out')
+    fs.mkdirSync(outDir, { recursive: true })
+    fs.writeFileSync(path.join(outDir, 'sentinel.txt'), 'prior bundle\n')
+
+    const files = new Map<string, Buffer>([
+      ['agents/new.md', Buffer.from('new bundle content\n')],
+    ])
+
+    const originalRenameSync = fs.renameSync.bind(fs)
+    let swapAttempts = 0
+    const renameSpy = spyOn(fs, 'renameSync').mockImplementation(
+      (src: fs.PathLike, dest: fs.PathLike) => {
+        // Let the aside-rename (outDir -> backup) succeed. Fail only the
+        // FIRST swap-rename (tempDir -> outDir) to simulate a crash
+        // mid-swap; the subsequent restore-rename (backup -> outDir) must
+        // still succeed so the prior bundle actually comes back.
+        if (String(dest) === outDir) {
+          swapAttempts += 1
+          if (swapAttempts === 1) {
+            throw new Error('simulated swap-rename failure')
+          }
+        }
+        return originalRenameSync(src, dest)
+      },
+    )
+
+    try {
+      expect(() => writePluginFiles(files, outDir)).toThrow(
+        /simulated swap-rename failure/,
+      )
+    } finally {
+      renameSpy.mockRestore()
+    }
+
+    // The prior bundle must be restored intact at outDir.
+    expect(fs.existsSync(path.join(outDir, 'sentinel.txt'))).toBe(true)
+    expect(fs.readFileSync(path.join(outDir, 'sentinel.txt'), 'utf8')).toBe(
+      'prior bundle\n',
+    )
+    expect(fs.existsSync(path.join(outDir, 'agents/new.md'))).toBe(false)
+
+    // No leftover staging temp dir or aside backup dir.
+    const siblingEntries = fs.readdirSync(root)
+    const strayDirs = siblingEntries.filter(
+      (name) =>
+        name.startsWith('.out-staging-') || name.startsWith('.out-old-'),
+    )
+    expect(strayDirs).toEqual([])
   })
 
   test('checkGeneratedNamespace gate failure prevents any claude-code/ output (gate runs before swap)', () => {

--- a/tests/unit/build-claude-code-plugin.test.ts
+++ b/tests/unit/build-claude-code-plugin.test.ts
@@ -730,6 +730,59 @@ describe('writePluginFiles — atomic staging write', () => {
     expect(strayDirs).toEqual([])
   })
 
+  test('a rename-aside failure (renameSync(outDir, asideDir) throws) leaves the prior bundle intact and cleans up both tempDir and any partial aside dir', () => {
+    const root = makeFixtureRepo()
+    const outDir = path.join(root, 'out')
+    fs.mkdirSync(outDir, { recursive: true })
+    fs.writeFileSync(path.join(outDir, 'sentinel.txt'), 'prior bundle\n')
+
+    const files = new Map<string, Buffer>([
+      ['agents/new.md', Buffer.from('new bundle content\n')],
+    ])
+
+    const originalRenameSync = fs.renameSync.bind(fs)
+    let renameCallCount = 0
+    const renameSpy = spyOn(fs, 'renameSync').mockImplementation(
+      (src: fs.PathLike, dest: fs.PathLike) => {
+        renameCallCount += 1
+        // The rename-aside step (outDir -> asideDir) is always the FIRST
+        // renameSync call when outDir pre-exists — fail it to simulate a
+        // permission error or similar mid-setup crash, before the swap
+        // rename is ever attempted.
+        if (renameCallCount === 1) {
+          throw new Error('simulated rename-aside failure')
+        }
+        return originalRenameSync(src, dest)
+      },
+    )
+
+    try {
+      expect(() => writePluginFiles(files, outDir)).toThrow(
+        /simulated rename-aside failure/,
+      )
+    } finally {
+      renameSpy.mockRestore()
+    }
+
+    // The prior bundle must still exist, untouched — the aside-rename never
+    // completed, so outDir was never moved.
+    expect(fs.existsSync(path.join(outDir, 'sentinel.txt'))).toBe(true)
+    expect(fs.readFileSync(path.join(outDir, 'sentinel.txt'), 'utf8')).toBe(
+      'prior bundle\n',
+    )
+    expect(fs.existsSync(path.join(outDir, 'agents/new.md'))).toBe(false)
+
+    // No leftover staging temp dir and no stray aside dir — this is the
+    // exact cleanup gap being closed: a throw during rename-aside setup
+    // must still clean up the already-populated tempDir.
+    const siblingEntries = fs.readdirSync(root)
+    const strayDirs = siblingEntries.filter(
+      (name) =>
+        name.startsWith('.out-staging-') || name.startsWith('.out-old-'),
+    )
+    expect(strayDirs).toEqual([])
+  })
+
   test('checkGeneratedNamespace gate failure prevents any claude-code/ output (gate runs before swap)', () => {
     const root = makeFixtureRepo()
     writeUsingSystematicAndProfile(root)

--- a/tests/unit/build-claude-code-plugin.test.ts
+++ b/tests/unit/build-claude-code-plugin.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
   buildHookFacts,
+  buildHooksJson,
   buildOutputStyleContent,
   buildPluginManifest,
   buildSourceInventory,
@@ -250,6 +251,103 @@ describe('flattenAgents — stem-uniqueness edge case', () => {
   })
 })
 
+describe('flattenAgents — hardened collision detection (frontmatter name, fold, fail-closed)', () => {
+  test('two agents with distinct stems but colliding frontmatter name fail the build', () => {
+    const root = makeFixtureRepo()
+    writeFile(
+      root,
+      'agents/review/alpha.md',
+      '---\nname: shared-dispatch\ndescription: Alpha agent.\nmode: subagent\ntemperature: 0.1\n---\nAgent body.\n',
+    )
+    writeFile(
+      root,
+      'agents/workflow/beta.md',
+      '---\nname: shared-dispatch\ndescription: Beta agent.\nmode: subagent\ntemperature: 0.1\n---\nAgent body.\n',
+    )
+
+    expect(() => flattenAgents(root)).toThrow(/frontmatter "name" collision/i)
+  })
+
+  test('two agent stems differing only by case fail the build (case-fold collision)', () => {
+    const root = makeFixtureRepo()
+    writeAgent(root, 'review', 'Reviewer', 'Reviewer agent.')
+    writeAgent(root, 'workflow', 'reviewer', 'reviewer agent (lowercase).')
+
+    expect(() => flattenAgents(root)).toThrow(/stem collision/i)
+  })
+
+  test('two agent stems differing only by Unicode normalization form fail the build (NFC-fold collision)', () => {
+    const root = makeFixtureRepo()
+    // "café" as precomposed NFC (é = U+00E9) vs decomposed NFD (e + combining acute U+0301).
+    const nfc = 'caf\u00e9'
+    const nfd = 'cafe\u0301'
+    expect(nfc).not.toBe(nfd)
+    expect(nfc.normalize('NFC')).toBe(nfd.normalize('NFC'))
+
+    writeAgent(root, 'review', nfc, 'NFC agent.')
+    writeAgent(root, 'workflow', nfd, 'NFD agent.')
+
+    expect(() => flattenAgents(root)).toThrow(/stem collision/i)
+  })
+
+  test('missing frontmatter name fails the build closed', () => {
+    const root = makeFixtureRepo()
+    writeFile(
+      root,
+      'agents/review/no-name.md',
+      '---\ndescription: No name agent.\nmode: subagent\ntemperature: 0.1\n---\nAgent body.\n',
+    )
+
+    expect(() => flattenAgents(root)).toThrow(
+      /missing a non-empty frontmatter "name"/i,
+    )
+  })
+
+  test('empty frontmatter name fails the build closed', () => {
+    const root = makeFixtureRepo()
+    writeFile(
+      root,
+      'agents/review/blank-name.md',
+      '---\nname: "  "\ndescription: Blank name agent.\nmode: subagent\ntemperature: 0.1\n---\nAgent body.\n',
+    )
+
+    expect(() => flattenAgents(root)).toThrow(
+      /missing a non-empty frontmatter "name"/i,
+    )
+  })
+
+  test('two agents with distinct stems and distinct names still flatten cleanly (no false positive)', () => {
+    const root = makeFixtureRepo()
+    writeAgent(root, 'review', 'bar', 'Bar agent.')
+    writeAgent(root, 'workflow', 'baz', 'Baz agent.')
+
+    const flattened = flattenAgents(root)
+    expect(flattened.map((a) => a.stem).sort()).toEqual(['bar', 'baz'])
+  })
+})
+
+describe('buildHooksJson — SessionStart matcher omission', () => {
+  test('the SessionStart entry has no "matcher" field (matches all sources: startup, resume, clear, compact)', () => {
+    const root = makeFixtureRepo()
+    const hooksJson = buildHooksJson(root)
+
+    const [sessionStartEntry] = hooksJson.hooks.SessionStart
+    expect(sessionStartEntry).toBeDefined()
+    expect(sessionStartEntry).not.toHaveProperty('matcher')
+    expect(Object.keys(sessionStartEntry ?? {})).toEqual(['hooks'])
+  })
+
+  test('the SessionStart command hook array is unchanged in shape', () => {
+    const root = makeFixtureRepo()
+    const hooksJson = buildHooksJson(root)
+
+    const [sessionStartEntry] = hooksJson.hooks.SessionStart
+    expect(sessionStartEntry?.hooks).toHaveLength(1)
+    expect(sessionStartEntry?.hooks[0]?.type).toBe('command')
+    expect(sessionStartEntry?.hooks[0]?.command).toContain('printf')
+  })
+})
+
 describe('buildHookFacts — payload cap edge case', () => {
   test('declarative hook payload is within the 10000 char cap for the real repo', () => {
     const facts = buildHookFacts(REPO_ROOT)
@@ -458,6 +556,92 @@ describe('checkGeneratedNamespace — integrity gate', () => {
 
 // ---------------------------------------------------------------------------
 // Real repo build (temp dir — the bundle is never committed)
+
+describe('writePluginFiles — atomic staging write', () => {
+  test('produces the full expected tree in outDir on success', () => {
+    const root = makeFixtureRepo()
+    writeUsingSystematicAndProfile(root)
+    writeSkill(root, 'foo', 'Foo skill.')
+    writeAgent(root, 'review', 'bar', 'Bar agent.')
+
+    const outDir = path.join(root, 'out')
+    const files = generatePluginFiles(root)
+    writePluginFiles(files, outDir)
+
+    expect(fs.existsSync(path.join(outDir, '.claude-plugin/plugin.json'))).toBe(
+      true,
+    )
+    expect(fs.existsSync(path.join(outDir, 'agents/bar.md'))).toBe(true)
+  })
+
+  test('leaves no stray staging temp dir behind after a successful write', () => {
+    const root = makeFixtureRepo()
+    writeUsingSystematicAndProfile(root)
+    writeSkill(root, 'foo', 'Foo skill.')
+
+    const outDir = path.join(root, 'out')
+    const files = generatePluginFiles(root)
+    writePluginFiles(files, outDir)
+
+    const siblingEntries = fs.readdirSync(root)
+    const strayStagingDirs = siblingEntries.filter((name) =>
+      name.startsWith('.out-staging-'),
+    )
+    expect(strayStagingDirs).toEqual([])
+  })
+
+  test('a pre-swap failure (simulated by an unwritable temp path) leaves the prior outDir untouched and cleans up the temp dir', () => {
+    const root = makeFixtureRepo()
+    const outDir = path.join(root, 'out')
+    fs.mkdirSync(outDir, { recursive: true })
+    fs.writeFileSync(path.join(outDir, 'sentinel.txt'), 'prior bundle\n')
+
+    // Force a write failure by including a file path with a bad relative
+    // path outside a plausible bundle shape is hard to trigger generically,
+    // so instead we assert the ordering contract directly: a thrown error
+    // during the write loop must not have already removed outDir, and must
+    // not leave a temp staging dir behind.
+    const badFiles = new Map<string, Buffer>([
+      // A relPath that collides with a directory-vs-file conflict forces
+      // fs.writeFileSync to throw after mkdirSync succeeds for the first
+      // entry, simulating a mid-build failure.
+      ['a', Buffer.from('first')],
+      ['a/b.md', Buffer.from('second')],
+    ])
+
+    expect(() => writePluginFiles(badFiles, outDir)).toThrow()
+
+    // outDir (the prior bundle) must still exist and be untouched — the
+    // rename never happened because the write loop failed first.
+    expect(fs.existsSync(path.join(outDir, 'sentinel.txt'))).toBe(true)
+    expect(fs.readFileSync(path.join(outDir, 'sentinel.txt'), 'utf8')).toBe(
+      'prior bundle\n',
+    )
+
+    // No leftover staging temp dir.
+    const siblingEntries = fs.readdirSync(root)
+    const strayStagingDirs = siblingEntries.filter((name) =>
+      name.startsWith('.out-staging-'),
+    )
+    expect(strayStagingDirs).toEqual([])
+  })
+
+  test('checkGeneratedNamespace gate failure prevents any claude-code/ output (gate runs before swap)', () => {
+    const root = makeFixtureRepo()
+    writeUsingSystematicAndProfile(root)
+    writeSkill(root, 'foo', 'Foo skill referencing ce:nonexistent for context.')
+    writeAgent(root, 'review', 'bar', 'Bar agent.')
+
+    const outDir = path.join(root, 'claude-code')
+
+    expect(() => generatePluginFiles(root)).toThrow(
+      /untranslated source identifier/,
+    )
+    // generatePluginFiles throws before writePluginFiles is ever called in
+    // the real main() flow — assert the outDir was never created.
+    expect(fs.existsSync(outDir)).toBe(false)
+  })
+})
 
 describe('build — real repo, temp dir', () => {
   test('building the real repo into a temp dir succeeds and passes the integrity gate', () => {


### PR DESCRIPTION
## What

Two deferred robustness fixes for the Claude Code plugin build, both surfaced (non-blocking) during the PR #660 review.

## Changes

**Agent flattening hardening** (`scripts/build-claude-code-plugin.ts`)
- Parse each agent's frontmatter during flatten and enforce uniqueness on the **NFC + case-folded dispatch identity** — both file stem and frontmatter `name` — instead of raw stems only. Fails closed on missing/empty `name`. This guards against a silent overwrite from a case- or Unicode-folded collision on a case-insensitive filesystem (macOS), which the existing namespace gate did not catch.
- **Atomic staging**: the bundle is written to a temp sibling dir and renamed into `claude-code/` only after a successful build; an interrupted build never leaves a partial bundle. The `checkGeneratedNamespace` gate still runs before the swap, so a gate failure produces no `claude-code/` dir.

**SessionStart hook widened** (`scripts/build-claude-code-plugin.ts`)
- Drop the `matcher: 'startup'` so the hook's declarative state facts fire on **all** SessionStart sources (startup, resume, clear, compact), not just fresh startup. Per Claude Code docs, omitting the matcher is the canonical "all sources" form (there is no documented alternation form for SessionStart). Output-style enforcement was already independent of this hook.

## Verification

- `bun run claude-code:build` — 151 files, 37 agents, 31 skills (unchanged shape on the clean corpus)
- `bun test tests/unit/build-claude-code-plugin.test.ts` — 41 pass (fixtures for frontmatter-name collision, case-fold + NFC/NFD Unicode-fold collision, fail-closed on empty name, atomic-write / no-partial-on-failure, and SessionStart matcher omission)
- `bun run lint` — 0 errors; `bun run typecheck` — clean
- No shipped-plugin behavior change when the corpus has no collisions