### PR TITLE
fix(document-review): align findings output contract

### DIFF
--- a/agents/document-review/adversarial-document-reviewer.md
+++ b/agents/document-review/adversarial-document-reviewer.md
@@ -73,9 +73,11 @@ Probe whether the document considered the obvious alternatives and whether the c
 
 ## Confidence calibration
 
-- **HIGH (0.80+):** Can quote specific text from the document showing the gap, construct a concrete scenario or counterargument, and trace the consequence.
-- **MODERATE (0.60-0.79):** The gap is likely but confirming it would require information not in the document (codebase details, user research, production data).
-- **Below 0.50:** Suppress.
+- **0:** The challenge is a false positive or a pre-existing issue. Suppress it.
+- **25:** The premise or assumption might be wrong, but the available document and codebase evidence cannot verify it. Suppress it.
+- **50:** The challenge is verified, but it is an advisory or low-impact concern that does not materially threaten the decision. Return it as FYI only.
+- **75:** You have double-checked the premise or decision against the document (and relevant codebase evidence where available), can construct a concrete failure scenario, and the consequence directly affects correctness in practice. This is actionable.
+- **100:** The document directly confirms the premise failure or missing assumption, and the concrete failure scenario will occur frequently on the plan's normal path. Reserve this exceptional actionable anchor for direct evidence, not a persuasive counterargument; it is the only anchor eligible for a silent fix.
 
 ## What you don't flag
 

--- a/agents/document-review/coherence-reviewer.md
+++ b/agents/document-review/coherence-reviewer.md
@@ -14,7 +14,7 @@ You are a technical editor reading for internal consistency. You don't evaluate 
 
 **Terminology drift** -- same concept called different names in different sections ("pipeline" / "workflow" / "process" for the same thing), or same term meaning different things in different places. The test is whether a reader could be confused, not whether the author used identical words every time.
 
-**Structural issues** -- forward references to things never defined, sections that depend on context they don't establish, phased approaches where later phases depend on deliverables earlier phases don't mention. Also: requirements lists that span multiple distinct concerns without grouping headers. When requirements cover different topics (e.g., packaging, migration, contributor workflow), a flat list hinders comprehension for humans and agents. Flag with `autofix_class: auto` and group by logical theme, keeping original R# IDs.
+**Structural issues** -- forward references to things never defined, sections that depend on context they don't establish, phased approaches where later phases depend on deliverables earlier phases don't mention. Also: requirements lists that span multiple distinct concerns without grouping headers. When requirements cover different topics (e.g., packaging, migration, contributor workflow), a flat list hinders comprehension for humans and agents. Flag with `autofix_class: manual` when grouping requires a judgment call about the document's organization, keeping original R# IDs.
 
 **Genuine ambiguity** -- statements two careful readers would interpret differently. Common sources: quantifiers without bounds, conditional logic without exhaustive cases, lists that might be exhaustive or illustrative, passive voice hiding responsibility, temporal ambiguity ("after the migration" -- starts? completes? verified?).
 
@@ -24,9 +24,11 @@ You are a technical editor reading for internal consistency. You don't evaluate 
 
 ## Confidence calibration
 
-- **HIGH (0.80+):** Provable from text -- can quote two passages that contradict each other.
-- **MODERATE (0.60-0.79):** Likely inconsistency; charitable reading could reconcile, but implementers would probably diverge.
-- **Below 0.50:** Suppress entirely.
+- **0:** The apparent inconsistency is a false positive or a pre-existing issue. Suppress it.
+- **25:** The wording might be inconsistent, but the document does not provide enough evidence to verify that readers would diverge. Suppress it.
+- **50:** The inconsistency is verified, but it is an advisory terminology or structural issue that is unlikely to affect implementation. Return it as FYI only.
+- **75:** Two passages or a concrete reference comparison have been double-checked and would cause implementers to diverge or produce an incorrect interpretation in practice. This is actionable.
+- **100:** Directly contradictory passages or a broken reference confirm an inconsistency that will recur frequently wherever the affected instruction is used. Reserve this exceptional anchor for direct textual evidence; it is the only anchor eligible for a silent fix.
 
 ## What you don't flag
 

--- a/agents/document-review/design-lens-reviewer.md
+++ b/agents/document-review/design-lens-reviewer.md
@@ -35,9 +35,11 @@ Explain what's missing: the functional design thinking that makes the interface 
 
 ## Confidence calibration
 
-- **HIGH (0.80+):** Missing states/flows that will clearly cause UX problems during implementation.
-- **MODERATE (0.60-0.79):** Gap exists but a skilled designer could resolve from context.
-- **Below 0.50:** Suppress.
+- **0:** The design concern is a false positive or a pre-existing issue. Suppress it.
+- **25:** A state, flow, or interaction might be missing, but the document does not let you verify the gap. Suppress it.
+- **50:** The gap is verified, but it is advisory or low-impact and a reasonable implementation can proceed without resolving it. Return it as FYI only.
+- **75:** You have double-checked a specific missing state, flow, or interaction against the document, and it will cause a practical implementation or user-flow failure. This is actionable.
+- **100:** The document directly confirms a missing state or flow on a normal, frequently encountered interaction path, and the omission will repeatedly cause users to fail or implementers to block. Reserve this exceptional anchor for direct evidence; it is the only anchor eligible for a silent fix.
 
 ## What you don't flag
 

--- a/agents/document-review/feasibility-reviewer.md
+++ b/agents/document-review/feasibility-reviewer.md
@@ -28,9 +28,11 @@ Apply each check only when relevant. Silence is only a finding when the gap woul
 
 ## Confidence calibration
 
-- **HIGH (0.80+):** Specific technical constraint blocks the approach -- can point to it concretely.
-- **MODERATE (0.60-0.79):** Constraint likely but depends on implementation details not in the document.
-- **Below 0.50:** Suppress entirely.
+- **0:** The feasibility concern is a false positive or a pre-existing issue. Suppress it.
+- **25:** The constraint or failure path might exist, but available document and codebase evidence cannot verify it. Suppress it.
+- **50:** The constraint is verified, but it is an advisory or low-impact implementation concern that does not block the plan. Return it as FYI only.
+- **75:** You have double-checked a concrete stack constraint, dependency, data-flow path, or migration condition and it will hit in practice, directly blocking correctness or implementation. This is actionable.
+- **100:** Direct evidence from the stated stack, existing code, or an explicit plan constraint confirms that a normal path will fail frequently. Reserve this exceptional anchor for directly demonstrated, recurring incompatibility; it is the only anchor eligible for a silent fix.
 
 ## What you don't flag
 

--- a/agents/document-review/product-lens-reviewer.md
+++ b/agents/document-review/product-lens-reviewer.md
@@ -59,9 +59,11 @@ If priority tiers exist: do assignments match stated goals? Are must-haves truly
 
 ## Confidence calibration
 
-- **HIGH (0.80+):** Can quote both the goal and the conflicting work -- disconnect is clear.
-- **MODERATE (0.60-0.79):** Likely misalignment, depends on business context not in document.
-- **Below 0.50:** Suppress.
+- **0:** The product concern is a false positive or a pre-existing issue. Suppress it.
+- **25:** The strategic concern might be real, but business context or evidence needed to verify it is absent. Suppress it.
+- **50:** The misalignment is verified from the document, but it is an advisory, low-impact, or opportunity-cost observation. Return it as FYI only.
+- **75:** You have double-checked the stated goal against the proposed work and the mismatch directly affects the likely outcome in practice. This is actionable. Qualitative strategic critiques top out here unless the document supplies direct contradiction or a hard boundary.
+- **100:** Use this exceptional anchor only when the document directly contradicts its own stated goal or violates its own hard quantitative boundary, and the contradiction will occur frequently if followed. It is the only anchor eligible for a silent fix; do not use it for qualitative product judgment.
 
 ## What you don't flag
 

--- a/agents/document-review/scope-guardian-reviewer.md
+++ b/agents/document-review/scope-guardian-reviewer.md
@@ -42,9 +42,11 @@ With AI-assisted implementation, the cost gap between shortcuts and complete sol
 
 ## Confidence calibration
 
-- **HIGH (0.80+):** Can quote goal statement and scope item showing the mismatch.
-- **MODERATE (0.60-0.79):** Misalignment likely but depends on context not in document.
-- **Below 0.50:** Suppress.
+- **0:** The scope concern is a false positive or a pre-existing issue. Suppress it.
+- **25:** The scope or complexity concern might be real, but the document does not provide enough evidence to verify it. Suppress it.
+- **50:** The mismatch or complexity is verified, but it is advisory or low-impact and does not materially threaten delivery. Return it as FYI only.
+- **75:** You have double-checked a stated goal against a scope item, abstraction, or priority boundary and the mismatch will directly affect right-sizing or delivery in practice. This is actionable. Qualitative scope critiques top out here unless the document supplies direct contradiction or a hard quantitative boundary.
+- **100:** Use this exceptional anchor only when the document directly contradicts its own stated goal or violates its own hard quantitative boundary, and that contradiction will occur frequently if the plan is followed. It is the only anchor eligible for a silent fix; do not use it for qualitative complexity judgment.
 
 ## What you don't flag
 

--- a/agents/document-review/security-lens-reviewer.md
+++ b/agents/document-review/security-lens-reviewer.md
@@ -26,9 +26,11 @@ Skip areas not relevant to the document's scope.
 
 ## Confidence calibration
 
-- **HIGH (0.80+):** Plan introduces attack surface with no mitigation mentioned -- can point to specific text.
-- **MODERATE (0.60-0.79):** Concern likely but plan may address implicitly or in a later phase.
-- **Below 0.50:** Suppress.
+- **0:** The security concern is a false positive or a pre-existing issue. Suppress it.
+- **25:** The threat might exist, but the plan and available context do not let you verify the exposure or missing control. Suppress it.
+- **50:** The security gap is verified, but its impact is advisory or low and does not materially affect the described attack surface. Return it as FYI only.
+- **75:** You have double-checked a concrete endpoint, trust boundary, input, secret, or data path against the plan and the missing control will directly affect security in practice. This is actionable.
+- **100:** The plan directly confirms an unmitigated attack surface on a normal path, and the resulting exposure or exploit will occur frequently if implemented as written. Reserve this exceptional anchor for direct evidence and recurring impact; it is the only anchor eligible for a silent fix.
 
 ## What you don't flag
 

--- a/docs/plans/2026-07-21-001-fix-document-review-findings-contract-plan.md
+++ b/docs/plans/2026-07-21-001-fix-document-review-findings-contract-plan.md
@@ -10,13 +10,13 @@ origin: docs/brainstorms/2026-07-21-document-review-findings-contract-alignment-
 
 ## Overview
 
-Align the shipped document-review contract surfaces to the existing anchor-based synthesis behavior, then extend the content-integrity gate with an explicit, schema-driven drift check. Add representative npm-packed and generated Claude Code sentinels after the source migration is complete.
+Align the document-review producer, consumer, and persona guidance to the existing anchor-based contract. Validate the executable JSON Schema with AJV, then verify the migrated guidance through real persona pressure scenarios and the existing reviewer-to-synthesis boundary.
 
 ---
 
 ## Problem Frame
 
-Issue #677 is a reproducible producer/consumer contract failure: the shipped schema and producer guidance emit continuous confidence values and `auto` / `present`, while synthesis accepts discrete anchors and `safe_auto` / `gated_auto` / `manual`. The formal dogfood reproduction produced five legacy-shaped findings from three personas, all of which synthesis correctly dropped as malformed. The mismatch also exists in headless wording, persona calibration, and the full review-output example, so correcting only the originally named files would leave shipped guidance contradictory.
+Issue #677 is a reproducible producer/consumer contract failure: the shipped schema and producer guidance emit continuous confidence values and `auto` / `present`, while synthesis accepts discrete anchors and `safe_auto` / `gated_auto` / `manual`. The formal dogfood reproduction produced five legacy-shaped findings from three personas, all of which synthesis correctly dropped as malformed. The mismatch also exists in headless wording, persona calibration, and the full review-output example, so correcting only the originally named surfaces would leave the workflow contradictory.
 
 ---
 
@@ -26,44 +26,44 @@ Issue #677 is a reproducible producer/consumer contract failure: the shipped sch
 
 | Requirement | Planned coverage |
 |---|---|
