### PR TITLE
fix(workflow): enforce delegated workspace attestation

### DIFF
--- a/docs/solutions/integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md
+++ b/docs/solutions/integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md
@@ -1,7 +1,7 @@
 ---
 title: Isolate harness subprocess and packaged-runtime fixtures
 date: 2026-05-14
-last_updated: 2026-07-14
+last_updated: 2026-07-31
 category: integration-issues
 module: harness integration tests
 problem_type: integration_issue
@@ -12,6 +12,7 @@ symptoms:
   - Pi can accept a raw tarball during install but fail when the next process tries to load it as an extension
   - Packaged-runtime tests can exercise stale `dist` output when `npm pack` runs without an explicit build
   - OpenCode can catch a plugin initialization failure and exit successfully, making exit code alone a false success signal
+  - Rebuilding the plugin and restarting OpenCode can still reproduce a persisted `guard-unavailable` transition when the same conversation is resumed
 root_cause: test_isolation
 resolution_type: test_fix
 severity: medium
@@ -40,6 +41,7 @@ Live harness tests need to verify the current checkout, not whatever Systematic 
 - Running `npm pack` without first building can package stale `dist` files; this repository's `prepublishOnly` script is not an `npm pack` build guarantee.
 - Loading `dist/index.js` directly does not exercise package-root resolution or prove that the expected files reached the tarball.
 - Requiring a nonzero child-process exit for invalid plugin config does not match OpenCode 1.17.18. The host catches plugin-factory failures, logs them, omits the hooks, and exits zero.
+- Restarting OpenCode alone is not a clean validation step: it reloads plugin code in a fresh process, but resuming the same conversation replays persisted message and tool metadata, including a pre-fix `guard-unavailable` transition.
 - For Pi 0.80.6, `pi install <raw-tarball.tgz> -l --approve` exits successfully but records the tarball as an extension path. The next Pi process then fails with `Failed to load extension` because a bare `.tgz` is not a managed package spec.
 - Checking `pi.extensions` paths or directly importing `dist/pi.js` proves package shape and module validity, but bypasses Pi's package installer and manifest-driven extension loader.
 
@@ -168,7 +170,7 @@ Explicit source-local and mixed-version scenarios keep the test's claim honest. 
 
 The packaged-artifact scenario closes a different gap: it validates the output of the real build-and-pack pipeline through package-root resolution. Building before packing prevents stale `dist` state from masquerading as a passing package test. Reusing one tarball controls setup cost, while per-test extraction preserves runtime isolation.
 
-OpenCode's successful process exit only describes the host process. It does not prove that a plugin factory or hook completed. Exact loader diagnostics plus positive registration probes distinguish a healthy plugin from a caught-and-logged failure. Each probe starts a fresh OpenCode process because active processes cache loaded plugin instances.
+OpenCode's successful process exit only describes the host process. It does not prove that a plugin factory or hook completed. Exact loader diagnostics plus positive registration probes distinguish a healthy plugin from a caught-and-logged failure. Each probe starts a fresh OpenCode process because active processes cache loaded plugin instances, so rebuilt plugin behavior is not observed reliably until the process is restarted. A process restart does not create a new conversation or session: resuming the same conversation replays persisted message and tool metadata. A conversation that already persisted a pre-fix `guard-unavailable` transition is therefore not a clean acceptance baseline; restarting alone correctly continues that contaminated state.
 
 Pi splits install from load. A raw tarball can install successfully while persisting the wrong resource kind and fail only in the next process. The managed npm spec drives package installation and manifest discovery; the isolated Node 24 RPC probe supplies observable extension-execution evidence.
 
@@ -184,6 +186,9 @@ Pi splits install from load. A raw tarball can install successfully while persis
 - Pack once per suite, but extract into a fresh fixture for each test.
 - Load the package root so package metadata participates in resolution.
 - Assert a positive registration marker such as `tool.definition`; process exit zero is not proof that plugin initialization succeeded.
