### PR TITLE
docs: document agent contract verification

### DIFF
--- a/docs/plans/2026-07-21-001-fix-document-review-findings-contract-plan.md
+++ b/docs/plans/2026-07-21-001-fix-document-review-findings-contract-plan.md
@@ -4,7 +4,7 @@ type: fix
 status: completed
 date: 2026-07-21
 origin: docs/brainstorms/2026-07-21-document-review-findings-contract-alignment-requirements.md
-shipped: "PR #679 / v3.2.4"
+shipped: "PR #679 → v3.2.4"
 ---
 
 # fix: Align document-review findings contract

--- a/docs/plans/2026-07-21-001-fix-document-review-findings-contract-plan.md
+++ b/docs/plans/2026-07-21-001-fix-document-review-findings-contract-plan.md
@@ -1,9 +1,10 @@
 ---
 title: "fix: Align document-review findings contract"
 type: fix
-status: active
+status: completed
 date: 2026-07-21
 origin: docs/brainstorms/2026-07-21-document-review-findings-contract-alignment-requirements.md
+shipped: "PR #679 / v3.2.4"
 ---
 
 # fix: Align document-review findings contract

--- a/docs/solutions/best-practices/behavior-first-ajv-contract-verification-2026-07-21.md
+++ b/docs/solutions/best-practices/behavior-first-ajv-contract-verification-2026-07-21.md
@@ -1,0 +1,92 @@
+---
+title: Behavior-first AJV contract verification for agent outputs
+date: 2026-07-21
+category: best-practices
+module: document-review-contract
+problem_type: best_practice
+component: testing_framework
+severity: medium
+applies_when:
+  - Aligning a schema, producer guidance, and agent-generated JSON
+  - Verifying whether emitted objects are accepted at a producer-consumer boundary
+  - Static prompt or artifact assertions would not prove the contract behavior
+tags:
+  - ajv
+  - json-schema
+  - agent-contract
+  - contract-testing
+  - persona-output
+  - verification
+---
+
+# Behavior-first AJV contract verification for agent outputs
+
+## Context
+
+Issue [#677](https://github.com/marcusrbrown/systematic/issues/677) exposed a contract split in
+the document-review workflow. The schema and reviewer guidance still taught continuous confidence
+values and legacy autofix classes, while synthesis accepted discrete confidence anchors and newer
+classes. A valid-looking reviewer response was therefore dropped as malformed.
+
+The fix in [#679](https://github.com/marcusrbrown/systematic/pull/679) aligned the bundled
+guidance, but verification focused on the contract objects rather than the surrounding Markdown.
+
+## Guidance
+
+Treat the schema that consumes agent output as the executable contract.
+
+1. Compile the real schema in a focused test. Do not duplicate its values in a second model.
+2. Validate representative accepted and rejected objects:
+   - every supported enum or anchor value passes;
+   - legacy, out-of-set, and structurally incomplete values fail;
+   - empty-but-valid reports remain valid where the contract permits them.
+3. Exercise real producers against a pressure scenario after the schema and guidance converge.
+   Accept their first response only when the existing consumer accepts the emitted objects; do not
+   re-prompt or normalize an invalid response into apparent success.
+4. Keep static assertions scoped to what they can actually prove. Prompt wording, file layout, and
+   generated text are not substitutes for validating emitted data at the consumer boundary.
+
+Use live producer verification for behavioral obligations the schema cannot express, such as
+whether an agent supplies a concrete remediation before assigning an auto-applicable class.
+
+## Why This Matters
+
+Prompt and artifact checks can prove that text changed while leaving the data contract broken. An
+agent may still emit an obsolete enum, choose a decimal where only anchors are allowed, or omit a
+field that synthesis needs. Compiling the real schema proves acceptance and rejection semantics;
+running real producers proves that the guidance produces objects the consumer can use.
+
+This creates a narrow, durable boundary: schema tests protect the executable vocabulary, and
+pressure scenarios protect the producer-to-consumer handoff.
+
+## When to Apply
+
+- Multiple agents or templates produce structured output consumed by a schema-aware workflow.
+- A defect is caused by producer/consumer disagreement rather than ordinary prose quality.
+- The important question is whether emitted objects are accepted, not whether a prompt contains a
+  particular phrase.
+- A schema has intentional limits that cannot express every behavioral obligation by itself.
+
+## Examples
+
+Compile the shipped schema and validate actual report objects:
+
+```ts
+const schema = JSON.parse(readFileSync(schemaPath, 'utf8')) as Record<string, unknown>
+const validate = new Ajv({ strict: false }).compile(schema)
+
+expect(validate(reportWithFinding({ confidence: 75 }))).toBe(true)
+expect(validate(reportWithFinding({ confidence: 0.9 }))).toBe(false)
+expect(validate(reportWithFinding({ autofix_class: 'auto' }))).toBe(false)
+```
+
+Then run the real producers without corrective prompting. In the document-review repair, all seven
+personas emitted first-pass reports accepted by the schema, using only the canonical classes. The
+existing synthesis boundary accepted those reports instead of classifying them as malformed.
+
+## Related
+
+- [Pin cross-harness adapter contracts at the boundary](cross-harness-adapter-parity-contract-tests-2026-07-14.md) — adapter-level version of testing observable boundary behavior rather than shared implementation details.
+- [Build-time codegen for typed config validation: four traps to avoid](typed-config-validation-build-time-codegen-2026-05-16.md) — schema-authoritative validation and producer/consumer drift prevention.
+- [Content-integrity gate should mirror runtime drop rules, not check raw YAML](content-integrity-mirror-runtime-drop-rules-2026-05-17.md) — verify the semantics a consumer actually enforces.
+- [Issue #677](https://github.com/marcusrbrown/systematic/issues/677) and [PR #679](https://github.com/marcusrbrown/systematic/pull/679).

--- a/docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md
+++ b/docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md
@@ -167,5 +167,6 @@ test('deprecated block missing since+removal triggers deprecated-missing-require
 ## Related
 
 - `docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md` — adjacent precedent for build-time codegen + runtime validation alignment
+- [Behavior-first AJV contract verification for agent outputs](behavior-first-ajv-contract-verification-2026-07-21.md) — applies the same consumer-semantic rule to schema-governed agent outputs.
 - `docs/solutions/workflow-issues/reconciliation-sync-reference-integrity-20260417.md` — moderate adjacency on the broader theme of CI catching post-write integrity gaps
 - PR #401 — v2.19.0 deprecation surface where this lesson surfaced

--- a/docs/solutions/best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md
+++ b/docs/solutions/best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md
@@ -133,5 +133,6 @@ OpenCode and Pi `systematic_skill` adapters in `tests/unit/pi.test.ts` and
 - [Isolate OpenCode subprocess fixtures from the real installation](../integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md)
 - [Test packaged harness extensions against the real Pi runtime](pi-real-runtime-integration-harness-2026-07-16.md) — the subprocess/package tier of this layer table, implemented for Pi
 - [OpenCode swallows plugin hook defects unless tests force invocation](../integration-issues/opencode-plugin-hook-silent-defect-swallow-2026-05-19.md)
+- [Behavior-first AJV contract verification for agent outputs](behavior-first-ajv-contract-verification-2026-07-21.md) — applies the same boundary-first test principle to schema-governed agent output.
 - [Pi harness support plan](../../plans/2026-07-06-003-feat-pi-harness-support-plan.md)
 - [Pi harness support requirements](../../brainstorms/2026-07-06-pi-harness-support-requirements.md)

--- a/docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md
+++ b/docs/solutions/best-practices/typed-config-validation-build-time-codegen-2026-05-16.md
@@ -376,6 +376,7 @@ This shape is integration-flavored — it runs against the live filesystem and a
 - [OpenCode /config HttpApi rejects ad-hoc bundled agent color names](../integration-issues/opencode-config-schema-rejects-ad-hoc-agent-colors-2026-05-09.md) — strict-schema migration on the downstream consumer side. Same "inventory the runtime-emitted surface before tightening" lesson, mirrored upstream.
 - [Trust-sensitive overlay fields in plugin configuration](./layered-trust-boundaries-overlay-config-2026-05-09.md) — companion guidance for `SECURITY_OVERLAY_FIELDS` allowlisting. Typed validation preserves the trust boundary by rejecting typos at parse time before the overlay-application phase.
 - [Plugin provider availability discovery and source-default resolution](./provider-availability-source-defaults-2026-05-12.md) — generator-owned dual outputs pattern. Useful precedent for runtime discovery driving generated artifacts.
+- [Behavior-first AJV contract verification for agent outputs](behavior-first-ajv-contract-verification-2026-07-21.md) — extends schema-authoritative validation to emitted agent objects and their live consumer boundary.
 - [Code Review Fixes for OCX Registry Support](../code-quality/ocx-registry-review-fixes.md) — earlier codegen + drift-gate work. The current doc formalizes the parity rule that registry codegen implicitly relied on.
 - PR #384 — implementation reference for all three lessons.
 - PR #393 — refactored the generator to remove the cache-bust workaround entirely; introduced `createSystematicConfigSchema` factory.


### PR DESCRIPTION
## What changed

- Added a behavior-first verification learning for schema-governed agent outputs.
- Linked it to adjacent contract-boundary and schema-validation guidance.
- Marked the #677 findings-contract plan completed with shipped v3.2.4 provenance.

## Verification

- `bun scripts/content-integrity.ts`

The learning records the verified boundary: compile the real schema, validate emitted objects, and confirm uncorrected live producer output is accepted by its existing consumer.