-| R1 | U1 changes `findings-schema.json` to the canonical integer confidence enum. |
-| R2 | U1 changes the schema autofix enum and descriptions to `safe_auto`, `gated_auto`, and `manual`. |
-| R3 | U1 records the five anchor meanings in the schema and shared producer guidance. |
-| R4 | U1 preserves strict malformed-output rejection with no legacy remapping; tests cover decimal and legacy values. |
-| R5 | U1 aligns the subagent template with exact enums, anchor selection, evidence, and the one-clear-fix classification test. |
-| R6 | U1 aligns suggested-fix obligations with synthesis: required for `safe_auto` and `gated_auto`, optional for `manual` when no obvious fix exists. |
-| R7 | U3 updates all seven persona calibrations to shared anchors while preserving concise role-specific examples and boundaries. |
-| R8 | U1 removes active legacy `auto` / `present` assignments from `SKILL.md`, including headless-mode wording, and aligns user-facing terms. |
+| R1 | U1 updates the canonical JSON Schema to the integer confidence enum `0 | 25 | 50 | 75 | 100`. |
+| R2 | U1 updates the schema autofix enum to `safe_auto | gated_auto | manual` and preserves the synthesis meanings. |
+| R3 | U1 aligns schema and producer guidance with the five existing anchor meanings; behavioral validation exercises the anchor values. |
+| R4 | U1 validates that decimal and legacy values are rejected without compatibility remapping. |
+| R5 | U1 aligns the subagent template with canonical enums, anchor selection, evidence, and the one-clear-fix classification test. U3 verifies the resulting persona behavior. |
+| R6 | U1 aligns suggested-fix guidance with synthesis; U3 verifies persona output behavior where conditionality is not structurally expressible in the schema. |
+| R7 | U3 updates all seven personas with shared anchor calibration and role-specific examples. |
+| R8 | U1 aligns interactive and headless guidance with canonical classes and user-facing vocabulary. |
 
-### Consumer, presentation, and integrity
-
-| Requirement | Planned coverage |
-|---|---|
-| R9 | U2 inspects transitional and legacy synthesis references, retaining only clearly non-normative historical mentions. |
-| R10 | U2 keeps current anchor gates, strict validation, class routing, and user-facing fixes/proposed fixes/decisions/FYI behavior unchanged. |
-| R11 | U2 fully converges the review-output example and rules, not just vocabulary. |
-| R12 | U2 updates coverage columns and examples to current post-synthesis route semantics without redesigning coverage. |
-| R13 | U4 adds a hard guard over an explicit manifest of the schema, skill, templates, synthesis, output template, and seven personas. |
-| R14 | U4 drives the guard from parsed schema values and context-aware contract sections rather than globally banning common English words. |
-| R15 | U4 reports actionable violations for schema drift, missing canonical guidance, active legacy assignments, and decimal examples. |
-
-### Delivery and carrying cost
+### Consumer and behavioral verification
 
 | Requirement | Planned coverage |
 |---|---|
-| R16 | U5 inspects an npm tarball for the shipped skill/reference and persona content, using representative canonical sentinels. |
-| R17 | U5 generates and inspects the ephemeral Claude Code bundle for copied references and flattened persona content. |
-| R18 | U5 retains source-to-artifact and source-unchanged assertions; the generated bundle remains uncommitted. |
-| R19 | U4 extends `scripts/content-integrity.ts` and does not introduce a TypeScript contract or code-generation layer. |
+| R9 | U2 aligns live synthesis guidance while retaining clearly non-normative historical references where needed. |
+| R10 | U2 preserves current anchor gates, strict validation, class routing, and fixes/proposed fixes/decisions/FYI behavior; U3 exercises that behavior end to end. |
+| R11 | U2 brings the review-output template to full contract convergence; human review and U3 pressure scenarios verify the result. |
+| R12 | U2 preserves current post-synthesis coverage semantics while aligning its vocabulary; U3 verifies route outcomes rather than presentation text. |
+| R13 | U1 adds AJV contract tests that compile the real canonical schema and validate representative reports and findings. |
+| R14 | U1 covers canonical acceptance, decimal/out-of-set rejection, legacy rejection, and schema-expressed required fields. |
+| R15 | U3 reruns all seven personas against representative requirements/plan pressure scenarios after U1-U3 converge. |
+| R16 | U3's behavioral verification demonstrates canonical reviewer JSON reaches synthesis without malformed classification for confidence/autofix vocabulary. |
+
+### Delivery invariants and carrying cost
+
+| Requirement | Planned coverage |
+|---|---|
+| R17 | Behavioral Verification records existing npm/package and Claude Code build/integration suites as unchanged regression checks; no new content assertions are added. |
+| R18 | U3 and Behavioral Verification preserve no-committed-generated-output and source-immutability/build invariants without adding content sentinels. |
+| R19 | U1 uses the JSON Schema as the canonical contract and introduces no TypeScript contract or code-generation layer. |
 
 ---
 
 ## Scope Boundaries
 
-- Included: canonical schema values and descriptions; producer template; main skill and headless wording; synthesis references and examples; review-output template; all seven persona prompts; explicit-surface content-integrity coverage; npm-packed sentinels; generated Claude Code sentinels.
-- Included: strict rejection of continuous confidence and `auto | present` output without compatibility remapping. The corrected schema, producer prompts, persona guidance, synthesis, and presentation assets are delivered together as one package/plugin release unit for newly dispatched reviews. Older or in-flight dispatches remain under the contract they were dispatched with and are not mixed into a newly dispatched review; compatibility remapping for their findings is not a target.
-- Excluded: synthesis retry policy, contradiction deduplication or recommended-action tie-break redesign, coverage redesign beyond vocabulary alignment, section normalization, runtime behavior changes, tolerant compatibility modes, unrelated content-integrity rules, and a new TypeScript/codegen contract abstraction.
-- Excluded: updating a committed generated `dist` or Claude Code copy. Claude Code output remains an ephemeral build artifact.
+- Included: the canonical schema, producer template, main skill and headless guidance, synthesis guidance, review-output template, all seven persona prompts, AJV behavioral contract tests, real persona pressure scenarios, and reviewer-to-synthesis verification.
+- Included: strict rejection of continuous confidence and `auto | present` output without compatibility remapping. The corrected producer and consumer assets are delivered together as one release unit for newly dispatched reviews. Older or in-flight dispatches remain under the contract they were dispatched with and are not mixed into a newly dispatched review.
+- Excluded: prose or structure tests, Markdown or file-content assertions, a new content-integrity contract gate, package-content or generated-content sentinels, and any inspection of text or file structure in delivered artifacts.
+- Excluded: synthesis retry policy, contradiction deduplication or recommended-action tie-break redesign, coverage redesign beyond vocabulary alignment, section normalization, runtime behavior changes, tolerant compatibility modes, unrelated skills or agents, committed generated output, and host behavior changes.
 - Bundled agents remain model-free; no frontmatter `model` changes are part of this work.
 
 ### Deferred to Separate Tasks
@@ -79,34 +79,30 @@ Issue #677 is a reproducible producer/consumer contract failure: the shipped sch
 
 ### Relevant Code and Patterns
 
-- `scripts/content-integrity.ts` has a violation-or-nothing enforcement model: checks add result data, are included in the aggregate count, and are printed by the CLI. The new check must follow that hard-gate shape rather than inventing a warning channel.
-- `scripts/content-integrity.ts` already provides bounded patterns for allowlist parsing, scan-target collection, migrated-skill identifiers, and banned-pattern checks. The new check should use an explicit contract-surface manifest and section-aware inspection rather than widening the global scan.
-- `tests/unit/content-integrity.test.ts` uses isolated fixture repositories, focused check tests, top-level wiring tests, and a real-tree clean assertion. The new seam should preserve those patterns.
-- `package.json` lists `skills` and `agents` in `files`, so npm consumers receive those source assets directly.
-- `scripts/build-claude-code-plugin.ts` copies skill files, flattens agents, translates only identifiers, and emits an ephemeral self-contained bundle. It does not generate a second findings contract.
-- `tests/unit/package-exports.test.ts` already packs the package and verifies tarball entries; its package sentinels can extend that evidence without duplicating the full integrity suite.
-- `tests/unit/build-claude-code-plugin.test.ts` already tests generated file maps, flattened agents, and real-repository generation into temporary output. Its unit-level generated-content sentinel is the narrowest Claude Code evidence.
-- `tests/integration/claude-code.test.ts` already verifies generated/source fidelity, self-containment, and source immutability in temporary output. No change is needed unless U5's unit generation seam cannot prove a required sentinel; existing integration coverage is otherwise sufficient.
-- Bundled agent frontmatter must continue omitting `model`; the existing integrity check and Claude Code flattening behavior are preserved.
+- `skills/document-review/references/findings-schema.json` is the executable contract input for AJV; the new focused test must compile this real schema rather than reproduce its values in a second contract model.
+- `skills/document-review/references/subagent-template.md`, `skills/document-review/SKILL.md`, `skills/document-review/references/synthesis-and-presentation.md`, and `skills/document-review/references/review-output-template.md` are the live guidance surfaces to align. They are changed as bundled workflow assets, not treated as test fixtures.
+- The seven files under `agents/document-review/` define role-specific calibration. Their behavior is verified by dispatching the real personas after the guidance migration, not by adding Markdown assertions.
+- `tests/unit/document-review-findings-schema.test.ts` is the focused executable-contract seam proposed for U1. AJV is already available in the repository's development dependencies.
+- Existing document-review orchestration and synthesis behavior remain the consumer boundary. No executable synthesis runtime is invented by this plan.
+- `package.json` keeps `skills/` and `agents/` in npm packaging. Existing package and Claude Code suites remain regression checks only; they receive no new content or structure assertions for this change.
+- `scripts/build-claude-code-plugin.ts` continues to generate the ephemeral Claude Code bundle from source. Its existing source-immutability and build invariants remain unchanged.
+- Bundled agents continue to omit `model` so they inherit the invoking model as currently configured.
 
 ### Institutional Learnings
 
-- `docs/solutions/best-practices/content-integrity-has-no-warning-channel-2026-06-06.md`: content-integrity checks are hard violations unless a separate warning system is justified; wire the result, aggregate count, printer, and real-tree assertion together.
-- `docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md`: a gate must mirror the contract it protects instead of checking a weaker or unrelated representation.
-- `docs/solutions/best-practices/undecidable-detection-honest-ban-rule-2026-06-04.md`: when meaning cannot be inferred safely, use a bounded explicit rule and document its scope rather than guessing from arbitrary prose.
-- `docs/solutions/workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md`: inspect emitted and packed artifacts in their delivery shape; a successful build is not artifact evidence.
-- `docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md`: strict contracts should derive from the canonical source and avoid duplicated producer/check inputs; parity between write and check paths matters.
+- `docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md`: strict validation should derive from one canonical source and avoid parallel contract representations.
+- The issue's Fro Bot triage and formal dogfood evidence establish that the failure is a producer/consumer contract mismatch, not a reviewer-quality edge case.
 
 ---
 
 ## Key Technical Decisions
 
-- Parse `findings-schema.json` at test and gate time. The schema supplies canonical enum values and descriptions; hard-coded values are limited to minimum diagnostic or sentinel expectations needed to detect schema drift itself.
-- Maintain an explicit manifest of contract-bearing files and the sections or contexts that carry normative assignments/examples. The guard will permit ordinary English `auto` or `present` outside those contexts and permit a clearly non-normative historical synthesis note.
-- Migrate U1-U3 as one content release slice before enabling or shipping U4. Test-first work may leave a temporary red branch while content is being corrected, but no shipped or mergeable state may contain a mixed producer/consumer contract.
-- Keep the existing synthesis lifecycle intact. U2 changes misleading live definitions and examples to describe the already-established behavior; it does not redesign routing, deduplication, retries, coverage computation, or section matching.
-- Use representative artifact sentinels rather than copying the entire integrity gate into npm or Claude Code outputs. Source-side integrity remains the complete contract check; delivery tests prove that corrected content survives packaging and generation.
-- Do not add a TypeScript contract model, generated findings constants, or another code-generation layer. The JSON Schema is the single contract source.
+- Compile the real `findings-schema.json` with AJV in the focused unit test. Validate representative data objects and reports, not schema descriptions or guidance prose.
+- Keep canonical values in the JSON Schema. Do not introduce a TypeScript findings model, generated constants, or code-generation layer.
+- Treat suggested-fix conditionality according to the schema's structural capabilities. If the schema does not encode a conditional requirement, do not fake one with a prose assertion; verify it through real persona behavior instead.
+- Migrate U1-U3 as one content release slice before behavioral verification or shipping. A temporary test-first failure is acceptable during local work, but no shipped or mergeable state may contain a mixed producer/consumer contract.
+- Preserve synthesis behavior and use U3 pressure scenarios as the integration boundary. Do not convert prose synthesis into executable runtime code.
+- Keep existing npm/package and Claude Code build/integration checks as regression evidence without adding assertions about Markdown, file contents, package contents, generated text, or structure.
 
 ---
 
@@ -114,8 +110,12 @@ Issue #677 is a reproducible producer/consumer contract failure: the shipped sch
 
 ### Resolved During Planning
 
-- The exact validation implementation remains owned by the existing schema/gate seams: the schema is embedded into reviewer prompts and read by synthesis as the contract, while the content-integrity guard parses the schema and checks explicit source surfaces. No runtime validator dependency is assumed by this plan.
-- `tests/integration/claude-code.test.ts` requires no change under the current evidence: its existing temporary generated-bundle assertions already cover source fidelity, self-containment, and source immutability; U5 adds only focused unit-generation sentinels.
+- AJV is the appropriate executable-schema test boundary and is already available to the repository's tests; no separate runtime validation dependency is required by this plan.
+- The existing reviewer-to-synthesis boundary is sufficient for end-to-end verification; no new synthesis runtime or content-integrity gate is needed.
+
+### Deferred to Implementation
+
+- The representative requirements/plan pressure document used for the seven-persona run can be selected during implementation, provided it elicits role-relevant findings and exercises canonical anchors, classes, evidence, and suggested-fix behavior.
 
 ---
 