+- For clean-start acceptance, start a brand-new conversation under the updated plugin; do not use a resumed pre-fix conversation as the baseline.
+- For restart-recovery acceptance, start that brand-new post-fix conversation, execute enough protected workflow activity to persist valid receipts and progression, restart OpenCode, then resume the same post-fix conversation and verify recovery.
+- Do not require a new conversation for every recovery test: distinguish the clean baseline from same-session restart recovery.
 - Keep the offline dependency-linking boundary explicit: it validates the packed plugin, not registry installation behavior.
 - Use a fresh OpenCode process when validating a rebuilt plugin.
 - Drive third-party package tests through the tool's real installer and loader; direct imports prove only module validity.

--- a/skills/orchestrating-subagents/SKILL.md
+++ b/skills/orchestrating-subagents/SKILL.md
@@ -17,6 +17,7 @@ Every subagent dispatch should carry the same bounded brief, expressed through t
 Specialist: systematic-implementer
 Objective: Implement the auth module
 Scope: Make only the changes needed for the auth module.
+Workspace: /absolute/path/to/expected-repository-or-worktree
 Return: List the changed files and summarize the implementation.
 ```
 
@@ -24,6 +25,7 @@ Return: List the changed files and summarize the implementation.
 - **Specialist** — the registered agent or persona best suited to the work (for example, an implementer or researcher)
 - **Objective** — a concise statement of the outcome
 - **Scope** — full instructions, boundaries, dependencies, and files in scope
+- **Workspace** — for any write-capable dispatch, the explicit expected repository or worktree root
 - **Return** — the result format expected from the specialist
 
 **Optional brief elements:**
@@ -61,6 +63,7 @@ After the first result, dispatch:
   Objective: Implement caching
   Scope: Implement caching based on the research result below.
   Input: Include the first specialist's returned research.
+  Workspace: /absolute/path/to/expected-repository-or-worktree
   Return: List changed files and summarize the implementation.
 ```
 
@@ -110,6 +113,12 @@ When dispatching units in parallel, include these instructions in each specialis
 
 > Do not stage files (`git add`), create commits, or run the project test suite. Leave staging and committing to the orchestrator or caller.
 
+## Workspace Attestation
+
+For every write-capable dispatch, the specialist must verify and return its actual repository or worktree root using available repository tooling (for example, `git rev-parse --show-toplevel` when Git is available) and an inventory of changed files. The orchestrator must independently verify the expected worktree's status and diff, plus the source or primary checkout's status, before accepting the result; a path in the brief or a specialist's self-report is not evidence.
+
+If writes landed in the wrong checkout, stop dependent dispatches, inspect both diffs, transfer only intended changes deliberately, and restore only confirmed accidental agent edits. Do not blindly copy or reset.
+
 ## Result Synthesis
 
 After specialists complete, the orchestrator synthesizes results:
@@ -138,6 +147,7 @@ After specialists complete, the orchestrator synthesizes results:
 | Background unavailable | Foreground only — serial or batched |
 | Specialist fails | Diagnose, correct the brief, then re-dispatch or resume the prior session where supported |
 | File collision detected post-parallel | Stage non-colliding files (if workflow owns git ops), re-run colliding units serially |
+| Write-capable dispatch | Include the expected root; require actual-root and changed-file attestation; independently verify both worktrees before acceptance |
 
 ## Common Mistakes
 


### PR DESCRIPTION
## Summary
- require write-capable delegation briefs to name the expected workspace and return actual-root/file-change attestation
- require independent verification of both expected and source checkouts before accepting delegated changes
- document the distinction between fresh plugin processes, clean conversations, and same-session restart recovery

## Why
An explicit worktree path in a delegation prompt is not proof that changes landed there. Separately, restarting OpenCode reloads plugin code but preserves resumed conversation history, so clean-start and restart-recovery validation need distinct setup.

## Verification
- bun scripts/content-integrity.ts
- bun test tests/unit/content-integrity.test.ts — 164 passed
- workspace-attestation pressure scenario
