### PR TITLE
fix(workflow): preserve observer Git context

### DIFF
--- a/src/lib/opencode-operation-observer.ts
+++ b/src/lib/opencode-operation-observer.ts
@@ -11,6 +11,16 @@ const DEFAULT_LIMITS = {
   maxPathBytes: 4096,
 } as const
 
+const UNTRACKED_FILES_ARGS = [
+  'ls-files',
+  '--others',
+  '--exclude-standard',
+  '--full-name',
+  '-z',
+  '--',
+  ':/',
+] as const
+
 export type OperationObserverReasonCode =
   | 'target-unavailable'
   | 'command-failed'
@@ -158,6 +168,11 @@ interface StageEntry {
   readonly record: string
   readonly mode: string
   readonly relativePath: string
+}
+
+interface RepositoryContext {
+  readonly commandDirectory: string
+  readonly worktreeRoot: string
 }
 
 function unavailable(result: {
@@ -326,7 +341,7 @@ function runCommand(
 
 function readRevision(
   runner: OperationObserverCommandRunner,
-  root: string,
+  context: RepositoryContext,
   limits: Limits,
 ):
   | { status: 'ok'; digest: string }
@@ -334,7 +349,7 @@ function readRevision(
   const branch = runCommand(
     runner,
     ['symbolic-ref', '--short', 'HEAD'],
-    root,
+    context.commandDirectory,
     limits,
   )
   if (branch.status === 'error' && branch.reasonCode !== 'command-failed') {
@@ -347,7 +362,7 @@ function readRevision(
   try {
     head = runner(
       ['rev-parse', '--verify', 'HEAD'],
-      root,
+      context.commandDirectory,
       limits.maxCommandOutputBytes,
       limits.maxCommandTimeoutMs,
     )
@@ -367,7 +382,7 @@ function readRevision(
   const inside = runCommand(
     runner,
     ['rev-parse', '--is-inside-work-tree'],
-    root,
+    context.commandDirectory,
     limits,
   )
   if (inside.status === 'error') return inside
@@ -393,7 +408,7 @@ function isEnoent(error: unknown): boolean {
 function appendSubmoduleFact(
   hash: ReturnType<typeof createHash>,
   runner: OperationObserverCommandRunner,
-  root: string,
+  submodulePath: string,
   relativePath: string,
   limits: Limits,
   totalBytes: number,
@@ -402,8 +417,8 @@ function appendSubmoduleFact(
   | { status: 'error'; reasonCode: OperationObserverReasonCode } {
   const submodule = runCommand(
     runner,
-    ['-C', relativePath, 'rev-parse', '--verify', 'HEAD'],
-    root,
+    ['rev-parse', '--verify', 'HEAD'],
+    submodulePath,
     limits,
   )
   if (submodule.status === 'error') return submodule
@@ -496,7 +511,7 @@ function appendFileFactV2(
   fileReader: (filePath: string) => Uint8Array,
   symlinkReader: (filePath: string) => string,
   statReader: (filePath: string) => OperationObserverFileStat,
-  root: string,
+  context: RepositoryContext,
   entry: Pick<StageEntry, 'mode' | 'relativePath'>,
   limits: Limits,
   totalBytes: number,
@@ -504,7 +519,7 @@ function appendFileFactV2(
   | { status: 'ok'; totalBytes: number }
   | { status: 'error'; reasonCode: OperationObserverReasonCode } {
   const { mode, relativePath } = entry
-  const absolutePath = safePath(root, relativePath)
+  const absolutePath = safePath(context.worktreeRoot, relativePath)
   if (!absolutePath || outputBytes(relativePath) > limits.maxPathBytes) {
     return { status: 'error', reasonCode: 'file-read-failed' }
   }
@@ -520,7 +535,7 @@ function appendFileFactV2(
     return appendSubmoduleFact(
       hash,
       runner,
-      root,
+      absolutePath,
       relativePath,
       limits,
       totalBytes,
@@ -551,19 +566,29 @@ function readWorktreeRevisionV2(
   fileReader: (filePath: string) => Uint8Array,
   symlinkReader: (filePath: string) => string,
   statReader: (filePath: string) => OperationObserverFileStat,
-  root: string,
+  context: RepositoryContext,
   limits: Limits,
 ):
   | { status: 'ok'; digest: string }
   | { status: 'error'; reasonCode: OperationObserverReasonCode } {
-  const tracked = runCommand(runner, ['ls-files', '-z'], root, limits)
+  const tracked = runCommand(
+    runner,
+    ['ls-files', '--full-name', '-z', '--', ':/'],
+    context.commandDirectory,
+    limits,
+  )
   if (tracked.status === 'error') return tracked
-  const staged = runCommand(runner, ['ls-files', '--stage', '-z'], root, limits)
+  const staged = runCommand(
+    runner,
+    ['ls-files', '--stage', '--full-name', '-z', '--', ':/'],
+    context.commandDirectory,
+    limits,
+  )
   if (staged.status === 'error') return staged
   const untracked = runCommand(
     runner,
-    ['ls-files', '--others', '--exclude-standard', '-z'],
-    root,
+    UNTRACKED_FILES_ARGS,
+    context.commandDirectory,
     limits,
   )
   if (untracked.status === 'error') return untracked
@@ -594,7 +619,7 @@ function readWorktreeRevisionV2(
       fileReader,
       symlinkReader,
       statReader,
-      root,
+      context,
       { relativePath, mode: modes.get(relativePath) ?? '' },
       limits,
       totalBytes,
@@ -607,7 +632,7 @@ function readWorktreeRevisionV2(
 
 function readCommitClosure(
   runner: OperationObserverCommandRunner,
-  root: string,
+  context: RepositoryContext,
   limits: Limits,
 ):
   | { status: 'ok'; closed: boolean }
@@ -615,8 +640,8 @@ function readCommitClosure(
   let diff: OperationObserverCommandResult
   try {
     diff = runner(
-      ['diff', '--quiet', 'HEAD', '--', '.'],
-      root,
+      ['diff', '--quiet', 'HEAD', '--', ':/'],
+      context.commandDirectory,
       limits.maxCommandOutputBytes,
       limits.maxCommandTimeoutMs,
     )
@@ -637,8 +662,8 @@ function readCommitClosure(
   }
   const untracked = runCommand(
     runner,
-    ['ls-files', '--others', '--exclude-standard', '-z'],
-    root,
+    UNTRACKED_FILES_ARGS,
+    context.commandDirectory,
     limits,
   )
   if (untracked.status === 'error') return untracked
@@ -973,12 +998,12 @@ function readRemoteSnapshot(
   runner: OperationObserverRemoteCommandRunner,
   operation: RemoteOperation,
   phase: RemoteReadbackPhase,
-  root: string,
+  commandDirectory: string,
   limits: Limits,
 ): OperationObserverRemoteResult {
   return operation === 'push'
-    ? readPushRemoteSnapshot(runner, phase, root, limits)
-    : readRemotePullRequest(runner, operation, root, limits)
+    ? readPushRemoteSnapshot(runner, phase, commandDirectory, limits)
+    : readRemotePullRequest(runner, operation, commandDirectory, limits)
 }
 
 export function createOpencodeOperationObserver(
@@ -1025,18 +1050,22 @@ export function createOpencodeOperationObserver(
       if (root.length === 0 || outputBytes(root) > limits.maxPathBytes) {
         return { status: 'unavailable', reasonCode: 'target-unavailable' }
       }
-      const repository = readRevision(runner, root, limits)
+      const context: RepositoryContext = {
+        commandDirectory: targetDirectory,
+        worktreeRoot: root,
+      }
+      const repository = readRevision(runner, context, limits)
       if (repository.status === 'error') return unavailable(repository)
       const worktree = readWorktreeRevisionV2(
         runner,
         fileReader,
         symlinkReader,
         statReader,
-        root,
+        context,
         limits,
       )
       if (worktree.status === 'error') return unavailable(worktree)
-      const closure = readCommitClosure(runner, root, limits)
+      const closure = readCommitClosure(runner, context, limits)
       if (closure.status === 'error') return unavailable(closure)
       return {
         status: 'available',
@@ -1062,7 +1091,13 @@ export function createOpencodeOperationObserver(
       if (root.length === 0 || outputBytes(root) > limits.maxPathBytes) {
         return { status: 'unavailable', reasonCode: 'target-unavailable' }
       }
-      return readRemoteSnapshot(remoteRunner, operation, phase, root, limits)
+      return readRemoteSnapshot(
+        remoteRunner,
+        operation,
+        phase,
+        targetDirectory,
+        limits,
+      )
     },
   }
 }

--- a/tests/unit/opencode-operation-observer.test.ts
+++ b/tests/unit/opencode-operation-observer.test.ts
@@ -16,6 +16,12 @@ interface GitFixture {
   cleanup(): void
 }
 
+interface SeparatedGitFixture {
+  gitDir: string
+  worktree: string
+  cleanup(): void
+}
+
 function runGit(
   root: string,
   args: readonly string[],
@@ -48,6 +54,72 @@ function createGitFixture(): GitFixture {
     root,
     cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
   }
+}
+
+function createSeparatedGitFixture(): SeparatedGitFixture {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'systematic-observer-separated-'),
+  )
+  const gitDir = path.join(root, 'repo.git')
+  const worktree = path.join(root, 'worktree')
+  fs.mkdirSync(worktree, { recursive: true })
+
+  const init = runGit(root, ['init', '--bare', gitDir])
+  if (init.status !== 0) throw new Error('git setup failed: init')
+
+  const git = (args: readonly string[], cwd = gitDir) => {
+    const result = runGit(cwd, args)
+    if (result.status !== 0) throw new Error(`git setup failed: ${args[0]}`)
+  }
+
+  git(['config', 'core.bare', 'false'])
+  git(['config', 'core.worktree', worktree])
+  git(['config', 'user.email', 'observer@example.invalid'])
+  git(['config', 'user.name', 'Observer Test'])
+  fs.writeFileSync(path.join(worktree, 'tracked.txt'), 'initial\n')
+  git(['--work-tree', worktree, 'add', 'tracked.txt'])
+  git([
+    '--work-tree',
+    worktree,
+    '-c',
+    'user.name=Observer Test',
+    '-c',
+    'user.email=observer@example.invalid',
+    'commit',
+    '-m',
+    'initial',
+  ])
+
+  return {
+    gitDir,
+    worktree,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  }
+}
+
+function createSeparatedGitRemoteFixture(): SeparatedGitFixture {
+  const fixture = createSeparatedGitFixture()
+  const root = path.dirname(fixture.gitDir)
+  const remote = path.join(root, 'remote.git')
+  const init = runGit(root, ['init', '--bare', '--quiet', remote])
+  if (init.status !== 0) throw new Error('git setup failed: remote init')
+
+  const configure = (args: readonly string[]) => {
+    const result = runGit(fixture.gitDir, args)
+    if (result.status !== 0) throw new Error(`git setup failed: ${args[0]}`)
+  }
+  configure(['remote', 'add', 'origin', remote])
+  configure(['branch', '-M', 'main'])
+  configure([
+    '--work-tree',
+    fixture.worktree,
+    'push',
+    '--quiet',
+    '--set-upstream',
+    'origin',
+    'main',
+  ])
+  return fixture
 }
 
 describe('OpenCode operation observer', () => {
@@ -89,6 +161,107 @@ describe('OpenCode operation observer', () => {
       expect(committed.snapshot.repositoryRevisionDigest).not.toBe(
         initial.snapshot.repositoryRevisionDigest,
       )
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('uses repository-root semantics when target is a repository subdirectory', async () => {
+    const fixture = createGitFixture()
+    try {
+      const subdirectory = path.join(fixture.root, 'nested')
+      fs.mkdirSync(subdirectory)
+      fs.writeFileSync(path.join(subdirectory, 'nested.txt'), 'nested\n')
+      runGit(fixture.root, ['add', 'nested/nested.txt'])
+      runGit(fixture.root, ['commit', '--quiet', '-m', 'nested'])
+
+      const observer = createOpencodeOperationObserver({
+        targetDirectory: subdirectory,
+      })
+      const initial = await observer.snapshot()
+      expect(initial.status).toBe('available')
+      if (initial.status !== 'available') return
+      expect(initial.snapshot.commitClosure).toBe(true)
+
+      fs.writeFileSync(path.join(fixture.root, 'tracked.txt'), 'root edited\n')
+      const changed = await observer.snapshot()
+      expect(changed.status).toBe('available')
+      if (changed.status !== 'available') return
+      expect(changed.snapshot.worktreeRevisionDigest).not.toBe(
+        initial.snapshot.worktreeRevisionDigest,
+      )
+      expect(changed.snapshot.commitClosure).toBe(false)
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('stays available when the git directory and worktree are separate', async () => {
+    const fixture = createSeparatedGitFixture()
+    try {
+      const observer = createOpencodeOperationObserver({
+        targetDirectory: fixture.gitDir,
+      })
+      const result = await observer.snapshot()
+      expect(result.status).toBe('available')
+      if (result.status !== 'available') return
+      expect(result.snapshot.commitClosure).toBe(true)
+      expect(result.snapshot.targetDigest).toMatch(/^[0-9a-f]{64}$/)
+
+      fs.writeFileSync(path.join(fixture.worktree, 'tracked.txt'), 'edited\n')
+      const edited = await observer.snapshot()
+      expect(edited.status).toBe('available')
+      if (edited.status !== 'available') return
+      expect(edited.snapshot.worktreeRevisionDigest).not.toBe(
+        result.snapshot.worktreeRevisionDigest,
+      )
+      expect(edited.snapshot.commitClosure).toBe(false)
+
+      const untrackedPath = path.join(fixture.worktree, 'untracked.txt')
+      fs.writeFileSync(untrackedPath, 'untracked\n')
+      const untracked = await observer.snapshot()
+      expect(untracked.status).toBe('available')
+      if (untracked.status !== 'available') return
+      expect(untracked.snapshot.worktreeRevisionDigest).not.toBe(
+        edited.snapshot.worktreeRevisionDigest,
+      )
+      expect(untracked.snapshot.commitClosure).toBe(false)
+
+      runGit(fixture.gitDir, [
+        '--work-tree',
+        fixture.worktree,
+        'add',
+        'tracked.txt',
+        'untracked.txt',
+      ])
+      runGit(fixture.gitDir, [
+        '--work-tree',
+        fixture.worktree,
+        'commit',
+        '--quiet',
+        '-m',
+        'edited',
+      ])
+      const committed = await observer.snapshot()
+      expect(committed.status).toBe('available')
+      if (committed.status !== 'available') return
+      expect(committed.snapshot.commitClosure).toBe(true)
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('stays available for remote readback when the git directory and worktree are separate', async () => {
+    const fixture = createSeparatedGitRemoteFixture()
+    try {
+      const observer = createOpencodeOperationObserver({
+        targetDirectory: fixture.gitDir,
+      })
+      const result = await observer.remoteSnapshot?.('push', 'before')
+      expect(result?.status).toBe('available')
+      if (result?.status !== 'available') return
+      expect(result.snapshot.resourceIdentity).toMatch(/^[0-9a-f]{64}$/)
+      expect(result.snapshot.resourceRevisionIdentity).toMatch(/^[0-9a-f]{64}$/)
     } finally {
       fixture.cleanup()
     }


### PR DESCRIPTION
## Problem and root cause
A Git worktree with a separate git directory (`core.worktree`) could report stale or unavailable snapshots. The observer used the same discovered path for both command execution and filesystem reads, so commands resolved paths relative to the `.git` directory while file hashing still used repository-subpath semantics. That broke readback/closure behavior for separate-layout repos and subdirectory targets.

## What changed
- Preserve command execution context and filesystem context separately:
  - command context now uses the discovered Git command directory (`targetDirectory`)
  - file-read context uses the resolved worktree root
- Read tracked/staged/untracked paths with repository-root pathspec semantics using `--full-name` and `:/` so snapshots remain repo-wide even when `targetDirectory` points to a subdirectory.
- Use absolute submodule paths for submodule revision reads to avoid path-resolution drift.
- Apply the same command-context semantics to remote readback operations so push/pull requests use the same Git invocation root as local snapshot collection.

## Coverage and regression focus
- Added tests for:
  - repository subdirectory targets observing the whole repo with root-relative pathspecs
  - `core.worktree` separate git-dir/worktree fixture staying available
  - remote readback in separate-layout setup for both local and remote snapshot paths
- These tests are real fixture-based regressions for the separate-layout/subdirectory behavior and are explicitly excluded from issue #715 scope.

## Verification
- `bun test tests/unit/opencode-operation-observer.test.ts` (18 passed, 0 failed)
- `bun run typecheck` (pass)
- `bunx biome check src/lib/opencode-operation-observer.ts tests/unit/opencode-operation-observer.test.ts` (pass)
- `git diff --check` (clean)

Fixes #716

## Post-Deploy Monitoring & Validation
Validate on the next protected workflow run using a separate git-dir/core.worktree layout.

- Healthy signal: observer snapshots remain available and guard state does not transition to `guard-unavailable`.
- Failure signal: `command-failed` or `guard-unavailable` observed in observer-related workflow checks.
- Mitigation: revert this commit (`14c1a9520c9cf22ed5959645b258f96dcbad56fd`).
- Owner: Marcus R. Brown
- First-run validation window: first protected workflow run after merge.