@@ -125,80 +125,75 @@ Issue #677 is a reproducible producer/consumer contract failure: the shipped sch
 
 Goal: Make the schema, producer template, and main skill teach exactly the contract that synthesis currently consumes, including anchor meanings, autofix semantics, suggested-fix obligations, and corrected headless wording.
 
-Requirements R-IDs: R1, R2, R3, R4, R5, R6, R8.
+Requirements R-IDs: R1, R2, R3, R4, R5, R6, R8, R13, R14, R19.
 
-Dependencies: None. U1 is the first content slice and establishes the source values used by later checks.
+Dependencies: None. U1 establishes the executable contract used by behavioral verification.
 
 Files:
 
 - Modify: `skills/document-review/references/findings-schema.json`
 - Modify: `skills/document-review/references/subagent-template.md`
 - Modify: `skills/document-review/SKILL.md`
-- Test: `tests/unit/content-integrity.test.ts`
+- Create/Test: `tests/unit/document-review-findings-schema.test.ts`
 
 Approach:
 
-- Change the schema to integer confidence anchors `0`, `25`, `50`, `75`, `100` and autofix classes `safe_auto`, `gated_auto`, `manual`.
-- Rewrite schema and template descriptions to carry the existing synthesis meanings, including evidence and suggested-fix rules.
-- Replace active `auto` / `present` headless assignments and wording in `SKILL.md` with canonical classes and user-facing presentation terms.
-- Add focused source-contract assertions in the existing content-integrity test seam where they establish behavior not covered by the later full gate.
+- Update the schema to integer confidence anchors `0`, `25`, `50`, `75`, `100` and autofix classes `safe_auto`, `gated_auto`, `manual`.
+- Align schema and producer guidance with the existing synthesis meanings, evidence requirements, classification test, and suggested-fix obligations.
+- Align interactive and headless wording without changing the underlying synthesis lifecycle.
+- Compile the real schema with AJV in the focused test and validate representative data objects; do not assert descriptions, Markdown, section names, token presence, or file contents.
 
-Execution note: Use the test-first posture for feature-bearing assertions: add failing canonical/legacy and guidance assertions before changing the content, then make them pass. Do not split this into RED/GREEN microsteps in the plan.
+Execution note: Use the test-first posture for the executable contract: add failing AJV cases before changing the schema, then make them pass. Do not split this into RED/GREEN microsteps.
 
-Patterns to follow: Parse structured JSON rather than matching a copied schema string; use isolated fixtures and real-tree assertions from `tests/unit/content-integrity.test.ts`; preserve model-free bundled-agent conventions.
+Patterns to follow: Compile the real JSON Schema; use representative object fixtures; keep canonical values owned by the schema; avoid a parallel TypeScript or prose-derived contract.
 
 Test scenarios:
 
-- Happy path: all five anchors and all three classes are represented as canonical and accepted by focused contract assertions.
-- Failure path: decimal confidence and legacy `auto` / `present` values are rejected as malformed; no remapping is described or asserted.
-- Failure path: missing or changed schema enum values fail the contract assertion.
-- Happy path: producer guidance contains anchor meanings and canonical classes.
-- Failure path: headless producer text contains no active legacy assignment.
-- Happy path: `safe_auto` and `gated_auto` guidance requires `suggested_fix`; `manual` guidance permits omission when no obvious fix exists.
+- Happy path: a valid report/finding for every confidence anchor and every autofix class is accepted by AJV.
+- Failure path: decimal confidence, out-of-set numbers, and legacy `auto` / `present` classes are rejected.
+- Failure path: missing schema-required report fields, finding fields, or evidence are rejected.
+- Conditionality boundary: test `suggested_fix` only if the schema encodes its conditional requiredness; otherwise leave that obligation to U3 persona behavior verification.
 
-Verification: The three live producer surfaces agree with synthesis terminology and semantics; focused assertions fail on the old contract and pass only on the canonical contract. No unrelated files or agent frontmatter are changed.
+Verification: The real schema compiles, canonical representative objects pass, malformed legacy/decimal objects fail, and no new contract abstraction is introduced.
 
 - [ ] **U2. Consumer and presentation convergence**
 
-Goal: Align synthesis references and the complete review-output template with existing anchor routing, user-facing buckets, and post-synthesis coverage semantics without changing the lifecycle.
+Goal: Align synthesis guidance and the complete review-output template with existing anchor routing, user-facing buckets, and post-synthesis coverage semantics without changing the lifecycle.
 
 Requirements R-IDs: R9, R10, R11, R12.
 
-Dependencies: U1 establishes canonical values and suggested-fix semantics.
+Dependencies: U1 establishes the canonical values and executable validation boundary.
 
 Files:
 
 - Modify: `skills/document-review/references/synthesis-and-presentation.md`
 - Modify: `skills/document-review/references/review-output-template.md`
-- Test: `tests/unit/content-integrity.test.ts`
 
 Approach:
 
-- Inspect transitional references and examples in synthesis, changing active contract instructions while retaining historical rejection notes only where their non-normative context is unmistakable.
-- Update the output template's example, summary, applied-fixes language, actionable buckets, FYI section, confidence display, and coverage table/rules to reflect the existing synthesis route semantics.
-- Preserve the current anchor gates, class routing, deduplication attribution, residual-count meaning, and presentation ordering.
+- Align active synthesis guidance and examples with canonical anchors, strict malformed rejection, canonical classes, and existing fixes/proposed fixes/decisions/FYI routes.
+- Bring the output template to full convergence, including its coverage semantics, while preserving the existing synthesis lifecycle.
+- Retain historical references only when clearly non-normative and non-misleading.
 
-Execution note: Add failing assertions for canonical examples, route vocabulary, coverage columns, and disallowed active legacy examples before editing the two references; then make the assertions pass. This is content alignment, not a synthesis redesign.
+Execution note: No automated content test is added for U2. Review the two updated assets with human document-review expertise, then rely on U3's real reviewer-to-synthesis pressure verification for behavioral evidence.
 
-Patterns to follow: Treat synthesis as the consumer source of behavioral truth; distinguish normative assignments from historical prose; use the existing explicit-scope and real-tree test styles rather than a global token ban.
+Patterns to follow: Treat current synthesis behavior as authoritative; preserve route, deduplication, coverage, retry, contradiction, and section-matching behavior; do not turn guidance into executable code.
 
 Test scenarios:
 
-- Happy path: synthesis and output-template examples show canonical anchors and fixes/proposed fixes/decisions/FYI sections.
-- Happy path: coverage examples and rules account for canonical route classes plus FYI observations and retain current post-synthesis totals.
-- Failure path: active legacy assignments or decimal confidence examples fail the focused content-integrity assertions.
-- Allowed historical case: the synthesis note explaining that `auto` / `present` are malformed remains accepted when clearly non-normative.
-- Failure path: changing a route bucket or removing a canonical presentation term produces a contract-surface diagnostic.
+- Human review confirms the output template communicates the existing canonical anchor routes and user-facing buckets.
+- Behavioral follow-through in U3 confirms canonical reviewer findings are consumed by existing synthesis routes.
+- Human review confirms no lifecycle redesign is hidden in vocabulary or example alignment.
 
-Verification: A reviewer output that conforms to the canonical schema is described as accepted and routed by the same synthesis lifecycle, while the template no longer teaches a competing shape. No retry, contradiction, deduplication, coverage-calculation, or section-normalization behavior changes.
+Verification: The two consumer/presentation assets align with existing behavior, and U3 demonstrates that valid canonical output is not classified malformed.
 
 - [ ] **U3. Persona anchor calibration**
 
-Goal: Replace continuous confidence ranges in all seven document-review personas with shared behavioral anchors and concise role-specific examples, without changing each persona's remit.
+Goal: Replace continuous confidence ranges in all seven document-review personas with shared behavioral anchors and concise role-specific examples, preserving each persona's remit and verifying the live reviewer-to-synthesis path.
 
-Requirements R-IDs: R7, R13, R14, R15.
+Requirements R-IDs: R7, R15, R16, R17, R18.
 
-Dependencies: U1 defines the shared anchor meanings; U2 defines the consumer-facing terminology. U3 must complete before U4 is enabled.
+Dependencies: U1 and U2. U1-U3 must converge before behavioral verification and shipping.
 
 Files:
 
@@ -209,112 +204,50 @@ Files:
 - Modify: `agents/document-review/security-lens-reviewer.md`
 - Modify: `agents/document-review/scope-guardian-reviewer.md`
 - Modify: `agents/document-review/adversarial-document-reviewer.md`
-- Test: `tests/unit/content-integrity.test.ts`
 
 Approach:
 
-- Update each confidence-calibration section to use the shared anchor behavior while retaining the persona's distinct evidence threshold and suppression boundary.
-- Keep examples concise and role-specific; do not mechanically turn `0.80+` into a numeric label that implies false precision.
-- Preserve every agent's existing frontmatter, including omission of `model`, and avoid changing role descriptions or tool declarations.
+- Update each persona's calibration to use shared anchor behavior while retaining role-specific evidence thresholds and suppression boundaries.
+- Preserve concise examples and avoid false-precision substitutions.
+- Preserve model-free agent frontmatter and all unrelated role/tool behavior.
+- After all three units converge, dispatch all seven real reviewers against the representative pressure document, validate each returned JSON report with AJV, and send the canonical reports through existing synthesis.
 
-Execution note: Add failing assertions that discover all seven calibration sections, reject decimal threshold prose, and require anchor behavior before changing persona files; then migrate all seven together as the content release slice.
+Execution note: Use writing-skills behavior verification after the content migration. Do not add Markdown tests or ad hoc re-prompts to make malformed outputs pass.
 
-Patterns to follow: Use explicit agent-path enumeration for the seven contract surfaces; preserve the existing model-free bundled-agent invariant; allow qualitative personas to cap below `100` unless direct textual or quantitative evidence supports the highest anchor.
-
-Test scenarios:
-
-- Happy path: all seven calibration sections are found and represent the canonical anchors and behavioral meanings.
-- Failure path: any decimal confidence threshold or continuous range in a calibration section is reported.
-- Failure path: a persona file regressed to a legacy class assignment or omitted shared anchor behavior is reported.
-- Role-boundary case: product-lens and scope-guardian qualitative findings do not claim `100` without direct textual or quantitative proof.
-- Portability case: no persona frontmatter gains a `model` field or otherwise changes bundled-agent portability metadata.
-
-Verification: All seven personas emit guidance compatible with U1 and U2, preserve their role boundaries, and pass the explicit-surface checks. No generated agent artifact is edited.
-
-- [ ] **U4. Schema-driven explicit-surface integrity gate**
-
-Goal: Extend `scripts/content-integrity.ts` with a hard, actionable drift guard driven by the parsed schema and an explicit contract-surface manifest, with no global ban on ordinary prose.
-
-Requirements R-IDs: R13, R14, R15, R19.
-
-Dependencies: U1-U3. These three units are one content-migration release slice and must be complete before this gate is enabled or shipped; a partial branch may be temporarily red only during test-first work.
-
-Files:
-
-- Modify: `scripts/content-integrity.ts`
-- Test: `tests/unit/content-integrity.test.ts`
-
-Approach:
-
-- Add a structured result category and hard-violation wiring consistent with existing content-integrity checks: collection, aggregate count, diagnostic printing, and real-tree clean verification.
-- Parse the findings schema at check time to obtain canonical enum values and anchor descriptions, then inspect an explicit manifest covering the schema, main skill, subagent template, synthesis reference, output template, and all seven persona prompts.
-- Associate each manifest entry with bounded normative sections or contexts. Detect missing/changed canonical values and active legacy assignments/examples without treating ordinary English `auto` or `present` elsewhere as contract drift.
-- Permit only clearly non-normative historical synthesis mentions, and report missing explicit surfaces or sections as actionable violations.
-- Keep the check source-side and independent of package generation; do not introduce a duplicate contract model or codegen output.
-
-Execution note: Add failing fixture and real-tree assertions before wiring the gate into the aggregate result, then make the corrected U1-U3 corpus pass. Keep the test-first posture at the unit level rather than documenting RED/GREEN microsteps.
-
-Patterns to follow: Mirror the existing allowlist/parser and migrated-identifier bounded checks; use explicit scan targets and path manifests; follow the violation-or-nothing rule; prefer parsed schema data over duplicated canonical lists; use context-aware checks instead of global lexical bans.
+Patterns to follow: Use real persona dispatch with the updated schema/template; validate data behaviorally; allow qualitative personas to remain below the highest anchor absent direct evidence; preserve each persona's remit.
 
 Test scenarios:
 
