### PR TITLE
docs(branding): reposition tagline to "compound-engineering loops"

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "systematic",
-      "description": "Structured engineering workflows for Claude Code.",
+      "description": "Compound-engineering loops for OpenCode, Pi, and Claude Code",
       "source": {
         "source": "github",
         "repo": "marcusrbrown/systematic",

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -3,7 +3,7 @@ _extends: .github:common-settings.yaml
 
 repository:
   name: systematic
-  description: Structured engineering workflows for OpenCode
+  description: Compound-engineering loops for OpenCode, Pi, and Claude Code
   homepage: https://fro.bot/systematic
   topics: opencode, plugin, ai, workflow, systematic, semantic-release, bun
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Systematic is an OpenCode plugin providing structured engineering workflows for AI-powered development. It ships as an npm package with two distinct parts: TypeScript source (`src/`) for plugin logic and bundled Markdown assets (`skills/`, `agents/`) for content. Full architectural detail lives in [`ARCHITECTURE.md`](ARCHITECTURE.md); directory layout and where to add new code lives in [`STRUCTURE.md`](STRUCTURE.md). This file covers contributor conventions, commands, and anti-patterns.
+Systematic is a plugin providing compound-engineering loops (brainstorm, plan, work, review) for OpenCode, Pi, and Claude Code. It ships as an npm package with two distinct parts: TypeScript source (`src/`) for plugin logic and bundled Markdown assets (`skills/`, `agents/`) for content. Full architectural detail lives in [`ARCHITECTURE.md`](ARCHITECTURE.md); directory layout and where to add new code lives in [`STRUCTURE.md`](STRUCTURE.md). This file covers contributor conventions, commands, and anti-patterns.
 
 ## For Architecture Questions
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> Systematic provides structured engineering workflows for AI-powered development, delivered natively
+> Systematic provides compound-engineering loops (brainstorm, plan, work, review) for AI-powered development, delivered natively
 > to three harnesses — OpenCode, Pi, and Claude Code — from one source tree.
 > This document describes the high-level structure; for file locations and naming conventions see `STRUCTURE.md`,
 > and for contributor guidelines see `AGENTS.md`.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./assets/banner.svg">
   <source media="(prefers-color-scheme: light)" srcset="./assets/banner.svg">
-  <img alt="Systematic — Compound-Engineering Workflows for OpenCode, Pi, and Claude Code" src="./assets/banner.svg" width="100%">
+  <img alt="Systematic — Compound-Engineering Loops for OpenCode, Pi, and Claude Code" src="./assets/banner.svg" width="100%">
 </picture>
 
 <br><br>
@@ -29,7 +29,7 @@ You want AI that follows your process, not just your prompts. You want repeatabl
 
 ## What You Get
 
-Systematic is a compound-engineering workflow: brainstorm, plan, work, review — each phase a structured skill that guides the AI through requirements exploration, implementation planning, execution, and code review, capturing what was learned along the way. It ships 31 bundled skills and 37 specialized agents for architecture, security, performance, design, and code review.
+Systematic is a compound-engineering loop: brainstorm, plan, work, review — each phase a structured skill that guides the AI through requirements exploration, implementation planning, execution, and code review, capturing what was learned along the way. It ships 31 bundled skills and 37 specialized agents for architecture, security, performance, design, and code review.
 
 The workflow runs on three harnesses from one source: [OpenCode](https://opencode.ai/), [Pi](https://github.com/earendil-works/pi-coding-agent), and Claude Code. Each gets a native install path; skill and agent content is identical across all three.
 

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 640" width="1280" height="640">
-  <title>Systematic — Compound-Engineering Workflows for OpenCode, Pi, and Claude Code</title>
-  <desc>Banner for Systematic featuring compound-engineering workflows (brainstorm, plan, work, review) delivered as skills and agents for OpenCode, Pi, and Claude Code.</desc>
+  <title>Systematic — Compound-Engineering Loops for OpenCode, Pi, and Claude Code</title>
+  <desc>Banner for Systematic featuring compound-engineering loops (brainstorm, plan, work, review) delivered as skills and agents for OpenCode, Pi, and Claude Code.</desc>
   
   <defs>
     <!-- Gradient inspired by Fro Bot's afro (blue-purple) -->
@@ -110,7 +110,7 @@
       fill="#B2F5EA" 
       text-anchor="middle"
     >
-      Compound-Engineering Workflows for OpenCode, Pi, and Claude Code
+      Compound-Engineering Loops for OpenCode, Pi, and Claude Code
     </text>
     
     <!-- Feature pills (tighter grouping: -140, 0, 140) -->

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -44,7 +44,7 @@ export default defineConfig({
       title: 'Systematic',
       favicon: '/favicon.svg',
       description:
-        'Systematic is a compound-engineering workflow — brainstorm, plan, work, and review — delivered as bundled skills and agents for OpenCode, Pi, and Claude Code.',
+        'Systematic is a compound-engineering loop — brainstorm, plan, work, and review — delivered as bundled skills and agents for OpenCode, Pi, and Claude Code.',
       head: [
         {
           tag: 'meta',
@@ -103,7 +103,7 @@ export default defineConfig({
             '@type': 'SoftwareSourceCode',
             name: 'Systematic',
             description:
-              'A compound-engineering workflow — brainstorm, plan, work, and review — delivered as bundled skills and agents for OpenCode, Pi, and Claude Code.',
+              'A compound-engineering loop — brainstorm, plan, work, and review — delivered as bundled skills and agents for OpenCode, Pi, and Claude Code.',
             codeRepository: 'https://github.com/marcusrbrown/systematic',
             license: 'https://opensource.org/licenses/MIT',
             programmingLanguage: 'TypeScript',

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Brainstorm, Plan, Work, Review — the Compound-Engineering Loop
-description: "Systematic is a compound-engineering pipeline — brainstorm, plan, work, and review — delivered as bundled skills and specialized agents for OpenCode, Pi, and Claude Code."
+description: "Systematic is a compound-engineering loop — brainstorm, plan, work, and review — delivered as bundled skills and specialized agents for OpenCode, Pi, and Claude Code."
 template: splash
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fro.bot/systematic",
   "version": "0.0.0-semantic-release",
-  "description": "Structured engineering workflows for OpenCode",
+  "description": "Compound-engineering loops for OpenCode, Pi, and Claude Code",
   "type": "module",
   "homepage": "https://fro.bot/systematic",
   "main": "./dist/index.js",

--- a/registry/files/profiles/omo/AGENTS.md
+++ b/registry/files/profiles/omo/AGENTS.md
@@ -2,7 +2,7 @@
 
 This profile provides a **powerful combined system** that brings together:
 - **Oh My OpenAgent (OMO)** — Multi-agent orchestration, parallel research, and advanced tooling
-- **Systematic** — Structured engineering workflows for disciplined execution
+- **Systematic** — Compound-engineering loops for disciplined execution
 
 Best for engineers who want both raw agent power AND enforced process discipline.
 

--- a/registry/files/profiles/standalone/AGENTS.md
+++ b/registry/files/profiles/standalone/AGENTS.md
@@ -1,6 +1,6 @@
 # Standalone Systematic Profile
 
-This profile provides **Systematic's structured engineering workflows** — brainstorming, planning, code review, and disciplined execution — without additional agents or plugins.
+This profile provides **Systematic's compound-engineering loops** — brainstorming, planning, code review, and disciplined execution — without additional agents or plugins.
 
 ## What's Included
 

--- a/registry/registry.jsonc
+++ b/registry/registry.jsonc
@@ -612,7 +612,7 @@
     {
       "name": "standalone",
       "type": "profile",
-      "description": "Standalone Systematic profile — structured engineering workflows with zero extra configuration",
+      "description": "Standalone Systematic profile — compound-engineering loops with zero extra configuration",
       "files": [
         {
           "path": "registry/files/profiles/standalone/opencode.jsonc",
@@ -654,7 +654,7 @@
     {
       "name": "plugin",
       "type": "plugin",
-      "description": "Systematic OpenCode plugin — registers skills, agents, commands, and bootstrap prompt",
+      "description": "Systematic — compound-engineering loops for OpenCode, Pi, and Claude Code; registers skills, agents, commands, and bootstrap prompt",
       "files": [],
       "opencode": {
         "plugins": {

--- a/registry/registry.jsonc
+++ b/registry/registry.jsonc
@@ -654,7 +654,7 @@
     {
       "name": "plugin",
       "type": "plugin",
-      "description": "Systematic — compound-engineering loops for OpenCode, Pi, and Claude Code; registers skills, agents, commands, and bootstrap prompt",
+      "description": "Systematic plugin — registers skills, agents, commands, and bootstrap prompt",
       "files": [],
       "opencode": {
         "plugins": {

--- a/scripts/build-claude-code-plugin.ts
+++ b/scripts/build-claude-code-plugin.ts
@@ -81,7 +81,7 @@ export interface ClaudePluginManifest {
 export function buildPluginManifest(_rootDir: string): ClaudePluginManifest {
   return {
     name: 'systematic',
-    description: 'Structured engineering workflows for Claude Code.',
+    description: 'Compound-engineering loops for OpenCode, Pi, and Claude Code',
     author: { name: 'Marcus R. Brown', email: 'human@fro.bot' },
   }
 }
@@ -138,7 +138,7 @@ ${profileContent}`
   const frontmatter = formatFrontmatter({
     name: 'systematic',
     description:
-      'Structured engineering workflows for Claude Code via the Systematic plugin.',
+      'Compound-engineering loops (brainstorm, plan, work, review) via the Systematic plugin.',
     'force-for-plugin': true,
   })
 


### PR DESCRIPTION
## Summary

Repositions the project tagline from "structured/compound-engineering **workflows**" to **"Compound-engineering loops for OpenCode, Pi, and Claude Code"** and applies it uniformly across every public surface. "Loops" reflects how agent-led workflow parlance has settled, while "compound-engineering" keeps the recognized brand anchor and "engineering" keeps the cold read clear.

## Also fixes stale harness lists

Several surfaces still named only one harness. This corrects them to name all three shipped harnesses (OpenCode, Pi, Claude Code):

- `package.json`, `.github/settings.yml` (GitHub About), `AGENTS.md`, registry — were **OpenCode-only**
- `.claude-plugin/marketplace.json` — was **Claude Code-only**

## Surfaces updated

- **Metadata:** `package.json`, `.github/settings.yml`, `.claude-plugin/marketplace.json`
- **Banner:** `assets/banner.svg` (title, description, rendered tagline — verified it renders correctly)
- **Docs:** `docs/astro.config.mjs` (site + JSON-LD description), `docs/src/content/docs/index.mdx`
- **Root docs:** `README.md`, `ARCHITECTURE.md`, `AGENTS.md`
- **Registry:** `registry/registry.jsonc` + both profile `AGENTS.md` files (regenerated; drift-clean)
- **Claude Code build:** `scripts/build-claude-code-plugin.ts` plugin + output-style descriptions

Runtime system-prompt prose (the bootstrap injection) is intentionally left unchanged.

## Verification

Registry drift clean, content-integrity clean, typecheck + lint clean, Claude Code plugin builds, full unit suite (1498) passes with the bootstrap snapshot unchanged, and the banner render was visually confirmed.
