### PR TITLE
fix(workflow): stop retries after guard-unavailable

### DIFF
--- a/skills/using-systematic/SKILL.md
+++ b/skills/using-systematic/SKILL.md
@@ -113,3 +113,5 @@ The four capabilities are subagent delegation, blocking user interaction, task t
 The bootstrap inlines the active harness profile naming the exact mechanisms for this session—consult it.
 
 When a mechanism is unavailable, present numbered options in chat and wait for questions, maintain a visible list for task tracking, and dispatch delegation sequentially or do the work inline.
+
+Check the workflow guard availability once per execution unit. If the guard reports `unavailable` or `guard-unavailable`, treat it as terminal for that unit: do not retry `systematic_workflow_start` or `systematic_workflow_complete`. Use the documented unguarded fallback only when authorized, and report the unavailable state once.

--- a/tests/unit/__snapshots__/bootstrap.test.ts.snap
+++ b/tests/unit/__snapshots__/bootstrap.test.ts.snap
@@ -115,6 +115,8 @@ The bootstrap inlines the active harness profile naming the exact mechanisms for
 
 When a mechanism is unavailable, present numbered options in chat and wait for questions, maintain a visible list for task tracking, and dispatch delegation sequentially or do the work inline.
 
+Check the workflow guard availability once per execution unit. If the guard reports \`unavailable\` or \`guard-unavailable\`, treat it as terminal for that unit: do not retry \`systematic_workflow_start\` or \`systematic_workflow_complete\`. Use the documented unguarded fallback only when authorized, and report the unavailable state once.
+
 **Skills naming:**
 - Systematic bundled skills use the \`systematic:\` prefix (e.g., \`systematic:onboarding\`)
 - Workflow skills with their own namespace keep it (e.g., \`ce:brainstorm\`)

--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -192,6 +192,8 @@ describe('getBootstrapContent', () => {
 
       When a mechanism is unavailable, present numbered options in chat and wait for questions, maintain a visible list for task tracking, and dispatch delegation sequentially or do the work inline.
 
+      Check the workflow guard availability once per execution unit. If the guard reports \`unavailable\` or \`guard-unavailable\`, treat it as terminal for that unit: do not retry \`systematic_workflow_start\` or \`systematic_workflow_complete\`. Use the documented unguarded fallback only when authorized, and report the unavailable state once.
+
       **Skills naming:**
       - Systematic bundled skills use the \`systematic:\` prefix (e.g., \`systematic:onboarding\`)
       - Workflow skills with their own namespace keep it (e.g., \`ce:brainstorm\`)
@@ -883,6 +885,17 @@ describe('using-systematic SKILL.md structural invariants', () => {
     expect(instructionPriority).toBeGreaterThan(-1)
     expect(howToAccess).toBeGreaterThan(-1)
     expect(instructionPriority).toBeLessThan(howToAccess)
+  })
+
+  test('bootstrap content tells agents not to retry workflow start or complete after guard-unavailable', () => {
+    const content = getBootstrapContent(defaultConfig, {
+      bundledSkillsDir: realBundledSkillsDir,
+    })
+    expect(content).not.toBeNull()
+    expect(content).toContain('guard reports `unavailable`')
+    expect(content).toContain(
+      'do not retry `systematic_workflow_start` or `systematic_workflow_complete`',
+    )
   })
 
   test('post-injection: applyBootstrapContent preserves SUBAGENT-STOP before EXTREMELY-IMPORTANT in rendered output.system[0]', () => {


### PR DESCRIPTION
Summary:
- Treat workflow guard state `unavailable` / `guard-unavailable` as terminal for the current execution unit.
- Do not retry `systematic_workflow_start` or `systematic_workflow_complete` after that state.
- Update `using-systematic` bootstrap guidance and pin the bootstrap regression coverage.

Why:
- Runtime behavior already closes over unavailable guarded operations, but the documented workflow guidance was ambiguous and could lead to retry loops.
- Canonicalizing this guidance prevents reattempted guarded calls when the guard is unavailable and makes the behavior deterministic under failure conditions.

Validation:
- bun test tests/unit
  - 1750 pass, 0 fail
- bun test tests/integration/claude-code.test.ts
  - 17 pass, 0 fail
- bun test tests/integration/opencode.test.ts
  - 22 pass, 0 fail
- bun test tests/integration/receipt-workflow-guard-real-host.test.ts
  - 4 pass, 0 fail
- bun test tests/integration/question-attestation-opencode.test.ts
  - 4 pass, 0 fail
- bun test tests/integration/receipt-workflow-recovery.test.ts
  - 8 pass, 0 fail
- bun test tests/integration/release-notes-ci.test.ts
  - 20 pass, 0 fail
- bun test tests/integration/receipt-workflow-dogfood.test.ts
  - 1 pass, 0 fail
- bun test tests/integration/pi.test.ts
  - 9 pass, 0 fail
- bun run lint (informational only)
  - warnings/info only, no lint failures
- bun run typecheck
  - passed
- bun run build
  - passed
- bun scripts/content-integrity.ts
  - content-integrity: clean (..., 0 warnings)
- bun run registry:drift
  - up to date
- git diff --check origin/main...HEAD
  - passed

Post-Deploy Monitoring & Validation:
- In the next fresh protected workflow unit after release, expect one unavailable report and no repeated `systematic_workflow_start`/`systematic_workflow_complete` calls in that unit.
- Failure condition: repeated guarded start/complete calls after unavailable state.
- Rollback condition: revert this PR.

Fixes #715