-- Happy path: the corrected real corpus produces no contract violations.
-- Failure path: schema confidence or autofix enums drift, or a canonical anchor/class is removed from a required surface.
-- Failure path: an explicit surface reintroduces `autofix_class: auto`, `autofix_class: present`, or a decimal confidence example.
-- Failure path: one persona loses its calibration section or regresses to continuous thresholds.
-- Allowed prose case: ordinary English uses of “auto” or “present” outside contract contexts do not fail.
-- Allowed historical case: the synthesis historical rejection note is accepted when marked non-normative.
-- Failure path: a manifest surface or required section is missing and the diagnostic identifies it.
-- Wiring case: the new violation appears in the aggregate result, hard-fails the CLI path, and prints an actionable location.
+- Happy path: all seven reviewers return JSON reports accepted by AJV using only canonical anchors and classes.
+- Behavior case: the pressure document elicits role-relevant findings, evidence, and suggested-fix behavior without ad hoc re-prompting or correction.
+- Integration case: canonical reports reach synthesis and are routed by existing confidence/autofix behavior rather than classified malformed.
+- Role-boundary case: product-lens and scope-guardian outputs do not claim the highest anchor without direct textual or quantitative proof.
+- Regression case: existing npm/package and Claude Code build/integration suites remain green; no generated output is committed and source-immutability/build invariants remain unchanged.
 
-Verification: The gate fails closed on explicit contract drift, passes the fully migrated source corpus, and leaves unrelated prose and existing integrity categories unchanged. It is not enabled against a mixed U1-U3 corpus.
+Verification: Seven real persona outputs compile against the canonical schema, synthesis consumes them without vocabulary-related malformed classification, and existing delivery regressions remain green.
 
-- [ ] **U5. Delivered-artifact sentinels**
+---
 
-Goal: Prove that the canonical source contract survives npm packing and Claude Code generation using minimal representative sentinels rather than duplicating the full integrity suite in each artifact.
+## Behavioral Verification
 
-Requirements R-IDs: R16, R17, R18.
+After U1-U3 converge as one release slice:
 
-Dependencies: U4 must pass against the complete source corpus. The npm and Claude Code delivery paths consume the same corrected `skills/` and `agents/` assets.
-
-Files:
-
-- Modify: `tests/unit/package-exports.test.ts`
-- Modify: `tests/unit/build-claude-code-plugin.test.ts`
-- Test (no change needed unless unit generation cannot provide the required evidence): `tests/integration/claude-code.test.ts`
-
-Approach:
-
-- Extend the existing npm pack/extract seam to assert that document-review references and all seven persona files are present, with representative schema, template, synthesis/output, main-skill, and persona text sentinels using canonical values and no active legacy assignment or decimal example.
-- Extend the generated Claude Code file-map or temporary-output seam to inspect the copied schema/template content and a flattened representative persona agent, while retaining existing namespace and self-containment checks.
-- Assert that generation uses source content and does not modify source runtime files; do not add or commit a generated bundle.
-- Do not duplicate every source-side contract assertion in artifacts; representative sentinels prove delivery, while U4 proves the complete explicit-surface corpus.
-
-Execution note: Add failing packed and generated-output sentinels before the content migration is considered complete, then make them pass after U1-U4 converge. Use the existing isolated temporary artifact patterns.
-
-Patterns to follow: `tests/unit/package-exports.test.ts` tarball listing and extraction patterns; `tests/unit/build-claude-code-plugin.test.ts` `generatePluginFiles` and temporary output patterns; existing generated namespace and source-immutability assertions. Keep `tests/integration/claude-code.test.ts` unchanged because its current assertions already cover generated fidelity and source immutability, unless the unit seam demonstrably lacks one required sentinel.
-
-Test scenarios:
-
-- Happy path: the npm tarball contains document-review references, all seven personas, and representative canonical schema/template/persona text.
-- Failure path: a packed file contains an active legacy assignment or decimal confidence sentinel.
-- Happy path: the generated Claude Code bundle contains the corrected schema/template and a flattened representative persona with no active legacy assignment or decimal sentinel.
-- Failure path: a generated bundle omits or regresses representative contract content.
-- Invariant case: source files remain unchanged after generation and generated output is temporary/uncommitted.
-- Regression case: existing namespace, flattening, and self-containment gates remain green.
-
-Verification: Both delivery paths contain the corrected contract as consumed by their target packaging shape; artifact checks remain complementary to, not replacements for, the source-side integrity gate.
+- Dispatch all seven document-review personas against one representative requirements or plan document that exercises role-specific findings, multiple confidence anchors, all autofix classes, evidence, and suggested-fix decisions.
+- Compile and validate each returned report with the real JSON Schema through AJV. Record failures by behavioral category: invalid confidence, invalid class, missing required field/evidence, or conditional suggested-fix behavior when structurally encoded.
+- Pass the canonical reports through the existing synthesis boundary and observe that valid confidence/autofix vocabulary is accepted and routed, not classified malformed.
+- Run existing npm/package and Claude Code build/integration suites as regression checks only. Add no assertions about Markdown, file contents, package contents, generated text, file structure, or snapshots.
+- Confirm no generated output is committed and existing source-immutability/build invariants remain unchanged.
 
 ---
 
 ## System-Wide Impact
 
-- Reviewer producers will emit discrete anchors and canonical autofix classes, allowing newly dispatched reviews to reach synthesis instead of being discarded for schema drift.
-- Synthesis and presentation behavior remains operationally unchanged; only misleading producer/consumer documentation and examples are aligned with the existing lifecycle.
-- `scripts/content-integrity.ts` gains one hard violation category over a narrow, explicit set of contract surfaces. Its existing scan targets, allowlist behavior, agent portability checks, and unrelated banned-pattern rules remain unchanged.
-- npm package contents continue to ship `skills/` and `agents/` directly, now with contract evidence in the packed artifact.
-- Claude Code continues to generate an ephemeral self-contained bundle from source, now with representative contract evidence in the generated output.
-- No runtime TypeScript or host behavior changes; no committed generated `dist` or Claude Code directory is introduced.
+- Newly dispatched reviewers will be guided toward discrete anchors and canonical autofix classes, allowing valid reports to reach synthesis.
+- Synthesis and presentation behavior remains operationally unchanged; only the guidance assets are aligned with that behavior.
+- AJV tests validate the executable findings contract without adding a parallel TypeScript model or a prose/file-content gate.
+- Real persona pressure verification covers the producer-to-consumer boundary that static prose checks cannot establish.
+- Existing npm/package and Claude Code delivery behavior remains covered by existing regression suites, with no new content or structure assertions.
+- No generated output, runtime TypeScript behavior, or host behavior changes are introduced.
 
 ---
 
@@ -322,24 +255,22 @@ Verification: Both delivery paths contain the corrected contract as consumed by 
 
 | Risk or dependency | Mitigation / verification |
 |---|---|
-| U1-U3 leave one live surface on the legacy contract. | Use the explicit U4 manifest, seven-persona enumeration, and real-tree clean assertion; do not enable U4 until the content slice converges. |
-| Context-aware drift detection becomes a global token ban. | Scope checks to named files and normative sections; include ordinary-English and historical-note fixtures that must pass. |
-| Schema values become duplicated in gate code and drift independently. | Parse the JSON schema at gate/test time; hard-code only diagnostic or sentinel expectations needed to detect schema changes. |
-| The content-integrity check is wired as a non-failing warning. | Follow the existing violation result, aggregate count, printer, and CLI exit model; test each wiring boundary. |
-| Output-template edits accidentally change synthesis behavior. | Limit U2 to vocabulary, examples, and documented coverage semantics; explicitly exclude lifecycle redesigns and assert canonical route examples. |
-| npm packing omits a reference or persona despite source tests passing. | Inspect the actual tarball and extracted paths in `package-exports.test.ts`; rely on `package.json`'s direct `skills`/`agents` entries. |
-| Claude Code generation transforms or drops contract content. | Inspect generated file-map/temp output sentinels and retain existing namespace/self-containment/source-immutability gates. |
-| A representative sentinel passes while another source surface drifts. | Keep U4 as the complete source-side gate; U5 is intentionally complementary, not exhaustive. |
-| Older or in-flight findings are interpreted as requiring compatibility remapping. | Treat contract versions as release-unit boundaries; do not mix older dispatch output into newly dispatched reviews and do not add remapping. |
+| U1-U3 leave producer guidance and consumer behavior mismatched. | Treat U1-U3 as one release slice; run the seven-persona pressure scenario and synthesis boundary only after all three converge. |
+| The schema cannot express suggested-fix conditionality. | Test only structural schema constraints with AJV; verify conditional suggested-fix behavior through real persona output instead of inventing a prose assertion. |
+| Persona outputs still use legacy or decimal values. | Validate every real report with AJV and require canonical output without ad hoc re-prompting. |
+| U2 example edits accidentally redesign synthesis. | Human review and U3 route outcomes must confirm existing gates, routing, deduplication, coverage, retry, contradiction, and section behavior remain unchanged. |
+| The pressure document fails to exercise all role boundaries. | Select a representative requirements/plan document that produces role-relevant findings and covers the required behavioral cases; the exact fixture remains an implementation-time choice. |
+| Existing package/plugin regressions are missed. | Keep existing npm/package and Claude Code build/integration suites green as unchanged regression checks. |
+| Older or in-flight findings are interpreted as requiring compatibility remapping. | Keep release-unit boundaries explicit; do not mix older dispatch output into newly dispatched reviews and do not add remapping. |
 
 ---
 
 ## Documentation / Operational Notes
 
-- The explicit contract-surface manifest and its scope rationale belong with the content-integrity implementation and tests so future edits have a discoverable drift boundary.
-- Diagnostics should identify the repo-relative surface and missing or conflicting contract context, following existing content-integrity diagnostic conventions.
-- The package and Claude Code checks should document that they inspect delivered artifacts, not merely source files or build success.
-- No new user-facing workflow documentation is needed beyond correcting the bundled document-review sources; the existing synthesis lifecycle remains authoritative.
+- Keep the updated schema, templates, and persona guidance as the bundled source contract; do not add a second contract representation.
+- Record the pressure-scenario verification outcome and AJV behavioral categories in the normal engineering verification record, without adding prose/file-content test machinery.
+- Existing package/plugin build documentation remains authoritative for delivery invariants; this change does not add artifact-content inspection.
+- No new user-facing workflow documentation is needed beyond correcting the bundled document-review guidance.
 
 ---
 
@@ -353,13 +284,9 @@ Verification: Both delivery paths contain the corrected contract as consumed by 
 - Synthesis rules: `skills/document-review/references/synthesis-and-presentation.md`
 - Review output contract: `skills/document-review/references/review-output-template.md`
 - Persona prompts: `agents/document-review/coherence-reviewer.md`, `agents/document-review/feasibility-reviewer.md`, `agents/document-review/product-lens-reviewer.md`, `agents/document-review/design-lens-reviewer.md`, `agents/document-review/security-lens-reviewer.md`, `agents/document-review/scope-guardian-reviewer.md`, `agents/document-review/adversarial-document-reviewer.md`
-- Gate implementation and tests: `scripts/content-integrity.ts`, `tests/unit/content-integrity.test.ts`
-- npm packaging tests: `tests/unit/package-exports.test.ts`
-- Claude Code build tests: `tests/unit/build-claude-code-plugin.test.ts`, `tests/integration/claude-code.test.ts`
+- Focused executable-schema test seam: `tests/unit/document-review-findings-schema.test.ts`
+- Existing package regression test: `tests/unit/package-exports.test.ts`
+- Existing Claude Code regression tests: `tests/unit/build-claude-code-plugin.test.ts`, `tests/integration/claude-code.test.ts`
 - Packaging manifest: `package.json`
 - Claude Code generator: `scripts/build-claude-code-plugin.ts`
-- Institutional learning: `docs/solutions/best-practices/content-integrity-has-no-warning-channel-2026-06-06.md`
-- Institutional learning: `docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md`
-- Institutional learning: `docs/solutions/best-practices/undecidable-detection-honest-ban-rule-2026-06-04.md`
-- Institutional learning: `docs/solutions/workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md`
-- Institutional learning: `docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md`
+- Strict-validation context: `docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md`

--- a/docs/plans/2026-07-21-001-fix-document-review-findings-contract-plan.md
+++ b/docs/plans/2026-07-21-001-fix-document-review-findings-contract-plan.md
@@ -156,7 +156,7 @@ Test scenarios:
 
 Verification: The real schema compiles, canonical representative objects pass, malformed legacy/decimal objects fail, and no new contract abstraction is introduced.
 
-- [ ] **U2. Consumer and presentation convergence**
+- [x] **U2. Consumer and presentation convergence**
 
 Goal: Align synthesis guidance and the complete review-output template with existing anchor routing, user-facing buckets, and post-synthesis coverage semantics without changing the lifecycle.
 

