### PR TITLE
fix(workflow-guard): recover per-registration under dual registration

### DIFF
--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -29,8 +29,10 @@ import {
 } from './receipt-ledger.js'
 import {
   extractReceiptReadbackSeed,
+  filterMarkersByRegistration,
   projectReceiptMintMarker,
   projectReceiptProgressionMarker,
+  validateReceiptMarker,
 } from './receipt-readback.js'
 import {
   createWorkflowGuard,
@@ -351,6 +353,13 @@ const statusToolSchema = z.object(statusToolShape).strict()
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** Decodes a 64-char lowercase hex session salt string to Uint8Array. */
+function decodeSessionSaltBytes(hex: string): Uint8Array | undefined {
+  if (typeof hex !== 'string' || hex.length !== 64 || !/^[0-9a-f]+$/.test(hex))
+    return undefined
+  return Uint8Array.from(Buffer.from(hex, 'hex'))
 }
 
 function boundedString(value: unknown, maxLength: number): value is string {
@@ -1158,7 +1167,74 @@ function createSessionRuntime(
     )
   }
 
+  /** Extract a candidate { salt, digest } from a seeded marker, or undefined. */
+  function candidateSeedFromMarker(
+    input: unknown,
+  ): { salt: Uint8Array; digest: string } | undefined {
+    const validation = validateReceiptMarker(input)
+    if (validation.status !== 'valid') return undefined
+    const marker = validation.marker
+    if (marker.kind === 'mint') {
+      const salt = decodeSessionSaltBytes(marker.sessionSalt)
+      return salt
+        ? { salt, digest: marker.envelope.registrationDigest }
+        : undefined
+    }
+    if (marker.kind === 'control' && marker.control === 'progression') {
+      const salt = decodeSessionSaltBytes(marker.sessionSalt)
+      return salt ? { salt, digest: marker.registrationDigest } : undefined
+    }
+    return undefined
+  }
+
+  /** Test whether a candidate salt agrees with this registration's identity. */
+  function candidateAgreesWithOwnIdentity(
+    salt: Uint8Array,
+    digest: string,
+  ): boolean {
+    try {
+      const probe = createReceiptLedger({
+        capabilityFlags: ['workflow-guard'],
+        registrationIdentity: options.registrationIdentity,
+        sessionSalt: salt,
+      })
+      return probe.metadata.registrationDigest === digest
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   * Finds the registrationDigest that belongs to THIS registration by scanning
+   * validated markers for candidate seeds and checking which one agrees with
+   * options.registrationIdentity. Returns undefined if no own seed is found.
+   *
+   * Known limitation: if the same canonical plugin source registers twice with
+   * different session salts (producing two distinct (identity, salt) → digest pairs
+   * for the same registrationIdentity string), this function picks whichever seed
+   * appears first in the markers array. This is sound for the primary dual-registration
+   * scenario where the two registrations have distinct canonical identities (different
+   * `options.registrationIdentity` values, e.g. published package vs repo path).
+   * Multiple-salt registration from a single canonical identity is a known limitation
+   * of this design and is not addressed here.
+   */
+  function resolveOwnRegistrationDigest(
+    markers: readonly unknown[],
+  ): string | undefined {
+    const seenDigests = new Set<string>()
+    for (const input of markers) {
+      const candidate = candidateSeedFromMarker(input)
+      if (!candidate || seenDigests.has(candidate.digest)) continue
+      seenDigests.add(candidate.digest)
+      if (candidateAgreesWithOwnIdentity(candidate.salt, candidate.digest)) {
+        return candidate.digest
+      }
+    }
+    return undefined
+  }
+
   function recoverPersistedMarkers(markers: readonly unknown[]): boolean {
+    // Callers must pass pre-filtered (own-registration) markers.
     const seed = extractReceiptReadbackSeed(markers)
     if (seed.status !== 'ready') return false
     let recoveredLedger: ReceiptLedger
@@ -1196,6 +1272,84 @@ function createSessionRuntime(
     return true
   }
 
+  type OwnMarkersClassification =
+    | { readonly kind: 'own'; readonly markers: readonly unknown[] }
+    | { readonly kind: 'foreign-empty' }
+    | { readonly kind: 'ambiguous' }
+
+  /**
+   * Classifies markers collected from session parts into three outcomes:
+   *
+   * - 'own': at least one valid own seed marker found; contains filtered own markers.
+   * - 'foreign-empty': every marker is a valid, salt-bearing marker that does NOT
+   *   agree with this registration's identity. Safe to treat as empty history.
+   * - 'ambiguous': own digest unresolvable AND ≥1 marker is malformed/invalid OR
+   *   seedless (consume). Cannot prove the markers don't include corrupted own state.
+   *   Must fail closed — never degrade to publishFresh / benign no-op.
+   *
+   * This correctly distinguishes genuinely-foreign marker arrays (safe → fresh) from
+   * own-state-loss / corruption scenarios (unsafe → fail closed).
+   */
+  function classifyMarkersFromParts(
+    parts: ReadonlyArray<unknown>,
+  ): OwnMarkersClassification {
+    const allMarkers: unknown[] = []
+    for (const part of parts) collectReceiptMarkers(part, allMarkers)
+    if (allMarkers.length === 0) return { kind: 'foreign-empty' }
+
+    const ownDigest = resolveOwnRegistrationDigest(allMarkers)
+    if (ownDigest !== undefined) {
+      return {
+        kind: 'own',
+        markers: filterMarkersByRegistration(allMarkers, ownDigest),
+      }
+    }
+
+    // Own digest not resolvable. Determine if every marker is provably foreign, or
+    // if any is ambiguous (malformed or seedless) and therefore could be corrupted own.
+    //
+    // Provably foreign: passes validateReceiptMarker AND is seed-bearing (mint or
+    //   progression — has a sessionSalt) AND candidateAgreesWithOwnIdentity is false.
+    //   Since resolveOwnRegistrationDigest found no match, every valid seed-bearing
+    //   marker already failed the agreement check.
+    //
+    // Ambiguous: malformed/invalid (cannot read) OR valid but seedless (consume
+    //   marker — carries registrationDigest but no sessionSalt, so we cannot run
+    //   the identity agreement check). Ambiguous markers MUST trigger fail-closed.
+    for (const input of allMarkers) {
+      const validation = validateReceiptMarker(input)
+      if (validation.status !== 'valid') {
+        // Malformed/invalid: could be a corrupted own marker → fail closed
+        return { kind: 'ambiguous' }
+      }
+      const candidate = candidateSeedFromMarker(input)
+      if (candidate === undefined) {
+        // Valid but seedless (consume marker, kind='control' control='consume'):
+        // registrationDigest is present but sessionSalt is absent — cannot verify
+        // ownership without a salt → fail closed
+        return { kind: 'ambiguous' }
+      }
+      // Valid seed-bearing (mint/progression): since resolveOwnRegistrationDigest
+      // returned undefined, this marker's (salt, digest) does not agree with our
+      // identity → provably foreign. Continue scanning.
+    }
+
+    // Every marker was valid, seed-bearing, and provably foreign.
+    return { kind: 'foreign-empty' }
+  }
+
+  function publishEmptyMarkers(
+    parts: ReadonlyArray<unknown>,
+    allowFresh: boolean,
+  ): void {
+    if (allowFresh && !parts.some((part) => containsGuardHistory(part))) {
+      publishFresh()
+    } else {
+      retryableEmptyHistory = true
+      publishUnavailable()
+    }
+  }
+
   async function initializeSession(
     sessionID: string,
     allowFresh: boolean,
@@ -1212,18 +1366,23 @@ function createSessionRuntime(
       publishUnavailable()
       return
     }
-    const markers: unknown[] = []
-    for (const part of parts) collectReceiptMarkers(part, markers)
-    if (markers.length === 0) {
-      if (allowFresh && !parts.some((part) => containsGuardHistory(part))) {
-        publishFresh()
-      } else {
-        retryableEmptyHistory = true
-        publishUnavailable()
-      }
+    const classification = classifyMarkersFromParts(parts)
+    if (classification.kind === 'ambiguous') {
+      // Cannot determine whether markers include corrupted own state → fail closed.
+      // Do NOT use retryableEmptyHistory here; this is a corruption signal, not a
+      // transient empty-history state.
+      publishUnavailable()
       return
     }
-    if (!recoverPersistedMarkers(markers)) publishUnavailable()
+    if (classification.kind === 'foreign-empty') {
+      // No own markers: either no history at all, or all markers are provably
+      // foreign (dual-registration, other registrations only). Use the normal
+      // empty-history path (publishFresh or publishUnavailable based on history check).
+      publishEmptyMarkers(parts, allowFresh)
+      return
+    }
+    // kind === 'own': recover from filtered own markers.
+    if (!recoverPersistedMarkers(classification.markers)) publishUnavailable()
   }
 
   async function recoverFromHost(
@@ -1274,10 +1433,17 @@ function createSessionRuntime(
       markUnavailable()
       return
     }
-    const markers: unknown[] = []
-    for (const part of parts) collectReceiptMarkers(part, markers)
-    if (markers.length === 0) return
-    const seed = extractReceiptReadbackSeed(markers)
+    // Classify child session markers: own (filter and recover), foreign-empty
+    // (benign no-op — no receipts to roll up), or ambiguous (corrupted/seedless
+    // markers that cannot be verified as foreign → fail closed).
+    const classification = classifyMarkersFromParts(parts)
+    if (classification.kind === 'foreign-empty') return
+    if (classification.kind === 'ambiguous') {
+      markUnavailable()
+      return
+    }
+    const ownMarkers = classification.markers
+    const seed = extractReceiptReadbackSeed(ownMarkers)
     if (seed.status !== 'ready') {
       markUnavailable()
       return
@@ -1291,7 +1457,7 @@ function createSessionRuntime(
       markUnavailable()
       return
     }
-    const recovered = childLedger.recoverReadback(markers)
+    const recovered = childLedger.recoverReadback(ownMarkers)
     if (recovered.status === 'rejected') {
       markUnavailable()
       return

--- a/src/lib/receipt-readback.ts
+++ b/src/lib/receipt-readback.ts
@@ -985,6 +985,38 @@ function seedFromMarker(marker: ReceiptMarker):
   }
 }
 
+/**
+ * Extracts the registrationDigest from a validated marker.
+ * Returns undefined for unknown/malformed shapes.
+ */
+function registrationDigestFromMarker(marker: ReceiptMarker): string {
+  if (marker.kind === 'mint') return marker.envelope.registrationDigest
+  return marker.registrationDigest
+}
+
+/**
+ * Filters a raw marker array, retaining only markers that belong to the given
+ * registrationDigest. Markers that cannot be parsed (malformed, unknown schema,
+ * etc.) are retained as-is so that downstream callers can fail-closed on them.
+ *
+ * Use this before extractReceiptReadbackSeed / foldReceiptReadback when the
+ * shared metadata array may contain markers from multiple concurrent
+ * registrations (e.g. dual-registration in a single OpenCode session).
+ */
+export function filterMarkersByRegistration(
+  markers: readonly unknown[],
+  ownRegistrationDigest: string,
+): unknown[] {
+  return markers.filter((input) => {
+    const validation = validateReceiptMarker(input)
+    // Cannot parse → retain fail-closed (caller will reject it)
+    if (validation.status !== 'valid') return true
+    return (
+      registrationDigestFromMarker(validation.marker) === ownRegistrationDigest
+    )
+  })
+}
+
 export function extractReceiptReadbackSeed(
   inputs: readonly unknown[],
 ): ReceiptReadbackSeedResult {

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -19,6 +19,12 @@ import {
   type ReceiptOperationObservation,
 } from '../../src/lib/receipt-classifier.js'
 import type { ReceiptLedger } from '../../src/lib/receipt-ledger.js'
+import { createReceiptLedger } from '../../src/lib/receipt-ledger.js'
+import {
+  projectReceiptConsumptionMarker,
+  projectReceiptMintMarker,
+  projectReceiptProgressionMarker,
+} from '../../src/lib/receipt-readback.js'
 import type { WorkflowStatus } from '../../src/lib/workflow-guard.js'
 
 const SESSION_A = 'session-1'
@@ -2073,5 +2079,1396 @@ describe('OpenCode workflow guard adapter', () => {
     expect(status(restored).satisfiedOperations).toContain('implementation')
     await restored.tools.systematic_workflow_status.execute({}, toolContext())
     expect(status(restored).epoch).not.toBeNull()
+  })
+
+  describe('dual-registration restart recovery (fix/workflow-guard-dual-registration-recovery)', () => {
+    // Helper: build a minimal marker array for a registration with a known sessionSalt
+    function buildMarkersForRegistration(
+      registrationIdentity: string,
+      sessionSalt: Uint8Array,
+    ): unknown[] {
+      const ledgerA = createReceiptLedger({
+        capabilityFlags: ['workflow-guard'],
+        registrationIdentity,
+        sessionSalt,
+      })
+      const EPOCH_ID_A = 'a'.repeat(32)
+      const UNIT_ID_A = 'b'.repeat(32)
+      const transitionDigest = (tag: string) =>
+        ledgerA.digestIdentity('call', tag)
+
+      const epochStart = projectReceiptProgressionMarker(ledgerA, {
+        target: 'epoch',
+        state: 'started',
+        epochId: EPOCH_ID_A,
+        family: 'work',
+        transitionDigest: transitionDigest('epoch-start'),
+        timestamp: 1,
+      })
+      const unitStart = projectReceiptProgressionMarker(ledgerA, {
+        target: 'unit',
+        state: 'started',
+        epochId: EPOCH_ID_A,
+        unitId: UNIT_ID_A,
+        family: 'work',
+        requiredOperations: ['implementation'],
+        resourceScopes: [],
+        transitionDigest: transitionDigest('unit-start'),
+        timestamp: 2,
+      })
+
+      // Create a receipt
+      ledgerA.prepareObservation({
+        callId: 'impl-call',
+        operation: 'implementation',
+        context: {
+          epochId: EPOCH_ID_A,
+          unitId: UNIT_ID_A,
+          workspaceIdentity: 'workspace-a',
+          worktreeIdentity: 'worktree-before',
+        },
+      })
+      const finalized = ledgerA.finalizeObservation({
+        callId: 'impl-call',
+        context: {
+          epochId: EPOCH_ID_A,
+          unitId: UNIT_ID_A,
+          workspaceIdentity: 'workspace-a',
+          worktreeIdentity: 'worktree-before',
+        },
+        after: {
+          workspaceIdentity: 'workspace-a',
+          worktreeIdentity: 'worktree-after',
+        },
+        classification: {
+          outcome: 'accepted',
+          category: 'implementation',
+          attribution: 'runtime-verified',
+          result: 'success',
+          sideEffect: 'required',
+          reasonCode: 'recognized-command',
+        },
+        terminal: { status: 'success', output: 'non-empty', noOp: false },
+      })
+      if (finalized.status !== 'finalized') throw new Error('finalize failed')
+      const mint = projectReceiptMintMarker(finalized.receipt, sessionSalt)
+      if (!mint || !epochStart || !unitStart)
+        throw new Error('marker projection failed')
+      return [epochStart, unitStart, mint]
+    }
+
+    test('RED: recovery with mixed-registration markers previously returned unavailable (bug reproduction)', async () => {
+      // Registration A: our "known" registration (matching what the guard uses)
+      const ownIdentity = 'own-registration-identity'
+      const ownSalt = new Uint8Array(32).fill(42)
+
+      // Registration B: a foreign/second registration in the same session
+      const foreignIdentity = 'foreign-registration-identity'
+      const foreignSalt = new Uint8Array(32).fill(99)
+
+      // Build markers from both registrations — this is what the shared metadata array contains
+      const ownMarkers = buildMarkersForRegistration(ownIdentity, ownSalt)
+      const foreignMarkers = buildMarkersForRegistration(
+        foreignIdentity,
+        foreignSalt,
+      )
+
+      // Combined marker array (shared metadata.systematic_workflow_receipt from both registrations)
+      const combinedMarkers = [...ownMarkers, ...foreignMarkers]
+
+      // Build a parts array that simulates what OpenCode persists
+      const parts = [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: combinedMarkers,
+                },
+              },
+            },
+          ],
+        },
+      ]
+
+      const restored = createOpencodeWorkflowGuard({
+        config: { mode: 'protected', debug: false },
+        workspaceIdentity: 'workspace-a',
+        registrationIdentity: ownIdentity,
+        sessionSalt: ownSalt,
+        hostReadback: {
+          readSessionParts: async () => parts,
+          listChildren: async () => [],
+        },
+      })
+
+      await restored.tools.systematic_workflow_status.execute(
+        {},
+        { sessionID: SESSION_A, metadata: () => {} },
+      )
+
+      // BEFORE FIX: guard would be 'unavailable' due to conflicting-seed
+      // AFTER FIX: guard should have recovered its own markers (epoch/unit not null)
+      const s = restored.status(SESSION_A)
+      expect(s.state).not.toBe('unavailable')
+      expect(s.epoch).not.toBeNull()
+    })
+
+    test('foreign-only marker array → fresh start, not unavailable', async () => {
+      const ownIdentity = 'my-registration'
+      const ownSalt = new Uint8Array(32).fill(11)
+
+      const foreignIdentity = 'foreign-only-registration'
+      const foreignSalt = new Uint8Array(32).fill(88)
+
+      const foreignMarkers = buildMarkersForRegistration(
+        foreignIdentity,
+        foreignSalt,
+      )
+
+      const parts = [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: foreignMarkers,
+                },
+              },
+            },
+          ],
+        },
+      ]
+
+      const restored = createOpencodeWorkflowGuard({
+        config: { mode: 'protected', debug: false },
+        workspaceIdentity: 'workspace-a',
+        registrationIdentity: ownIdentity,
+        sessionSalt: ownSalt,
+        hostReadback: {
+          readSessionParts: async () => parts,
+          listChildren: async () => [],
+        },
+      })
+
+      // Trigger initialize (simulated by observing a skill to force status evaluation)
+      const skillOutput = { title: 'loaded', output: 'ok', metadata: {} }
+      await restored.hooks['tool.execute.before'](
+        {
+          tool: 'systematic_skill',
+          sessionID: SESSION_A,
+          callID: 'skill-foreign-only',
+        },
+        { args: { name: 'ce:work' } },
+      )
+      await restored.hooks['tool.execute.after'](
+        {
+          tool: 'systematic_skill',
+          sessionID: SESSION_A,
+          callID: 'skill-foreign-only',
+          args: { name: 'ce:work' },
+        },
+        skillOutput,
+      )
+
+      // Should have recovered fresh (not unavailable), so skill can activate epoch
+      const s = restored.status(SESSION_A)
+      // After fresh start + skill, epoch should be active
+      expect(s.state).not.toBe('unavailable')
+    })
+
+    test('single-registration array is unchanged by filter (regression guard)', async () => {
+      // The existing 'recovers persisted receipt markers once and restores the workflow state'
+      // test covers this, but we add an explicit filter regression test here.
+      const ownIdentity = 'single-reg-identity'
+      const ownSalt = new Uint8Array(32).fill(33)
+      const ownMarkers = buildMarkersForRegistration(ownIdentity, ownSalt)
+
+      const parts = [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: ownMarkers,
+                },
+              },
+            },
+          ],
+        },
+      ]
+
+      const restored = createOpencodeWorkflowGuard({
+        config: { mode: 'protected', debug: false },
+        workspaceIdentity: 'workspace-a',
+        registrationIdentity: ownIdentity,
+        sessionSalt: ownSalt,
+        hostReadback: {
+          readSessionParts: async () => parts,
+          listChildren: async () => [],
+        },
+      })
+
+      await restored.tools.systematic_workflow_status.execute(
+        {},
+        { sessionID: SESSION_A, metadata: () => {} },
+      )
+
+      const s = restored.status(SESSION_A)
+      // Single-registration: should recover successfully (not unavailable)
+      expect(s.state).not.toBe('unavailable')
+      expect(s.epoch).not.toBeNull()
+    })
+
+    test('genuinely corrupt marker for own registration still fails closed', async () => {
+      const ownIdentity = 'corrupt-test-registration'
+      const ownSalt = new Uint8Array(32).fill(77)
+      const ownMarkers = buildMarkersForRegistration(ownIdentity, ownSalt)
+
+      // Corrupt first marker (integrity mismatch)
+      const corruptedMarker = {
+        ...(ownMarkers[0] as Record<string, unknown>),
+        integrity: 'a'.repeat(64),
+      }
+
+      const parts = [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: [
+                    corruptedMarker,
+                    ...ownMarkers.slice(1),
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ]
+
+      const restored = createOpencodeWorkflowGuard({
+        config: { mode: 'protected', debug: false },
+        workspaceIdentity: 'workspace-a',
+        registrationIdentity: ownIdentity,
+        sessionSalt: ownSalt,
+        hostReadback: {
+          readSessionParts: async () => parts,
+          listChildren: async () => [],
+        },
+      })
+
+      await restored.tools.systematic_workflow_status.execute(
+        {},
+        { sessionID: SESSION_A, metadata: () => {} },
+      )
+
+      const s = restored.status(SESSION_A)
+      // Genuine corruption → still fails closed → unavailable
+      expect(s.state).toBe('unavailable')
+    })
+
+    test('empty array after filter → fresh start, not guard-unavailable', async () => {
+      // This is effectively the foreign-only case: after filtering there are no own markers.
+      // The guard should treat this as a fresh start (allowFresh path in initializeSession),
+      // NOT as guard-unavailable. A fresh guard without an active epoch has state
+      // 'unavailable' with reasonCode 'no-active-epoch' — distinct from 'guard-unavailable'.
+      const ownIdentity = 'empty-after-filter-reg'
+      const ownSalt = new Uint8Array(32).fill(55)
+      const foreignIdentity = 'unrelated-foreign-reg'
+      const foreignSalt = new Uint8Array(32).fill(66)
+
+      const foreignMarkers = buildMarkersForRegistration(
+        foreignIdentity,
+        foreignSalt,
+      )
+
+      const parts = [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: foreignMarkers,
+                },
+              },
+            },
+          ],
+        },
+      ]
+
+      const restored = createOpencodeWorkflowGuard({
+        config: { mode: 'protected', debug: false },
+        workspaceIdentity: 'workspace-a',
+        registrationIdentity: ownIdentity,
+        sessionSalt: ownSalt,
+        hostReadback: {
+          readSessionParts: async () => parts,
+          listChildren: async () => [],
+        },
+      })
+
+      await restored.tools.systematic_workflow_status.execute(
+        {},
+        { sessionID: SESSION_A, metadata: () => {} },
+      )
+
+      // A fresh guard (no epoch activated yet) has state 'unavailable' / 'no-active-epoch'.
+      // The key invariant: it must NOT be 'guard-unavailable' (which publishUnavailable sets).
+      const s = restored.status(SESSION_A)
+      expect(s.reasonCode).not.toBe('guard-unavailable')
+      expect(s.reasonCode).toBe('no-active-epoch')
+    })
+
+    // ── Ambiguity fail-closed tests (Oracle-identified defect) ──────────────────
+    //
+    // These are RED before the fix: ambiguous markers currently collapse to the
+    // foreign-empty path (publishFresh → no-active-epoch) instead of failing closed
+    // (publishUnavailable → guard-unavailable).
+    //
+    // Distinguisher: publishUnavailable produces 'guard-unavailable';
+    //                publishFresh produces 'no-active-epoch'. Both have epoch=null.
+
+    // Helper: wrap markers in the parts structure used by readSessionParts
+    function wrapMarkers(markers: unknown[]): readonly unknown[] {
+      return [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: markers,
+                },
+              },
+            },
+          ],
+        },
+      ]
+    }
+
+    // Helper: build an own guard-capable ledger for the ambiguity tests
+    function buildOwnLedger(
+      registrationIdentity: string,
+      sessionSalt: Uint8Array,
+    ) {
+      return createReceiptLedger({
+        capabilityFlags: ['workflow-guard'],
+        registrationIdentity,
+        sessionSalt,
+      })
+    }
+
+    test('RED main: all own seed-bearing markers corrupted → fail-closed guard-unavailable, not fresh', async () => {
+      // Scenario: all own mint/progression markers have corrupted integrity.
+      // resolveOwnRegistrationDigest can't find a valid own seed (validation fails
+      // for every candidate). The corrupted marker is ambiguous (could be ours) →
+      // must publishUnavailable(), NOT publishFresh().
+      const ownIdentity = 'ambig-all-corrupted'
+      const ownSalt = new Uint8Array(32).fill(11)
+      const ledger = buildOwnLedger(ownIdentity, ownSalt)
+      const EPOCH_ID = 'a'.repeat(32)
+
+      const validMarker = projectReceiptProgressionMarker(ledger, {
+        target: 'epoch',
+        state: 'started',
+        epochId: EPOCH_ID,
+        family: 'work',
+        transitionDigest: ledger.digestIdentity('call', 'ep'),
+        timestamp: 1,
+      })
+      if (!validMarker) throw new Error('marker projection failed')
+      // Corrupt the integrity so validateReceiptMarker → integrity-mismatch → rejected
+      const corruptedMarker = { ...validMarker, integrity: 'f'.repeat(64) }
+
+      const adapter = createOpencodeWorkflowGuard({
+        config: { mode: 'protected', debug: false },
+        workspaceIdentity: 'workspace',
+        registrationIdentity: ownIdentity,
+        sessionSalt: ownSalt,
+        hostReadback: {
+          readSessionParts: async () => wrapMarkers([corruptedMarker]),
+          listChildren: async () => [],
+        },
+      })
+
+      await adapter.tools.systematic_workflow_status.execute(
+        {},
+        { sessionID: SESSION_A, metadata: () => {} },
+      )
+
+      const s = adapter.status(SESSION_A)
+      // BEFORE FIX: 'no-active-epoch' (wrong — publishFresh was called).
+      // AFTER FIX:  'guard-unavailable' (correct — publishUnavailable was called).
+      expect(s.reasonCode).toBe('guard-unavailable')
+      expect(s.epoch).toBeNull() // fresh guard, no epoch started
+    })
+
+    test('RED main: consume-only markers (no salt/seed) → fail-closed guard-unavailable, not fresh', async () => {
+      // Scenario: parts contain only a valid consume marker carrying the own
+      // registrationDigest but no sessionSalt. candidateSeedFromMarker returns
+      // undefined for consume markers (no sessionSalt field on consume). We cannot
+      // verify ownership without a salt → ambiguous → must fail closed.
+      const ownIdentity = 'ambig-consume-only'
+      const ownSalt = new Uint8Array(32).fill(22)
+      const ownLedger = buildOwnLedger(ownIdentity, ownSalt)
+      const EPOCH_ID = 'a'.repeat(32)
+      const UNIT_ID = 'b'.repeat(32)
+
+      // Build an own receipt via prepare+finalize, then project ONLY the consume marker
+      ownLedger.prepareObservation({
+        callId: 'impl',
+        operation: 'implementation',
+        context: {
+          epochId: EPOCH_ID,
+          unitId: UNIT_ID,
+          workspaceIdentity: 'ws',
+          worktreeIdentity: 'before',
+        },
+      })
+      const finalized = ownLedger.finalizeObservation({
+        callId: 'impl',
+        context: {
+          epochId: EPOCH_ID,
+          unitId: UNIT_ID,
+          workspaceIdentity: 'ws',
+          worktreeIdentity: 'before',
+        },
+        after: { workspaceIdentity: 'ws', worktreeIdentity: 'after' },
+        classification: {
+          outcome: 'accepted',
+          category: 'implementation',
+          attribution: 'runtime-verified',
+          result: 'success',
+          sideEffect: 'required',
+          reasonCode: 'recognized-command',
+        },
+        terminal: { status: 'success', output: 'non-empty', noOp: false },
+      })
+      if (finalized.status !== 'finalized') throw new Error('finalize failed')
+
+      const consumeMarker = projectReceiptConsumptionMarker(
+        finalized.receipt,
+        ownLedger.digestIdentity('call', 'transition'),
+        Date.now(),
+      )
+      if (!consumeMarker) throw new Error('consume marker projection failed')
+
+      // Parts contain ONLY the consume marker: no mint/progression seed markers
+      const adapter = createOpencodeWorkflowGuard({
+        config: { mode: 'protected', debug: false },
+        workspaceIdentity: 'workspace',
+        registrationIdentity: ownIdentity,
+        sessionSalt: ownSalt,
+        hostReadback: {
+          readSessionParts: async () => wrapMarkers([consumeMarker]),
+          listChildren: async () => [],
+        },
+      })
+
+      await adapter.tools.systematic_workflow_status.execute(
+        {},
+        { sessionID: SESSION_A, metadata: () => {} },
+      )
+
+      const s = adapter.status(SESSION_A)
+      // BEFORE FIX: 'no-active-epoch' (wrong — consume is seedless, treated as empty).
+      // AFTER FIX:  'guard-unavailable' (correct — consume is ambiguous → fail closed).
+      expect(s.reasonCode).toBe('guard-unavailable')
+      expect(s.epoch).toBeNull()
+    })
+
+    test('RED main: valid foreign markers + malformed marker → fail-closed, not fresh', async () => {
+      // Scenario: valid provably-foreign seed-bearing markers PLUS one malformed
+      // marker (own markers removed, unknown corruption). The malformed marker is
+      // ambiguous (could be a corrupted own marker) → must fail closed.
+      const ownIdentity = 'ambig-foreign-plus-malformed'
+      const ownSalt = new Uint8Array(32).fill(33)
+      const foreignIdentity = 'provably-foreign-reg'
+      const foreignSalt = new Uint8Array(32).fill(44)
+
+      // Valid provably-foreign markers (buildMarkersForRegistration uses the SAME helper
+      // defined in the dual-registration restart recovery describe block above)
+      const foreignMarkers = buildMarkersForRegistration(
+        foreignIdentity,
+        foreignSalt,
+      )
+      // Malformed: not a valid marker shape → validateReceiptMarker → unknown-kind
+      const malformedMarker = { kind: 'corrupt-unknown', data: 'x' }
+
+      const adapter = createOpencodeWorkflowGuard({
+        config: { mode: 'protected', debug: false },
+        workspaceIdentity: 'workspace',
+        registrationIdentity: ownIdentity,
+        sessionSalt: ownSalt,
+        hostReadback: {
+          readSessionParts: async () =>
+            wrapMarkers([...foreignMarkers, malformedMarker]),
+          listChildren: async () => [],
+        },
+      })
+
+      await adapter.tools.systematic_workflow_status.execute(
+        {},
+        { sessionID: SESSION_A, metadata: () => {} },
+      )
+
+      const s = adapter.status(SESSION_A)
+      // BEFORE FIX: 'no-active-epoch' (wrong — malformed marker silently ignored).
+      // AFTER FIX:  'guard-unavailable' (correct — malformed is ambiguous → fail closed).
+      expect(s.reasonCode).toBe('guard-unavailable')
+      expect(s.epoch).toBeNull()
+    })
+
+    test('regression guard main: all provably-foreign valid markers → fresh start, NOT fail-closed', async () => {
+      // This must pass BOTH before and after the fix. Genuinely foreign-only markers
+      // (valid, salt-bearing, none agree with own identity) → foreign-empty → publishFresh.
+      // Verifies the true-foreign case is never regressed to fail-closed.
+      const ownIdentity = 'provably-foreign-only'
+      const ownSalt = new Uint8Array(32).fill(55)
+      const foreignIdentity = 'all-foreign-reg'
+      const foreignSalt = new Uint8Array(32).fill(66)
+
+      const foreignMarkers = buildMarkersForRegistration(
+        foreignIdentity,
+        foreignSalt,
+      )
+
+      const adapter = createOpencodeWorkflowGuard({
+        config: { mode: 'protected', debug: false },
+        workspaceIdentity: 'workspace',
+        registrationIdentity: ownIdentity,
+        sessionSalt: ownSalt,
+        hostReadback: {
+          readSessionParts: async () => wrapMarkers(foreignMarkers),
+          listChildren: async () => [],
+        },
+      })
+
+      await adapter.tools.systematic_workflow_status.execute(
+        {},
+        { sessionID: SESSION_A, metadata: () => {} },
+      )
+
+      const s = adapter.status(SESSION_A)
+      // Foreign-only → publishFresh → no-active-epoch (NOT guard-unavailable).
+      expect(s.reasonCode).toBe('no-active-epoch')
+      expect(s.epoch).toBeNull()
+    })
+  })
+
+  describe('dual-registration rollupForegroundTask recovery (fix/workflow-guard-dual-registration-recovery)', () => {
+    // Re-usable: build a mint marker array for a guard-capable ledger.
+    // These are the markers that appear in a child session's parts when that
+    // child session ran under a given registration.
+    function buildChildMarkers(
+      registrationIdentity: string,
+      sessionSalt: Uint8Array,
+      workspaceIdentity: string,
+      repositoryIdentity: string,
+      worktreeBeforeIdentity: string,
+      worktreeAfterIdentity: string,
+    ): unknown[] {
+      const childLedger = createReceiptLedger({
+        capabilityFlags: ['workflow-guard'],
+        registrationIdentity,
+        sessionSalt,
+      })
+      const EPOCH_ID = 'c'.repeat(32)
+      const UNIT_ID = 'd'.repeat(32)
+      const td = (tag: string) => childLedger.digestIdentity('call', tag)
+
+      const epochStart = projectReceiptProgressionMarker(childLedger, {
+        target: 'epoch',
+        state: 'started',
+        epochId: EPOCH_ID,
+        family: 'work',
+        transitionDigest: td('epoch-start'),
+        timestamp: 10,
+      })
+      const unitStart = projectReceiptProgressionMarker(childLedger, {
+        target: 'unit',
+        state: 'started',
+        epochId: EPOCH_ID,
+        unitId: UNIT_ID,
+        family: 'work',
+        requiredOperations: ['implementation'],
+        resourceScopes: [],
+        transitionDigest: td('unit-start'),
+        timestamp: 11,
+      })
+
+      childLedger.prepareObservation({
+        callId: 'child-impl',
+        operation: 'implementation',
+        context: {
+          epochId: EPOCH_ID,
+          unitId: UNIT_ID,
+          workspaceIdentity,
+          repositoryIdentity,
+          worktreeIdentity: worktreeBeforeIdentity,
+        },
+      })
+      const finalized = childLedger.finalizeObservation({
+        callId: 'child-impl',
+        context: {
+          epochId: EPOCH_ID,
+          unitId: UNIT_ID,
+          workspaceIdentity,
+          repositoryIdentity,
+          worktreeIdentity: worktreeBeforeIdentity,
+        },
+        after: {
+          workspaceIdentity,
+          repositoryIdentity,
+          worktreeIdentity: worktreeAfterIdentity,
+        },
+        classification: {
+          outcome: 'accepted',
+          category: 'implementation',
+          attribution: 'runtime-verified',
+          result: 'success',
+          sideEffect: 'required',
+          reasonCode: 'recognized-command',
+        },
+        terminal: { status: 'success', output: 'non-empty', noOp: false },
+      })
+      if (finalized.status !== 'finalized')
+        throw new Error('child finalize failed')
+      const mint = projectReceiptMintMarker(finalized.receipt, sessionSalt)
+      if (!mint || !epochStart || !unitStart)
+        throw new Error('child marker projection failed')
+      return [epochStart, unitStart, mint]
+    }
+
+    // Helper: fire the task after hook with a given child session's parts
+    async function fireTaskAfter(
+      adapter: OpencodeWorkflowGuard,
+      childSessionID: string,
+      sessionID = SESSION_A,
+    ): Promise<void> {
+      await adapter.hooks['tool.execute.after'](
+        {
+          tool: 'task',
+          sessionID,
+          callID: 'task-call-1',
+          args: {},
+        },
+        {
+          title: 'task result',
+          output: 'done',
+          metadata: { sessionId: childSessionID },
+        },
+      )
+    }
+
+    test('RED: mixed-registration child markers must not mark parent unavailable (rollup bug reproduction)', async () => {
+      // Setup: own registration
+      const ownIdentity = 'rollup-own-registration'
+      const ownSalt = new Uint8Array(32).fill(13)
+      const foreignIdentity = 'rollup-foreign-registration'
+      const foreignSalt = new Uint8Array(32).fill(14)
+      const childSessionID = 'child-session-mixed'
+      const parentSessionID = SESSION_A
+
+      const ownChildMarkers = buildChildMarkers(
+        ownIdentity,
+        ownSalt,
+        OPERATION_SCOPE.workspaceIdentity,
+        OPERATION_SCOPE.repositoryIdentity,
+        'worktree-before',
+        OPERATION_SCOPE.worktreeIdentity,
+      )
+      const foreignChildMarkers = buildChildMarkers(
+        foreignIdentity,
+        foreignSalt,
+        OPERATION_SCOPE.workspaceIdentity,
+        OPERATION_SCOPE.repositoryIdentity,
+        'worktree-before',
+        OPERATION_SCOPE.worktreeIdentity,
+      )
+      // Combined: both registrations' markers in the same child session parts
+      const combinedMarkers = [...ownChildMarkers, ...foreignChildMarkers]
+      const childParts = [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: combinedMarkers,
+                },
+              },
+            },
+          ],
+        },
+      ]
+
+      // Track whether observer.snapshot() was called during rollup.
+      // BEFORE FIX: conflicting-seed → markUnavailable() BEFORE snapshot call → snapshotCalled stays false.
+      // AFTER FIX: own markers filtered → seed extracted → snapshot IS called.
+      let snapshotCalled = false
+      const ownAdapter = createOpencodeWorkflowGuard({
+        config: { mode: 'observe', debug: false },
+        ...OPERATION_SCOPE,
+        registrationIdentity: ownIdentity,
+        sessionSalt: ownSalt,
+        observer: {
+          targetDigest: OPERATION_SCOPE.workspaceIdentity,
+          async snapshot() {
+            snapshotCalled = true
+            return {
+              status: 'available' as const,
+              snapshot: operationSnapshot(),
+            }
+          },
+          async remoteSnapshot() {
+            return {
+              status: 'unavailable' as const,
+              reasonCode: 'remote-missing-field' as const,
+            }
+          },
+        },
+        hostReadback: {
+          readSessionParts: async (sid) => {
+            if (sid === parentSessionID) return []
+            return childParts
+          },
+          listChildren: async (sid) =>
+            sid === parentSessionID
+              ? [{ sessionId: childSessionID, parentID: parentSessionID }]
+              : [],
+        },
+      })
+
+      // Activate epoch via skill
+      await observeSkill(
+        ownAdapter,
+        'systematic_skill',
+        'ce:work',
+        'rollup-skill',
+        parentSessionID,
+      )
+
+      // Confirm epoch is active before rollup
+      expect(ownAdapter.status(parentSessionID).epoch).not.toBeNull()
+
+      // Fire task after hook → triggers rollupForegroundTask
+      // BEFORE FIX: extractReceiptReadbackSeed sees two differing seeds → conflicting-seed → markUnavailable
+      //   before snapshot is ever called → snapshotCalled stays false.
+      // AFTER FIX: foreign markers filtered out → own markers only → seed ready → snapshot called.
+      await fireTaskAfter(ownAdapter, childSessionID, parentSessionID)
+
+      // Key assertion: snapshot must have been called, proving rollup got past the conflicting-seed gate.
+      // Before the fix, markUnavailable() fires at the seed check, BEFORE the observer snapshot call.
+      expect(snapshotCalled).toBe(true)
+    })
+
+    test('foreign-only child markers → benign no-op, session not marked unavailable', async () => {
+      const ownIdentity = 'rollup-own-foreign-only'
+      const ownSalt = new Uint8Array(32).fill(21)
+      const foreignIdentity = 'rollup-foreign-only'
+      const foreignSalt = new Uint8Array(32).fill(22)
+      const childSessionID = 'child-session-foreign-only'
+      const parentSessionID = SESSION_A
+
+      const foreignChildMarkers = buildChildMarkers(
+        foreignIdentity,
+        foreignSalt,
+        OPERATION_SCOPE.workspaceIdentity,
+        OPERATION_SCOPE.repositoryIdentity,
+        'worktree-before',
+        OPERATION_SCOPE.worktreeIdentity,
+      )
+      const childParts = [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]:
+                    foreignChildMarkers,
+                },
+              },
+            },
+          ],
+        },
+      ]
+
+      const ownAdapter = createOpencodeWorkflowGuard({
+        config: { mode: 'observe', debug: false },
+        ...OPERATION_SCOPE,
+        registrationIdentity: ownIdentity,
+        sessionSalt: ownSalt,
+        observer: sequenceObserver([operationSnapshot(), operationSnapshot()]),
+        hostReadback: {
+          readSessionParts: async (sid) => {
+            if (sid === parentSessionID) return []
+            return childParts
+          },
+          listChildren: async (sid) =>
+            sid === parentSessionID
+              ? [{ sessionId: childSessionID, parentID: parentSessionID }]
+              : [],
+        },
+      })
+
+      await observeSkill(
+        ownAdapter,
+        'systematic_skill',
+        'ce:work',
+        'foreign-only-skill',
+        parentSessionID,
+      )
+      const beforeState = ownAdapter.status(parentSessionID).reasonCode
+
+      // All child markers are foreign → benign no-op after filtering
+      await fireTaskAfter(ownAdapter, childSessionID, parentSessionID)
+
+      const s = ownAdapter.status(parentSessionID)
+      expect(s.reasonCode).not.toBe('guard-unavailable')
+      // State should be unchanged (epoch still active, not marked unavailable)
+      expect(s.reasonCode).toBe(beforeState)
+    })
+
+    test('genuine corruption in own child markers still fails closed (markUnavailable)', async () => {
+      const ownIdentity = 'rollup-corrupt-test'
+      const ownSalt = new Uint8Array(32).fill(33)
+      const childSessionID = 'child-session-corrupt'
+      const parentSessionID = SESSION_A
+
+      const ownChildMarkers = buildChildMarkers(
+        ownIdentity,
+        ownSalt,
+        OPERATION_SCOPE.workspaceIdentity,
+        OPERATION_SCOPE.repositoryIdentity,
+        'worktree-before',
+        OPERATION_SCOPE.worktreeIdentity,
+      )
+      // Corrupt the first marker's integrity
+      const corruptedMarker = {
+        ...(ownChildMarkers[0] as Record<string, unknown>),
+        integrity: 'b'.repeat(64),
+      }
+      const corruptedMarkers = [corruptedMarker, ...ownChildMarkers.slice(1)]
+
+      const childParts = [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: corruptedMarkers,
+                },
+              },
+            },
+          ],
+        },
+      ]
+
+      const ownAdapter = createOpencodeWorkflowGuard({
+        config: { mode: 'observe', debug: false },
+        ...OPERATION_SCOPE,
+        registrationIdentity: ownIdentity,
+        sessionSalt: ownSalt,
+        observer: sequenceObserver([operationSnapshot(), operationSnapshot()]),
+        hostReadback: {
+          readSessionParts: async (sid) => {
+            if (sid === parentSessionID) return []
+            return childParts
+          },
+          listChildren: async (sid) =>
+            sid === parentSessionID
+              ? [{ sessionId: childSessionID, parentID: parentSessionID }]
+              : [],
+        },
+      })
+
+      await observeSkill(
+        ownAdapter,
+        'systematic_skill',
+        'ce:work',
+        'corrupt-skill',
+        parentSessionID,
+      )
+      expect(ownAdapter.status(parentSessionID).state).not.toBe('unavailable')
+
+      // Corrupt own marker → filter retains it → extractReceiptReadbackSeed fails on integrity → markUnavailable
+      await fireTaskAfter(ownAdapter, childSessionID, parentSessionID)
+
+      // Must still fail closed
+      expect(ownAdapter.status(parentSessionID).reasonCode).toBe(
+        'guard-unavailable',
+      )
+    })
+
+    test('own-only child markers → regression guard (seed extraction and observer reach identical to before fix)', async () => {
+      // Verify that when only own markers are present, the rollup path reaches
+      // observer.snapshot() — which is the same behavior as before the fix
+      // (filter is a no-op, seed is found cleanly, flow continues normally).
+      const ownIdentity = 'rollup-own-only'
+      const ownSalt = new Uint8Array(32).fill(44)
+      const childSessionID = 'child-session-own-only'
+      const parentSessionID = SESSION_A
+
+      const ownChildMarkers = buildChildMarkers(
+        ownIdentity,
+        ownSalt,
+        OPERATION_SCOPE.workspaceIdentity,
+        OPERATION_SCOPE.repositoryIdentity,
+        'worktree-before',
+        OPERATION_SCOPE.worktreeIdentity,
+      )
+      const childParts = [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: ownChildMarkers,
+                },
+              },
+            },
+          ],
+        },
+      ]
+
+      let snapshotCalled = false
+      const ownAdapter = createOpencodeWorkflowGuard({
+        config: { mode: 'observe', debug: false },
+        ...OPERATION_SCOPE,
+        registrationIdentity: ownIdentity,
+        sessionSalt: ownSalt,
+        observer: {
+          targetDigest: OPERATION_SCOPE.workspaceIdentity,
+          async snapshot() {
+            snapshotCalled = true
+            return {
+              status: 'available' as const,
+              snapshot: operationSnapshot(),
+            }
+          },
+          async remoteSnapshot() {
+            return {
+              status: 'unavailable' as const,
+              reasonCode: 'remote-missing-field' as const,
+            }
+          },
+        },
+        hostReadback: {
+          readSessionParts: async (sid) => {
+            if (sid === parentSessionID) return []
+            return childParts
+          },
+          listChildren: async (sid) =>
+            sid === parentSessionID
+              ? [{ sessionId: childSessionID, parentID: parentSessionID }]
+              : [],
+        },
+      })
+
+      await observeSkill(
+        ownAdapter,
+        'systematic_skill',
+        'ce:work',
+        'own-only-skill',
+        parentSessionID,
+      )
+      expect(ownAdapter.status(parentSessionID).epoch).not.toBeNull()
+
+      // Own-only: filter is a no-op → same behavior as before fix → reaches observer snapshot
+      await fireTaskAfter(ownAdapter, childSessionID, parentSessionID)
+
+      // Regression guard: seed extraction succeeds, rollup reaches the observer snapshot call.
+      // This proves the single-registration path is unaffected by the filter change.
+      expect(snapshotCalled).toBe(true)
+    })
+
+    // ── Rollup ambiguity fail-closed tests (Oracle-identified defect) ─────────
+    //
+    // Signal: snapshotCalled === false means markUnavailable() fired BEFORE the
+    // observer snapshot call (mode-level unavailable). If snapshot was called but
+    // reasonCode is still guard-unavailable, it came from a unit-level issue (no
+    // classifier), not from our new ambiguity guard.
+    //
+    // Assertion pattern for ambiguous rollup:
+    //   snapshotCalled === false  (rollup bailed before observer)
+    //   AND reasonCode === 'guard-unavailable' (mode-level, from markUnavailable)
+    //
+    // Assertion pattern for benign foreign-only rollup:
+    //   snapshotCalled === false  (early return before observer)
+    //   AND reasonCode !== 'guard-unavailable' (epoch still active as before)
+
+    function buildCorruptedChildParts(
+      registrationIdentity: string,
+      sessionSalt: Uint8Array,
+    ): readonly unknown[] {
+      const ledger = createReceiptLedger({
+        capabilityFlags: ['workflow-guard'],
+        registrationIdentity,
+        sessionSalt,
+      })
+      const EPOCH_ID = 'e'.repeat(32)
+      const validMarker = projectReceiptProgressionMarker(ledger, {
+        target: 'epoch',
+        state: 'started',
+        epochId: EPOCH_ID,
+        family: 'work',
+        transitionDigest: ledger.digestIdentity('call', 'ep'),
+        timestamp: 1,
+      })
+      if (!validMarker) throw new Error('marker projection failed')
+      const corruptedMarker = { ...validMarker, integrity: 'e'.repeat(64) }
+      return [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: [corruptedMarker],
+                },
+              },
+            },
+          ],
+        },
+      ]
+    }
+
+    function buildConsumeOnlyChildParts(
+      registrationIdentity: string,
+      sessionSalt: Uint8Array,
+    ): readonly unknown[] {
+      const ownLedger = createReceiptLedger({
+        capabilityFlags: ['workflow-guard'],
+        registrationIdentity,
+        sessionSalt,
+      })
+      const EPOCH_ID = 'f'.repeat(32)
+      const UNIT_ID = '0'.repeat(32)
+      ownLedger.prepareObservation({
+        callId: 'ci',
+        operation: 'implementation',
+        context: {
+          epochId: EPOCH_ID,
+          unitId: UNIT_ID,
+          workspaceIdentity: 'ws',
+          worktreeIdentity: 'b',
+        },
+      })
+      const finalized = ownLedger.finalizeObservation({
+        callId: 'ci',
+        context: {
+          epochId: EPOCH_ID,
+          unitId: UNIT_ID,
+          workspaceIdentity: 'ws',
+          worktreeIdentity: 'b',
+        },
+        after: { workspaceIdentity: 'ws', worktreeIdentity: 'a' },
+        classification: {
+          outcome: 'accepted',
+          category: 'implementation',
+          attribution: 'runtime-verified',
+          result: 'success',
+          sideEffect: 'required',
+          reasonCode: 'recognized-command',
+        },
+        terminal: { status: 'success', output: 'non-empty', noOp: false },
+      })
+      if (finalized.status !== 'finalized')
+        throw new Error('child finalize failed')
+      const consumeMarker = projectReceiptConsumptionMarker(
+        finalized.receipt,
+        ownLedger.digestIdentity('call', 'tr'),
+        1,
+      )
+      if (!consumeMarker) throw new Error('consume marker projection failed')
+      return [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: [consumeMarker],
+                },
+              },
+            },
+          ],
+        },
+      ]
+    }
+
+    function makeRollupAdapter(
+      ownIdentity: string,
+      ownSalt: Uint8Array,
+      snapshotRef: { called: boolean },
+      childSessionID: string,
+      childPartsFactory: () => readonly unknown[],
+      parentSessionID: string,
+    ): OpencodeWorkflowGuard {
+      return createOpencodeWorkflowGuard({
+        config: { mode: 'observe', debug: false },
+        ...OPERATION_SCOPE,
+        registrationIdentity: ownIdentity,
+        sessionSalt: ownSalt,
+        observer: {
+          targetDigest: OPERATION_SCOPE.workspaceIdentity,
+          async snapshot() {
+            snapshotRef.called = true
+            return {
+              status: 'available' as const,
+              snapshot: operationSnapshot(),
+            }
+          },
+          async remoteSnapshot() {
+            return {
+              status: 'unavailable' as const,
+              reasonCode: 'remote-missing-field' as const,
+            }
+          },
+        },
+        hostReadback: {
+          readSessionParts: async (sid) => {
+            if (sid === parentSessionID) return []
+            return childPartsFactory()
+          },
+          listChildren: async (sid) =>
+            sid === parentSessionID
+              ? [{ sessionId: childSessionID, parentID: parentSessionID }]
+              : [],
+        },
+      })
+    }
+
+    test('RED rollup: all own child seed markers corrupted → markUnavailable before snapshot', async () => {
+      // BEFORE FIX: corrupted marker → ownMarkersFromParts returns [] → benign return.
+      //   snapshotCalled stays false AND reasonCode stays 'missing-evidence' (active epoch).
+      // AFTER FIX:  corrupted marker → ambiguous → markUnavailable() before snapshot.
+      //   snapshotCalled stays false AND reasonCode becomes 'guard-unavailable'.
+      const ownIdentity = 'rollup-corrupt-seed'
+      const ownSalt = new Uint8Array(32).fill(77)
+      const childSessionID = 'child-corrupt-seed'
+      const parentSessionID = SESSION_A
+
+      const snapshotRef = { called: false }
+      const ownAdapter = makeRollupAdapter(
+        ownIdentity,
+        ownSalt,
+        snapshotRef,
+        childSessionID,
+        () => buildCorruptedChildParts(ownIdentity, ownSalt),
+        parentSessionID,
+      )
+
+      await observeSkill(
+        ownAdapter,
+        'systematic_skill',
+        'ce:work',
+        'corrupt-seed-skill',
+        parentSessionID,
+      )
+      expect(ownAdapter.status(parentSessionID).epoch).not.toBeNull()
+
+      await fireTaskAfter(ownAdapter, childSessionID, parentSessionID)
+
+      // BEFORE FIX: snapshotRef.called === false (early return) but reasonCode ≠ 'guard-unavailable'
+      // AFTER FIX:  snapshotRef.called === false (markUnavailable fires) + reasonCode = 'guard-unavailable'
+      expect(snapshotRef.called).toBe(false)
+      expect(ownAdapter.status(parentSessionID).reasonCode).toBe(
+        'guard-unavailable',
+      )
+    })
+
+    test('RED rollup: consume-only child markers (no salt) → markUnavailable before snapshot', async () => {
+      // BEFORE FIX: consume-only → ownMarkersFromParts returns [] → benign return.
+      // AFTER FIX:  consume-only → ambiguous → markUnavailable().
+      const ownIdentity = 'rollup-consume-only'
+      const ownSalt = new Uint8Array(32).fill(88)
+      const childSessionID = 'child-consume-only'
+      const parentSessionID = SESSION_A
+
+      const snapshotRef = { called: false }
+      const ownAdapter = makeRollupAdapter(
+        ownIdentity,
+        ownSalt,
+        snapshotRef,
+        childSessionID,
+        () => buildConsumeOnlyChildParts(ownIdentity, ownSalt),
+        parentSessionID,
+      )
+
+      await observeSkill(
+        ownAdapter,
+        'systematic_skill',
+        'ce:work',
+        'consume-only-skill',
+        parentSessionID,
+      )
+      expect(ownAdapter.status(parentSessionID).epoch).not.toBeNull()
+
+      await fireTaskAfter(ownAdapter, childSessionID, parentSessionID)
+
+      expect(snapshotRef.called).toBe(false)
+      expect(ownAdapter.status(parentSessionID).reasonCode).toBe(
+        'guard-unavailable',
+      )
+    })
+
+    test('rollup: valid foreign marker + malformed marker → ambiguous → markUnavailable before snapshot', async () => {
+      // Child session parts contain one valid provably-foreign seed-bearing marker
+      // (different registrationDigest that does NOT agree with our identity) PLUS one
+      // malformed/invalid marker. classifyMarkersFromParts → ambiguous (malformed is
+      // not provably foreign) → rollupForegroundTask → markUnavailable() before snapshot.
+      const ownIdentity = 'rollup-foreign-plus-malformed'
+      const ownSalt = new Uint8Array(32).fill(111)
+      const foreignIdentity = 'rollup-provably-foreign-reg'
+      const foreignSalt = new Uint8Array(32).fill(112)
+      const childSessionID = 'child-foreign-plus-malformed'
+      const parentSessionID = SESSION_A
+
+      // Build one valid foreign seed marker (provably foreign: valid + seed-bearing + ≠ own identity)
+      const foreignLedger = createReceiptLedger({
+        capabilityFlags: ['workflow-guard'],
+        registrationIdentity: foreignIdentity,
+        sessionSalt: foreignSalt,
+      })
+      const foreignEpochMarker = projectReceiptProgressionMarker(
+        foreignLedger,
+        {
+          target: 'epoch',
+          state: 'started',
+          epochId: '1'.repeat(32),
+          family: 'work',
+          transitionDigest: foreignLedger.digestIdentity('call', 'ep'),
+          timestamp: 1,
+        },
+      )
+      if (!foreignEpochMarker)
+        throw new Error('foreign marker projection failed')
+
+      // Malformed marker: unparseable shape → validateReceiptMarker → unknown-kind → ambiguous
+      const malformedMarker = { kind: 'corrupt-unknown', payload: 'x' }
+
+      const childParts = [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: [
+                    foreignEpochMarker,
+                    malformedMarker,
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ]
+
+      const snapshotRef = { called: false }
+      const ownAdapter = makeRollupAdapter(
+        ownIdentity,
+        ownSalt,
+        snapshotRef,
+        childSessionID,
+        () => childParts,
+        parentSessionID,
+      )
+
+      await observeSkill(
+        ownAdapter,
+        'systematic_skill',
+        'ce:work',
+        'foreign-malformed-skill',
+        parentSessionID,
+      )
+      expect(ownAdapter.status(parentSessionID).epoch).not.toBeNull()
+
+      await fireTaskAfter(ownAdapter, childSessionID, parentSessionID)
+
+      // Ambiguous (malformed marker present) → markUnavailable() fires before snapshot.
+      expect(snapshotRef.called).toBe(false)
+      expect(ownAdapter.status(parentSessionID).reasonCode).toBe(
+        'guard-unavailable',
+      )
+    })
+
+    test('regression guard rollup: genuinely foreign-only child → benign no-op, NOT markUnavailable', async () => {
+      // All valid, salt-bearing, provably-foreign child markers → foreign-empty → early return.
+      // Must NOT regress to markUnavailable. Passes both before and after the fix.
+      const ownIdentity = 'rollup-foreign-regression'
+      const ownSalt = new Uint8Array(32).fill(99)
+      const foreignIdentity = 'rollup-foreign-valid-only'
+      const foreignSalt = new Uint8Array(32).fill(100)
+      const childSessionID = 'child-foreign-valid-only'
+      const parentSessionID = SESSION_A
+
+      const foreignChildMarkers = buildChildMarkers(
+        foreignIdentity,
+        foreignSalt,
+        OPERATION_SCOPE.workspaceIdentity,
+        OPERATION_SCOPE.repositoryIdentity,
+        'worktree-b',
+        OPERATION_SCOPE.worktreeIdentity,
+      )
+      const childParts = [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]:
+                    foreignChildMarkers,
+                },
+              },
+            },
+          ],
+        },
+      ]
+
+      const snapshotRef = { called: false }
+      const ownAdapter = makeRollupAdapter(
+        ownIdentity,
+        ownSalt,
+        snapshotRef,
+        childSessionID,
+        () => childParts,
+        parentSessionID,
+      )
+
+      await observeSkill(
+        ownAdapter,
+        'systematic_skill',
+        'ce:work',
+        'foreign-regression-skill',
+        parentSessionID,
+      )
+      const beforeReasonCode = ownAdapter.status(parentSessionID).reasonCode
+      expect(ownAdapter.status(parentSessionID).epoch).not.toBeNull()
+
+      await fireTaskAfter(ownAdapter, childSessionID, parentSessionID)
+
+      // Benign no-op: snapshot not called, guard not marked unavailable
+      expect(snapshotRef.called).toBe(false)
+      expect(ownAdapter.status(parentSessionID).reasonCode).not.toBe(
+        'guard-unavailable',
+      )
+      expect(ownAdapter.status(parentSessionID).reasonCode).toBe(
+        beforeReasonCode,
+      )
+    })
   })
 })

