### PR TITLE
fix(workflow): preserve delegated receipt evidence

### DIFF
--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -1415,6 +1415,9 @@ function createSessionRuntime(
     if (!childSessionID) return
     const rollupKey = `${host.sessionID}:${host.callID}:${childSessionID}`
     if (rolledUpChildren.has(rollupKey)) return
+    // Capture the parent's operation-before identities before reading child
+    // history. These are guard-owned digests, not boot-time path values.
+    const parentBefore = guard.currentOperationContext()
     const children = await options.hostReadback.listChildren(host.sessionID)
     if (
       !children.some(
@@ -1469,30 +1472,43 @@ function createSessionRuntime(
     }
     const currentStatus = guard.status()
     if (!currentStatus.epoch || !currentStatus.unit) return
-    const expectedWorkspace = ledger.digestIdentity(
+    const expectedWorkspace = childLedger.digestIdentity(
       'workspace',
-      options.workspaceIdentity,
+      parentBefore.workspaceIdentity,
     )
-    const expectedRepository = ledger.digestIdentity(
+    const expectedRepository = childLedger.digestIdentity(
       'repository',
-      options.repositoryIdentity ?? current.snapshot.repositoryRevisionDigest,
+      current.snapshot.repositoryRevisionDigest,
     )
-    const expectedWorktree = ledger.digestIdentity(
+    const expectedWorktree = childLedger.digestIdentity(
       'worktree',
-      options.worktreeIdentity ?? current.snapshot.worktreeRevisionDigest,
+      current.snapshot.worktreeRevisionDigest,
     )
-    let minted = false
+    const candidates: Array<(typeof recovered.receipts)[number]> = []
     for (const childReceipt of recovered.receipts) {
       const operation = childReceipt.canonical.operation
       if (!localOperation(operation)) continue
-      if (
-        childReceipt.canonical.workspaceDigest !== expectedWorkspace ||
-        childReceipt.canonical.repositoryDigest !== expectedRepository ||
-        childReceipt.canonical.worktreeDigest !== expectedWorktree
-      ) {
+      if (childReceipt.canonical.workspaceDigest !== expectedWorkspace) {
         markUnavailable()
         return
       }
+      if (
+        childReceipt.canonical.repositoryDigest !== expectedRepository ||
+        childReceipt.canonical.worktreeDigest !== expectedWorktree
+      ) {
+        // Stale relative to the current single observer snapshot (repository
+        // or worktree revision has moved since this receipt was minted) —
+        // skip this receipt without minting it, but keep evaluating later
+        // chronological receipts from the same child rollup.
+        continue
+      }
+      candidates.push(childReceipt)
+    }
+
+    let minted = false
+    for (const childReceipt of candidates) {
+      const operation = childReceipt.canonical.operation
+      const parentContext = guard.currentOperationContext()
       const callID = `task-${host.callID}-${childReceipt.canonical.receiptId}`
       const observation = {
         callId: callID,
@@ -1501,20 +1517,16 @@ function createSessionRuntime(
         context: {
           epochId: currentStatus.epoch.epochId,
           unitId: currentStatus.unit.unitId,
-          workspaceIdentity: options.workspaceIdentity,
-          repositoryIdentity:
-            operation === 'commit'
-              ? (options.repositoryIdentity ??
-                current.snapshot.repositoryRevisionDigest)
-              : current.snapshot.repositoryRevisionDigest,
-          worktreeIdentity:
-            operation === 'implementation'
-              ? (options.worktreeIdentity ??
-                current.snapshot.worktreeRevisionDigest)
-              : current.snapshot.worktreeRevisionDigest,
+          workspaceIdentity: parentContext.workspaceIdentity,
+          ...(parentContext.repositoryIdentity
+            ? { repositoryIdentity: parentContext.repositoryIdentity }
+            : {}),
+          ...(parentContext.worktreeIdentity
+            ? { worktreeIdentity: parentContext.worktreeIdentity }
+            : {}),
         },
         after: {
-          workspaceIdentity: options.workspaceIdentity,
+          workspaceIdentity: parentContext.workspaceIdentity,
           repositoryIdentity: current.snapshot.repositoryRevisionDigest,
           worktreeIdentity: current.snapshot.worktreeRevisionDigest,
         },
@@ -1524,7 +1536,7 @@ function createSessionRuntime(
           noOp: false,
         },
       }
-      const result = await guard.observeOperation(observation)
+      const result = await guard.observeTrustedRecoveredOperation(observation)
       if (result.status === 'accepted') {
         const receipt = receiptForOperation(callID, operation)
         if (receipt) mergeReceiptMarker(output, receipt)
@@ -1749,12 +1761,28 @@ function createSessionRuntime(
     return result
   }
 
+  function progressionResourceScopes(
+    unit: NonNullable<WorkflowStatus['unit']>,
+  ): readonly { operation: ReceiptOperation; resourceIdentity: string }[] {
+    return [...unit.resourceScopes]
+      .sort((first, second) => first.operation.localeCompare(second.operation))
+      .map((scope) => ({
+        operation: scope.operation,
+        resourceIdentity: ledger.digestIdentity(
+          'resource',
+          scope.resourceIdentity,
+        ),
+      }))
+  }
+
   function writeStartResult(output: unknown, result: StartUnitResult): void {
     if (!isRecord(output)) return
+    const existingMetadata = isRecord(output.metadata) ? output.metadata : {}
     if (result.status === 'started') {
       output.title = 'Workflow unit started'
       output.output = JSON.stringify({ status: 'started' })
       output.metadata = {
+        ...existingMetadata,
         ...metadata(),
         workflowGuard: { status: 'started' },
       }
@@ -1768,6 +1796,7 @@ function createSessionRuntime(
       reasonCode,
     })
     output.metadata = {
+      ...existingMetadata,
       ...metadata(),
       workflowGuard: {
         status: 'rejected',
@@ -2189,7 +2218,7 @@ function createSessionRuntime(
           unitId: status.unit.unitId,
           family: status.epoch.family,
           requiredOperations: status.unit.requiredOperations,
-          resourceScopes: [],
+          resourceScopes: progressionResourceScopes(status.unit),
           state: 'started',
           transitionDigest: ledger.digestIdentity('call', host.callID),
         }),
@@ -2270,7 +2299,7 @@ function createSessionRuntime(
           unitId: unit.unitId,
           family: epoch.family,
           requiredOperations: unit.requiredOperations,
-          resourceScopes: [],
+          resourceScopes: progressionResourceScopes(unit),
           state: 'started',
           transitionDigest: ledger.digestIdentity('call', host.callID),
         }),
@@ -2786,9 +2815,14 @@ function createSessionRuntime(
     if (!isRecord(output) || !isRecord(output.metadata)) return
     const marker = projectReceiptMintMarker(receipt, ledger.getSessionSalt())
     if (!marker) return
+    const existing = output.metadata[SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]
     output.metadata = {
       ...output.metadata,
-      [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: marker,
+      [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: existing
+        ? Array.isArray(existing)
+          ? [...existing, marker]
+          : [existing, marker]
+        : marker,
     }
   }
 

--- a/src/lib/receipt-readback.ts
+++ b/src/lib/receipt-readback.ts
@@ -1620,8 +1620,23 @@ function applyUnitStart(
     return undefined
   }
   if (current.unitId === marker.unitId) {
-    if (!sameUnitDeclaration(current, marker)) return 'conflicting-marker'
-    return current.state === 'completed' ? 'out-of-order' : 'conflicting-marker'
+    if (current.state === 'completed') return 'out-of-order'
+    if (
+      !sameUnitDeclaration(current, marker) &&
+      unitHasMintedEvidence(current, context)
+    ) {
+      return 'out-of-order'
+    }
+    if (
+      sameUnitDeclaration(current, marker) &&
+      current.transitionDigest !== marker.transitionDigest
+    ) {
+      return 'conflicting-marker'
+    }
+    if (!unitDeclarationExtends(current, marker)) return 'conflicting-marker'
+    if (sameUnitDeclaration(current, marker)) return undefined
+    context.progression = { epoch, unit: snapshot }
+    return undefined
   }
   if (current.state !== 'completed') return 'out-of-order'
   context.progression = { epoch, unit: snapshot }
@@ -1646,6 +1661,17 @@ function applyUnitComplete(
   return undefined
 }
 
+function unitHasMintedEvidence(
+  current: ReceiptUnitProgressionSnapshot,
+  context: FoldContext,
+): boolean {
+  return [...context.mintByReceipt.values()].some(
+    (envelope) =>
+      envelope.canonical.epochDigest === current.epochDigest &&
+      envelope.canonical.unitDigest === current.unitDigest,
+  )
+}
+
 function sameUnitDeclaration(
   current: ReceiptUnitProgressionSnapshot,
   marker: ReceiptUnitProgressionMarker,
@@ -1658,6 +1684,36 @@ function sameUnitDeclaration(
       JSON.stringify(marker.requiredOperations) &&
     JSON.stringify(current.resourceScopes) ===
       JSON.stringify(marker.resourceScopes)
+  )
+}
+
+function unitDeclarationExtends(
+  current: ReceiptUnitProgressionSnapshot,
+  marker: ReceiptUnitProgressionMarker,
+): boolean {
+  if (
+    current.epochDigest !== marker.epochDigest ||
+    current.unitDigest !== marker.unitDigest ||
+    current.family !== marker.family
+  ) {
+    return false
+  }
+  const nextOperations = new Set(marker.requiredOperations)
+  if (
+    current.requiredOperations.some(
+      (operation) => !nextOperations.has(operation),
+    )
+  ) {
+    return false
+  }
+  const nextScopes = new Map(
+    marker.resourceScopes.map((scope) => [
+      scope.operation,
+      scope.resourceIdentity,
+    ]),
+  )
+  return [...current.resourceScopes].every(
+    (scope) => nextScopes.get(scope.operation) === scope.resourceIdentity,
   )
 }
 

--- a/src/lib/workflow-guard.ts
+++ b/src/lib/workflow-guard.ts
@@ -114,6 +114,13 @@ export interface UnitSnapshot {
   status: 'active' | 'completed'
   requiredOperations: readonly ReceiptOperation[]
   requiredResourceOperations: readonly ReceiptOperation[]
+  resourceScopes: readonly ReceiptResourceScope[]
+}
+
+export interface CurrentOperationContext {
+  readonly workspaceIdentity: string
+  readonly repositoryIdentity?: string
+  readonly worktreeIdentity?: string
 }
 
 export interface WorkflowStatus {
@@ -187,7 +194,16 @@ export interface WorkflowGuard {
   observeReceipt(input: unknown): EvidenceObservationResult
   observeAttempt(input: unknown): EvidenceObservationResult
   observeOperation(input: unknown): Promise<EvidenceObservationResult>
+  /**
+   * Internal recovery seam. Callers MUST validate host lineage, own
+   * registration/seed/readback, stable workspace, and current mutable
+   * revisions before using this classifier-bypassing path.
+   */
+  observeTrustedRecoveredOperation(
+    input: unknown,
+  ): Promise<EvidenceObservationResult>
   observeReadback(input: unknown): ReadbackObservationResult
+  currentOperationContext(): CurrentOperationContext
   status(): WorkflowStatus
   prepareTransition(input: unknown): TransitionPrepareResult
   finalizeTransition(input: unknown): TransitionFinalizeResult
@@ -661,6 +677,12 @@ function cloneUnit(unit: UnitState): UnitSnapshot {
     requiredResourceOperations: Object.freeze([
       ...unit.declaredResourceOperations,
     ]),
+    resourceScopes: Object.freeze(
+      [...unit.resourceScopes].map(([operation, resourceIdentity]) => ({
+        operation,
+        resourceIdentity,
+      })),
+    ),
   })
 }
 
@@ -1281,6 +1303,18 @@ export function createWorkflowGuard(
     return context.worktreeIdentity !== currentWorktreeIdentity
       ? 'receipt-mismatch'
       : undefined
+  }
+
+  function currentOperationContext(): CurrentOperationContext {
+    return Object.freeze({
+      workspaceIdentity: currentWorkspaceIdentity,
+      ...(currentRepositoryIdentity === undefined
+        ? {}
+        : { repositoryIdentity: currentRepositoryIdentity }),
+      ...(currentWorktreeIdentity === undefined
+        ? {}
+        : { worktreeIdentity: currentWorktreeIdentity }),
+    })
   }
 
   function resourceBeforeReason(
@@ -2399,9 +2433,13 @@ export function createWorkflowGuard(
   function mergeResourceScopes(
     trustedPolicy: ParsedUnitRequest,
     modelScopes: ReadonlyMap<ReceiptOperation, string>,
+    existingScopes?: ReadonlyMap<ReceiptOperation, string>,
   ): ReadonlyMap<ReceiptOperation, string> | undefined {
-    const result = new Map(runtimeScopes)
-    for (const scopes of [trustedPolicy.resourceScopes, modelScopes]) {
+    const result = new Map(existingScopes ?? runtimeScopes)
+    const scopesToMerge = existingScopes
+      ? [runtimeScopes, trustedPolicy.resourceScopes, modelScopes]
+      : [trustedPolicy.resourceScopes, modelScopes]
+    for (const scopes of scopesToMerge) {
       for (const [operation, resource] of scopes) {
         const existing = result.get(operation)
         if (existing && existing !== resource) return undefined
@@ -2415,16 +2453,102 @@ export function createWorkflowGuard(
     trustedPolicy: ParsedUnitRequest,
     model: ParsedUnitRequest,
     resourceScopes: ReadonlyMap<ReceiptOperation, string>,
+    existingOperations: readonly ReceiptOperation[] = [],
   ): readonly ReceiptOperation[] {
     return Object.freeze([
       ...new Set([
         ...MANDATORY_OPERATIONS,
         ...runtimeRequired,
+        ...existingOperations,
         ...trustedPolicy.expectedOperations,
         ...model.expectedOperations,
         ...resourceScopes.keys(),
       ]),
     ])
+  }
+
+  function resourceIdentitiesMatchUnit(unit: UnitState): boolean {
+    const expected = new Map(runtimeScopes)
+    for (const [operation, resource] of unit.resourceScopes) {
+      expected.set(operation, resource)
+    }
+    if (currentResourceIdentities.size !== expected.size) return false
+    for (const [operation, resource] of expected) {
+      if (currentResourceIdentities.get(operation) !== resource) return false
+    }
+    return true
+  }
+
+  function pristineActiveUnit(unit: UnitState): boolean {
+    return (
+      unit.evidence.size === 0 &&
+      unit.issues.size === 0 &&
+      unit.staleReceiptIds.size === 0 &&
+      unit.recoveredReceiptIds.size === 0 &&
+      unit.operationStates.size === 0 &&
+      unit.ledgerContexts.size === 0 &&
+      globalIssue === undefined &&
+      transitionsByCall.size === 0 &&
+      terminalOperationCalls.size === 0 &&
+      currentResourceRevisionIdentities.size === 0 &&
+      currentPullRequestFingerprint === undefined &&
+      currentWorkspaceIdentity === initialWorkspaceIdentity &&
+      currentRepositoryIdentity === initialRepositoryIdentity &&
+      currentWorktreeIdentity === initialWorktreeIdentity &&
+      resourceIdentitiesMatchUnit(unit)
+    )
+  }
+
+  function declarationChanged(
+    unit: UnitState,
+    requiredOperations: readonly ReceiptOperation[],
+    resourceScopes: ReadonlyMap<ReceiptOperation, string>,
+  ): boolean {
+    if (
+      JSON.stringify(unit.requiredOperations) !==
+      JSON.stringify(requiredOperations)
+    ) {
+      return true
+    }
+    if (unit.resourceScopes.size !== resourceScopes.size) return true
+    for (const [operation, resource] of resourceScopes) {
+      if (unit.resourceScopes.get(operation) !== resource) return true
+    }
+    return false
+  }
+
+  function startActiveUnit(
+    parsed: ParsedUnitRequest,
+    trustedPolicy: ParsedUnitRequest,
+    unit: UnitState,
+  ): StartUnitResult {
+    if (!pristineActiveUnit(unit)) {
+      return { status: 'rejected', reasonCode: 'unit-active' }
+    }
+    const resourceScopes = mergeResourceScopes(
+      trustedPolicy,
+      parsed.resourceScopes,
+      unit.resourceScopes,
+    )
+    if (!resourceScopes) {
+      return { status: 'rejected', reasonCode: 'runtime-scope-conflict' }
+    }
+    const requiredOperations = requiredOperationsFor(
+      trustedPolicy,
+      parsed,
+      resourceScopes,
+      unit.requiredOperations,
+    )
+    if (!declarationChanged(unit, requiredOperations, resourceScopes)) {
+      return { status: 'rejected', reasonCode: 'unit-active' }
+    }
+    unit.requiredOperations = requiredOperations
+    unit.declaredResourceOperations = Object.freeze([...resourceScopes.keys()])
+    unit.resourceScopes = resourceScopes
+    for (const [operation, resource] of resourceScopes) {
+      currentResourceIdentities.set(operation, resource)
+    }
+    return { status: 'started', unit: cloneUnit(unit) }
   }
 
   function startParsedUnit(
@@ -2433,7 +2557,7 @@ export function createWorkflowGuard(
   ): StartUnitResult {
     if (!epoch) return { status: 'rejected', reasonCode: 'no-active-epoch' }
     if (epoch.unit?.status === 'active') {
-      return { status: 'rejected', reasonCode: 'unit-active' }
+      return startActiveUnit(parsed, trustedPolicy, epoch.unit)
     }
     const resourceScopes = mergeResourceScopes(
       trustedPolicy,
@@ -2542,6 +2666,7 @@ export function createWorkflowGuard(
     input: unknown,
     parsed: ParsedOperationObservation,
     unit: UnitState,
+    trustedClassification?: ReceiptClassification,
   ): Promise<EvidenceObservationResult> {
     if (!unit.requiredOperations.includes(parsed.operation)) {
       markTerminalOperation(parsed, input)
@@ -2563,7 +2688,9 @@ export function createWorkflowGuard(
         ? { status: 'rejected', reasonCode: 'call-context-conflict' }
         : { status: 'rejected', reasonCode: 'rejected-operation' }
     }
-    const classification = await classifyPreparedOperation(parsed, input, unit)
+    const classification =
+      trustedClassification ??
+      (await classifyPreparedOperation(parsed, input, unit))
     return classification
       ? finalizeOperation(parsed, input, unit, classification)
       : { status: 'rejected', reasonCode: 'guard-unavailable' }
@@ -3295,10 +3422,55 @@ export function createWorkflowGuard(
       return processOperation(input, parsed, epoch.unit)
     },
 
+    /**
+     * Trusted host-recovery callers have already validated lineage, ownership,
+     * seed/readback integrity, stable workspace, and current mutable revisions.
+     * Keep this path internal and do not expose it as a host/model tool.
+     */
+    async observeTrustedRecoveredOperation(
+      input: unknown,
+    ): Promise<EvidenceObservationResult> {
+      const modeResult = evidenceModeResult()
+      if (modeResult) return modeResult
+      if (!epoch) return { status: 'rejected', reasonCode: 'no-active-epoch' }
+      if (!epoch.unit)
+        return { status: 'rejected', reasonCode: 'no-active-unit' }
+      if (epoch.unit.status === 'completed') {
+        return { status: 'rejected', reasonCode: 'unit-completed' }
+      }
+
+      const terminalResult = terminalOperationResult(input)
+      if (terminalResult) return terminalResult
+
+      const parsed = parseReceiptOperationObservation(input)
+      if (!parsed) {
+        markTerminalOperation(undefined, input)
+        return recordGlobalEvidenceIssue('invalid-receipt')
+      }
+      const classification: ReceiptClassification = {
+        outcome: 'accepted',
+        category: parsed.operation,
+        attribution: 'runtime-verified',
+        result: 'success',
+        sideEffect:
+          parsed.operation === 'verification' ||
+          parsed.operation === 'check-readback' ||
+          parsed.operation === 'review-readback'
+            ? 'not-required'
+            : 'required',
+        reasonCode: 'recognized-command',
+      }
+      return processOperation(input, parsed, epoch.unit, classification)
+    },
+
     observeReadback(input: unknown): ReadbackObservationResult {
       const parsed = parseReadback(input)
       if (!parsed) return { status: 'rejected', reasonCode: 'invalid-receipt' }
       return observeRevision(parsed, epoch?.unit)
+    },
+
+    currentOperationContext(): CurrentOperationContext {
+      return currentOperationContext()
     },
 
     status(): WorkflowStatus {

--- a/tests/integration/opencode.test.ts
+++ b/tests/integration/opencode.test.ts
@@ -343,7 +343,7 @@ function expectSetupSkillLoaded(result: OpencodeResult): void {
   expect(result.stderr).toMatch(
     /(?:Skill\s+"?git-clean-gone-branches"?|systematic_skill\s*\{"name":"(?:systematic:)?git-clean-gone-branches"\})/i,
   )
-  expect(result.stdout).toMatch(/branch/i)
+  expect(result.stdout).toMatch(/(?:branch|repositor(?:y|ies)|\brepo\b)/i)
 }
 
 test('expectSetupSkillLoaded accepts git-clean-gone-branches output without tool id mention', () => {

--- a/tests/integration/receipt-workflow-guard-real-host.test.ts
+++ b/tests/integration/receipt-workflow-guard-real-host.test.ts
@@ -40,8 +40,21 @@ interface HostEvidence {
   pid: number
   markerKinds: string[]
   registrationDigests: string[]
+  mintEvidence: RegistrationMintEvidence[]
   operations: string[]
   workflow: Record<string, unknown>
+}
+
+interface RegistrationMintEvidence {
+  registrationDigest: string
+  operations: string[]
+  receiptIds: string[]
+}
+
+interface MintMarkerEvidence {
+  registrationDigest: string
+  operation: string
+  receiptId: string
 }
 
 function sseChunk(value: unknown): string {
@@ -300,6 +313,55 @@ function registrationDigests(messages: unknown[]): string[] {
   })
 }
 
+function registrationMintEvidence(
+  messages: unknown[],
+): RegistrationMintEvidence[] {
+  const groups = new Map<
+    string,
+    { operations: string[]; receiptIds: string[] }
+  >()
+  for (const marker of persistedMarkers(messages)) {
+    const evidence = parseMintMarkerEvidence(marker)
+    if (!evidence) continue
+    const group = groups.get(evidence.registrationDigest) ?? {
+      operations: [],
+      receiptIds: [],
+    }
+    group.operations.push(evidence.operation)
+    group.receiptIds.push(evidence.receiptId)
+    groups.set(evidence.registrationDigest, group)
+  }
+  return [...groups].map(([registrationDigest, evidence]) => ({
+    registrationDigest,
+    ...evidence,
+  }))
+}
+
+function parseMintMarkerEvidence(
+  marker: unknown,
+): MintMarkerEvidence | undefined {
+  if (!marker || typeof marker !== 'object') return undefined
+  const value = marker as Record<string, unknown>
+  if (value.kind !== 'mint') return undefined
+  const envelope = value.envelope
+  if (!envelope || typeof envelope !== 'object') return undefined
+  const envelopeValue = envelope as Record<string, unknown>
+  const canonical = envelopeValue.canonical
+  if (!canonical || typeof canonical !== 'object') return undefined
+  const canonicalValue = canonical as Record<string, unknown>
+  const registrationDigest = envelopeValue.registrationDigest
+  const operation = canonicalValue.operation
+  const receiptId = canonicalValue.receiptId
+  if (
+    typeof registrationDigest !== 'string' ||
+    typeof operation !== 'string' ||
+    typeof receiptId !== 'string'
+  ) {
+    return undefined
+  }
+  return { registrationDigest, operation, receiptId }
+}
+
 function workflowEvidence(messages: unknown[]): Record<string, unknown> {
   const workflows = toolParts(messages).filter(
     (part) => part.tool === 'systematic_workflow_complete',
@@ -433,6 +495,7 @@ async function runObserveCell(
         markers,
         markerSummary: markerSummary(messages),
         registrationDigests: registrationDigests(messages),
+        mintEvidence: registrationMintEvidence(messages),
         operations: toolParts(messages).map((part) => part.tool),
         workflow: workflowEvidence(messages),
       })}`,
@@ -447,6 +510,7 @@ async function runObserveCell(
       pid: host.pid,
       markerKinds: markers,
       registrationDigests: registrationDigests(messages),
+      mintEvidence: registrationMintEvidence(messages),
       operations: toolParts(messages)
         .map((part) => part.tool)
         .filter((tool): tool is string => typeof tool === 'string'),
@@ -549,10 +613,15 @@ describe.skipIf(!OPENCODE_AVAILABLE)('U7a real host', () => {
         expect(
           evidence.operations.filter((tool) => tool === 'write'),
         ).toHaveLength(1)
-        expect(
-          evidence.markerKinds.filter((kind) => kind === 'mint').length,
-        ).toBeLessThanOrEqual(2)
-        expect(evidence.registrationDigests).toHaveLength(2)
+        expect(new Set(evidence.registrationDigests)).toHaveLength(2)
+        expect(evidence.mintEvidence).toHaveLength(2)
+        for (const registration of evidence.mintEvidence) {
+          expect([...registration.operations].sort()).toEqual([
+            'implementation',
+            'verification',
+          ])
+          expect(new Set(registration.receiptIds)).toHaveLength(2)
+        }
         expect(
           evidence.registrationDigests.every((digest) =>
             /^[a-f0-9]{64}$/.test(digest),

--- a/tests/integration/receipt-workflow-recovery.test.ts
+++ b/tests/integration/receipt-workflow-recovery.test.ts
@@ -266,7 +266,6 @@ function outputShape(tool, output) {
       present: Boolean(output && Object.prototype.hasOwnProperty.call(output, 'output')),
       type: typeof output?.output,
       empty: output?.output === '',
-      length: typeof output?.output === 'string' ? output.output.length : null,
     },
     metadata: {
       present: Boolean(output && Object.prototype.hasOwnProperty.call(output, 'metadata')),
@@ -641,7 +640,7 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             tool: 'bash',
             outputKeys: ['attachments', 'metadata', 'output', 'title'],
             title: { present: true, type: 'string', empty: false },
-            output: { present: true, type: 'string', empty: false, length: 13 },
+            output: { present: true, type: 'string', empty: false },
             metadata: {
               present: true,
               type: 'object',
@@ -1084,6 +1083,20 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             sessionID,
             directory: localFixture.projectDir,
           })
+          const beforeSkillParts = completedToolParts(
+            beforeRestart.data,
+            'systematic_skill',
+          )
+          expect(beforeSkillParts).toHaveLength(1)
+          const beforeSkillState = beforeSkillParts[0]?.state as Record<
+            string,
+            unknown
+          >
+          const beforeSkillOutput = beforeSkillState.output
+          expect(typeof beforeSkillOutput === 'string').toBe(true)
+          expect(beforeSkillOutput).toContain('<skill_content name="ce:work">')
+          expect(beforeSkillOutput).toContain('# Skill: ce:work')
+          expect(beforeSkillOutput).toContain('Base directory for this skill:')
           const beforeMarkers = systematicMarkers(beforeRestart.data)
           expect(
             readProbeEvents(hookProbe.capturePath).filter(
@@ -1099,7 +1112,6 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
                 present: true,
                 type: 'string',
                 empty: false,
-                length: 23518,
               },
               metadata: {
                 present: true,
@@ -1117,7 +1129,6 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
                 present: true,
                 type: 'string',
                 empty: false,
-                length: 40,
               },
               metadata: {
                 present: true,
@@ -1143,7 +1154,6 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
                 present: true,
                 type: 'string',
                 empty: false,
-                length: 24,
               },
               metadata: {
                 present: true,
@@ -1161,7 +1171,6 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
                 present: true,
                 type: 'string',
                 empty: false,
-                length: 36,
               },
               metadata: {
                 present: true,

--- a/tests/integration/receipt-workflow-recovery.test.ts
+++ b/tests/integration/receipt-workflow-recovery.test.ts
@@ -35,6 +35,7 @@ interface ScriptedResponse {
 
 interface MockModelServer {
   url: string
+  requests: unknown[]
   stop(): void
 }
 
@@ -194,6 +195,7 @@ function startMockModelServer(
   responses: readonly ScriptedResponse[],
 ): MockModelServer {
   let requestIndex = 0
+  const requests: unknown[] = []
   const server = Bun.serve({
     port: 0,
     async fetch(request) {
@@ -204,7 +206,7 @@ function startMockModelServer(
         return new Response('not found', { status: 404 })
       }
 
-      await request.json()
+      requests.push(await request.json())
       const response = responses[requestIndex] ?? { text: '' }
       requestIndex += 1
       const id = `receipt-probe-${requestIndex}`
@@ -215,6 +217,7 @@ function startMockModelServer(
 
   return {
     url: `http://localhost:${server.port}/v1`,
+    requests,
     stop: () => server.stop(true),
   }
 }
@@ -474,6 +477,38 @@ function systematicMarkers(messages: unknown[]): unknown[] {
         .systematic_workflow_receipt
       return marker === undefined ? [] : [marker]
     })
+  })
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function receiptMintSummariesForValue(
+  value: unknown,
+): Array<{ operation: string; receiptId: string }> {
+  const markers = Array.isArray(value) ? value : [value]
+  return markers.flatMap((marker) => {
+    if (!isRecord(marker) || marker.kind !== 'mint') return []
+    const envelope = marker.envelope
+    if (!isRecord(envelope) || !isRecord(envelope.canonical)) return []
+    const { operation, receiptId } = envelope.canonical
+    return typeof operation === 'string' && typeof receiptId === 'string'
+      ? [{ operation, receiptId }]
+      : []
+  })
+}
+
+function receiptMintSummaries(
+  messages: unknown[],
+): Array<{ operation: string; receiptId: string }> {
+  return systematicMarkers(messages).flatMap(receiptMintSummariesForValue)
+}
+
+function receiptMintSessionSalts(messages: unknown[]): string[] {
+  return systematicMarkers(messages).flatMap((marker) => {
+    if (!isRecord(marker) || marker.kind !== 'mint') return []
+    return typeof marker.sessionSalt === 'string' ? [marker.sessionSalt] : []
   })
 }
 
@@ -1402,16 +1437,239 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
           expect(childMarkers.length).toBeGreaterThan(0)
           assertPrivacySafeMarkers(childMessages.data)
 
-          const parentMarkers = systematicMarkers(parentMessages.data)
-          expect(parentMarkers).toHaveLength(1)
+          const parentMints = receiptMintSummaries(parentMessages.data)
+          expect(parentMints).toHaveLength(1)
+          expect(parentMints[0]?.operation).toBe('implementation')
           const repeatedParentMessages = await client.session.messages({
             sessionID: parentSessionID,
             directory: localFixture.projectDir,
           })
-          expect(systematicMarkers(repeatedParentMessages.data).length).toBe(
-            parentMarkers.length,
+          const repeatedParentMints = receiptMintSummaries(
+            repeatedParentMessages.data,
           )
+          expect(repeatedParentMints).toEqual(parentMints)
           assertPrivacySafeMarkers(parentMessages.data)
+        } finally {
+          if (host) await host.stop()
+          model.stop()
+          destroyIsolatedFixture(localFixture)
+        }
+      },
+      TIMEOUT_MS * 4,
+    )
+
+    test(
+      'rolls up a foreground child commit despite a stale earlier implementation receipt',
+      async () => {
+        const localFixture = createIsolatedFixture()
+        initializeIsolatedRepository(localFixture)
+        const localPackagedPluginUrl =
+          extractPackagedPlugin(localFixture).pluginUrl
+        const model = startMockModelServer([
+          {
+            toolCalls: [
+              {
+                id: 'u5b-parent-skill',
+                name: 'systematic_skill',
+                arguments: { name: 'ce:work' },
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5b-parent-start',
+                name: 'systematic_workflow_start',
+                arguments: {
+                  expected_operations: [
+                    'implementation',
+                    'verification',
+                    'commit',
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5b-parent-task',
+                name: 'task',
+                arguments: {
+                  description: 'foreground child commit lane',
+                  prompt:
+                    'Use systematic tools in the child, write a file, then commit it.',
+                  subagent_type: 'systematic-implementer',
+                },
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5b-child-skill',
+                name: 'systematic_skill',
+                arguments: { name: 'git-commit' },
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5b-child-start',
+                name: 'systematic_workflow_start',
+                arguments: {},
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5b-child-write',
+                name: 'write',
+                arguments: {
+                  filePath: 'u5b-child.txt',
+                  content: 'opaque integration content',
+                },
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5b-child-verify',
+                name: 'bash',
+                arguments: { command: 'git status --short' },
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5b-child-add',
+                name: 'bash',
+                arguments: { command: 'git add -A' },
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5b-child-commit',
+                name: 'bash',
+                arguments: { command: 'git commit -m u5b-commit-message' },
+              },
+            ],
+          },
+          { text: 'child committed' },
+          { text: 'parent finished' },
+          {
+            toolCalls: [
+              {
+                id: 'u5b-parent-status',
+                name: 'systematic_workflow_status',
+                arguments: {},
+              },
+            ],
+          },
+          { text: 'status checked' },
+        ])
+        const configContent = buildProviderConfig(
+          [localPackagedPluginUrl],
+          model.url,
+        )
+        let host: Awaited<ReturnType<typeof startOpencodeServer>> | undefined
+        try {
+          host = await startOpencodeServer(localFixture, configContent)
+          const client = createOpencodeClient({
+            baseUrl: host.url,
+            directory: localFixture.projectDir,
+          })
+          const parentSessionID = await createSession(
+            client,
+            localFixture.projectDir,
+            'u5b foreground child commit rollup',
+          )
+          await promptSession(
+            client,
+            parentSessionID,
+            localFixture.projectDir,
+            'Start a guarded unit and run one foreground child that commits a change.',
+          )
+
+          const parentMessages = await client.session.messages({
+            sessionID: parentSessionID,
+            directory: localFixture.projectDir,
+          })
+          const taskParts = completedToolParts(parentMessages.data, 'task')
+          expect(taskParts).toHaveLength(1)
+          const taskState = taskParts[0]?.state as Record<string, unknown>
+          const taskMetadata = taskState.metadata as Record<string, unknown>
+          const childSessionID = taskMetadata.sessionId
+          expect(typeof childSessionID).toBe('string')
+
+          const children = await client.session.children({
+            sessionID: parentSessionID,
+            directory: localFixture.projectDir,
+          })
+          const child = children.data.find(
+            (entry) => entry.id === childSessionID,
+          )
+          expect(child).toBeDefined()
+          expect(child?.parentID).toBe(parentSessionID)
+
+          const childMessages = await client.session.messages({
+            sessionID: childSessionID as string,
+            directory: localFixture.projectDir,
+          })
+          const childMarkers = systematicMarkers(childMessages.data)
+          expect(childMarkers.length).toBeGreaterThan(0)
+          assertPrivacySafeMarkers(childMessages.data)
+          const childSessionSalts = receiptMintSessionSalts(childMessages.data)
+          expect(childSessionSalts.length).toBeGreaterThan(0)
+          const childSessionSalt = childSessionSalts[0]
+          if (childSessionSalt === undefined) {
+            throw new Error('child receipt session salt missing')
+          }
+          expect(model.requests.length).toBeGreaterThan(1)
+          expect(JSON.stringify(model.requests.slice(1))).not.toContain(
+            childSessionSalt,
+          )
+
+          await promptSession(
+            client,
+            parentSessionID,
+            localFixture.projectDir,
+            'Check workflow status only.',
+          )
+          const afterStatusMessages = await client.session.messages({
+            sessionID: parentSessionID,
+            directory: localFixture.projectDir,
+          })
+          const statusParts = completedToolParts(
+            afterStatusMessages.data,
+            'systematic_workflow_status',
+          )
+          expect(statusParts.length).toBeGreaterThan(0)
+          const lastStatus = statusParts.at(-1)
+          const lastStatusState = lastStatus?.state as Record<string, unknown>
+          const lastStatusOutput = (lastStatusState as { output?: unknown })
+            .output
+          expect(typeof lastStatusOutput).toBe('string')
+          const parsedStatus = JSON.parse(lastStatusOutput as string) as {
+            state: string
+            reasonCode: string
+            satisfiedOperations: string[]
+          }
+          // The bug: an earlier implementation receipt from the same
+          // foreground child, whose mutable revision digests are stale
+          // relative to the final HEAD after the child's own commit,
+          // must not make the parent's rollup fail closed before the
+          // matching (later, current) commit receipt is evaluated.
+          expect(parsedStatus.state).not.toBe('unavailable')
+          expect(parsedStatus.reasonCode).not.toBe('guard-unavailable')
+          expect(parsedStatus.satisfiedOperations).toContain('commit')
+          assertPrivacySafeMarkers(afterStatusMessages.data)
         } finally {
           if (host) await host.stop()
           model.stop()

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -1517,6 +1517,7 @@ describe('OpenCode workflow guard adapter', () => {
       }
       expect(output.metadata.hostMetadata).toBe('preserved')
       const marker = output.metadata[SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]
+      expect(Array.isArray(marker)).toBe(false)
       expect(marker).toMatchObject({
         envelope: {
           canonical: {
@@ -1537,6 +1538,33 @@ describe('OpenCode workflow guard adapter', () => {
           output.metadata[SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY],
         ),
       ).not.toContain('new content')
+    })
+
+    test('appends progression markers in order while preserving unrelated metadata', async () => {
+      const adapter = createAdapter('observe')
+      const output = {
+        title: 'Loaded skill',
+        output: 'skill result',
+        metadata: { hostMetadata: 'preserved' },
+      }
+
+      await observeSkill(
+        adapter,
+        'systematic_skill',
+        'ce:work',
+        'progression-markers',
+        SESSION_A,
+        output,
+      )
+
+      expect(output.metadata.hostMetadata).toBe('preserved')
+      const marker = output.metadata[SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]
+      expect(Array.isArray(marker)).toBe(true)
+      expect(marker).toHaveLength(2)
+      expect(marker).toEqual([
+        expect.objectContaining({ control: 'progression', target: 'epoch' }),
+        expect.objectContaining({ control: 'progression', target: 'unit' }),
+      ])
     })
   }
 

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -18,7 +18,10 @@ import {
   createReceiptClassifier,
   type ReceiptOperationObservation,
 } from '../../src/lib/receipt-classifier.js'
-import type { ReceiptLedger } from '../../src/lib/receipt-ledger.js'
+import type {
+  ReceiptLedger,
+  ReceiptOperation,
+} from '../../src/lib/receipt-ledger.js'
 import { createReceiptLedger } from '../../src/lib/receipt-ledger.js'
 import {
   projectReceiptConsumptionMarker,
@@ -261,6 +264,14 @@ function mintReceipt(
 }
 
 describe('OpenCode workflow guard adapter', () => {
+  test('does not expose the trusted recovery seam as a host/model tool', () => {
+    const adapter = createAdapter('observe')
+
+    expect(Object.keys(adapter.tools)).not.toContain(
+      'observeTrustedRecoveredOperation',
+    )
+  })
+
   test('selects trusted required operations from the activated skill', async () => {
     const adapter = createAdapter('observe')
     await observeSkill(adapter, 'systematic_skill', 'git-commit')
@@ -269,6 +280,203 @@ describe('OpenCode workflow guard adapter', () => {
       'verification',
       'commit',
     ])
+  })
+
+  test('projects the upgraded declaration with its actual operations and resource scopes', async () => {
+    const adapter = createAdapter('observe')
+    await observeSkill(adapter, 'systematic_skill', 'ce:work')
+    const output = {
+      title: 'pending',
+      output: 'start complete',
+      metadata: {},
+    }
+    const args = {
+      expected_operations: ['commit'],
+      resource_scopes: {
+        'review-readback': 'review-resource',
+        push: 'remote-resource',
+      },
+    }
+    await adapter.hooks['tool.execute.before'](
+      {
+        tool: 'systematic_workflow_start',
+        sessionID: SESSION_A,
+        callID: 'expanded-start',
+      },
+      { args },
+    )
+    await adapter.hooks['tool.execute.after'](
+      {
+        tool: 'systematic_workflow_start',
+        sessionID: SESSION_A,
+        callID: 'expanded-start',
+        args,
+      },
+      output,
+    )
+
+    const markers = output.metadata[SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]
+    expect(markers).toBeDefined()
+    const unitMarker = Array.isArray(markers)
+      ? markers.find(
+          (marker): marker is Record<string, unknown> =>
+            typeof marker === 'object' &&
+            marker !== null &&
+            (marker as Record<string, unknown>).target === 'unit',
+        )
+      : markers
+    expect(unitMarker).toMatchObject({
+      target: 'unit',
+      state: 'started',
+      requiredOperations: [
+        'implementation',
+        'verification',
+        'commit',
+        'push',
+        'review-readback',
+      ],
+      resourceScopes: [
+        {
+          operation: 'push',
+          resourceIdentity: ledger(adapter).digestIdentity(
+            'resource',
+            'remote-resource',
+          ),
+        },
+        {
+          operation: 'review-readback',
+          resourceIdentity: ledger(adapter).digestIdentity(
+            'resource',
+            'review-resource',
+          ),
+        },
+      ],
+    })
+    expect(status(adapter)).toMatchObject({
+      state: 'waiting',
+      missingOperations: [
+        'implementation',
+        'verification',
+        'commit',
+        'review-readback',
+        'push',
+      ],
+    })
+  })
+
+  test('does not emit a second progression marker for a no-growth start', async () => {
+    const adapter = createAdapter('observe')
+    await observeSkill(adapter, 'systematic_skill', 'ce:work')
+    const output = {
+      title: 'pending',
+      output: 'start complete',
+      metadata: {},
+    }
+    const args = { expected_operations: [] }
+    await adapter.hooks['tool.execute.before'](
+      {
+        tool: 'systematic_workflow_start',
+        sessionID: SESSION_A,
+        callID: 'no-growth-start',
+      },
+      { args },
+    )
+    await adapter.hooks['tool.execute.after'](
+      {
+        tool: 'systematic_workflow_start',
+        sessionID: SESSION_A,
+        callID: 'no-growth-start',
+        args,
+      },
+      output,
+    )
+
+    expect(output.metadata[SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]).toBe(
+      undefined,
+    )
+    expect(output.output).toContain('unit-active')
+  })
+
+  test('replays an expanded parent declaration without becoming unavailable', async () => {
+    const source = createAdapter(
+      'observe',
+      false,
+      sequenceObserver([{ targetDigest: 'a'.repeat(64) }]),
+      [],
+      undefined,
+      undefined,
+      true,
+    )
+    const skillOutput = { title: 'skill', output: 'loaded', metadata: {} }
+    await observeSkill(
+      source,
+      'systematic_skill',
+      'ce:work',
+      'replay-skill',
+      SESSION_A,
+      skillOutput,
+    )
+    const startOutput = {
+      title: 'start',
+      output: 'started',
+      metadata: {},
+    }
+    const startArgs = { expected_operations: ['commit'] }
+    await source.hooks['tool.execute.before'](
+      {
+        tool: 'systematic_workflow_start',
+        sessionID: SESSION_A,
+        callID: 'replay-start',
+      },
+      { args: startArgs },
+    )
+    await source.hooks['tool.execute.after'](
+      {
+        tool: 'systematic_workflow_start',
+        sessionID: SESSION_A,
+        callID: 'replay-start',
+        args: startArgs,
+      },
+      startOutput,
+    )
+
+    const markers = [
+      skillOutput.metadata[SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY],
+      startOutput.metadata[SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY],
+    ].flatMap((value) => (Array.isArray(value) ? value : [value]))
+    const parts = [
+      {
+        info: {},
+        parts: [
+          {
+            state: {
+              metadata: {
+                [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: markers,
+              },
+            },
+          },
+        ],
+      },
+    ]
+    const restored = createAdapter(
+      'observe',
+      false,
+      sequenceObserver([{ targetDigest: 'a'.repeat(64) }]),
+      [],
+      undefined,
+      {
+        readSessionParts: async () => parts,
+        listChildren: async () => [],
+      },
+      true,
+    )
+    await restored.tools.systematic_workflow_status.execute({}, toolContext())
+
+    expect(status(restored)).toMatchObject({
+      state: 'waiting',
+      missingOperations: ['implementation', 'verification', 'commit'],
+    })
+    expect(status(restored).reasonCode).not.toBe('guard-unavailable')
   })
 
   test('falls back to the mandatory floor for unknown guarded skills', async () => {
@@ -2747,12 +2955,122 @@ describe('OpenCode workflow guard adapter', () => {
       return [epochStart, unitStart, mint]
     }
 
+    function buildChildMarkersWithReceipts(
+      registrationIdentity: string,
+      sessionSalt: Uint8Array,
+      workspaceIdentity: string,
+      receipts: readonly {
+        operation: 'implementation' | 'verification' | 'commit'
+        workspaceIdentity?: string
+        repositoryBeforeIdentity: string
+        repositoryAfterIdentity: string
+        worktreeBeforeIdentity: string
+        worktreeAfterIdentity: string
+      }[],
+    ): unknown[] {
+      const childLedger = createReceiptLedger({
+        capabilityFlags: ['workflow-guard'],
+        registrationIdentity,
+        sessionSalt,
+      })
+      const epochId = '8'.repeat(32)
+      const unitId = '9'.repeat(32)
+      const digestCall = (tag: string) =>
+        childLedger.digestIdentity('call', tag)
+      const epochStart = projectReceiptProgressionMarker(childLedger, {
+        target: 'epoch',
+        state: 'started',
+        epochId,
+        family: 'work',
+        transitionDigest: digestCall('epoch-start'),
+        timestamp: 10,
+      })
+      const unitStart = projectReceiptProgressionMarker(childLedger, {
+        target: 'unit',
+        state: 'started',
+        epochId,
+        unitId,
+        family: 'work',
+        requiredOperations: receipts.map(({ operation }) => operation),
+        resourceScopes: [],
+        transitionDigest: digestCall('unit-start'),
+        timestamp: 11,
+      })
+      if (!epochStart || !unitStart)
+        throw new Error('progression marker failed')
+
+      const mints = receipts.map((receipt, index) => {
+        const callId = `child-${receipt.operation}-${index}`
+        const receiptWorkspaceIdentity =
+          receipt.workspaceIdentity ?? workspaceIdentity
+        const context = {
+          epochId,
+          unitId,
+          workspaceIdentity: receiptWorkspaceIdentity,
+          repositoryIdentity: receipt.repositoryBeforeIdentity,
+          worktreeIdentity: receipt.worktreeBeforeIdentity,
+        }
+        expect(
+          childLedger.prepareObservation({
+            callId,
+            operation: receipt.operation,
+            context,
+          }).status,
+        ).toBe('prepared')
+        const finalized = childLedger.finalizeObservation({
+          callId,
+          context,
+          after: {
+            workspaceIdentity: receiptWorkspaceIdentity,
+            repositoryIdentity: receipt.repositoryAfterIdentity,
+            worktreeIdentity: receipt.worktreeAfterIdentity,
+            ...(receipt.operation === 'commit' ? { commitClosure: true } : {}),
+          },
+          classification: {
+            outcome: 'accepted',
+            category: receipt.operation,
+            attribution: 'runtime-verified',
+            result: 'success',
+            sideEffect: 'required',
+            reasonCode: 'recognized-command',
+          },
+          terminal: { status: 'success', output: 'non-empty', noOp: false },
+        })
+        if (finalized.status !== 'finalized')
+          throw new Error('child receipt did not finalize')
+        const mint = projectReceiptMintMarker(finalized.receipt, sessionSalt)
+        if (!mint) throw new Error('child mint marker failed')
+        return mint
+      })
+
+      return [epochStart, unitStart, ...mints]
+    }
+
     // Helper: fire the task after hook with a given child session's parts
     async function fireTaskAfter(
       adapter: OpencodeWorkflowGuard,
       childSessionID: string,
       sessionID = SESSION_A,
-    ): Promise<void> {
+    ): Promise<{
+      title: string
+      output: string
+      metadata: Record<string, unknown>
+    }> {
+      const output: {
+        title: string
+        output: string
+        metadata: Record<string, unknown>
+      } = {
+        title: 'task result',
+        output: 'done',
+        metadata: { sessionId: childSessionID },
+      }
+      await adapter.hooks['tool.execute.before']({
+        tool: 'task',
+        sessionID,
+        callID: 'task-call-1',
+        args: {},
+      })
       await adapter.hooks['tool.execute.after'](
         {
           tool: 'task',
@@ -2760,12 +3078,9 @@ describe('OpenCode workflow guard adapter', () => {
           callID: 'task-call-1',
           args: {},
         },
-        {
-          title: 'task result',
-          output: 'done',
-          metadata: { sessionId: childSessionID },
-        },
+        output,
       )
+      return output
     }
 
     test('RED: mixed-registration child markers must not mark parent unavailable (rollup bug reproduction)', async () => {
@@ -3215,19 +3530,28 @@ describe('OpenCode workflow guard adapter', () => {
       childSessionID: string,
       childPartsFactory: () => readonly unknown[],
       parentSessionID: string,
+      runtimeRequiredOperations: readonly ReceiptOperation[] = [],
+      repositoryIdentity = OPERATION_SCOPE.repositoryIdentity,
+      snapshotRepositoryIdentity = OPERATION_SCOPE.repositoryIdentity,
+      snapshotWorktreeIdentity = OPERATION_SCOPE.worktreeIdentity,
     ): OpencodeWorkflowGuard {
       return createOpencodeWorkflowGuard({
         config: { mode: 'observe', debug: false },
         ...OPERATION_SCOPE,
+        repositoryIdentity,
         registrationIdentity: ownIdentity,
         sessionSalt: ownSalt,
+        runtimeRequiredOperations,
         observer: {
           targetDigest: OPERATION_SCOPE.workspaceIdentity,
           async snapshot() {
             snapshotRef.called = true
             return {
               status: 'available' as const,
-              snapshot: operationSnapshot(),
+              snapshot: operationSnapshot(
+                snapshotRepositoryIdentity,
+                snapshotWorktreeIdentity,
+              ),
             }
           },
           async remoteSnapshot() {
@@ -3468,6 +3792,581 @@ describe('OpenCode workflow guard adapter', () => {
       )
       expect(ownAdapter.status(parentSessionID).reasonCode).toBe(
         beforeReasonCode,
+      )
+    })
+
+    test('foreign workspace child receipt still makes the parent unavailable', async () => {
+      const ownIdentity = 'rollup-foreign-workspace'
+      const ownSalt = new Uint8Array(32).fill(121)
+      const childSessionID = 'child-foreign-workspace'
+      const parentSessionID = SESSION_A
+      const childMarkers = buildChildMarkers(
+        ownIdentity,
+        ownSalt,
+        'workspace-other',
+        OPERATION_SCOPE.repositoryIdentity,
+        'worktree-before',
+        OPERATION_SCOPE.worktreeIdentity,
+      )
+      const childParts = [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: childMarkers,
+                },
+              },
+            },
+          ],
+        },
+      ]
+      const snapshotRef = { called: false }
+      const adapter = makeRollupAdapter(
+        ownIdentity,
+        ownSalt,
+        snapshotRef,
+        childSessionID,
+        () => childParts,
+        parentSessionID,
+      )
+
+      await observeSkill(
+        adapter,
+        'systematic_skill',
+        'ce:work',
+        'foreign-workspace-skill',
+      )
+      await fireTaskAfter(adapter, childSessionID, parentSessionID)
+
+      expect(snapshotRef.called).toBe(true)
+      expect(adapter.status(parentSessionID).reasonCode).toBe(
+        'guard-unavailable',
+      )
+    })
+
+    test('RED rollup preflights every local child receipt before minting any parent evidence', async () => {
+      const ownIdentity = 'rollup-preflight-before-mint'
+      const ownSalt = new Uint8Array(32).fill(126)
+      const childSessionID = 'child-preflight-before-mint'
+      const parentSessionID = SESSION_A
+      const finalRepository = 'f'.repeat(64)
+      const finalWorktree = '1'.repeat(64)
+      const childMarkers = buildChildMarkersWithReceipts(
+        ownIdentity,
+        ownSalt,
+        OPERATION_SCOPE.workspaceIdentity,
+        [
+          {
+            operation: 'implementation',
+            repositoryBeforeIdentity: OPERATION_SCOPE.repositoryIdentity,
+            repositoryAfterIdentity: finalRepository,
+            worktreeBeforeIdentity: OPERATION_SCOPE.worktreeIdentity,
+            worktreeAfterIdentity: finalWorktree,
+          },
+          {
+            operation: 'verification',
+            workspaceIdentity: 'workspace-other',
+            repositoryBeforeIdentity: finalRepository,
+            repositoryAfterIdentity: finalRepository,
+            worktreeBeforeIdentity: finalWorktree,
+            worktreeAfterIdentity: finalWorktree,
+          },
+        ],
+      )
+      const childParts = [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: childMarkers,
+                },
+              },
+            },
+          ],
+        },
+      ]
+      const snapshotRef = { called: false }
+      const adapter = makeRollupAdapter(
+        ownIdentity,
+        ownSalt,
+        snapshotRef,
+        childSessionID,
+        () => childParts,
+        parentSessionID,
+        ['implementation', 'verification'],
+        OPERATION_SCOPE.repositoryIdentity,
+        finalRepository,
+        finalWorktree,
+      )
+
+      await observeSkill(
+        adapter,
+        'systematic_skill',
+        'ce:work',
+        'preflight-before-mint-skill',
+        parentSessionID,
+      )
+      const beforeReceiptCount = ledger(adapter, parentSessionID).listReceipts()
+        .length
+
+      const output = await fireTaskAfter(
+        adapter,
+        childSessionID,
+        parentSessionID,
+      )
+      expect(snapshotRef.called).toBe(true)
+      expect(adapter.status(parentSessionID).reasonCode).toBe(
+        'guard-unavailable',
+      )
+      expect(ledger(adapter, parentSessionID).listReceipts()).toHaveLength(
+        beforeReceiptCount,
+      )
+      expect(
+        output.metadata[SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY],
+      ).toBeUndefined()
+    })
+
+    test('RED rollup mints implementation and verification from fresh parent context exactly once', async () => {
+      const ownIdentity = 'rollup-fresh-context-per-candidate'
+      const ownSalt = new Uint8Array(32).fill(127)
+      const childSessionID = 'child-fresh-context-per-candidate'
+      const parentSessionID = SESSION_A
+      const finalRepository = 'f'.repeat(64)
+      const finalWorktree = '1'.repeat(64)
+      const childMarkers = buildChildMarkersWithReceipts(
+        ownIdentity,
+        ownSalt,
+        OPERATION_SCOPE.workspaceIdentity,
+        [
+          {
+            operation: 'implementation',
+            repositoryBeforeIdentity: OPERATION_SCOPE.repositoryIdentity,
+            repositoryAfterIdentity: finalRepository,
+            worktreeBeforeIdentity: OPERATION_SCOPE.worktreeIdentity,
+            worktreeAfterIdentity: finalWorktree,
+          },
+          {
+            operation: 'verification',
+            repositoryBeforeIdentity: OPERATION_SCOPE.repositoryIdentity,
+            repositoryAfterIdentity: finalRepository,
+            worktreeBeforeIdentity: OPERATION_SCOPE.worktreeIdentity,
+            worktreeAfterIdentity: finalWorktree,
+          },
+        ],
+      )
+      const childParts = [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: childMarkers,
+                },
+              },
+            },
+          ],
+        },
+      ]
+      const snapshotRef = { called: false }
+      const adapter = makeRollupAdapter(
+        ownIdentity,
+        ownSalt,
+        snapshotRef,
+        childSessionID,
+        () => childParts,
+        parentSessionID,
+        ['implementation', 'verification'],
+        OPERATION_SCOPE.repositoryIdentity,
+        finalRepository,
+        finalWorktree,
+      )
+
+      await observeSkill(
+        adapter,
+        'systematic_skill',
+        'ce:work',
+        'fresh-context-per-candidate-skill',
+        parentSessionID,
+      )
+
+      const firstOutput = await fireTaskAfter(
+        adapter,
+        childSessionID,
+        parentSessionID,
+      )
+      const firstReceipts = ledger(adapter, parentSessionID).listReceipts()
+      const firstMarkers = [
+        firstOutput.metadata[SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY],
+      ].flatMap((value) =>
+        Array.isArray(value) ? value : value ? [value] : [],
+      )
+      const firstMarkerReceiptIDs = firstMarkers.map(
+        (marker) =>
+          (
+            marker as {
+              envelope: { canonical: { receiptId: string } }
+            }
+          ).envelope.canonical.receiptId,
+      )
+
+      expect(snapshotRef.called).toBe(true)
+      expect(firstReceipts).toHaveLength(2)
+      expect(
+        firstReceipts.map((receipt) => receipt.canonical.operation),
+      ).toEqual(['implementation', 'verification'])
+      expect(status(adapter, parentSessionID).satisfiedOperations).toEqual(
+        expect.arrayContaining(['implementation', 'verification']),
+      )
+      expect(status(adapter, parentSessionID).reasonCode).not.toBe(
+        'fresh-readback',
+      )
+      expect(firstMarkers).toHaveLength(2)
+      expect(new Set(firstMarkerReceiptIDs).size).toBe(2)
+
+      const secondOutput = await fireTaskAfter(
+        adapter,
+        childSessionID,
+        parentSessionID,
+      )
+      expect(ledger(adapter, parentSessionID).listReceipts()).toHaveLength(2)
+      expect(
+        secondOutput.metadata[SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY],
+      ).toBeUndefined()
+    })
+
+    test('skips stale child receipts, mints a later current receipt, and rolls up once', async () => {
+      const ownIdentity = 'rollup-stale-then-current'
+      const ownSalt = new Uint8Array(32).fill(122)
+      const childSessionID = 'child-stale-then-current'
+      const parentSessionID = SESSION_A
+      const childMarkers = buildChildMarkersWithReceipts(
+        ownIdentity,
+        ownSalt,
+        OPERATION_SCOPE.workspaceIdentity,
+        [
+          {
+            operation: 'implementation',
+            repositoryBeforeIdentity: 'd'.repeat(64),
+            repositoryAfterIdentity: 'e'.repeat(64),
+            worktreeBeforeIdentity: 'f'.repeat(64),
+            worktreeAfterIdentity: '1'.repeat(64),
+          },
+          {
+            operation: 'commit',
+            repositoryBeforeIdentity: 'd'.repeat(64),
+            repositoryAfterIdentity: OPERATION_SCOPE.repositoryIdentity,
+            worktreeBeforeIdentity: OPERATION_SCOPE.worktreeIdentity,
+            worktreeAfterIdentity: OPERATION_SCOPE.worktreeIdentity,
+          },
+        ],
+      )
+      const childParts = [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: childMarkers,
+                },
+              },
+            },
+          ],
+        },
+      ]
+      const snapshotRef = { called: false }
+      const adapter = makeRollupAdapter(
+        ownIdentity,
+        ownSalt,
+        snapshotRef,
+        childSessionID,
+        () => childParts,
+        parentSessionID,
+        ['commit'],
+        'd'.repeat(64),
+      )
+
+      await observeSkill(
+        adapter,
+        'systematic_skill',
+        'ce:work',
+        'stale-then-current-skill',
+      )
+      await fireTaskAfter(adapter, childSessionID, parentSessionID)
+
+      const firstReceipts = ledger(adapter, parentSessionID).listReceipts()
+      expect(
+        firstReceipts.filter((receipt) => receipt.canonical.operation),
+      ).toHaveLength(1)
+      expect(firstReceipts[0]?.canonical.operation).toBe('commit')
+      expect(status(adapter, parentSessionID).satisfiedOperations).toContain(
+        'commit',
+      )
+
+      await fireTaskAfter(adapter, childSessionID, parentSessionID)
+      const secondReceipts = ledger(adapter, parentSessionID).listReceipts()
+      expect(secondReceipts).toHaveLength(firstReceipts.length)
+      expect(snapshotRef.called).toBe(true)
+    })
+
+    test('does not mark the parent unavailable when every child receipt is stale, and retries fresh evidence', async () => {
+      const ownIdentity = 'rollup-stale-only-retry'
+      const ownSalt = new Uint8Array(32).fill(123)
+      const childSessionID = 'child-stale-only-retry'
+      const parentSessionID = SESSION_A
+      let childMarkers = buildChildMarkersWithReceipts(
+        ownIdentity,
+        ownSalt,
+        OPERATION_SCOPE.workspaceIdentity,
+        [
+          {
+            operation: 'commit',
+            repositoryBeforeIdentity: 'd'.repeat(64),
+            repositoryAfterIdentity: 'e'.repeat(64),
+            worktreeBeforeIdentity: 'f'.repeat(64),
+            worktreeAfterIdentity: '1'.repeat(64),
+          },
+        ],
+      )
+      const childParts = () => [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: childMarkers,
+                },
+              },
+            },
+          ],
+        },
+      ]
+      const snapshotRef = { called: false }
+      const adapter = makeRollupAdapter(
+        ownIdentity,
+        ownSalt,
+        snapshotRef,
+        childSessionID,
+        childParts,
+        parentSessionID,
+        ['commit'],
+        'd'.repeat(64),
+      )
+
+      await observeSkill(
+        adapter,
+        'systematic_skill',
+        'ce:work',
+        'stale-only-retry-skill',
+      )
+      await fireTaskAfter(adapter, childSessionID, parentSessionID)
+
+      expect(snapshotRef.called).toBe(true)
+      expect(status(adapter, parentSessionID).reasonCode).not.toBe(
+        'guard-unavailable',
+      )
+      expect(ledger(adapter, parentSessionID).listReceipts()).toHaveLength(0)
+      expect(
+        status(adapter, parentSessionID).satisfiedOperations,
+      ).not.toContain('commit')
+
+      childMarkers = buildChildMarkersWithReceipts(
+        ownIdentity,
+        ownSalt,
+        OPERATION_SCOPE.workspaceIdentity,
+        [
+          {
+            operation: 'commit',
+            repositoryBeforeIdentity: 'd'.repeat(64),
+            repositoryAfterIdentity: OPERATION_SCOPE.repositoryIdentity,
+            worktreeBeforeIdentity: OPERATION_SCOPE.worktreeIdentity,
+            worktreeAfterIdentity: OPERATION_SCOPE.worktreeIdentity,
+          },
+        ],
+      )
+      await fireTaskAfter(adapter, childSessionID, parentSessionID)
+
+      expect(ledger(adapter, parentSessionID).listReceipts()).toHaveLength(1)
+      expect(status(adapter, parentSessionID).satisfiedOperations).toContain(
+        'commit',
+      )
+    })
+
+    test('uses the guard current context after a parent implementation before rolling up a child commit', async () => {
+      const ownIdentity = 'rollup-parent-local-before-child-commit'
+      const ownSalt = new Uint8Array(32).fill(124)
+      const childSessionID = 'child-parent-local-before-commit'
+      const parentSessionID = SESSION_A
+      const parentRepository = 'd'.repeat(64)
+      const parentWorktree = 'e'.repeat(64)
+      const finalRepository = 'f'.repeat(64)
+      const finalWorktree = '1'.repeat(64)
+      const childMarkers = buildChildMarkersWithReceipts(
+        ownIdentity,
+        ownSalt,
+        OPERATION_SCOPE.workspaceIdentity,
+        [
+          {
+            operation: 'commit',
+            repositoryBeforeIdentity: parentRepository,
+            repositoryAfterIdentity: finalRepository,
+            worktreeBeforeIdentity: parentWorktree,
+            worktreeAfterIdentity: finalWorktree,
+          },
+        ],
+      )
+      const snapshot = sequenceObserver([
+        operationSnapshot(),
+        operationSnapshot(parentRepository, parentWorktree),
+        operationSnapshot(finalRepository, finalWorktree),
+      ])
+      const adapter = createOpencodeWorkflowGuard({
+        config: { mode: 'observe', debug: false },
+        ...OPERATION_SCOPE,
+        registrationIdentity: ownIdentity,
+        sessionSalt: ownSalt,
+        runtimeRequiredOperations: ['commit'],
+        classifier: createReceiptClassifier(),
+        observer: snapshot,
+        hostReadback: {
+          readSessionParts: async (sessionID) =>
+            sessionID === parentSessionID
+              ? []
+              : [
+                  {
+                    info: {},
+                    parts: [
+                      {
+                        state: {
+                          metadata: {
+                            [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]:
+                              childMarkers,
+                          },
+                        },
+                      },
+                    ],
+                  },
+                ],
+          listChildren: async (sessionID) =>
+            sessionID === parentSessionID
+              ? [{ sessionId: childSessionID, parentID: parentSessionID }]
+              : [],
+        },
+      })
+
+      await observeSkill(
+        adapter,
+        'systematic_skill',
+        'ce:work',
+        'parent-local-before-child-commit-skill',
+        parentSessionID,
+      )
+      await observeOperationTool(
+        adapter,
+        'write',
+        { filePath: 'parent-local.txt', content: 'parent change' },
+        { title: 'write', output: 'changed', metadata: {} },
+        'parent-local-implementation',
+        parentSessionID,
+      )
+      expect(ledger(adapter, parentSessionID).listReceipts()).toHaveLength(1)
+      expect(status(adapter, parentSessionID).satisfiedOperations).toContain(
+        'implementation',
+      )
+
+      await fireTaskAfter(adapter, childSessionID, parentSessionID)
+
+      const receipts = ledger(adapter, parentSessionID).listReceipts()
+      expect(receipts).toHaveLength(2)
+      expect(receipts.map((receipt) => receipt.canonical.operation)).toEqual([
+        'implementation',
+        'commit',
+      ])
+      expect(status(adapter, parentSessionID).satisfiedOperations).toContain(
+        'commit',
+      )
+      expect(status(adapter, parentSessionID).reasonCode).not.toBe(
+        'guard-unavailable',
+      )
+    })
+
+    test('rolls up a child commit when boot repository and worktree identities are omitted', async () => {
+      const ownIdentity = 'rollup-optional-boot-identities'
+      const ownSalt = new Uint8Array(32).fill(125)
+      const childSessionID = 'child-optional-boot-identities'
+      const parentSessionID = SESSION_A
+      const childMarkers = buildChildMarkersWithReceipts(
+        ownIdentity,
+        ownSalt,
+        OPERATION_SCOPE.workspaceIdentity,
+        [
+          {
+            operation: 'commit',
+            repositoryBeforeIdentity: 'd'.repeat(64),
+            repositoryAfterIdentity: OPERATION_SCOPE.repositoryIdentity,
+            worktreeBeforeIdentity: OPERATION_SCOPE.worktreeIdentity,
+            worktreeAfterIdentity: OPERATION_SCOPE.worktreeIdentity,
+          },
+        ],
+      )
+      const adapter = createOpencodeWorkflowGuard({
+        config: { mode: 'observe', debug: false },
+        workspaceIdentity: OPERATION_SCOPE.workspaceIdentity,
+        registrationIdentity: ownIdentity,
+        sessionSalt: ownSalt,
+        runtimeRequiredOperations: ['commit'],
+        observer: sequenceObserver([
+          operationSnapshot('d'.repeat(64), OPERATION_SCOPE.worktreeIdentity),
+          operationSnapshot(),
+        ]),
+        hostReadback: {
+          readSessionParts: async (sessionID) =>
+            sessionID === parentSessionID
+              ? []
+              : [
+                  {
+                    info: {},
+                    parts: [
+                      {
+                        state: {
+                          metadata: {
+                            [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]:
+                              childMarkers,
+                          },
+                        },
+                      },
+                    ],
+                  },
+                ],
+          listChildren: async (sessionID) =>
+            sessionID === parentSessionID
+              ? [{ sessionId: childSessionID, parentID: parentSessionID }]
+              : [],
+        },
+      })
+
+      await observeSkill(
+        adapter,
+        'systematic_skill',
+        'ce:work',
+        'optional-boot-identities-skill',
+        parentSessionID,
+      )
+      await adapter.tools.systematic_workflow_status.execute(
+        {},
+        toolContext(parentSessionID),
+      )
+      await fireTaskAfter(adapter, childSessionID, parentSessionID)
+
+      expect(ledger(adapter, parentSessionID).listReceipts()).toHaveLength(1)
+      expect(status(adapter, parentSessionID).satisfiedOperations).toContain(
+        'commit',
       )
     })
   })

--- a/tests/unit/receipt-classifier.test.ts
+++ b/tests/unit/receipt-classifier.test.ts
@@ -288,6 +288,34 @@ describe('receipt classifier', () => {
     await classifier.close()
   })
 
+  test('does not let a non-shell write claim a commit operation', async () => {
+    const classifier = createReceiptClassifier()
+    const identity = 'a'.repeat(64)
+    const result = await classifier.classifyOperation({
+      callId: 'non-shell-commit-claim',
+      operation: 'commit',
+      tool: 'write',
+      context: {
+        epochId: 'epoch-1',
+        unitId: 'unit-1',
+        workspaceIdentity: identity,
+        repositoryIdentity: 'b'.repeat(64),
+        worktreeIdentity: 'c'.repeat(64),
+      },
+      after: {
+        workspaceIdentity: identity,
+        repositoryIdentity: 'd'.repeat(64),
+        worktreeIdentity: 'e'.repeat(64),
+        commitClosure: true,
+      },
+      terminal: successfulTerminal,
+    })
+
+    expect(result.outcome).toBe('rejected')
+    expect(result.category).not.toBe('commit')
+    await classifier.close()
+  })
+
   test('rejects prohibited shell shapes without a string fallback', async () => {
     const classifier = createReceiptClassifier()
     const prohibited = [

--- a/tests/unit/receipt-operations.test.ts
+++ b/tests/unit/receipt-operations.test.ts
@@ -94,6 +94,9 @@ interface ReadbackResult {
 
 interface OperationWorkflowGuard extends WorkflowGuard {
   observeOperation(input: unknown): Promise<EvidenceObservationResult>
+  observeTrustedRecoveredOperation(
+    input: unknown,
+  ): Promise<EvidenceObservationResult>
   observeReadback(input: unknown): ReadbackResult
 }
 
@@ -248,6 +251,16 @@ function bindOperation(
       unitId: status.unit.unitId,
     },
   }
+}
+
+async function observeTrustedRecoveredOperation(
+  guard: OperationWorkflowGuard,
+  input: Record<string, unknown>,
+): Promise<EvidenceObservationResult> {
+  if (typeof guard.observeTrustedRecoveredOperation !== 'function') {
+    return { status: 'rejected', reasonCode: 'guard-unavailable' }
+  }
+  return guard.observeTrustedRecoveredOperation(bindOperation(guard, input))
 }
 
 function mintSyntheticReceipt(
@@ -496,6 +509,113 @@ async function buildFullOperationScenario(): Promise<{
 }
 
 describe('receipt operation adapters', () => {
+  test('observes a trusted recovered commit without invoking command classification', async () => {
+    const scenario = createScenario(
+      {
+        classifyOperation: async () => {
+          throw new Error('trusted recovery must bypass classification')
+        },
+      },
+      ['commit'],
+    )
+    const input = operationInput('commit', {
+      tool: 'write',
+      command: undefined,
+      context: {
+        ...baseContext,
+        repositoryIdentity: REPOSITORY_CURRENT,
+      },
+      after: {
+        workspaceIdentity: WORKSPACE_CURRENT,
+        repositoryIdentity: REPOSITORY_AFTER,
+        worktreeIdentity: WORKTREE_CURRENT,
+      },
+    })
+
+    await expect(
+      observeTrustedRecoveredOperation(scenario.guard, input),
+    ).resolves.toEqual({
+      status: 'accepted',
+      operation: 'commit',
+    })
+    expect(scenario.guard.status().satisfiedOperations).toContain('commit')
+  })
+
+  test('ordinary write-to-commit observation remains classifier-rejected', async () => {
+    const classifier = createReceiptClassifier()
+    const scenario = createScenario(classifier, ['commit'])
+    const input = operationInput('commit', {
+      tool: 'write',
+      command: undefined,
+      context: {
+        ...baseContext,
+        repositoryIdentity: REPOSITORY_CURRENT,
+      },
+      after: {
+        workspaceIdentity: WORKSPACE_CURRENT,
+        repositoryIdentity: REPOSITORY_AFTER,
+        worktreeIdentity: WORKTREE_CURRENT,
+      },
+    })
+
+    await expect(
+      scenario.guard.observeOperation(bindOperation(scenario.guard, input)),
+    ).resolves.toMatchObject({ status: 'rejected' })
+    expect(scenario.guard.status().satisfiedOperations).not.toContain('commit')
+    await classifier.close()
+  })
+
+  test('keeps required-operation and identity checks on trusted recovered operations', async () => {
+    const scenario = createScenario({
+      classifyOperation: async () => {
+        throw new Error('trusted recovery must bypass classification')
+      },
+    })
+    const commit = operationInput('commit', {
+      tool: 'write',
+      command: undefined,
+      context: {
+        ...baseContext,
+        repositoryIdentity: REPOSITORY_CURRENT,
+      },
+    })
+
+    await expect(
+      observeTrustedRecoveredOperation(scenario.guard, commit),
+    ).resolves.toEqual({
+      status: 'rejected',
+      reasonCode: 'operation-not-required',
+    })
+
+    const requiredScenario = createScenario(
+      {
+        classifyOperation: async () => {
+          throw new Error('trusted recovery must bypass classification')
+        },
+      },
+      ['implementation'],
+    )
+    const wrongWorkspace = operationInput('implementation', {
+      tool: 'write',
+      command: undefined,
+      context: {
+        ...baseContext,
+        workspaceIdentity: WORKSPACE_OTHER,
+      },
+      after: {
+        ...operationInput('implementation').after,
+        workspaceIdentity: WORKSPACE_OTHER,
+        worktreeIdentity: WORKTREE_AFTER,
+      },
+    })
+    await expect(
+      observeTrustedRecoveredOperation(requiredScenario.guard, wrongWorkspace),
+    ).resolves.toEqual({
+      status: 'rejected',
+      reasonCode: 'workspace-mismatch',
+    })
+  })
+
   test('recognizes all seven operation classes without returning command or resource data', async () => {
     const classifier =
       createReceiptClassifier() as unknown as OperationClassifier

--- a/tests/unit/receipt-readback.test.ts
+++ b/tests/unit/receipt-readback.test.ts
@@ -369,6 +369,219 @@ describe('receipt readback', () => {
     }
   })
 
+  test('folds a same-unit monotonic started declaration extension', () => {
+    const fixture = createFixture()
+    const expanded = required(
+      projectReceiptProgressionMarker(fixture.ledger, {
+        target: 'unit',
+        state: 'started',
+        epochId: EPOCH_ID,
+        unitId: UNIT_ID,
+        family: 'work',
+        requiredOperations: ['implementation', 'verification'],
+        resourceScopes: [],
+        transitionDigest: fixture.ledger.digestIdentity(
+          'call',
+          'unit-start-expanded',
+        ),
+        timestamp: 6,
+      }),
+      'expanded-unit-start-not-projected',
+    )
+
+    const result = foldReceiptReadback(
+      [fixture.epochStart, fixture.unitStart, expanded, fixture.mint],
+      expectationOf(fixture),
+    )
+
+    expect(result).toMatchObject({
+      status: 'reconstructed',
+      state: {
+        progression: {
+          unit: {
+            state: 'started',
+            requiredOperations: ['implementation', 'verification'],
+          },
+        },
+      },
+    })
+  })
+
+  test('treats identical same-unit declarations as idempotent across marker metadata', () => {
+    const fixture = createFixture()
+    const duplicateDeclaration = required(
+      projectReceiptProgressionMarker(fixture.ledger, {
+        target: 'unit',
+        state: 'started',
+        epochId: EPOCH_ID,
+        unitId: UNIT_ID,
+        family: 'work',
+        requiredOperations: ['implementation'],
+        resourceScopes: [],
+        transitionDigest: fixture.ledger.digestIdentity('call', 'unit-start'),
+        timestamp: 6,
+      }),
+      'duplicate-unit-start-not-projected',
+    )
+
+    expect(
+      foldReceiptReadback(
+        [fixture.epochStart, fixture.unitStart, duplicateDeclaration],
+        expectationOf(fixture),
+      ),
+    ).toMatchObject({ status: 'reconstructed' })
+  })
+
+  test('rejects same-unit declaration growth after evidence has been minted', () => {
+    const fixture = createFixture()
+    const expanded = required(
+      projectReceiptProgressionMarker(fixture.ledger, {
+        target: 'unit',
+        state: 'started',
+        epochId: EPOCH_ID,
+        unitId: UNIT_ID,
+        family: 'work',
+        requiredOperations: ['implementation', 'verification'],
+        resourceScopes: [],
+        transitionDigest: fixture.ledger.digestIdentity(
+          'call',
+          'unit-start-after-evidence',
+        ),
+        timestamp: 6,
+      }),
+      'expanded-unit-start-not-projected',
+    )
+
+    expect(
+      foldReceiptReadback(
+        [fixture.epochStart, fixture.unitStart, fixture.mint, expanded],
+        expectationOf(fixture),
+      ),
+    ).toEqual({ status: 'rejected', category: 'out-of-order' })
+  })
+
+  test('rejects same-unit declaration shrink and changed existing resource scope', () => {
+    const fixture = createFixture()
+    const expanded = required(
+      projectReceiptProgressionMarker(fixture.ledger, {
+        target: 'unit',
+        state: 'started',
+        epochId: EPOCH_ID,
+        unitId: UNIT_ID,
+        family: 'work',
+        requiredOperations: ['implementation', 'verification'],
+        resourceScopes: [
+          {
+            operation: 'push',
+            resourceIdentity: 'c'.repeat(64),
+          },
+        ],
+        transitionDigest: fixture.ledger.digestIdentity(
+          'call',
+          'unit-start-expanded',
+        ),
+        timestamp: 6,
+      }),
+      'expanded-unit-start-not-projected',
+    )
+    const shrink = required(
+      projectReceiptProgressionMarker(fixture.ledger, {
+        target: 'unit',
+        state: 'started',
+        epochId: EPOCH_ID,
+        unitId: UNIT_ID,
+        family: 'work',
+        requiredOperations: ['implementation'],
+        resourceScopes: [],
+        transitionDigest: fixture.ledger.digestIdentity(
+          'call',
+          'unit-start-shrink',
+        ),
+        timestamp: 7,
+      }),
+      'shrink-unit-start-not-projected',
+    )
+    const changedScope = required(
+      projectReceiptProgressionMarker(fixture.ledger, {
+        target: 'unit',
+        state: 'started',
+        epochId: EPOCH_ID,
+        unitId: UNIT_ID,
+        family: 'work',
+        requiredOperations: ['implementation', 'verification'],
+        resourceScopes: [
+          {
+            operation: 'push',
+            resourceIdentity: 'd'.repeat(64),
+          },
+        ],
+        transitionDigest: fixture.ledger.digestIdentity(
+          'call',
+          'unit-start-changed-scope',
+        ),
+        timestamp: 8,
+      }),
+      'changed-scope-unit-start-not-projected',
+    )
+
+    expect(
+      foldReceiptReadback(
+        [fixture.epochStart, fixture.unitStart, expanded, shrink],
+        expectationOf(fixture),
+      ),
+    ).toEqual({ status: 'rejected', category: 'conflicting-marker' })
+    expect(
+      foldReceiptReadback(
+        [fixture.epochStart, fixture.unitStart, expanded, changedScope],
+        expectationOf(fixture),
+      ),
+    ).toEqual({ status: 'rejected', category: 'conflicting-marker' })
+  })
+
+  test('retains added resource scopes in the recovered progression', () => {
+    const fixture = createFixture()
+    const scoped = required(
+      projectReceiptProgressionMarker(fixture.ledger, {
+        target: 'unit',
+        state: 'started',
+        epochId: EPOCH_ID,
+        unitId: UNIT_ID,
+        family: 'work',
+        requiredOperations: ['implementation', 'push'],
+        resourceScopes: [
+          {
+            operation: 'push',
+            resourceIdentity: 'c'.repeat(64),
+          },
+        ],
+        transitionDigest: fixture.ledger.digestIdentity(
+          'call',
+          'unit-start-scoped',
+        ),
+        timestamp: 6,
+      }),
+      'scoped-unit-start-not-projected',
+    )
+
+    const result = foldReceiptReadback(
+      [fixture.epochStart, fixture.unitStart, scoped],
+      expectationOf(fixture),
+    )
+    expect(result).toMatchObject({
+      status: 'reconstructed',
+      state: {
+        progression: {
+          unit: {
+            requiredOperations: ['implementation', 'push'],
+            resourceScopes: [
+              { operation: 'push', resourceIdentity: 'c'.repeat(64) },
+            ],
+          },
+        },
+      },
+    })
+  })
+
   test('extracts an agreeing seed and rejects salt, registration, or capability disagreement', () => {
     const fixture = createFixture()
     const ready = extractReceiptReadbackSeed([

--- a/tests/unit/workflow-guard-recovery.test.ts
+++ b/tests/unit/workflow-guard-recovery.test.ts
@@ -191,12 +191,14 @@ function createProgressionMarkers(
 
 function createGuard(
   ledger: ReturnType<typeof createReceiptLedger>,
+  runtimeResourceScopes: Readonly<Record<string, string>> = {},
 ): WorkflowGuard {
   return createWorkflowGuard({
     ledger,
     workspaceIdentity: WORKSPACE_ID,
     repositoryIdentity: REPOSITORY_ID,
     worktreeIdentity: WORKTREE_ID,
+    runtimeResourceScopes,
     mode: 'protected',
   })
 }
@@ -624,8 +626,22 @@ describe('workflow guard recovery', () => {
       reasonCode: 'resource-mismatch',
       repair: 'fresh-readback',
       missingOperations: ['push'],
-      unit: { requiredResourceOperations: ['push'] },
+      unit: {
+        requiredResourceOperations: ['push'],
+        resourceScopes: [],
+      },
     })
+
+    const trustedGuard = createGuard(fixture.ledger, {
+      push: 'remote-current',
+    })
+    expect(
+      trustedGuard.restore({ provenance: 'restart', state: fixture.state }),
+    ).toMatchObject({ status: 'restored' })
+    expect(trustedGuard.status().unit?.resourceScopes).toEqual([
+      { operation: 'push', resourceIdentity: 'remote-current' },
+    ])
+
     expect(
       guard.observeReadback({
         operation: 'push',
@@ -641,5 +657,129 @@ describe('workflow guard recovery', () => {
       satisfiedOperations: ['push'],
       missingOperations: [],
     })
+
+    const conflictingGuard = createGuard(fixture.ledger, {
+      push: 'remote-before',
+    })
+    expect(
+      conflictingGuard.restore({
+        provenance: 'restart',
+        state: fixture.state,
+      }),
+    ).toEqual({ status: 'rejected', reasonCode: 'resource-mismatch' })
+  })
+
+  test('recovers a monotonic declaration extension with its added resource scope', () => {
+    const sourceLedger = createReceiptLedger({
+      registrationIdentity: 'registration-a',
+      sessionSalt: SESSION_SALT,
+    })
+    const epochStart = projectReceiptProgressionMarker(sourceLedger, {
+      target: 'epoch',
+      state: 'started',
+      epochId: EPOCH_ID,
+      family: 'shipping',
+      transitionDigest: sourceLedger.digestIdentity('call', 'epoch-start'),
+      timestamp: 1,
+    })
+    const unitStart = projectReceiptProgressionMarker(sourceLedger, {
+      target: 'unit',
+      state: 'started',
+      epochId: EPOCH_ID,
+      unitId: UNIT_ID,
+      family: 'shipping',
+      requiredOperations: ['implementation'],
+      resourceScopes: [],
+      transitionDigest: sourceLedger.digestIdentity('call', 'unit-start'),
+      timestamp: 2,
+    })
+    const expanded = projectReceiptProgressionMarker(sourceLedger, {
+      target: 'unit',
+      state: 'started',
+      epochId: EPOCH_ID,
+      unitId: UNIT_ID,
+      family: 'shipping',
+      requiredOperations: ['implementation', 'push'],
+      resourceScopes: [
+        {
+          operation: 'push',
+          resourceIdentity: sourceLedger.digestIdentity(
+            'resource',
+            'remote-resource',
+          ),
+        },
+      ],
+      transitionDigest: sourceLedger.digestIdentity(
+        'call',
+        'unit-start-expanded',
+      ),
+      timestamp: 3,
+    })
+    expect(epochStart && unitStart && expanded).toBeTruthy()
+    if (!epochStart || !unitStart || !expanded)
+      throw new Error('declaration-marker-not-projected')
+
+    const recoveredLedger = createReceiptLedger({
+      registrationIdentity: 'registration-a',
+      sessionSalt: SESSION_SALT,
+    })
+    const markers = [epochStart, unitStart, expanded]
+    expect(recoveredLedger.recoverReadback(markers)).toMatchObject({
+      status: 'recovered',
+    })
+    const folded = foldReceiptReadback(markers, {
+      registrationDigest: recoveredLedger.metadata.registrationDigest,
+      capabilityFlags: recoveredLedger.metadata.capabilityFlags,
+      expectedSource: 'runtime-verified',
+      sessionSalt: SESSION_SALT,
+    })
+    expect(folded.status).toBe('reconstructed')
+    if (folded.status !== 'reconstructed')
+      throw new Error('declaration-state-not-folded')
+
+    const guard = createGuard(recoveredLedger, { push: 'remote-resource' })
+    expect(
+      guard.restore({ provenance: 'restart', state: folded.state }),
+    ).toMatchObject({ status: 'restored' })
+    expect(guard.status()).toMatchObject({
+      unit: {
+        unitId: UNIT_ID,
+        requiredOperations: ['implementation', 'push'],
+        requiredResourceOperations: ['push'],
+        resourceScopes: [
+          { operation: 'push', resourceIdentity: 'remote-resource' },
+        ],
+      },
+    })
+
+    const conflictingState = {
+      ...folded.state,
+      progression: {
+        ...folded.state.progression,
+        unit: folded.state.progression.unit
+          ? {
+              ...folded.state.progression.unit,
+              resourceScopes: [
+                {
+                  operation: 'push' as const,
+                  resourceIdentity: recoveredLedger.digestIdentity(
+                    'resource',
+                    'other-resource',
+                  ),
+                },
+              ],
+            }
+          : null,
+      },
+    }
+    const conflictingGuard = createGuard(recoveredLedger, {
+      push: 'remote-resource',
+    })
+    expect(
+      conflictingGuard.restore({
+        provenance: 'restart',
+        state: conflictingState,
+      }),
+    ).toEqual({ status: 'rejected', reasonCode: 'invalid-recovery' })
   })
 })

--- a/tests/unit/workflow-guard.test.ts
+++ b/tests/unit/workflow-guard.test.ts
@@ -173,6 +173,30 @@ function guardWithReceipts(
 }
 
 describe('workflow guard', () => {
+  test('exposes a frozen current operation context without mutable state', () => {
+    const { guard } = createGuard()
+
+    expect(guard.currentOperationContext()).toEqual({
+      workspaceIdentity: SCOPE.workspaceIdentity,
+      repositoryIdentity: SCOPE.repositoryIdentity,
+      worktreeIdentity: SCOPE.worktreeIdentity,
+    })
+    expect(Object.isFrozen(guard.currentOperationContext())).toBe(true)
+
+    expect(
+      guard.observeReadback({
+        workspaceIdentity: 'workspace-next',
+        repositoryIdentity: 'repository-next',
+        worktreeIdentity: 'worktree-next',
+      }),
+    ).toMatchObject({ status: 'accepted' })
+    expect(guard.currentOperationContext()).toEqual({
+      workspaceIdentity: 'workspace-next',
+      repositoryIdentity: 'repository-next',
+      worktreeIdentity: 'worktree-next',
+    })
+  })
+
   test('activates on successful guarded skills, reuses work, and attaches nested shipping', () => {
     const { guard } = createGuard()
 
@@ -1173,6 +1197,102 @@ describe('workflow guard', () => {
       status: 'rejected',
       reasonCode: 'runtime-scope-conflict',
     })
+  })
+
+  test('upgrades a pristine active unit monotonically without changing its identity', () => {
+    const { guard } = createGuard()
+    activateWork(guard)
+    startUnit(guard)
+    const before = guard.status()
+    const epochId = before.epoch?.epochId
+    const unitId = before.unit?.unitId
+
+    const result = guard.startUnit({
+      expectedOperations: ['commit'],
+      resourceScopes: { push: 'remote-resource' },
+    })
+
+    expect(result).toMatchObject({
+      status: 'started',
+      unit: {
+        unitId,
+        requiredOperations: [
+          'implementation',
+          'verification',
+          'commit',
+          'push',
+        ],
+        requiredResourceOperations: ['push'],
+      },
+    })
+    expect(guard.status()).toMatchObject({
+      epoch: { epochId },
+      unit: { unitId, requiredResourceOperations: ['push'] },
+      missingOperations: ['implementation', 'verification', 'commit', 'push'],
+    })
+  })
+
+  test('rejects a no-growth redeclaration without changing the active declaration', () => {
+    const { guard } = createGuard()
+    activateWork(guard)
+    startUnit(guard)
+    const before = guard.status()
+
+    expect(
+      guard.startUnit({
+        expectedOperations: [],
+        resourceScopes: {},
+      }),
+    ).toEqual({ status: 'rejected', reasonCode: 'unit-active' })
+    expect(guard.status()).toEqual(before)
+  })
+
+  test('rejects declaration expansion after evidence or attempt state exists', () => {
+    const withAttempt = createGuard()
+    activateWork(withAttempt.guard)
+    startUnit(withAttempt.guard)
+    expect(
+      withAttempt.guard.observeAttempt({
+        operation: 'implementation',
+        outcome: 'running',
+      }),
+    ).toMatchObject({ status: 'rejected' })
+    expect(
+      withAttempt.guard.startUnit({ expectedOperations: ['commit'] }),
+    ).toEqual({ status: 'rejected', reasonCode: 'unit-active' })
+
+    const withEvidence = createGuard()
+    activateWork(withEvidence.guard)
+    startUnit(withEvidence.guard)
+    expect(
+      withEvidence.guard.observeReceipt(
+        mintReceipt(withEvidence.guard, withEvidence.ledger, 'implementation'),
+      ),
+    ).toMatchObject({ status: 'accepted', operation: 'implementation' })
+    expect(
+      withEvidence.guard.startUnit({ expectedOperations: ['commit'] }),
+    ).toEqual({ status: 'rejected', reasonCode: 'unit-active' })
+  })
+
+  test('persists added resource scopes and rejects conflicting redeclarations', () => {
+    const { guard } = createGuard()
+    activateWork(guard)
+    startUnit(guard)
+    const upgraded = guard.startUnit({
+      expectedOperations: [],
+      resourceScopes: { push: 'remote-resource' },
+    })
+    expect(upgraded).toMatchObject({
+      status: 'started',
+      unit: { requiredResourceOperations: ['push'] },
+    })
+    expect(
+      guard.startUnit({
+        expectedOperations: [],
+        resourceScopes: { push: 'other-resource' },
+      }),
+    ).toEqual({ status: 'rejected', reasonCode: 'runtime-scope-conflict' })
+    expect(guard.status().unit?.requiredResourceOperations).toEqual(['push'])
   })
 
   test('status counts only currently qualified available evidence', () => {


### PR DESCRIPTION
## Summary

Protected workflows could fail closed after successful foreground task delegation. Child receipts were compared with the parent session's salt and boot-time revisions, stale intermediate receipts aborted the entire rollup, and explicit operation requirements declared after skill activation were not preserved across recovery.

This change:

- validates foreground child lineage and reconstructs receipt identities with the child session salt
- preflights receipt batches before minting, skips stale mutable revisions, and keeps foreign workspaces fail-closed
- re-attests current child evidence against the parent's live pre-task state without exposing a classifier bypass to model tools
- allows explicit starts to monotonically extend pristine auto-started units, including resource scopes, with replay-safe recovery
- preserves exactly-once rollup behavior across duplicate callbacks and host restarts
- replaces model-wording-sensitive and raw marker-count assertions with semantic integration checks

## Verification

- `bun test` — 1,828 passed, 0 failed, 1 skipped
- `bunx biome check .` — 137 files checked, no errors
- `bun run typecheck`
- `bun run build`