--- a/docs/plans/2026-07-21-001-fix-document-review-findings-contract-plan.md
+++ b/docs/plans/2026-07-21-001-fix-document-review-findings-contract-plan.md
@@ -187,7 +187,7 @@ Test scenarios:
 
 Verification: The two consumer/presentation assets align with existing behavior, and U3 demonstrates that valid canonical output is not classified malformed.
 
-- [ ] **U3. Persona anchor calibration**
+- [x] **U3. Persona anchor calibration**
 
 Goal: Replace continuous confidence ranges in all seven document-review personas with shared behavioral anchors and concise role-specific examples, preserving each persona's remit and verifying the live reviewer-to-synthesis path.
 

--- a/docs/plans/2026-07-21-001-fix-document-review-findings-contract-plan.md
+++ b/docs/plans/2026-07-21-001-fix-document-review-findings-contract-plan.md
@@ -1,0 +1,365 @@
+---
+title: "fix: Align document-review findings contract"
+type: fix
+status: active
+date: 2026-07-21
+origin: docs/brainstorms/2026-07-21-document-review-findings-contract-alignment-requirements.md
+---
+
+# fix: Align document-review findings contract
+
+## Overview
+
+Align the shipped document-review contract surfaces to the existing anchor-based synthesis behavior, then extend the content-integrity gate with an explicit, schema-driven drift check. Add representative npm-packed and generated Claude Code sentinels after the source migration is complete.
+
+---
+
+## Problem Frame
+
+Issue #677 is a reproducible producer/consumer contract failure: the shipped schema and producer guidance emit continuous confidence values and `auto` / `present`, while synthesis accepts discrete anchors and `safe_auto` / `gated_auto` / `manual`. The formal dogfood reproduction produced five legacy-shaped findings from three personas, all of which synthesis correctly dropped as malformed. The mismatch also exists in headless wording, persona calibration, and the full review-output example, so correcting only the originally named files would leave shipped guidance contradictory.
+
+---
+
+## Requirements Trace
+
+### Canonical contract and producers
+
+| Requirement | Planned coverage |
+|---|---|
+| R1 | U1 changes `findings-schema.json` to the canonical integer confidence enum. |
+| R2 | U1 changes the schema autofix enum and descriptions to `safe_auto`, `gated_auto`, and `manual`. |
+| R3 | U1 records the five anchor meanings in the schema and shared producer guidance. |
+| R4 | U1 preserves strict malformed-output rejection with no legacy remapping; tests cover decimal and legacy values. |
+| R5 | U1 aligns the subagent template with exact enums, anchor selection, evidence, and the one-clear-fix classification test. |
+| R6 | U1 aligns suggested-fix obligations with synthesis: required for `safe_auto` and `gated_auto`, optional for `manual` when no obvious fix exists. |
+| R7 | U3 updates all seven persona calibrations to shared anchors while preserving concise role-specific examples and boundaries. |
+| R8 | U1 removes active legacy `auto` / `present` assignments from `SKILL.md`, including headless-mode wording, and aligns user-facing terms. |
+
+### Consumer, presentation, and integrity
+
+| Requirement | Planned coverage |
+|---|---|
+| R9 | U2 inspects transitional and legacy synthesis references, retaining only clearly non-normative historical mentions. |
+| R10 | U2 keeps current anchor gates, strict validation, class routing, and user-facing fixes/proposed fixes/decisions/FYI behavior unchanged. |
+| R11 | U2 fully converges the review-output example and rules, not just vocabulary. |
+| R12 | U2 updates coverage columns and examples to current post-synthesis route semantics without redesigning coverage. |
+| R13 | U4 adds a hard guard over an explicit manifest of the schema, skill, templates, synthesis, output template, and seven personas. |
+| R14 | U4 drives the guard from parsed schema values and context-aware contract sections rather than globally banning common English words. |
+| R15 | U4 reports actionable violations for schema drift, missing canonical guidance, active legacy assignments, and decimal examples. |
+
+### Delivery and carrying cost
+
+| Requirement | Planned coverage |
+|---|---|
+| R16 | U5 inspects an npm tarball for the shipped skill/reference and persona content, using representative canonical sentinels. |
+| R17 | U5 generates and inspects the ephemeral Claude Code bundle for copied references and flattened persona content. |
+| R18 | U5 retains source-to-artifact and source-unchanged assertions; the generated bundle remains uncommitted. |
+| R19 | U4 extends `scripts/content-integrity.ts` and does not introduce a TypeScript contract or code-generation layer. |
+
+---
+
+## Scope Boundaries
+
+- Included: canonical schema values and descriptions; producer template; main skill and headless wording; synthesis references and examples; review-output template; all seven persona prompts; explicit-surface content-integrity coverage; npm-packed sentinels; generated Claude Code sentinels.
+- Included: strict rejection of continuous confidence and `auto | present` output without compatibility remapping. The corrected schema, producer prompts, persona guidance, synthesis, and presentation assets are delivered together as one package/plugin release unit for newly dispatched reviews. Older or in-flight dispatches remain under the contract they were dispatched with and are not mixed into a newly dispatched review; compatibility remapping for their findings is not a target.
+- Excluded: synthesis retry policy, contradiction deduplication or recommended-action tie-break redesign, coverage redesign beyond vocabulary alignment, section normalization, runtime behavior changes, tolerant compatibility modes, unrelated content-integrity rules, and a new TypeScript/codegen contract abstraction.
+- Excluded: updating a committed generated `dist` or Claude Code copy. Claude Code output remains an ephemeral build artifact.
+- Bundled agents remain model-free; no frontmatter `model` changes are part of this work.
+
+### Deferred to Separate Tasks
+
+- Synthesis retry policy and handling for failed or timed-out reviewer dispatches.
+- Contradiction handling and deterministic recommended-action tie-break redesign.
+- Coverage calculation or attribution redesign beyond aligning the output vocabulary with existing semantics.
+- Section normalization or changes to finding fingerprints.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/content-integrity.ts` has a violation-or-nothing enforcement model: checks add result data, are included in the aggregate count, and are printed by the CLI. The new check must follow that hard-gate shape rather than inventing a warning channel.
+- `scripts/content-integrity.ts` already provides bounded patterns for allowlist parsing, scan-target collection, migrated-skill identifiers, and banned-pattern checks. The new check should use an explicit contract-surface manifest and section-aware inspection rather than widening the global scan.
+- `tests/unit/content-integrity.test.ts` uses isolated fixture repositories, focused check tests, top-level wiring tests, and a real-tree clean assertion. The new seam should preserve those patterns.
+- `package.json` lists `skills` and `agents` in `files`, so npm consumers receive those source assets directly.
+- `scripts/build-claude-code-plugin.ts` copies skill files, flattens agents, translates only identifiers, and emits an ephemeral self-contained bundle. It does not generate a second findings contract.
+- `tests/unit/package-exports.test.ts` already packs the package and verifies tarball entries; its package sentinels can extend that evidence without duplicating the full integrity suite.
+- `tests/unit/build-claude-code-plugin.test.ts` already tests generated file maps, flattened agents, and real-repository generation into temporary output. Its unit-level generated-content sentinel is the narrowest Claude Code evidence.
+- `tests/integration/claude-code.test.ts` already verifies generated/source fidelity, self-containment, and source immutability in temporary output. No change is needed unless U5's unit generation seam cannot prove a required sentinel; existing integration coverage is otherwise sufficient.
+- Bundled agent frontmatter must continue omitting `model`; the existing integrity check and Claude Code flattening behavior are preserved.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/content-integrity-has-no-warning-channel-2026-06-06.md`: content-integrity checks are hard violations unless a separate warning system is justified; wire the result, aggregate count, printer, and real-tree assertion together.
+- `docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md`: a gate must mirror the contract it protects instead of checking a weaker or unrelated representation.
+- `docs/solutions/best-practices/undecidable-detection-honest-ban-rule-2026-06-04.md`: when meaning cannot be inferred safely, use a bounded explicit rule and document its scope rather than guessing from arbitrary prose.
+- `docs/solutions/workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md`: inspect emitted and packed artifacts in their delivery shape; a successful build is not artifact evidence.
+- `docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md`: strict contracts should derive from the canonical source and avoid duplicated producer/check inputs; parity between write and check paths matters.
+
+---
+
+## Key Technical Decisions
+
+- Parse `findings-schema.json` at test and gate time. The schema supplies canonical enum values and descriptions; hard-coded values are limited to minimum diagnostic or sentinel expectations needed to detect schema drift itself.
+- Maintain an explicit manifest of contract-bearing files and the sections or contexts that carry normative assignments/examples. The guard will permit ordinary English `auto` or `present` outside those contexts and permit a clearly non-normative historical synthesis note.
+- Migrate U1-U3 as one content release slice before enabling or shipping U4. Test-first work may leave a temporary red branch while content is being corrected, but no shipped or mergeable state may contain a mixed producer/consumer contract.
+- Keep the existing synthesis lifecycle intact. U2 changes misleading live definitions and examples to describe the already-established behavior; it does not redesign routing, deduplication, retries, coverage computation, or section matching.
+- Use representative artifact sentinels rather than copying the entire integrity gate into npm or Claude Code outputs. Source-side integrity remains the complete contract check; delivery tests prove that corrected content survives packaging and generation.
+- Do not add a TypeScript contract model, generated findings constants, or another code-generation layer. The JSON Schema is the single contract source.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- The exact validation implementation remains owned by the existing schema/gate seams: the schema is embedded into reviewer prompts and read by synthesis as the contract, while the content-integrity guard parses the schema and checks explicit source surfaces. No runtime validator dependency is assumed by this plan.
+- `tests/integration/claude-code.test.ts` requires no change under the current evidence: its existing temporary generated-bundle assertions already cover source fidelity, self-containment, and source immutability; U5 adds only focused unit-generation sentinels.
+
+---
+
+## Implementation Units
+
+- [ ] **U1. Canonical producer contract**
+
+Goal: Make the schema, producer template, and main skill teach exactly the contract that synthesis currently consumes, including anchor meanings, autofix semantics, suggested-fix obligations, and corrected headless wording.
+
+Requirements R-IDs: R1, R2, R3, R4, R5, R6, R8.
+
+Dependencies: None. U1 is the first content slice and establishes the source values used by later checks.
+
+Files:
+
+- Modify: `skills/document-review/references/findings-schema.json`
+- Modify: `skills/document-review/references/subagent-template.md`
+- Modify: `skills/document-review/SKILL.md`
+- Test: `tests/unit/content-integrity.test.ts`
+
+Approach:
+
+- Change the schema to integer confidence anchors `0`, `25`, `50`, `75`, `100` and autofix classes `safe_auto`, `gated_auto`, `manual`.
+- Rewrite schema and template descriptions to carry the existing synthesis meanings, including evidence and suggested-fix rules.
+- Replace active `auto` / `present` headless assignments and wording in `SKILL.md` with canonical classes and user-facing presentation terms.
+- Add focused source-contract assertions in the existing content-integrity test seam where they establish behavior not covered by the later full gate.
+
+Execution note: Use the test-first posture for feature-bearing assertions: add failing canonical/legacy and guidance assertions before changing the content, then make them pass. Do not split this into RED/GREEN microsteps in the plan.
+
+Patterns to follow: Parse structured JSON rather than matching a copied schema string; use isolated fixtures and real-tree assertions from `tests/unit/content-integrity.test.ts`; preserve model-free bundled-agent conventions.
+
+Test scenarios:
+
+- Happy path: all five anchors and all three classes are represented as canonical and accepted by focused contract assertions.
+- Failure path: decimal confidence and legacy `auto` / `present` values are rejected as malformed; no remapping is described or asserted.
+- Failure path: missing or changed schema enum values fail the contract assertion.
+- Happy path: producer guidance contains anchor meanings and canonical classes.
+- Failure path: headless producer text contains no active legacy assignment.
+- Happy path: `safe_auto` and `gated_auto` guidance requires `suggested_fix`; `manual` guidance permits omission when no obvious fix exists.
+
+Verification: The three live producer surfaces agree with synthesis terminology and semantics; focused assertions fail on the old contract and pass only on the canonical contract. No unrelated files or agent frontmatter are changed.
+
+- [ ] **U2. Consumer and presentation convergence**
+
+Goal: Align synthesis references and the complete review-output template with existing anchor routing, user-facing buckets, and post-synthesis coverage semantics without changing the lifecycle.
+
+Requirements R-IDs: R9, R10, R11, R12.
+
+Dependencies: U1 establishes canonical values and suggested-fix semantics.
+
+Files:
+
+- Modify: `skills/document-review/references/synthesis-and-presentation.md`
+- Modify: `skills/document-review/references/review-output-template.md`
+- Test: `tests/unit/content-integrity.test.ts`
+
+Approach:
+
+- Inspect transitional references and examples in synthesis, changing active contract instructions while retaining historical rejection notes only where their non-normative context is unmistakable.
+- Update the output template's example, summary, applied-fixes language, actionable buckets, FYI section, confidence display, and coverage table/rules to reflect the existing synthesis route semantics.
+- Preserve the current anchor gates, class routing, deduplication attribution, residual-count meaning, and presentation ordering.
+
+Execution note: Add failing assertions for canonical examples, route vocabulary, coverage columns, and disallowed active legacy examples before editing the two references; then make the assertions pass. This is content alignment, not a synthesis redesign.
+
+Patterns to follow: Treat synthesis as the consumer source of behavioral truth; distinguish normative assignments from historical prose; use the existing explicit-scope and real-tree test styles rather than a global token ban.
+
+Test scenarios:
+
+- Happy path: synthesis and output-template examples show canonical anchors and fixes/proposed fixes/decisions/FYI sections.
+- Happy path: coverage examples and rules account for canonical route classes plus FYI observations and retain current post-synthesis totals.
+- Failure path: active legacy assignments or decimal confidence examples fail the focused content-integrity assertions.
+- Allowed historical case: the synthesis note explaining that `auto` / `present` are malformed remains accepted when clearly non-normative.
+- Failure path: changing a route bucket or removing a canonical presentation term produces a contract-surface diagnostic.
+
+Verification: A reviewer output that conforms to the canonical schema is described as accepted and routed by the same synthesis lifecycle, while the template no longer teaches a competing shape. No retry, contradiction, deduplication, coverage-calculation, or section-normalization behavior changes.
+
+- [ ] **U3. Persona anchor calibration**
+
+Goal: Replace continuous confidence ranges in all seven document-review personas with shared behavioral anchors and concise role-specific examples, without changing each persona's remit.
+
+Requirements R-IDs: R7, R13, R14, R15.
+
+Dependencies: U1 defines the shared anchor meanings; U2 defines the consumer-facing terminology. U3 must complete before U4 is enabled.
+
+Files:
+
+- Modify: `agents/document-review/coherence-reviewer.md`
+- Modify: `agents/document-review/feasibility-reviewer.md`
+- Modify: `agents/document-review/product-lens-reviewer.md`
+- Modify: `agents/document-review/design-lens-reviewer.md`
+- Modify: `agents/document-review/security-lens-reviewer.md`
+- Modify: `agents/document-review/scope-guardian-reviewer.md`
+- Modify: `agents/document-review/adversarial-document-reviewer.md`
+- Test: `tests/unit/content-integrity.test.ts`
+
+Approach:
+
+- Update each confidence-calibration section to use the shared anchor behavior while retaining the persona's distinct evidence threshold and suppression boundary.
+- Keep examples concise and role-specific; do not mechanically turn `0.80+` into a numeric label that implies false precision.
+- Preserve every agent's existing frontmatter, including omission of `model`, and avoid changing role descriptions or tool declarations.
+
+Execution note: Add failing assertions that discover all seven calibration sections, reject decimal threshold prose, and require anchor behavior before changing persona files; then migrate all seven together as the content release slice.
+
+Patterns to follow: Use explicit agent-path enumeration for the seven contract surfaces; preserve the existing model-free bundled-agent invariant; allow qualitative personas to cap below `100` unless direct textual or quantitative evidence supports the highest anchor.
+
+Test scenarios:
+
+- Happy path: all seven calibration sections are found and represent the canonical anchors and behavioral meanings.
+- Failure path: any decimal confidence threshold or continuous range in a calibration section is reported.
+- Failure path: a persona file regressed to a legacy class assignment or omitted shared anchor behavior is reported.
+- Role-boundary case: product-lens and scope-guardian qualitative findings do not claim `100` without direct textual or quantitative proof.
+- Portability case: no persona frontmatter gains a `model` field or otherwise changes bundled-agent portability metadata.
+
+Verification: All seven personas emit guidance compatible with U1 and U2, preserve their role boundaries, and pass the explicit-surface checks. No generated agent artifact is edited.
+
+- [ ] **U4. Schema-driven explicit-surface integrity gate**
+
+Goal: Extend `scripts/content-integrity.ts` with a hard, actionable drift guard driven by the parsed schema and an explicit contract-surface manifest, with no global ban on ordinary prose.
+
+Requirements R-IDs: R13, R14, R15, R19.
+
+Dependencies: U1-U3. These three units are one content-migration release slice and must be complete before this gate is enabled or shipped; a partial branch may be temporarily red only during test-first work.
+
+Files:
+
+- Modify: `scripts/content-integrity.ts`
+- Test: `tests/unit/content-integrity.test.ts`
+
+Approach:
+
+- Add a structured result category and hard-violation wiring consistent with existing content-integrity checks: collection, aggregate count, diagnostic printing, and real-tree clean verification.
+- Parse the findings schema at check time to obtain canonical enum values and anchor descriptions, then inspect an explicit manifest covering the schema, main skill, subagent template, synthesis reference, output template, and all seven persona prompts.
+- Associate each manifest entry with bounded normative sections or contexts. Detect missing/changed canonical values and active legacy assignments/examples without treating ordinary English `auto` or `present` elsewhere as contract drift.
+- Permit only clearly non-normative historical synthesis mentions, and report missing explicit surfaces or sections as actionable violations.
+- Keep the check source-side and independent of package generation; do not introduce a duplicate contract model or codegen output.
+
+Execution note: Add failing fixture and real-tree assertions before wiring the gate into the aggregate result, then make the corrected U1-U3 corpus pass. Keep the test-first posture at the unit level rather than documenting RED/GREEN microsteps.
+
+Patterns to follow: Mirror the existing allowlist/parser and migrated-identifier bounded checks; use explicit scan targets and path manifests; follow the violation-or-nothing rule; prefer parsed schema data over duplicated canonical lists; use context-aware checks instead of global lexical bans.
+
+Test scenarios:
+
+- Happy path: the corrected real corpus produces no contract violations.
+- Failure path: schema confidence or autofix enums drift, or a canonical anchor/class is removed from a required surface.
+- Failure path: an explicit surface reintroduces `autofix_class: auto`, `autofix_class: present`, or a decimal confidence example.
+- Failure path: one persona loses its calibration section or regresses to continuous thresholds.
+- Allowed prose case: ordinary English uses of “auto” or “present” outside contract contexts do not fail.
+- Allowed historical case: the synthesis historical rejection note is accepted when marked non-normative.
+- Failure path: a manifest surface or required section is missing and the diagnostic identifies it.
+- Wiring case: the new violation appears in the aggregate result, hard-fails the CLI path, and prints an actionable location.
+
+Verification: The gate fails closed on explicit contract drift, passes the fully migrated source corpus, and leaves unrelated prose and existing integrity categories unchanged. It is not enabled against a mixed U1-U3 corpus.
+
+- [ ] **U5. Delivered-artifact sentinels**
+
+Goal: Prove that the canonical source contract survives npm packing and Claude Code generation using minimal representative sentinels rather than duplicating the full integrity suite in each artifact.
+
+Requirements R-IDs: R16, R17, R18.
+
+Dependencies: U4 must pass against the complete source corpus. The npm and Claude Code delivery paths consume the same corrected `skills/` and `agents/` assets.
+
+Files:
+
+- Modify: `tests/unit/package-exports.test.ts`
+- Modify: `tests/unit/build-claude-code-plugin.test.ts`
+- Test (no change needed unless unit generation cannot provide the required evidence): `tests/integration/claude-code.test.ts`
+
+Approach:
+
+- Extend the existing npm pack/extract seam to assert that document-review references and all seven persona files are present, with representative schema, template, synthesis/output, main-skill, and persona text sentinels using canonical values and no active legacy assignment or decimal example.
+- Extend the generated Claude Code file-map or temporary-output seam to inspect the copied schema/template content and a flattened representative persona agent, while retaining existing namespace and self-containment checks.
+- Assert that generation uses source content and does not modify source runtime files; do not add or commit a generated bundle.
+- Do not duplicate every source-side contract assertion in artifacts; representative sentinels prove delivery, while U4 proves the complete explicit-surface corpus.
+
+Execution note: Add failing packed and generated-output sentinels before the content migration is considered complete, then make them pass after U1-U4 converge. Use the existing isolated temporary artifact patterns.
+
+Patterns to follow: `tests/unit/package-exports.test.ts` tarball listing and extraction patterns; `tests/unit/build-claude-code-plugin.test.ts` `generatePluginFiles` and temporary output patterns; existing generated namespace and source-immutability assertions. Keep `tests/integration/claude-code.test.ts` unchanged because its current assertions already cover generated fidelity and source immutability, unless the unit seam demonstrably lacks one required sentinel.
+
+Test scenarios:
+
+- Happy path: the npm tarball contains document-review references, all seven personas, and representative canonical schema/template/persona text.
+- Failure path: a packed file contains an active legacy assignment or decimal confidence sentinel.
+- Happy path: the generated Claude Code bundle contains the corrected schema/template and a flattened representative persona with no active legacy assignment or decimal sentinel.
+- Failure path: a generated bundle omits or regresses representative contract content.
+- Invariant case: source files remain unchanged after generation and generated output is temporary/uncommitted.
+- Regression case: existing namespace, flattening, and self-containment gates remain green.
+
+Verification: Both delivery paths contain the corrected contract as consumed by their target packaging shape; artifact checks remain complementary to, not replacements for, the source-side integrity gate.
+
+---
+
+## System-Wide Impact
+
+- Reviewer producers will emit discrete anchors and canonical autofix classes, allowing newly dispatched reviews to reach synthesis instead of being discarded for schema drift.
+- Synthesis and presentation behavior remains operationally unchanged; only misleading producer/consumer documentation and examples are aligned with the existing lifecycle.
+- `scripts/content-integrity.ts` gains one hard violation category over a narrow, explicit set of contract surfaces. Its existing scan targets, allowlist behavior, agent portability checks, and unrelated banned-pattern rules remain unchanged.
+- npm package contents continue to ship `skills/` and `agents/` directly, now with contract evidence in the packed artifact.
+- Claude Code continues to generate an ephemeral self-contained bundle from source, now with representative contract evidence in the generated output.
+- No runtime TypeScript or host behavior changes; no committed generated `dist` or Claude Code directory is introduced.
+
+---
+
+## Risks & Dependencies
+
+| Risk or dependency | Mitigation / verification |
+|---|---|
+| U1-U3 leave one live surface on the legacy contract. | Use the explicit U4 manifest, seven-persona enumeration, and real-tree clean assertion; do not enable U4 until the content slice converges. |
+| Context-aware drift detection becomes a global token ban. | Scope checks to named files and normative sections; include ordinary-English and historical-note fixtures that must pass. |
+| Schema values become duplicated in gate code and drift independently. | Parse the JSON schema at gate/test time; hard-code only diagnostic or sentinel expectations needed to detect schema changes. |
+| The content-integrity check is wired as a non-failing warning. | Follow the existing violation result, aggregate count, printer, and CLI exit model; test each wiring boundary. |
+| Output-template edits accidentally change synthesis behavior. | Limit U2 to vocabulary, examples, and documented coverage semantics; explicitly exclude lifecycle redesigns and assert canonical route examples. |
+| npm packing omits a reference or persona despite source tests passing. | Inspect the actual tarball and extracted paths in `package-exports.test.ts`; rely on `package.json`'s direct `skills`/`agents` entries. |
+| Claude Code generation transforms or drops contract content. | Inspect generated file-map/temp output sentinels and retain existing namespace/self-containment/source-immutability gates. |
+| A representative sentinel passes while another source surface drifts. | Keep U4 as the complete source-side gate; U5 is intentionally complementary, not exhaustive. |
+| Older or in-flight findings are interpreted as requiring compatibility remapping. | Treat contract versions as release-unit boundaries; do not mix older dispatch output into newly dispatched reviews and do not add remapping. |
+
+---
+
+## Documentation / Operational Notes
+
+- The explicit contract-surface manifest and its scope rationale belong with the content-integrity implementation and tests so future edits have a discoverable drift boundary.
+- Diagnostics should identify the repo-relative surface and missing or conflicting contract context, following existing content-integrity diagnostic conventions.
+- The package and Claude Code checks should document that they inspect delivered artifacts, not merely source files or build success.
+- No new user-facing workflow documentation is needed beyond correcting the bundled document-review sources; the existing synthesis lifecycle remains authoritative.
+
+---
+
+## Sources & References
+
+- Origin requirements: `docs/brainstorms/2026-07-21-document-review-findings-contract-alignment-requirements.md`
+- Issue and triage: `https://github.com/marcusrbrown/systematic/issues/677`
+- Canonical schema: `skills/document-review/references/findings-schema.json`
+- Producer template: `skills/document-review/references/subagent-template.md`
+- Main workflow: `skills/document-review/SKILL.md`
+- Synthesis rules: `skills/document-review/references/synthesis-and-presentation.md`
+- Review output contract: `skills/document-review/references/review-output-template.md`
+- Persona prompts: `agents/document-review/coherence-reviewer.md`, `agents/document-review/feasibility-reviewer.md`, `agents/document-review/product-lens-reviewer.md`, `agents/document-review/design-lens-reviewer.md`, `agents/document-review/security-lens-reviewer.md`, `agents/document-review/scope-guardian-reviewer.md`, `agents/document-review/adversarial-document-reviewer.md`
+- Gate implementation and tests: `scripts/content-integrity.ts`, `tests/unit/content-integrity.test.ts`
+- npm packaging tests: `tests/unit/package-exports.test.ts`
+- Claude Code build tests: `tests/unit/build-claude-code-plugin.test.ts`, `tests/integration/claude-code.test.ts`
+- Packaging manifest: `package.json`
+- Claude Code generator: `scripts/build-claude-code-plugin.ts`
+- Institutional learning: `docs/solutions/best-practices/content-integrity-has-no-warning-channel-2026-06-06.md`
+- Institutional learning: `docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md`
+- Institutional learning: `docs/solutions/best-practices/undecidable-detection-honest-ban-rule-2026-06-04.md`
+- Institutional learning: `docs/solutions/workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md`
+- Institutional learning: `docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md`