--- a/tests/unit/receipt-readback.test.ts
+++ b/tests/unit/receipt-readback.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   digestReceiptIdentity,
   extractReceiptReadbackSeed,
+  filterMarkersByRegistration,
   foldReceiptReadback,
   projectReceiptConsumptionMarker,
   projectReceiptMintMarker,
@@ -548,5 +549,138 @@ describe('receipt readback', () => {
       expect(result.state.progression.epoch?.epochId).toMatch(/^[0-9a-f]{32}$/)
       expect(result.state.progression.unit?.unitId).toMatch(/^[0-9a-f]{32}$/)
     }
+  })
+
+  describe('filterMarkersByRegistration', () => {
+    test('keeps only markers belonging to the given registrationDigest', () => {
+      const own = createFixture()
+      const foreign = createFixture({
+        registrationIdentity: 'foreign-registration',
+        sessionSalt: Uint8Array.from({ length: 32 }, (_, i) => i + 100),
+      })
+      const ownDigest = own.ledger.metadata.registrationDigest
+      const foreignDigest = foreign.ledger.metadata.registrationDigest
+
+      // Sanity: digests must differ
+      expect(ownDigest).not.toBe(foreignDigest)
+
+      const mixed: unknown[] = [
+        own.mint,
+        own.epochStart,
+        own.unitStart,
+        own.consume,
+        own.unitComplete,
+        own.epochComplete,
+        foreign.mint,
+        foreign.epochStart,
+        foreign.unitStart,
+        foreign.consume,
+      ]
+
+      const filtered = filterMarkersByRegistration(mixed, ownDigest)
+      // All own markers retained
+      expect(filtered).toHaveLength(6)
+      // All foreign markers stripped
+      for (const item of filtered) {
+        const result = validateReceiptMarker(item)
+        expect(result.status).toBe('valid')
+        if (result.status === 'valid') {
+          const marker = result.marker
+          if (marker.kind === 'mint') {
+            expect(marker.envelope.registrationDigest).toBe(ownDigest)
+          } else {
+            expect(marker.registrationDigest).toBe(ownDigest)
+          }
+        }
+      }
+    })
+
+    test('passes through malformed/unreadable markers fail-closed (does not silently drop)', () => {
+      const own = createFixture()
+      const ownDigest = own.ledger.metadata.registrationDigest
+
+      // A malformed entry: must be retained (fail-closed — caller will reject it)
+      const malformed: unknown = { kind: 'mint', schemaVersion: 999 }
+      const result = filterMarkersByRegistration(
+        [own.mint, malformed, own.epochStart],
+        ownDigest,
+      )
+      // malformed marker must be retained so extractReceiptReadbackSeed can fail-close on it
+      expect(result).toHaveLength(3)
+      expect(result[1]).toBe(malformed)
+    })
+
+    test('returns empty array when all markers are from a foreign registration', () => {
+      const own = createFixture()
+      const foreign = createFixture({
+        registrationIdentity: 'entirely-foreign',
+        sessionSalt: Uint8Array.from({ length: 32 }, (_, i) => i + 77),
+      })
+      const ownDigest = own.ledger.metadata.registrationDigest
+
+      const result = filterMarkersByRegistration(
+        [foreign.mint, foreign.epochStart, foreign.unitStart],
+        ownDigest,
+      )
+      expect(result).toHaveLength(0)
+    })
+
+    test('is a no-op when all markers already belong to own registration', () => {
+      const own = createFixture()
+      const ownDigest = own.ledger.metadata.registrationDigest
+      const ownMarkers: unknown[] = [
+        own.epochStart,
+        own.unitStart,
+        own.mint,
+        own.consume,
+        own.unitComplete,
+        own.epochComplete,
+      ]
+
+      const result = filterMarkersByRegistration(ownMarkers, ownDigest)
+      expect(result).toHaveLength(ownMarkers.length)
+      expect(result).toEqual(ownMarkers)
+    })
+
+    test('retain consume markers (no seed, but carry registrationDigest) for own registration', () => {
+      const own = createFixture()
+      const foreign = createFixture({
+        registrationIdentity: 'another-registration',
+        sessionSalt: Uint8Array.from({ length: 32 }, (_, i) => i + 55),
+      })
+      const ownDigest = own.ledger.metadata.registrationDigest
+
+      // consume markers are "seedless" (no sessionSalt) but have registrationDigest
+      const filtered = filterMarkersByRegistration(
+        [own.consume, foreign.consume],
+        ownDigest,
+      )
+      expect(filtered).toHaveLength(1)
+      const only = validateReceiptMarker(filtered[0])
+      expect(only.status).toBe('valid')
+      if (only.status === 'valid' && only.marker.kind === 'control') {
+        expect(only.marker.registrationDigest).toBe(ownDigest)
+      }
+    })
+
+    test('progression markers (epoch + unit) are filtered by registrationDigest correctly', () => {
+      const own = createFixture()
+      const foreign = createFixture({
+        registrationIdentity: 'progression-foreign',
+        sessionSalt: Uint8Array.from({ length: 32 }, (_, i) => i + 200),
+      })
+      const ownDigest = own.ledger.metadata.registrationDigest
+
+      const mixed: unknown[] = [
+        own.epochStart,
+        foreign.epochStart,
+        own.unitStart,
+        foreign.unitStart,
+        own.epochComplete,
+        foreign.epochComplete,
+      ]
+      const filtered = filterMarkersByRegistration(mixed, ownDigest)
+      expect(filtered).toHaveLength(3)
+    })
   })
 })


