### PR TITLE
fix(ce-review): enforce bounded diff-first prompt contract

### DIFF
--- a/skills/ce-review/references/subagent-template.md
+++ b/skills/ce-review/references/subagent-template.md
@@ -17,6 +17,10 @@ You are a specialist code reviewer.
 {diff_scope_rules}
 </scope-rules>
 
+<bounded-investigation>
+The supplied diff is the primary source of truth. Use the supplied paths and line numbers, and read each unresolved surrounding range or symbol once. Re-read only when a concrete ambiguity remains or the file changed since the prior read. Stop and return a finding or verdict once the evidence is sufficient. If evidence cannot be obtained within this bounded pass, return an explicit blocker or residual risk instead of broadening the investigation indefinitely.
+</bounded-investigation>
+
 <output-contract>
 You produce up to two outputs depending on whether a run ID was provided:
 

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -556,6 +556,29 @@ describe('checkSkillReferenceIntegrity', () => {
   })
 })
 
+describe('ce-review bounded review prompt contract', () => {
+  test('shared reviewer prompt stays diff-first, bounded, and stop-conditioned', () => {
+    const subagentTemplate = fs.readFileSync(
+      path.join(REPO_ROOT, 'skills/ce-review/references/subagent-template.md'),
+      'utf8',
+    )
+
+    expect(subagentTemplate).toMatch(/diff is the primary source of truth/i)
+    expect(subagentTemplate).toMatch(
+      /read each unresolved surrounding range or symbol once/i,
+    )
+    expect(subagentTemplate).toMatch(
+      /re-read only when a concrete ambiguity remains or the file changed/i,
+    )
+    expect(subagentTemplate).toMatch(
+      /stop and (?:emit|return) (?:a )?(?:finding|verdict).*evidence is sufficient/i,
+    )
+    expect(subagentTemplate).toMatch(
+      /within this bounded pass.*explicit blocker or residual risk/i,
+    )
+  })
+})
+
 describe('checkBannedPatterns', () => {
   test('flags banned patterns in markdown outside the allowlist', () => {
     const root = makeFixtureRepo()


### PR DESCRIPTION
## Summary
- Enforces a bounded, diff-first review prompt contract in `ce-review` so investigators treat the supplied diff as primary truth, read each unresolved surrounding range once, and only re-read when ambiguity remains or the file changed.
- Requires a terminal conclusion path: return a finding/verdict or an explicit blocker/residual risk rather than broadening scope indefinitely.
- Adds a contract test pinning these semantics in content-integrity checks.

## Why
The shared reviewer prompt previously encouraged open-ended surrounding-code investigation, which led to repeated reads of unchanged files and reviewer drift across one unresolved area.

## Validation
- Unit tests: **1751 pass, 0 fail** (including this change).
- Integration: **85 pass, 0 fail, 1 skipped**.
- `bun run lint`, `bun run typecheck`, `bun run build`, full content-integrity suite, `bun run registry:drift`, diagnostics, and `git diff --check origin/main...HEAD`: **pass**.
- Live pressure review converged after one diff read.
- Seven-reviewer structured dogfood completed; one P2 issue was fixed and re-reviewed, one local-convention P3 finding was suppressed. One task had roughly one hour elapsed with no evidence of repeated unchanged-file reread.

## Post-Deploy Monitoring & Validation
- Observe the next structured review after patch release.
- Healthy: reviewers use supplied diff first, avoid repeated unchanged-range reads, and return a terminal finding/verdict or explicit blocker/residual risk.
- Failure: repeated broad/unchanged reads without resolution, non-terminal tasks, or missing terminal conclusion.
- Rollback: revert this PR.

Fixes #714