--- a/docs/plans/2026-07-21-001-fix-document-review-findings-contract-plan.md
+++ b/docs/plans/2026-07-21-001-fix-document-review-findings-contract-plan.md
@@ -121,7 +121,7 @@ Issue #677 is a reproducible producer/consumer contract failure: the shipped sch
 
 ## Implementation Units
 
-- [ ] **U1. Canonical producer contract**
+- [x] **U1. Canonical producer contract**
 
 Goal: Make the schema, producer template, and main skill teach exactly the contract that synthesis currently consumes, including anchor meanings, autofix semantics, suggested-fix obligations, and corrected headless wording.
 

--- a/skills/document-review/SKILL.md
+++ b/skills/document-review/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[mode:headless] [path/to/document.md]"
 
 # Document Review
 
-Review requirements or plan documents through multi-persona analysis. Dispatches specialized reviewer agents in parallel, auto-fixes quality issues, and presents strategic questions for user decision.
+Review requirements or plan documents through multi-persona analysis. Dispatches specialized reviewer agents in parallel, applies clear fixes, and presents proposed fixes and decisions for user input.
 
 ## Phase 0: Detect Mode
 
@@ -14,12 +14,13 @@ Check the skill arguments for `mode:headless`. Arguments may contain a document 
 
 If `mode:headless` is present, set **headless mode** for the rest of the workflow.
 