### PR DESCRIPTION
## Summary

Fixes a workflow-guard restart-recovery bug that made the guard report `guard-unavailable` — even under `protected` config — whenever Systematic is registered twice in one OpenCode session (for example, the published package loaded via user config **and** the repo source loaded via project config).

## Root cause

Both registrations append receipt markers into the **same** shared, unnamespaced `output.metadata.systematic_workflow_receipt` array (OpenCode shares the `output` object reference across plugins). Each registration has a distinct registration digest and session salt. On restart recovery, each registration read the **combined** array, saw the other registration's seed, and returned `conflicting-seed` — forcing the runtime to `unavailable`. Both registrations failed closed, so the guard could never reach an enforcing state.

This defeated the guard's intended per-registration isolation: the isolation held in memory but was lost at the shared persistence layer.

## Fix

Recovery now classifies the markers collected from session parts into three cases and recovers **only this registration's own markers**:

- **own** — at least one valid own seed resolves; filter to own markers by registration digest and recover.
- **foreign-empty** — every marker is valid, seed-bearing, and provably belongs to a different registration; start fresh (this registration legitimately has no receipts).
- **ambiguous** — no own seed resolves **and** any marker is malformed or seedless (consume-only); **fail closed** (`guard-unavailable`) rather than silently resetting to a fresh ledger.

Applied on both the main-session recovery path and the foreground-task child-rollup path.

Read-side only — the persisted marker format is unchanged and backward-compatible with existing sessions. Single-registration sessions are unaffected (the filter is a no-op when every marker shares the own digest).

## Fail-closed integrity

The ambiguous case is the security-relevant one: own-state loss (all own salt-bearing markers corrupted), consume-only readback, or own markers removed while foreign markers remain must **not** degrade to a fresh guard — they now report `guard-unavailable`. Genuinely foreign-only arrays still start fresh. Malformed own markers are retained through filtering so seed extraction still rejects them.

## Verification

Full unit suite green (1521 tests), typecheck / lint / content-integrity clean. New tests cover both recovery paths: mixed-registration recovery, foreign-only fresh-start, single-registration regression, and the fail-closed cases (own-seed corruption, consume-only, foreign + malformed) on both the main and rollup paths.

## Blast radius

Primarily affects dual-registration setups (a Systematic plugin present in both user and project config). Single-registration users recover their own salt normally and are unaffected.