-**Headless mode** changes the interaction model, not the classification boundaries. Document-review still applies the same judgment about what has one clear correct fix vs. what needs user judgment. The only difference is how non-auto findings are delivered:
-- `auto` fixes are applied silently (same as interactive)
-- `present` findings are returned as structured text for the caller to handle -- no question prompts, no interactive approval
+**Headless mode** changes the interaction model, not the classification boundaries. Document-review still applies the same judgment about what has one clear correct fix vs. what needs user judgment. The only difference is how findings are delivered:
+- `safe_auto` fixes at confidence anchor `100` are applied silently (same as interactive)
+- `gated_auto` proposed fixes and `manual` decisions are returned as structured text for the caller to handle -- no question prompts, no interactive approval
+- Findings at confidence anchor `50` are returned as FYI observations only -- no interaction or action
 - Phase 5 returns immediately with "Review complete" (no refine/complete question)
 
-The caller receives findings with their original classifications intact and decides what to do with them.
+The caller receives applied fixes, proposed fixes, decisions, and FYI observations with their original classifications intact; proposed fixes and decisions remain for the caller to handle.
 
 Callers invoke headless mode by including `mode:headless` in the skill arguments, e.g.:
 ```
@@ -133,7 +134,7 @@ Pass each agent the **full document** -- do not split into sections.
 
 ## Phases 3-5: Synthesis, Presentation, and Next Action
 
-After all dispatched agents return, read `references/synthesis-and-presentation.md` for the synthesis pipeline (validate, gate, dedup, promote, resolve contradictions, route by autofix class), auto-fix application, finding presentation, and next-action menu. Do not load this file before agent dispatch completes.
+After all dispatched agents return, read `references/synthesis-and-presentation.md` for the synthesis pipeline (validate, gate, dedup, promote, resolve contradictions, route by autofix class), fix application, finding presentation, and next-action menu. Do not load this file before agent dispatch completes.
 
 ---
 

--- a/skills/document-review/references/findings-schema.json
+++ b/skills/document-review/references/findings-schema.json
@@ -45,8 +45,8 @@
           },
           "autofix_class": {
             "type": "string",
-            "enum": ["auto", "present"],
-            "description": "How this issue should be handled. auto = one clear correct fix that can be applied silently (terminology, formatting, cross-references, completeness corrections, additions mechanically implied by other content). present = requires individual user judgment."
+            "enum": ["safe_auto", "gated_auto", "manual"],
+            "description": "How this issue should be handled. safe_auto = one mechanical, unambiguous fix suitable for silent application only at confidence 100; gated_auto = a codebase-pattern-resolved, factually incorrect, standard security or reliability, framework-native, or substantive mechanically implied fix that needs user confirmation; manual = multiple reasonable choices requiring user judgment."
           },
           "finding_type": {
             "type": "string",
@@ -58,10 +58,9 @@
             "description": "Concrete fix text. Omit or null if no good fix is obvious -- a bad suggestion is worse than none."
           },
           "confidence": {
-            "type": "number",
-            "description": "Reviewer confidence in this finding, calibrated per persona",
-            "minimum": 0.0,
-            "maximum": 1.0
+            "type": "integer",
+            "enum": [0, 25, 50, 75, 100],
+            "description": "Reviewer confidence anchor: 0 = false positive or pre-existing issue; 25 = might be real but could not verify; 50 = verified real but nitpick, advisory, or not very important; 75 = double-checked, will hit in practice, and directly impacts correctness; 100 = evidence directly confirms and the issue will happen frequently."
           },
           "evidence": {
             "type": "array",

--- a/skills/document-review/references/review-output-template.md
+++ b/skills/document-review/references/review-output-template.md
@@ -12,56 +12,67 @@ Use this **exact format** when presenting synthesized review findings. Findings 
 **Document:** docs/plans/2026-03-15-feat-user-auth-plan.md
 **Type:** plan
 **Reviewers:** coherence, feasibility, security-lens, scope-guardian
-- security-lens -- plan adds public API endpoint with auth flow
+- security-lens -- plan adds a public API endpoint with an auth flow
 - scope-guardian -- plan has 15 requirements across 3 priority levels
 
-Applied 5 auto-fixes. 4 findings to consider (2 errors, 2 omissions).
+Applied 2 fixes. 4 items need attention (2 errors, 2 omissions). 1 FYI observation.
 
-### Auto-fixes Applied
+### Applied fixes
 
-- Standardized "pipeline"/"workflow" terminology to "pipeline" throughout (coherence)
-- Fixed cross-reference: Section 4 referenced "Section 3.2" which is actually "Section 3.1" (coherence)
-- Updated unit count from "6 units" to "7 units" to match listed units (coherence)
-- Added "update API rate-limit config" step to Unit 4 -- implied by Unit 3's rate-limit introduction (feasibility)
-- Added auth token refresh to test scenarios -- required by Unit 2's token expiry handling (security-lens)
+- Corrected the stale cross-reference from Section 3.2 to Section 3.1 (coherence, confidence 100)
+- Updated the unit count from 6 to 7 to match the listed units (feasibility, confidence 100)
 
 ### P0 -- Must Fix
 
 #### Errors
 
+**Decisions**
+
 | # | Section | Issue | Reviewer | Confidence |
 |---|---------|-------|----------|------------|
-| 1 | Requirements Trace | Goal states "offline support" but technical approach assumes persistent connectivity | coherence | 0.92 |
+| 1 | Requirements Trace | The goal requires offline support, but the approach assumes persistent connectivity | coherence | 75 |
 
 ### P1 -- Should Fix
 
 #### Errors
 
-| # | Section | Issue | Reviewer | Confidence |
-|---|---------|-------|----------|------------|
-| 2 | Scope Boundaries | 8 of 12 units build admin infrastructure; only 2 touch stated goal | scope-guardian | 0.80 |
+**Proposed fixes**
+
+| # | Section | Issue | Suggested fix | Reviewer | Confidence |
+|---|---------|-------|---------------|----------|------------|
+| 2 | API Design | The plan claims Rails lacks native JSON error responses and proposes a custom serializer | Use Rails' existing `render json:` response path and remove the custom serializer step | feasibility | 75 |
 
 #### Omissions
 
-| # | Section | Issue | Reviewer | Confidence |
-|---|---------|-------|----------|------------|
-| 3 | Implementation Unit 3 | Plan proposes custom auth but does not mention existing Devise setup or migration path | feasibility | 0.85 |
+**Proposed fixes**
+
+| # | Section | Issue | Suggested fix | Reviewer | Confidence |
+|---|---------|-------|---------------|----------|------------|
+| 3 | Implementation Unit 3 | The custom auth plan omits the existing Devise setup and migration path | Extend the existing Devise flow and document its migration path instead of introducing a parallel auth setup | feasibility | 100 |
 
 ### P2 -- Consider Fixing
 
 #### Omissions
 
-| # | Section | Issue | Reviewer | Confidence |
-|---|---------|-------|----------|------------|
-| 4 | API Design | Public webhook endpoint has no rate limiting mentioned | security-lens | 0.75 |
+**Proposed fixes**
 
-### Residual Concerns
+| # | Section | Issue | Suggested fix | Reviewer | Confidence |
+|---|---------|-------|---------------|----------|------------|
+| 4 | API Design | The public webhook endpoint has no rate limiting plan | Add the established request-throttling middleware to the webhook route and document its limit | security-lens | 75 |
+
+### FYI observations
+
+| # | Section | Observation | Reviewer | Confidence |
+|---|---------|-------------|----------|------------|
+| 5 | Error Handling | The plan does not say whether rate-limit responses include retry guidance | security-lens | 50 |
+
+### Residual concerns
 
 | # | Concern | Source |
 |---|---------|--------|
-| 1 | Migration rollback strategy not addressed for Phase 2 data changes | feasibility |
+| 1 | Migration rollback strategy is not addressed for Phase 2 data changes | feasibility |
 
-### Deferred Questions
+### Deferred questions
 
 | # | Question | Source |
 |---|---------|--------|
@@ -69,21 +80,24 @@ Applied 5 auto-fixes. 4 findings to consider (2 errors, 2 omissions).
 
 ### Coverage
 
-| Persona | Status | Findings | Auto | Present | Residual |
-|---------|--------|----------|------|---------|----------|
-| coherence | completed | 4 | 3 | 1 | 0 |
-| feasibility | completed | 2 | 1 | 1 | 1 |
-| security-lens | completed | 2 | 1 | 1 | 0 |
-| scope-guardian | completed | 1 | 0 | 1 | 0 |
-| product-lens | not activated | -- | -- | -- | -- |
-| design-lens | not activated | -- | -- | -- | -- |
+| Persona | Status | Findings | Fixes | Proposed fixes | Decisions | FYI observations | Residual |
+|---------|--------|----------|-------|----------------|-----------|------------------|----------|
+| coherence | completed | 2 | 1 | 0 | 1 | 0 | 0 |
+| feasibility | completed | 3 | 1 | 2 | 0 | 0 | 1 |
+| security-lens | completed | 2 | 0 | 1 | 0 | 1 | 0 |
+| scope-guardian | completed | 0 | 0 | 0 | 0 | 0 | 1 |
+| product-lens | not activated | -- | -- | -- | -- | -- | -- |
+| design-lens | not activated | -- | -- | -- | -- | -- | -- |
 ```
 
 ## Section Rules
 
-- **Summary line**: Always present after the reviewer list. Format: "Applied N auto-fixes. K findings to consider (X errors, Y omissions)." Omit any zero clause.
-- **Auto-fixes Applied**: List all fixes that were applied automatically (auto class). Include enough detail per fix to convey the substance -- especially for fixes that add content or touch document meaning. Omit section if none.
+- **Summary line**: Always present after the reviewer list. Format: "Applied N fixes. K items need attention (X errors, Y omissions). Z FYI observations." Omit any zero clause. `K` counts actionable proposed fixes and decisions; FYI observations are counted separately.
+- **Applied fixes**: List all fixes applied silently (`safe_auto` at confidence `100`). Include enough detail per fix to convey the substance -- especially for fixes that add content or touch document meaning. A `safe_auto` finding at confidence `75` is demoted before routing and is not silently applied. Omit section if none.
 - **P0-P3 sections**: Only include sections that have findings. Omit empty severity levels. Within each severity, separate into **Errors** and **Omissions** sub-headers. Omit a sub-header if that severity has none of that type.
-- **Residual Concerns**: Findings below confidence threshold that were promoted by cross-persona corroboration, plus unpromoted residual risks. Omit if none.
-- **Deferred Questions**: Questions for later workflow stages. Omit if none.
-- **Coverage**: Always include. All counts are **post-synthesis**. **Findings** must equal Auto + Present exactly -- if deduplication merged a finding across personas, attribute it to the persona with the highest confidence and reduce the other persona's count. **Residual** = count of `residual_risks` from this persona's raw output (not the promoted subset in the Residual Concerns section).
+- **Proposed fixes**: Findings with `gated_auto` at confidence `75` or `100`. Include the concrete suggested fix and require user confirmation. Omit if none.
+- **Decisions**: Findings with `manual` at confidence `75` or `100`. Include the suggested fix when one exists; otherwise present the judgment call without inventing a fix. Omit if none.
+- **FYI observations**: Findings at confidence `50`, regardless of autofix class. They require no decision or action. Omit if none.
+- **Residual concerns**: Unresolved residual risks that remain after restatement suppression, plus any residual items explicitly retained by synthesis. Omit if none.
+- **Deferred questions**: Questions for later workflow stages. Omit if none.
+- **Coverage**: Always include. All finding and route counts are **post-synthesis**. For each persona, **Findings** equals **Fixes + Proposed fixes + Decisions + FYI observations**. If deduplication merges a finding across personas, attribute it to the persona with the highest confidence anchor; if anchors tie, use document order, and reduce the other persona's finding and route counts. **Residual** remains the count of `residual_risks` from that persona's raw output, not the promoted or suppressed subset shown in Residual concerns. Failed or malformed reviewers are marked in Status and do not contribute findings.

--- a/skills/document-review/references/subagent-template.md
+++ b/skills/document-review/references/subagent-template.md
@@ -26,18 +26,18 @@ Rules:
 - Set `finding_type` for every finding:
   - `error`: Something the document says that is wrong -- contradictions, incorrect statements, design tensions, incoherent tradeoffs.
   - `omission`: Something the document forgot to say -- missing mechanical steps, absent list entries, undefined thresholds, forgotten cross-references.
+- Set `confidence` to exactly one anchor from the schema, based on the evidence available:
+  - `0`: False positive or pre-existing issue. Suppress the finding.
+  - `25`: Might be real but could not verify. Suppress the finding.
+  - `50`: Verified real but nitpick, advisory, or not very important. This becomes an FYI observation.
+  - `75`: Double-checked, will hit in practice, and directly impacts correctness. This is actionable.
+  - `100`: Evidence directly confirms the issue and it will happen frequently. This is actionable and is the only anchor eligible for silent fixes.
 - Set `autofix_class` based on whether there is one clear correct fix, not on severity or importance:
-  - `auto`: One clear correct fix, applied silently. This includes trivial fixes AND substantive ones:
-    - Internal reconciliation -- one document part authoritative over another (summary/detail mismatches, wrong counts, stale cross-references, terminology drift)
-    - Implied additions -- correct content mechanically obvious from the document (missing steps, unstated thresholds, completeness gaps)
-    - Codebase-pattern-resolved -- an established codebase pattern resolves ambiguity (cite the specific file/function in `why_it_matters`)
-    - Incorrect behavior -- the document describes behavior that is factually wrong, and the correct behavior is obvious from context or the codebase
-    - Missing standard security measures -- HTTPS enforcement, checksum verification, input sanitization, private IP rejection, or other controls with known implementations where omission is clearly a bug
-    - Incomplete technical descriptions -- the accurate/complete version is directly derivable from the codebase
-    - Missing requirements that follow mechanically from the document's own explicit, concrete decisions (not high-level goals -- a goal can be satisfied by multiple valid requirements)
-    The test is not "is this fix important?" but "is there more than one reasonable way to fix this?" If a competent implementer would arrive at the same fix independently, it is auto -- even if the fix is substantive. Always include `suggested_fix`. NOT auto if more than one reasonable fix exists or if scope/priority judgment is involved.
-  - `present`: Requires user judgment -- genuinely multiple valid approaches where the right choice depends on priorities, tradeoffs, or context the reviewer does not have. Examples: architectural choices with real tradeoffs, scope decisions, feature prioritization, UX design choices.
-- `suggested_fix` is required for `auto` findings. For `present` findings, include only when the fix is obvious.
+  - `safe_auto`: A truly mechanical one-correct-fix case suitable for silent application only at anchor `100`: summary/detail mismatches, wrong counts, stale internal references, terminology drift, or additions mechanically implied by explicit content. Do not use this for codebase-pattern, factual, security/reliability, framework-native, or substantive completeness cases.
+  - `gated_auto`: A concrete fix resolved by an existing codebase pattern, factually incorrect behavior, a missing standard security or reliability control, a framework-native substitution, or a substantive mechanically implied completeness addition. The user confirms before applying it.
+  - `manual`: Multiple reasonable choices require user judgment, such as architectural tradeoffs, scope or priority decisions, feature prioritization, or UX choices.
+  The test is not "is this fix important?" but "is there more than one reasonable way to fix this?" If a competent implementer would arrive at the same fix independently, use `safe_auto` only for the truly mechanical cases above; use `gated_auto` when codebase or factual evidence resolves the choice but the fix is substantive. Do not classify a judgment call as automatic.
+- `suggested_fix` is required for `safe_auto` and `gated_auto` findings. For `manual` findings, include it only when the fix is obvious.
 - If you find no issues, return an empty findings array. Still populate residual_risks and deferred_questions if applicable.
 - Use your suppress conditions. Do not flag issues that belong to other personas.
 </output-contract>

--- a/skills/document-review/references/synthesis-and-presentation.md
+++ b/skills/document-review/references/synthesis-and-presentation.md
@@ -9,14 +9,14 @@ Process findings from all agents through this pipeline. Order matters — each s
 Check each agent's returned JSON against the findings schema:
 
 - Drop findings missing any required field defined in the schema
-- Drop findings with invalid enum values (including the pre-rename `auto` / `present` values from older personas — treat those as malformed until all persona output has been regenerated)
+- Drop findings with invalid enum values. Legacy `auto` / `present` values from older or in-flight dispatches are malformed; reject them without remapping rather than treating them as an alternate contract.
 - Note the agent name for any malformed output in the Coverage section
 
 **Do not narrate remap / validation diagnostics to the user.** Schema-drift notes ("persona X returned unknown enum Y, remapped to Z"), persona-prompt-drift commentary, and other validator-internal diagnostics are maintainer-facing information. They do not belong in the Phase 4 output the user reads. If a persona's output is malformed, the only user-visible consequence is a Coverage-row annotation (e.g., the persona shows fewer findings or a `malformed` marker). Everything else stays internal.
 
 ### 3.2 Confidence Gate (Anchor-Based)
 
-Gate findings by their `confidence` anchor value. Anchors are discrete integers (`0`, `25`, `50`, `75`, `100`) with behavioral definitions documented in `references/findings-schema.json` and embedded in the persona rubric (`references/subagent-template.md`). This replaces the prior continuous 0.0-1.0 scale with per-severity gates — doc-review economics do not warrant threshold gradation by severity, and coarse anchors prevent false-precision gaming.
+Gate findings by their `confidence` anchor value. Anchors are discrete integers (`0`, `25`, `50`, `75`, `100`) with behavioral definitions documented in `references/findings-schema.json` and embedded in the persona rubric (`references/subagent-template.md`). The anchors provide per-severity gates — doc-review economics do not warrant threshold gradation by severity, and coarse anchors prevent false-precision gaming. Continuous values from an older contract are malformed, not remapped.
 
 | Anchor | Meaning | Route |
 |--------|---------|-------|
@@ -174,7 +174,7 @@ Do NOT reclassify, re-route, or change the confidence anchor of any finding in t
 - P1 manual "Migration lacks rollback strategy" — migration needs rollback regardless of scope. NOT linked (independence safeguard).
 - P0 gated_auto "Deployment-ordering between migration and code" — concrete fix user confirms regardless. NOT linked (safeguard: gated_auto with own resolution path).
 
-Result: 1 root + 4 dependents. User sees the root first; rejecting it cascades the 4 dependents to auto-resolved. Manual engagement drops from 11 → 7 (6 unlinked + 1 visible root).
+Result: 1 root + 4 dependents. User sees the root first; rejecting it cascades the 4 dependents out of the active decision set. Manual engagement drops from 11 → 7 (6 unlinked + 1 visible root).
 
 **Worked example B (auth-shape).** Review of a plan to introduce a new session-management middleware. One finding is P1 manual "Middleware rewrite premise unsupported — existing session handling has no reported reliability issues" in Problem Frame. Scanning the other findings:
 

--- a/tests/unit/document-review-findings-schema.test.ts
+++ b/tests/unit/document-review-findings-schema.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import path from 'node:path'
+import Ajv from 'ajv'
+
+type Finding = {
+  title: string
+  severity: 'P0' | 'P1' | 'P2' | 'P3'
+  section: string
+  why_it_matters: string
+  finding_type: 'error' | 'omission'
+  autofix_class: 'safe_auto' | 'gated_auto' | 'manual'
+  confidence: number
+  evidence: string[]
+  suggested_fix?: string
+}
+
+type Report = {
+  reviewer: string
+  findings: Finding[]
+  residual_risks: string[]
+  deferred_questions: string[]
+}
+
+const schemaPath = path.resolve(
+  import.meta.dir,
+  '../../skills/document-review/references/findings-schema.json',
+)
+const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8')) as Record<
+  string,
+  unknown
+>
+const validate = new Ajv({ strict: false }).compile(schema)
+
+const baseFinding: Finding = {
+  title: 'Missing deployment ordering',
+  severity: 'P1',
+  section: 'Implementation',
+  why_it_matters: 'The deployment can fail when the migration runs too late.',
+  finding_type: 'omission',
+  autofix_class: 'gated_auto',
+  confidence: 75,
+  evidence: ['Deploy the application before the migration.'],
+  suggested_fix: 'Specify the migration and deployment ordering.',
+}
+
+const baseReport: Report = {
+  reviewer: 'feasibility',
+  findings: [baseFinding],
+  residual_risks: [],
+  deferred_questions: [],
+}
+
+function reportWithFinding(changes: Partial<Finding>): Report {
+  return {
+    ...baseReport,
+    findings: [{ ...baseFinding, ...changes }],
+  }
+}
+
+describe('document review findings schema', () => {
+  test('accepts every confidence anchor', () => {
+    for (const confidence of [0, 25, 50, 75, 100]) {
+      expect(validate(reportWithFinding({ confidence }))).toBe(true)
+    }
+  })
+
+  test('accepts every autofix class', () => {
+    for (const autofix_class of [
+      'safe_auto',
+      'gated_auto',
+      'manual',
+    ] as const) {
+      expect(validate(reportWithFinding({ autofix_class }))).toBe(true)
+    }
+  })
+
+  test('rejects decimal confidence', () => {
+    expect(validate(reportWithFinding({ confidence: 0.9 }))).toBe(false)
+  })
+
+  test('rejects out-of-set confidence values', () => {
+    expect(validate(reportWithFinding({ confidence: 60 }))).toBe(false)
+    expect(validate(reportWithFinding({ confidence: 101 }))).toBe(false)
+  })
+
+  test('rejects legacy autofix classes', () => {
+    expect(
+      validate({
+        ...baseReport,
+        findings: [{ ...baseFinding, autofix_class: 'auto' }],
+      }),
+    ).toBe(false)
+    expect(
+      validate({
+        ...baseReport,
+        findings: [{ ...baseFinding, autofix_class: 'present' }],
+      }),
+    ).toBe(false)
+  })
+
+  test('rejects a report missing a required field', () => {
+    const { reviewer: _reviewer, ...missingReviewer } = baseReport
+    expect(validate(missingReviewer)).toBe(false)
+  })
+
+  test('rejects a finding missing a required field', () => {
+    const { title: _title, ...missingTitle } = baseFinding
+    expect(validate({ ...baseReport, findings: [missingTitle] })).toBe(false)
+  })
+
+  test('rejects empty evidence', () => {
+    expect(validate(reportWithFinding({ evidence: [] }))).toBe(false)
+  })
+
+  test('accepts a report with no findings', () => {
+    expect(validate({ ...baseReport, findings: [] })).toBe(true)
+  })
+})


### PR DESCRIPTION
## What changed

Document review now uses one findings contract from reviewer output through synthesis:

- discrete confidence anchors: `0`, `25`, `50`, `75`, `100`
- canonical autofix classes: `safe_auto`, `gated_auto`, `manual`
- aligned producer guidance, headless behavior, synthesis examples, presentation templates, and all seven reviewer personas
- strict rejection of legacy decimal confidence and `auto` / `present` values
- deterministic demotion of auto-class findings that omit a suggested fix

## Why

The shipped reviewer schema and prompts still produced the legacy vocabulary while synthesis expected the newer contract. Valid reviewer findings were therefore classified as malformed and dropped. This change makes the JSON Schema authoritative and aligns every live producer and consumer surface to it.

## Verification

- `bun test tests/unit/document-review-findings-schema.test.ts` — 9 passed
- `bun run typecheck`
- `bunx biome check tests/unit/document-review-findings-schema.test.ts`
- seven reviewer personas produced first-pass reports accepted by the real AJV schema without re-emission
- observed reports exercised `safe_auto`, `gated_auto`, and `manual` with anchors `75` and `100`; synthesis accepted and routed all reports

No prose, Markdown structure, package-content, or snapshot assertions were added.

Closes #677
