### PR TITLE
fix(guard): observe worktree-targeted child operations in the receipt guard

### DIFF
--- a/docs/plans/2026-08-01-001-fix-worktree-targeted-receipt-observation-plan.md
+++ b/docs/plans/2026-08-01-001-fix-worktree-targeted-receipt-observation-plan.md
@@ -1,0 +1,707 @@
+---
+title: 'fix: Observe worktree-targeted child operations in the receipt guard'
+type: fix
+status: active
+date: 2026-08-01
+deepened: 2026-08-01
+---
+
+# fix: Observe worktree-targeted child operations in the receipt guard
+
+## Overview
+
+The receipt guard mints cryptographic receipts proving guarded operations
+(implementation / verification / commit) actually happened before a protected
+workflow unit may complete. It observes real git state through a single
+operation observer created once at plugin init, pinned to the parent checkout's
+absolute path.
+
+When a foreground `task` child stays host-rooted at the parent checkout but its
+tools target an isolated nested git worktree (via `bash` `workdir` or absolute
+file paths), the fixed observer reads the unchanged parent tree. Before-state
+equals after-state, so every operation is a no-op, no receipts are minted, and
+the parent unit ends `waiting/missing-evidence` (issue #678).
+
+This plan makes the observer target the directory a tool actually operated on —
+derived from host-observed tool inputs, validated as a registered worktree of the
+parent repository, and pinned to the unit through a new authenticated receipt
+field. It closes #678 without weakening the existing stable-workspace / mutable-
+revision trust boundary.
+
+## Problem Frame
+
+The prior delegated-receipt fix (PR #719, documented in
+`docs/solutions/integration-issues/delegated-receipt-rollup-live-state-recovery-2026-07-31.md`)
+recovered child receipts across session and revision boundaries, but assumed the
+child wrote into the **same** checkout the fixed observer reads. The isolated-
+nested-worktree case is the unclosed remainder of #678.
+
+Root cause, confirmed from source:
+
+- `src/index.ts:72-74` creates one `createOpencodeOperationObserver` rooted at
+  `worktree ?? directory` (the parent checkout). Its `targetDigest` becomes
+  `workspaceIdentity`.
+- `src/lib/opencode-operation-observer.ts` `snapshot()` always runs git at that
+  fixed `targetDirectory`, regardless of which directory a tool touched.
+- `prepareOperation` / `captureAfterOperation`
+  (`src/lib/opencode-workflow-guard.ts:1958`, `2568`) snapshot that fixed
+  observer for before/after.
+- `src/lib/receipt-ledger.ts:1231` `implementationNoOpReason` rejects a receipt
+  when `after.worktreeDigest === context.worktreeDigest` → `unchanged-worktree`.
+
+Because the observed parent tree never changes when work lands in a foreign
+worktree, the guard classifies real work as a no-op and mints nothing.
+
+An Oracle design review established that the minimal "derive target from tool
+args" fix is **exploitable**: a bare `--git-common-dir` check is spoofable by a
+fake `.git` gitfile, and inherited `GIT_*` environment can make any directory
+resolve as the parent repository. The safe fix therefore combines host-derived
+observation with registered-worktree validation, `GIT_*` sanitization, and an
+authenticated per-unit target identity.
+
+## Requirements Trace
+
+- R1. A guarded local operation whose tool targets an isolated worktree of the
+  parent repository mints the correct implementation/verification/commit receipt.
+  **Units:** U2, U4.
+- R2. The observed directory is derived only from host-observed tool inputs
+  (`bash.workdir`; write/edit/apply_patch file target(s)), never from model or
+  child prose. **Units:** U2.
+- R3. A derived target is trusted only after it is validated as a registered
+  worktree of the parent repository (common-dir identity + `git worktree list`
+  membership + `.git` linkage), with all `GIT_*` variables stripped from observer
+  subprocesses. **Units:** U1, U2.
+- R4. Each receipt carries an authenticated `operationTargetIdentity` bound into
+  its salted integrity digest; a unit pins one local target and fails closed on a
+  target switch. **Units:** U3, U4.
+- R5. Parent rollup observes each child receipt's authenticated target (not the
+  fixed parent observer); target/common-dir/registration mismatches are fatal,
+  while repository/worktree revision staleness remains skippable. **Units:** U5.
+- R6. The existing shared-parent-repo child rollup (u5) and all current fixed-
+  observer behavior are preserved unchanged. **Units:** U4, U5, U6.
+- R7. On an explicit tool target that resolves to an unrelated or invalid
+  directory, the guard fails closed (marks unavailable); it does **not** fall
+  back to the fixed parent observer. **Units:** U2, U4.
+
+## Scope Boundaries
+
+- Foreground `task` children only. Background/detached child lineage remains out
+  of V1 scope, consistent with the existing guard.
+- Local operations (`write`/`edit`/`apply_patch`/`bash`) and their
+  implementation/verification/commit receipts. Remote operations (push,
+  pr-creation, check/review readback) follow the same derived-target observer but
+  add no new remote semantics here.
+- No change to the observe-vs-protected default, disablement model, or Question
+  attestation channel.
+
+### Deferred to Separate Tasks
+
+- Multiple distinct local targets satisfying one unit (a target-keyed revision
+  map). This plan pins exactly one local target per unit; a multi-target identity
+  map is a larger follow-up if a real workflow needs it.
+- Sandboxed/traced confinement of arbitrary `bash` side effects. Receipt
+  semantics remain "a recognized command succeeded when launched from the
+  attested target," not "every I/O stayed inside it." **Existing mitigation
+  (verified):** the receipt classifier (`src/lib/receipt-classifier.ts`) already
+  allowlists exact command forms — the only permitted prefix is `cd
+  <safe-relative>` (no absolute, `~`, or `..`; `isSafeRelativeCwd`), and `git` is
+  matched by exact recognized forms only, so `git -C <dir> …` is unrecognized and
+  mints nothing. The residual is confined to in-process side effects of an
+  otherwise-recognized command (e.g. a test script that writes into another
+  checkout) — which is exactly this deferred sandbox item, not a new hole opened
+  by the derived-target observer.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/lib/opencode-operation-observer.ts` — `createOpencodeOperationObserver`,
+  `defaultCommandRunner` (`spawnSync`, inherits process env — the GIT_* leak),
+  `RepositoryContext { commandDirectory, worktreeRoot }`, `snapshot()`.
+- `src/lib/opencode-workflow-guard.ts` — `prepareOperation` (1958),
+  `captureAfterOperation` (2568), `buildOperationObservation` (2611),
+  `rollupForegroundTask` (1404), `PendingOperation` (277).
+- `src/lib/receipt-ledger.ts` — `CanonicalReceiptFields` (124-139),
+  `mintReceipt` (1266), `digestContext` (1074), `digestAfter` (1200),
+  `implementationNoOpReason` (1231), `commitNoOpReason` (1242).
+- `src/lib/receipt-readback.ts` — `mintIntegrity` (salted SHA-256 over the
+  serialized envelope, 668-676), `CANONICAL_REQUIRED_KEYS` / `_OPTIONAL_KEYS`
+  (266-284), `cloneCanonical` (520), `parseEnvelope` (552), `serializeEnvelope`
+  (641).
+- `src/lib/workflow-guard.ts` — `currentIdentityReason` (1296),
+  `currentOperationContext` (1308), `observeTrustedRecoveredOperation` (3430).
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/delegated-receipt-rollup-live-state-recovery-2026-07-31.md`
+  — the trust-boundary discipline this plan must preserve: stable workspace
+  mismatch is fatal, mutable revision staleness is skippable, batch preflight
+  before any mint, fresh parent context per mint, never trust child prose.
+- `docs/solutions/integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md`
+  — isolate by real runtime boundaries, not shallow tree checks.
+
+### External References
+
+- Vendored OpenCode source `.slim/clonedeps/repos/anomalyco__opencode/`:
+  `packages/core/src/tool/bash.ts` (relative `workdir` resolves from session
+  Location; external/absolute needs approval), `packages/opencode/src/patch/index.ts`
+  (`apply_patch` optional `workdir`, multi-file `patchText`). Use to confirm the
+  exact per-tool argument keys during implementation.
+
+## Key Technical Decisions
+
+- **Host-derived target + registered-worktree validation (Oracle option A+),
+  not bare common-dir.** Common-dir equality is necessary but demonstrably
+  insufficient (fake gitfile spoof). Trust requires common-dir identity **and**
+  `git worktree list` membership **and** `.git` linkage validation.
+- **Authenticated `operationTargetIdentity`, not repository-scoped workspace.**
+  Keep `workspaceIdentity` as the stable parent lineage identity; add a separate
+  authenticated target identity. Repository-scoping the workspace (option C)
+  would weaken the principal boundary and is rejected.
+- **In v2, every local receipt carries an explicit `operationTargetIdentity` —
+  including parent-target operations.** Absence must **not** mean "parent target"
+  in v2; that would let a receipt omit the field to dodge target validation.
+  Parent-target operations get an explicit parent-checkout target identity.
+  Absence is meaningful only through the v1 legacy read shim below. (Architect
+  review: the biggest single correction — absence as an implicit mode is an
+  evidence-omission bypass.)
+- **Version bump ships with a one-version backward-read shim (resolved, not
+  deferred).** No version constant in this repo has ever been bumped; all
+  parsers hard-reject on version inequality, and durable v1 markers persist in
+  session ToolPart metadata, so a live user can carry v1 receipts into v2 code.
+  Therefore: mint only v2 going forward; read v1 only for recovery; a v1 receipt
+  with no target field maps to **parent-target only** after workspace/parent
+  validation; v1 receipts are **rejected for foreign/worktree-targeted recovery**
+  because they cannot prove a target identity. Keep the v1 acceptance narrow,
+  documented, and removable. Hard-rejecting v1 outright is only acceptable if we
+  explicitly accept "upgrade invalidates in-flight guarded units" — we do not.
+- **Unit pins one local target; target switch fails closed — an intentional V1
+  limitation.** The first trusted local target pins the unit; a later local op
+  resolving to a different worktree fails closed with an explicit message
+  (unit pinned to target X, operation targeted Y; split into separate units or
+  await multi-target support). This rejects some legitimate mixed-checkout
+  workflows (e.g. parent-side docs write + worktree code change); accepting them
+  safely needs a target-keyed progression map, which is deferred. Failing closed
+  is correct over laundering evidence from checkout A into checkout B.
+- **The pin lives in durable unit progression state AND the receipt, not just
+  `PendingOperation`.** Durable progression state is the authoritative
+  cross-restart/replay enforcement (`pinnedOperationTargetIdentity`); the receipt
+  canonical field is the authenticated per-operation evidence; `PendingOperation`
+  holds only the observer instance for before/after convenience. An in-memory-only
+  pin lets restart forget target A and admit target B into the same unit.
+- **No fixed-observer fallback on explicit-but-invalid target.** Falling back
+  could mint evidence from an incidental parent change during an unrelated
+  operation. Absent any override, the natural parent target remains the fast path.
+- **Strip `GIT_*` from observer subprocesses.** At minimum `GIT_DIR`,
+  `GIT_WORK_TREE`, `GIT_COMMON_DIR`, `GIT_INDEX_FILE`, `GIT_OBJECT_DIRECTORY`,
+  `GIT_ALTERNATE_OBJECT_DIRECTORIES`, `GIT_CONFIG*`.
+- **Same observer instance for before and after.** Store the resolved target and
+  observer in `PendingOperation`; re-derivation from after-args is rejected.
+- **Rollup validation ordering is fixed:** (1) child lineage/salt/readback
+  integrity, (2) stable parent workspace identity, (3) target identity present +
+  registered + common-dir match + unit-pin match, (4) *only then* repository/
+  worktree revision staleness as skippable. Target mismatch is **fatal**, never
+  treated as skippable mutable-revision staleness (that ordering inversion is a
+  bypass).
+
+## Open Questions
+
+### Resolved During Planning
+
+- Is receipt integrity an HMAC that a new field must be wired into separately?
+  No — `mintIntegrity` is a salted SHA-256 over the whole serialized envelope, so
+  adding `operationTargetIdentity` to `CanonicalReceiptFields` is covered
+  automatically, but every canonical-field enumerator (parse/clone/serialize/
+  compare/version-check across ledger + readback) must be updated, **including the
+  closed-set gate `hasExactKeys` (`receipt-readback.ts:362-373`) and
+  `CANONICAL_OPTIONAL_KEYS` (280-284), which will otherwise reject the new field.**
+- Does adding a canonical field break durable readback compatibility? Yes —
+  `RECEIPT_SCHEMA_VERSION` / `RECEIPT_PROTOCOL_VERSION`, the readback versions,
+  and `MARKER_PROTOCOL_VERSION` are hard-checked (strict equality only; no bump
+  has ever occurred in this repo). Adding the field requires a coordinated bump
+  of all of them.
+- **Version-bump compatibility: one-version backward-read shim** (moved out of
+  Deferred — it is design-gating, not an implementation detail). See Key
+  Technical Decisions. Mint v2 only; read v1 for recovery as parent-target only;
+  reject v1 for foreign-target recovery. Durable v1 markers in session ToolPart
+  metadata make a hard break lose in-flight guarded units, which we reject.
+- **Optional-field serialization has one canonical representation.**
+  `serializeEnvelope` emits absent optional fields as `null` and `parseEnvelope`
+  treats absent/undefined consistently, so `undefined` / absent / `null` must not
+  become three semantic states for `operationTargetIdentity`. Mirror the existing
+  `worktreeDigest` `?? null` normalization exactly; add a test that insertion
+  order does not change the serialized string or integrity digest.
+
+### Deferred to Implementation
+
+- **Exact per-tool argument keys in the running host.** The vendored core uses
+  `args.path` for write/edit while current tests and guard code reference
+  `filePath`; `apply_patch` may carry `workdir` plus multi-file `patchText`.
+  Confirm the real keys in OpenCode v1.18.x (memory #7248) before finalizing
+  target derivation; derive from **every** file target, not one representative.
+- Whether common-dir identity should compare `dev`/`ino` in addition to the
+  canonical path (stronger against path-equal spoofs) — decide when writing the
+  validation helper against real fixtures.
+- Whether the schema/protocol bump ships as a hard bump + backward-read shim
+  (current design) or a staged dual-read/dual-write migration. The shim covers
+  parent-target legacy v1 receipts; a staged dual-read would further reduce
+  upgrade risk but adds transitional complexity. Decide from observed persistence
+  of in-flight guarded units at upgrade time.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review,
+> not implementation specification. The implementing agent should treat it as
+> context, not code to reproduce.*
+
+```
+tool.execute.before (write/edit/apply_patch/bash)
+  └─ deriveTarget(host tool args)          # U2: workdir | file target(s)
+       ├─ none/relative-to-parent → parent checkout (fast path, unchanged)
+       └─ explicit override → canonicalize (realpath, resolve symlinks)
+             └─ validateRegisteredWorktree(candidate)   # U1
+                  ├─ strip GIT_* ; git rev-parse checks
+                  ├─ common-dir == parent common-dir
+                  ├─ toplevel ∈ parent `git worktree list --porcelain`
+                  └─ .git linkage back-reference intact
+             ── invalid/unrelated ─→ markUnavailable (NO fallback)   # R7
+       └─ observer(targetDir).snapshot()  → PendingOperation{ target, observer, before }
+             └─ pin unit target ; switch ⇒ fail closed                # U4
+
+tool.execute.after
+  └─ same PendingOperation.observer.snapshot() → after
+       └─ buildOperationObservation binds context + operationTargetIdentity  # U3
+            └─ ledger mints receipt (integrity digest now covers target id)
+
+task.after (foreground child rollup)                                  # U5
+  └─ for each recovered child receipt:
+       observe the receipt's authenticated target (not fixed observer)
+       fatal:  workspace / target / common-dir / registration mismatch
+       skip:   repository / worktree revision staleness (after target matches)
+       mint through observeTrustedRecoveredOperation (batch-preflighted)
+```
+
+## Implementation Units
+
+**Terminology anchor** (one meaning per term, used consistently below):
+- **`workspaceIdentity`** — the stable parent-checkout lineage digest, fixed at
+  plugin init. Never changes per operation. The principal trust boundary.
+- **`targetRoot`** — the canonical absolute filesystem path of the worktree a
+  specific operation acted on (parent checkout or a nested worktree).
+- **`operationTargetIdentity`** — the authenticated digest of `targetRoot`,
+  carried as a canonical receipt field and pinned to the unit
+  (`pinnedOperationTargetIdentity` in `UnitState`). This is what rollup compares.
+- **`repositoryIdentity` / `worktreeIdentity`** — mutable revision digests of the
+  target's HEAD/tree; staleness is skippable, target identity mismatch is not.
+
+- [ ] **Unit 1: Git-sanitized observer with worktree-structure validation**
+
+**Goal:** Give the observer a trustworthy way to validate that an arbitrary
+candidate directory is a registered worktree of the parent repository, with
+`GIT_*` stripped from every git subprocess.
+
+**Requirements:** R3.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `src/lib/opencode-operation-observer.ts`
+- Test: `tests/unit/opencode-operation-observer.test.ts`
+
+**Approach:**
+- Strip the `GIT_*` allowlist (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_COMMON_DIR`,
+  `GIT_INDEX_FILE`, `GIT_OBJECT_DIRECTORY`, `GIT_ALTERNATE_OBJECT_DIRECTORIES`,
+  `GIT_CONFIG*`) in `defaultCommandRunner` and `defaultRemoteCommandRunner` by
+  passing an explicit sanitized `env`.
+- Capture immutable parent identity at observer creation: canonical worktree
+  root, `--absolute-git-dir`, `--path-format=absolute --git-common-dir`
+  (optionally common-dir `dev`/`ino`), and the parent's
+  `git worktree list --porcelain -z`.
+- Add a validation helper that, from a candidate directory: requires
+  `--is-inside-work-tree` true; resolves canonical `--show-toplevel`,
+  `--absolute-git-dir`, `--git-common-dir`; requires common-dir match to the
+  parent; requires canonical top-level to be a member of the parent worktree
+  list; validates `.git` linkage (main: git dir == common dir; linked: git dir
+  under `<common>/worktrees/…` with intact backlink).
+
+**Patterns to follow:** existing `runCommand` / `readRevision` error-result
+shape; `createSeparatedGitFixture` for exotic git layouts.
+
+**Test scenarios:**
+- Happy path: candidate is a real registered linked worktree of the parent →
+  validation succeeds; common-dir and toplevel match.
+- Happy path: parent main checkout validates as its own registered worktree.
+- Edge case: root symlink to a legitimate worktree canonicalizes to the same
+  identity.
+- Error path: independent unrelated repository → common-dir mismatch → rejected.
+- Error path: independent nested repo inside the parent checkout → rejected.
+- Error path: submodule target (common dir under `.git/modules/…`) → rejected.
+- Error path (security): fake `.git` gitfile pointing directly at the parent
+  `.git` → passes bare common-dir but fails registration/linkage → rejected.
+- Error path (security): fake `.git` gitfile pointing at a registered linked-
+  worktree admin dir → rejected.
+- Error path (security): poisoned ambient `GIT_DIR` / `GIT_WORK_TREE` /
+  `GIT_COMMON_DIR` / `GIT_INDEX_FILE` cannot make an unrelated cwd validate as
+  the parent (assert via injected env in the command runner).
+
+**Verification:** validation helper accepts only registered same-repository
+worktrees and rejects every spoof fixture; all git subprocesses run with `GIT_*`
+stripped.
+
+- [ ] **Unit 2: Host tool target derivation**
+
+**Goal:** Resolve the canonical directory a guarded tool actually operated on
+from host-observed arguments, or the parent checkout when there is no override.
+
+**Requirements:** R1, R2, R3, R7.
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `src/lib/opencode-workflow-guard.ts`
+- Test: `tests/unit/opencode-workflow-guard.test.ts`
+
+**Approach:**
+- Add a target-derivation function keyed by tool:
+  - `bash` → resolve `args.workdir`; absent → the trusted session/parent target.
+  - `write` / `edit` → resolve the file target's existing containing directory
+    (canonicalize existing parent for a new file), then normalize to git
+    top-level.
+  - `apply_patch` → derive **every** file target (plus optional `workdir`);
+    require all targets to resolve to one worktree.
+- Canonicalize with `realpath`, resolving existing symlinks; reject a final
+  target that escapes the validated root or lands in git admin storage.
+- No override (missing `workdir`, relative paths under the parent) → parent
+  checkout fast path (preserves u5).
+- Explicit override that fails Unit 1 validation → signal fail-closed (caller
+  marks unavailable); never fall back to the fixed observer.
+
+**Execution note:** Implement test-first — derivation branches and the fail-
+closed vs fast-path fork are the core correctness surface.
+
+**Patterns to follow:** existing `bashCommand` arg extraction; `isLocalOperationTool`.
+
+**Test scenarios:**
+- Happy path: `bash` with `workdir` = registered worktree → that worktree.
+- Happy path: relative `bash` `workdir` resolves identically to the session
+  Location (parent) → parent target.
+- Happy path: `write`/`edit` file inside a registered worktree → that worktree
+  top-level.
+- Edge case: two files in different subdirectories of the same worktree → one
+  target.
+- Edge case: absent override → parent checkout (u5 fast path).
+- Error path: `apply_patch` with targets spanning two worktrees → fail closed.
+- Error path (security): explicit target resolves to an unrelated/invalid dir →
+  fail closed, no fallback.
+- Error path (security): final file symlink escapes the registered root →
+  rejected.
+
+**Verification:** derivation returns the correct worktree for every valid case,
+the parent for no-override cases, and fails closed for invalid explicit targets
+with no fixed-observer fallback.
+
+- [ ] **Unit 3: `operationTargetIdentity` authenticated canonical field**
+
+**Goal:** Add a target identity to the receipt's canonical fields so it is
+covered by the salted integrity digest and survives serialize → marker →
+child readback → parent recovery.
+
+**Requirements:** R4.
+
+**Dependencies:** None (can land in parallel with U1/U2; U4 consumes it).
+
+**Files:**
+- Modify: `src/lib/receipt-ledger.ts`
+- Modify: `src/lib/receipt-readback.ts`
+- Test: `tests/unit/receipt-ledger.test.ts`
+- Test: `tests/unit/receipt-readback.test.ts`
+
+**Approach:**
+- Add `operationTargetIdentity` to `CanonicalReceiptFields`. **Schema shape vs
+  protocol rule are distinct:** the field is *optional in the shared canonical
+  type* (so the v1 backward-read shim can parse legacy receipts that lack it),
+  but *required by the v2 mint and v2 readback paths* for every local receipt
+  (parent-target included). Do not conflate "optional in the type" with "optional
+  at runtime" — a v2 local receipt missing the field is rejected, not treated as
+  parent-target. Thread it through **every** `worktreeDigest` edit site (the
+  exact precedent checklist, verified against source):
+  - `receipt-ledger.ts`: type decls (132, 241); `envelopesEqual` (404-425);
+    `storedReceiptFromEnvelope` (492-504); `compareDigestedContexts` (862-877);
+    `parseEnvelope` (928-987); `digestContext` (1074-1089); `digestAfter`
+    (1200-1215); `mintReceipt` (1266-1309); `recoverReceipt` (1358-1390);
+    `recoverReadback` (1392-1432).
+  - `receipt-readback.ts`: `CANONICAL_OPTIONAL_KEYS` (280-284);
+    **`hasExactKeys` closed-set gate (362-373) — rejects the field if omitted**;
+    `cloneCanonical` (520-539); `parseEnvelope` (552-618); `serializeEnvelope`
+    (641-666, emit `?? null` like `worktreeDigest`).
+  - `workflow-guard.ts`: revision/scope comparison sites that must consider the
+    target semantically (`compareReceiptRepositoryScope` 1838-1858, and the
+    stale-clear path 1628-1640) — decide per-site whether target participates.
+- Bump `RECEIPT_SCHEMA_VERSION` / `RECEIPT_PROTOCOL_VERSION`, the readback
+  schema/protocol versions, and `MARKER_PROTOCOL_VERSION` in lockstep; update
+  every hard version check (`receipt-ledger.ts` 899-918, 928-987;
+  `receipt-readback.ts` 552-618, 620-638, 741-764, 773-806, 826-852, 953-964;
+  `opencode-workflow-guard.ts` marker checks at 52/761/885/1733/3012/3037).
+- Implement the **v1 backward-read shim**: v2 mint path requires the field; v1
+  readback maps absent field → parent-target only after workspace/parent
+  validation, and rejects v1 for foreign-target recovery.
+- Because `mintIntegrity` digests the whole serialized envelope, verify the new
+  field changes the integrity digest and that mismatched target identities fail
+  readback. Preserve the single canonical serialization (`?? null`) so absent /
+  undefined / null do not become distinct semantic states.
+
+**Execution note:** Test-first for tamper-evidence, version-bump rejection, and
+the v1 shim before wiring all enumerators.
+
+**Patterns to follow:** the existing `worktreeDigest` optional-field threading is
+the exact template — mirror it at every site above.
+
+**Test scenarios:**
+- Happy path: minted v2 receipt carries `operationTargetIdentity`; round-trips
+  through serialize → parse unchanged.
+- Happy path: mint marker → child-style readback recovers the field intact.
+- Edge case: insertion order of canonical fields does not change the serialized
+  string or the integrity digest.
+- Edge case (compat): a v1 receipt with no target field recovers as parent-target
+  after workspace validation.
+- Error path (security): a v1 receipt used for foreign-target recovery is
+  rejected (cannot prove target identity).
+- Error path (security): flipping `operationTargetIdentity` in a serialized
+  envelope changes the integrity digest and fails validation.
+- Error path (security): a v2 local receipt omitting the field is rejected (no
+  implicit parent-target fallback).
+- Error path: version mismatch after the bump is rejected as incompatible; a v2
+  receipt missing the field at `hasExactKeys` is rejected.
+
+**Verification:** the field is covered by integrity, survives full readback, the
+v1 shim admits only parent-target legacy evidence, and version/closed-set checks
+reject incompatible or field-omitting envelopes.
+
+- [ ] **Unit 4: Per-operation observer wiring and unit target pinning**
+
+**Goal:** Use a derived-target observer for before/after, bind
+`operationTargetIdentity` into the observation, and pin one local target per unit.
+
+**Requirements:** R1, R4, R6, R7.
+
+**Dependencies:** Units 1, 2, 3.
+
+**Files:**
+- Modify: `src/lib/opencode-workflow-guard.ts`
+- Modify: `src/lib/workflow-guard.ts` (authoritative pin: `UnitState`,
+  `parseRecoveryUnit`, and the transition that sets/enforces it)
+- Modify: `src/lib/receipt-readback.ts` (progression-marker serialize/recover of
+  the pin so it survives restart — mirror the `requiredOperations` /
+  `resourceScopes` threading through `applyUnitStart` / `unitDeclarationExtends`
+  and the progression-base parse/`hasOnlyFields` gate)
+- Test: `tests/unit/opencode-workflow-guard.test.ts`
+- Test: `tests/unit/workflow-guard.test.ts`
+- Test: `tests/unit/receipt-readback.test.ts`
+
+**Approach:**
+- In `prepareOperation`, derive the target (U2), obtain/reuse an observer for
+  that directory, snapshot before, and store `{ targetRoot, targetIdentity,
+  observer, before }` in `PendingOperation` (observer convenience only).
+- In `captureAfterOperation`, reuse the stored observer instance; revalidate the
+  target still resolves to the same registered worktree; reject path replacement
+  / worktree removal / symlink retargeting between hooks.
+- In `buildOperationObservation`, set `operationTargetIdentity` (explicit even
+  for parent-target ops — no implicit absence) and bind `worktreeIdentity` /
+  `repositoryIdentity` from the target snapshot while keeping `workspaceIdentity`
+  = parent fixed digest.
+- **Pin the unit's local target in the authoritative `UnitState`
+  (`pinnedOperationTargetIdentity`)**, not just in memory, so a restart cannot
+  forget target A and admit target B. On first trusted local operation, set the
+  pin; a later local operation resolving to a different target fails closed with
+  an explicit message. Thread the pin through the same recovery path as
+  `requiredOperations`/`resourceScopes`: authoritative state + `parseRecoveryUnit`
+  in `workflow-guard.ts`, and the progression-marker serialize/recover in
+  `receipt-readback.ts` (including its `hasOnlyFields`/closed-set gate).
+- Enforce the pin at restart: `parseRecoveryUnit` must reject a recovered unit
+  whose subsequent evidence targets a different identity, so the boundary holds
+  across replay, not only in a single live session.
+- Keep the fixed observer as the fast path when the derived target is the parent
+  checkout, so u5 and all current unit tests are unaffected.
+
+**Execution note:** Characterization-first — capture current fixed-observer
+behavior for the parent-target path before refactoring, and add a restart/replay
+test proving the durable pin survives, before wiring worktree targets.
+
+**Patterns to follow:** existing `PendingOperation` lifecycle and `sealOperation`
+/ `takePendingOperation` discipline.
+
+**Test scenarios:**
+- Happy path: operation targeting a registered worktree mints an implementation
+  receipt (before≠after on the worktree).
+- Happy path (regression): parent-target operation still mints exactly as today
+  (u5 fast path).
+- Edge case: two operations on the same pinned target both mint.
+- Error path (security): target A implementation then target B verification/commit
+  → second fails closed (target switch).
+- Error path: worktree removed/recreated at the same path between before and
+  after → rejected.
+- Error path (security): explicit invalid target concurrent with an incidental
+  parent change → no fallback receipt.
+
+**Verification:** worktree-targeted operations mint; parent-targeted operations
+are unchanged; target switches and between-hook tampering fail closed.
+
+- [ ] **Unit 5: Worktree-aware foreground child rollup**
+
+**Goal:** Roll up child receipts against each receipt's authenticated target
+instead of the fixed parent observer, preserving the fatal-vs-skippable
+classification.
+
+**Requirements:** R5, R6.
+
+**Dependencies:** Units 1, 3, 4.
+
+**Files:**
+- Modify: `src/lib/opencode-workflow-guard.ts`
+- Test: `tests/unit/opencode-workflow-guard.test.ts`
+- Test: `tests/integration/receipt-workflow-recovery.test.ts`
+
+**Approach:**
+- In `rollupForegroundTask`, for each recovered child receipt, snapshot the
+  receipt's authenticated target (validated via U1) rather than
+  `options.observer`.
+- Classify: workspace digest mismatch, missing/mismatched target identity,
+  target no longer a registered same-repo worktree, common-dir mismatch →
+  **fatal** (markUnavailable). Repository/worktree revision staleness (after
+  target identity matches) → **skippable**, preserving the existing chronological
+  batch behavior.
+- Preflight the whole batch before minting; mint through
+  `observeTrustedRecoveredOperation` with a fresh parent context per mint (as
+  today).
+- Do not compare a parent-root before digest against an isolated-worktree after
+  digest — pin/compare within the receipt's own target.
+
+**Patterns to follow:** the existing preflight/candidate loop in
+`rollupForegroundTask` (1487-1546) and the fatal-vs-stale distinction documented
+in the 2026-07-31 solution doc.
+
+**Test scenarios:**
+- Happy path (integration): parent-rooted child + isolated worktree write/verify/
+  commit → parent mints implementation/verification/commit.
+- Happy path (regression, integration): existing u5 shared-parent write rollup
+  unchanged.
+- Happy path: stale earlier implementation + current commit in the worktree →
+  commit still rolls up.
+- Error path (security): child receipt with correct parent workspace digest but
+  missing/wrong target identity → fatal.
+- Error path (security): target A receipt cannot validate against target B even
+  when revision digests are identical.
+- Error path: malformed later receipt in the batch → preflight prevents partial
+  parent mutation.
+
+**Verification:** worktree-targeted child work rolls up into the parent unit;
+shared-parent u5 is unchanged; every spoof/malformed case fails closed without
+partial mutation.
+
+- [ ] **Unit 6: Dogfood reproduction and attack-matrix consolidation**
+
+**Goal:** Lock in a failing-then-passing reproduction of #678 and consolidate the
+negative/attack matrix into durable regression coverage.
+
+**Requirements:** R1, R5, R6, R7.
+
+**Dependencies:** Units 1-5.
+
+**Files:**
+- Test: `tests/integration/receipt-workflow-recovery.test.ts`
+- Test: `tests/unit/opencode-operation-observer.test.ts`
+- Test: `tests/unit/opencode-workflow-guard.test.ts`
+
+**Approach:**
+- Add the exact #678 integration reproduction: parent starts a protected unit,
+  runs a foreground child whose tools target `.worktrees/<x>` on its own branch;
+  assert the parent mints the required receipts and the unit can complete.
+- Ensure every security scenario from U1/U2/U4/U5 has an owned regression test;
+  fill any gaps.
+- Confirm restart/recovery preserves target identity (resume the accepted
+  conversation and re-read parent mints are stable).
+
+**Execution note:** Start from a failing reproduction test on the pre-fix
+behavior to prove the test bites before U1-U5 land.
+
+**Patterns to follow:** `startMockModelServer` / `startOpencodeServer` /
+`createIsolatedFixture` / `receiptMintSummaries` harness in
+`tests/integration/receipt-workflow-recovery.test.ts`.
+
+**Test scenarios:**
+- Integration: #678 reproduction fails before the fix, passes after.
+- Integration: two worktrees with identical HEAD and contents remain distinct by
+  target digest.
+- Integration: restart/recovery preserves target identity and stable mints.
+
+**Verification:** the #678 reproduction passes; the full negative matrix is
+covered; restart replay is stable.
+
+## System-Wide Impact
+
+- **Interaction graph:** `tool.execute.before/after` for local operation tools,
+  `task.after` rollup, and the receipt ledger/readback serialization path are all
+  touched. Remote push/PR observation inherits the derived-target observer.
+- **Error propagation:** target validation failures and between-hook tampering
+  must reach `markUnavailable` (fail-closed), never silently downgrade to the
+  fixed observer.
+- **State lifecycle risks:** unit target pinning adds per-unit state; ensure it is
+  captured in the same durable progression that survives restart, and that batch
+  rollup remains preflighted so a late failure cannot leave partial mints.
+- **API surface parity:** the new canonical field must be threaded through every
+  enumerator in both ledger and readback; a missed site silently drops the field
+  from one path and breaks recovery.
+- **Integration coverage:** the real-host recovery harness is the only place that
+  proves the parent-rooted-session / worktree-targeted-tool combination end to
+  end — unit tests with stubbed runners cannot.
+- **Unchanged invariants:** `workspaceIdentity` remains the stable parent lineage
+  identity (not repository-scoped); the observe-vs-protected default, disablement
+  model, and Question attestation channel are unchanged; the fixed-observer parent
+  path stays the fast path.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Bare common-dir check spoofable by fake gitfile | Require `git worktree list` membership + `.git` linkage validation, not just common-dir (U1). |
+| Inherited `GIT_*` laundering an unrelated dir as parent | Strip the `GIT_*` allowlist in both command runners; test with injected poisoned env (U1). |
+| New canonical field missed at one enumerator → broken recovery | Enumerate all edit sites from the `worktreeDigest` precedent map (U3), including the `hasExactKeys` closed-set gate that would otherwise reject the field; readback round-trip test. |
+| Schema/protocol version bump breaks durable persisted v1 receipts in session metadata | Ship the resolved one-version backward-read shim (v1 → parent-target only, reject v1 foreign-target); version-mismatch + v1-shim tests (U3). |
+| Optional field becomes an evidence-omission bypass (omit to dodge target validation) | v2 requires the field for all local ops incl. parent-target; single canonical `?? null` serialization; omit-field-rejected test (U3, U4). |
+| In-memory-only target pin forgotten on restart → target B admitted into unit A | Pin lives in durable unit progression state (`pinnedOperationTargetIdentity`); restart/replay pin-survival test (U4). |
+| Single-target pinning rejects legitimate mixed-checkout workflows | Documented intentional V1 limitation with explicit failure message; multi-target map deferred; mixed-target rejection test (U4). |
+| Bash command-internal escape (script writes into another checkout) launders a receipt | Accepted residual: the classifier already blocks `git -C`/absolute `cd` (only exact recognized forms + safe-relative `cd` mint); in-process side effects of a recognized command are the deferred sandbox item, not a new hole. Receipt semantics are "recognized command succeeded from the attested target," not "all I/O stayed inside it." |
+| Per-target observer regresses u5 shared-parent rollup | Parent-target fast path preserved; characterization-first before refactor; u5 regression test kept green (U4, U5). |
+| Wrong per-tool arg key (`filePath` vs `path`) in real host | Confirm keys against OpenCode v1.18.x before finalizing derivation; derive from every file target (U2, deferred question). |
+| Partial rollup mutation on a malformed batch | Preserve batch preflight before first mint; malformed-later-receipt test (U5). |
+
+## Documentation / Operational Notes
+
+- After merge, add a `docs/solutions/` entry extending the 2026-07-31 delegated-
+  receipt learning with the foreign-worktree observation layer and the spoof
+  matrix.
+- Regenerate config schema / registry only if a version-bump surfaces a
+  user-visible field (unlikely — receipt internals are not user config).
+- **Upgrade staging (receipt version bump):** because durable v1 markers persist
+  in session ToolPart metadata, a user resuming a conversation across the upgrade
+  can carry v1 receipts into v2 code. The v1 backward-read shim admits only
+  parent-target legacy evidence; v1 foreign-target evidence is unrecoverable and
+  fails closed (guarded unit re-derives evidence rather than silently completing).
+  This is the accepted upgrade behavior — no in-flight unit is silently
+  completed, at worst it must re-run a recognized operation. Call this out in the
+  release notes for the version-bump release.
+
+## Sources & References
+
+- Issue: [#678](https://github.com/marcusrbrown/systematic/issues/678)
+- Prior fix: [PR #719](https://github.com/marcusrbrown/systematic/pull/719),
+  documented in
+  `docs/solutions/integration-issues/delegated-receipt-rollup-live-state-recovery-2026-07-31.md`
+- Handoff: `.context/handoffs/678-receipt-guard-worktree-observer-regression.md`
+- Prior guard plan: `docs/plans/2026-07-25-001-feat-receipt-backed-workflow-guard-plan.md`
+- Key code: `src/index.ts:72-98`, `src/lib/opencode-operation-observer.ts`,
+  `src/lib/opencode-workflow-guard.ts` (`rollupForegroundTask` 1404,
+  `prepareOperation` 1958, `captureAfterOperation` 2568,
+  `buildOperationObservation` 2611), `src/lib/receipt-ledger.ts` (124-139, 1231),
+  `src/lib/receipt-readback.ts` (`mintIntegrity` 668-676)
+- Vendored host source: `.slim/clonedeps/repos/anomalyco__opencode/`

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,8 @@ const initializePlugin = async ({
     repositoryIdentity: initialIdentities.repositoryRevisionDigest,
     worktreeIdentity: initialIdentities.worktreeRevisionDigest,
     registrationIdentity: registrationSourceIdentity,
+    targetDirectory: typeof worktree === 'string' ? worktree : directory,
+    sessionLocation: directory,
     observer,
     classifier: createReceiptClassifier(),
     hostReadback: (() => {

--- a/src/lib/opencode-operation-observer.ts
+++ b/src/lib/opencode-operation-observer.ts
@@ -37,6 +37,31 @@ export type OperationObserverReasonCode =
   | 'remote-not-advanced'
   | 'commit-not-closed'
 
+export interface RegisteredWorktreeParentIdentity {
+  readonly targetRoot: string
+  readonly gitDir: string
+  readonly commonDir: string
+  readonly registeredWorktreeRoots: readonly string[]
+}
+
+export interface RegisteredWorktreeValidationOptions {
+  readonly commandRunner?: OperationObserverCommandRunner
+  readonly limits?: OperationObserverLimits
+  readonly realPath?: (filePath: string) => string
+}
+
+export type RegisteredWorktreeValidationResult =
+  | {
+      readonly status: 'ok'
+      readonly targetRoot: string
+      readonly gitDir: string
+      readonly commonDir: string
+    }
+  | {
+      readonly status: 'error'
+      readonly reasonCode: OperationObserverReasonCode
+    }
+
 export type RemoteOperation =
   | 'push'
   | 'pr-creation'
@@ -145,6 +170,9 @@ export interface OpencodeOperationObserverOptions {
 
 export interface OpencodeOperationObserver {
   readonly targetDigest: string
+  validateRegisteredWorktree(
+    candidateDirectory: string,
+  ): RegisteredWorktreeValidationResult
   snapshot(): Promise<OperationObserverResult>
   remoteSnapshot?(
     operation: RemoteOperation,
@@ -175,6 +203,10 @@ interface RepositoryContext {
   readonly worktreeRoot: string
 }
 
+type ParentIdentityCaptureResult =
+  | { status: 'ok'; identity: RegisteredWorktreeParentIdentity }
+  | { status: 'error'; reasonCode: OperationObserverReasonCode }
+
 function unavailable(result: {
   readonly status: 'error'
   readonly reasonCode: OperationObserverReasonCode
@@ -201,6 +233,16 @@ function isCommandTimeout(error: unknown): boolean {
   )
 }
 
+function sanitizedEnvironment(): NodeJS.ProcessEnv {
+  const env = { ...process.env }
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('GIT_')) {
+      delete env[key]
+    }
+  }
+  return env
+}
+
 function defaultCommandRunner(
   args: readonly string[],
   cwd: string,
@@ -210,6 +252,7 @@ function defaultCommandRunner(
   try {
     const result = spawnSync('git', [...args], {
       cwd,
+      env: sanitizedEnvironment(),
       encoding: 'utf8',
       maxBuffer: maxOutputBytes,
       timeout: timeoutMs,
@@ -235,6 +278,7 @@ function defaultRemoteCommandRunner(
   try {
     const result = spawnSync(executable, [...args], {
       cwd,
+      env: sanitizedEnvironment(),
       encoding: 'utf8',
       maxBuffer: maxOutputBytes,
       timeout: timeoutMs,
@@ -337,6 +381,253 @@ function runCommand(
     return { status: 'error', reasonCode: 'command-failed' }
   }
   return { status: 'ok', output: { stdout: result.stdout } }
+}
+
+function canonicalPath(
+  filePath: string,
+  realPath: (filePath: string) => string = fs.realpathSync,
+): string | undefined {
+  try {
+    return realPath(filePath)
+  } catch {
+    return undefined
+  }
+}
+
+function requiredGitPath(
+  runner: OperationObserverCommandRunner,
+  args: readonly string[],
+  cwd: string,
+  limits: Limits,
+  realPath: (filePath: string) => string = fs.realpathSync,
+):
+  | { status: 'ok'; value: string }
+  | { status: 'error'; reasonCode: OperationObserverReasonCode } {
+  const result = runCommand(runner, args, cwd, limits)
+  if (result.status === 'error') return result
+  const rawValue = result.output.stdout.trim()
+  if (!path.isAbsolute(rawValue)) {
+    return { status: 'error', reasonCode: 'target-unavailable' }
+  }
+  const value = canonicalPath(rawValue, realPath)
+  return value === undefined
+    ? { status: 'error', reasonCode: 'target-unavailable' }
+    : { status: 'ok', value }
+}
+
+function captureParentIdentity(
+  targetDirectory: string,
+  runner: OperationObserverCommandRunner,
+  limits: Limits,
+  realPath: (filePath: string) => string = fs.realpathSync,
+): ParentIdentityCaptureResult {
+  const targetRoot = requiredGitPath(
+    runner,
+    ['rev-parse', '--show-toplevel'],
+    targetDirectory,
+    limits,
+    realPath,
+  )
+  if (targetRoot.status === 'error') return targetRoot
+  const gitDir = requiredGitPath(
+    runner,
+    ['rev-parse', '--absolute-git-dir'],
+    targetDirectory,
+    limits,
+    realPath,
+  )
+  if (gitDir.status === 'error') return gitDir
+  const commonDir = requiredGitPath(
+    runner,
+    ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+    targetDirectory,
+    limits,
+    realPath,
+  )
+  if (commonDir.status === 'error') return commonDir
+  const worktreeList = runCommand(
+    runner,
+    ['worktree', 'list', '--porcelain', '-z'],
+    targetDirectory,
+    limits,
+  )
+  if (worktreeList.status === 'error') return worktreeList
+  const registeredWorktreeRoots = worktreeList.output.stdout
+    .split('\0')
+    .filter((record) => record.startsWith('worktree '))
+    .map((record) => canonicalPath(record.slice('worktree '.length), realPath))
+  if (registeredWorktreeRoots.some((root) => root === undefined)) {
+    return { status: 'error', reasonCode: 'target-unavailable' }
+  }
+  const roots = registeredWorktreeRoots.filter(
+    (root): root is string => root !== undefined,
+  )
+  return roots.length > 0
+    ? {
+        status: 'ok',
+        identity: {
+          targetRoot: targetRoot.value,
+          gitDir: gitDir.value,
+          commonDir: commonDir.value,
+          registeredWorktreeRoots: roots,
+        },
+      }
+    : { status: 'error', reasonCode: 'target-unavailable' }
+}
+
+function readGitfileTarget(
+  gitfilePath: string,
+  realPath: (filePath: string) => string = fs.realpathSync,
+): string | undefined {
+  let contents: string
+  try {
+    contents = fs.readFileSync(gitfilePath, 'utf8')
+  } catch {
+    return undefined
+  }
+  const match = /^gitdir:\s*(.+?)\s*$/im.exec(contents)
+  if (!match) return undefined
+  const target = path.isAbsolute(match[1])
+    ? match[1]
+    : path.resolve(path.dirname(gitfilePath), match[1])
+  return canonicalPath(target, realPath)
+}
+
+function readGitdirBacklink(
+  backlinkPath: string,
+  realPath: (filePath: string) => string,
+): string | undefined {
+  let contents: string
+  try {
+    contents = fs.readFileSync(backlinkPath, 'utf8').trim()
+  } catch {
+    return undefined
+  }
+  if (contents.length === 0) return undefined
+  const target = path.isAbsolute(contents)
+    ? contents
+    : path.resolve(path.dirname(backlinkPath), contents)
+  return canonicalPath(target, realPath)
+}
+
+function isPathWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate)
+  return (
+    relative !== '' &&
+    relative !== '..' &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  )
+}
+
+function validateDotGitLinkage(
+  targetRoot: string,
+  gitDir: string,
+  commonDir: string,
+  realPath: (filePath: string) => string,
+): boolean {
+  const dotGit = path.join(targetRoot, '.git')
+  let dotGitStat: fs.Stats
+  try {
+    dotGitStat = fs.lstatSync(dotGit)
+  } catch {
+    return false
+  }
+  if (dotGitStat.isDirectory()) {
+    return gitDir === commonDir && canonicalPath(dotGit, realPath) === commonDir
+  }
+  if (
+    !dotGitStat.isFile() ||
+    dotGitStat.isSymbolicLink() ||
+    !isPathWithin(path.join(commonDir, 'worktrees'), gitDir) ||
+    readGitfileTarget(dotGit, realPath) !== gitDir
+  ) {
+    return false
+  }
+
+  const backlinkPath = path.join(gitDir, 'gitdir')
+  let backlinkStat: fs.Stats
+  try {
+    backlinkStat = fs.lstatSync(backlinkPath)
+  } catch {
+    return false
+  }
+  return (
+    backlinkStat.isFile() &&
+    !backlinkStat.isSymbolicLink() &&
+    readGitdirBacklink(backlinkPath, realPath) ===
+      canonicalPath(dotGit, realPath)
+  )
+}
+
+export function validateRegisteredWorktree(
+  candidateDirectory: string,
+  parentIdentity: RegisteredWorktreeParentIdentity,
+  options: RegisteredWorktreeValidationOptions = {},
+): RegisteredWorktreeValidationResult {
+  const runner = options.commandRunner ?? defaultCommandRunner
+  const limits = mergeLimits(options.limits)
+  const realPath = options.realPath ?? fs.realpathSync
+  const candidateRoot = canonicalPath(candidateDirectory, realPath)
+  if (candidateRoot === undefined) {
+    return { status: 'error', reasonCode: 'target-unavailable' }
+  }
+  const inside = runCommand(
+    runner,
+    ['rev-parse', '--is-inside-work-tree'],
+    candidateRoot,
+    limits,
+  )
+  if (inside.status === 'error') return inside
+  if (inside.output.stdout.trim() !== 'true') {
+    return { status: 'error', reasonCode: 'target-unavailable' }
+  }
+  const targetRoot = requiredGitPath(
+    runner,
+    ['rev-parse', '--show-toplevel'],
+    candidateRoot,
+    limits,
+    realPath,
+  )
+  if (targetRoot.status === 'error') return targetRoot
+  const gitDir = requiredGitPath(
+    runner,
+    ['rev-parse', '--absolute-git-dir'],
+    candidateRoot,
+    limits,
+    realPath,
+  )
+  if (gitDir.status === 'error') return gitDir
+  const commonDir = requiredGitPath(
+    runner,
+    ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+    candidateRoot,
+    limits,
+    realPath,
+  )
+  if (commonDir.status === 'error') return commonDir
+  if (
+    commonDir.value !== parentIdentity.commonDir ||
+    !parentIdentity.registeredWorktreeRoots.includes(targetRoot.value)
+  ) {
+    return { status: 'error', reasonCode: 'target-unavailable' }
+  }
+  if (
+    !validateDotGitLinkage(
+      targetRoot.value,
+      gitDir.value,
+      commonDir.value,
+      realPath,
+    )
+  ) {
+    return { status: 'error', reasonCode: 'target-unavailable' }
+  }
+  return {
+    status: 'ok',
+    targetRoot: targetRoot.value,
+    gitDir: gitDir.value,
+    commonDir: commonDir.value,
+  }
 }
 
 function readRevision(
@@ -1018,9 +1309,16 @@ export function createOpencodeOperationObserver(
   } catch {
     targetDirectory = path.resolve(options.targetDirectory)
   }
-  const targetDigest = digest('target', [targetDirectory])
   const runner = options.commandRunner ?? defaultCommandRunner
   const remoteRunner = options.remoteCommandRunner ?? defaultRemoteCommandRunner
+  const realPath = options.realPath ?? fs.realpathSync
+  const parentIdentityResult = captureParentIdentity(
+    targetDirectory,
+    runner,
+    limits,
+    realPath,
+  )
+  const targetDigest = digest('target', [targetDirectory])
   const fileReader = options.fileReader ?? fs.readFileSync
   const symlinkReader = options.symlinkReader ?? fs.readlinkSync
   const statReader =
@@ -1038,6 +1336,14 @@ export function createOpencodeOperationObserver(
 
   return {
     targetDigest,
+    validateRegisteredWorktree(candidateDirectory) {
+      if (parentIdentityResult.status === 'error') return parentIdentityResult
+      return validateRegisteredWorktree(
+        candidateDirectory,
+        parentIdentityResult.identity,
+        { commandRunner: runner, limits, realPath },
+      )
+    },
     async snapshot(): Promise<OperationObserverResult> {
       const rootResult = runCommand(
         runner,

--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -294,6 +294,22 @@ interface PendingOperation {
   remoteBefore?: OperationObserverRemoteResult
 }
 
+interface OperationObserverRegistration {
+  readonly targetRoot: string
+  readonly registeredWorktreeIdentity: string
+  readonly observer: OpencodeOperationObserver
+}
+
+type OperationObserverRegistry = Map<string, OperationObserverRegistration>
+
+interface RecoveredOperationContext {
+  readonly targetIdentity: string
+  readonly before: OperationObserverSnapshot
+  readonly after: OperationObserverSnapshot
+}
+
+type RecoveredOperationRegistry = Map<string, RecoveredOperationContext>
+
 interface PendingQuestionChallenge {
   readonly challenge: QuestionChallengeRecord
   readonly purpose: 'transition' | 'session-disablement'
@@ -315,7 +331,11 @@ interface TerminalComplete {
 }
 
 type OperationCompletionResult =
-  | { status: 'accepted'; operation: ReceiptOperation }
+  | {
+      status: 'accepted'
+      operation: ReceiptOperation
+      after: OperationObserverSnapshot
+    }
   | { status: 'deferred' | 'ignored' | 'unavailable' }
 
 interface MarkerSource {
@@ -1298,6 +1318,8 @@ function buildMarker(
 
 function createSessionRuntime(
   options: OpencodeWorkflowGuardOptions,
+  operationObservers: OperationObserverRegistry,
+  recoveredOperationContexts: RecoveredOperationRegistry,
 ): SessionRuntime {
   let ledger!: ReceiptLedger
   let guard!: WorkflowGuard
@@ -1321,6 +1343,55 @@ function createSessionRuntime(
   const pendingQuestionChallenges = new Map<string, PendingQuestionChallenge>()
   const blockedQuestionCalls = new Map<string, string>()
   const consumedQuestionTargets = new Set<TransitionTarget>()
+
+  function rememberOperationObserver(
+    registration: OperationObserverRegistration,
+  ): void {
+    const existing = operationObservers.get(registration.observer.targetDigest)
+    if (existing && existing.targetRoot !== registration.targetRoot) return
+    operationObservers.set(registration.observer.targetDigest, registration)
+  }
+
+  function parentObserverRegistration():
+    | OperationObserverRegistration
+    | undefined {
+    if (!options.observer) return undefined
+    const targetRoot = canonicalExistingPath(
+      options.targetDirectory ?? process.cwd(),
+      fs.realpathSync,
+    )
+    if (!targetRoot) return undefined
+    let validation: RegisteredWorktreeValidationResult
+    try {
+      validation = options.observer.validateRegisteredWorktree(targetRoot)
+    } catch {
+      return undefined
+    }
+    const registeredIdentity = registeredWorktreeIdentity(validation)
+    if (
+      validation.status !== 'ok' ||
+      registeredIdentity === undefined ||
+      validation.targetRoot !== targetRoot
+    ) {
+      return undefined
+    }
+    const registration = {
+      targetRoot,
+      registeredWorktreeIdentity: registeredIdentity,
+      observer: options.observer,
+    }
+    rememberOperationObserver(registration)
+    return registration
+  }
+
+  function operationObserverRegistration(
+    targetIdentity: string,
+  ): OperationObserverRegistration | undefined {
+    const existing = operationObservers.get(targetIdentity)
+    if (existing) return existing
+    if (options.observer?.targetDigest !== targetIdentity) return undefined
+    return parentObserverRegistration()
+  }
 
   function questionResource(target: TransitionTarget): string {
     const status = guard.status()
@@ -1872,10 +1943,14 @@ function createSessionRuntime(
       markUnavailable()
       return
     }
-    const current = await options.observer?.snapshot()
-    if (!current || current.status === 'unavailable') {
-      markUnavailable()
-      return
+    // Touch the fixed parent observer for the stable workspace path, but do
+    // not use its mutable repository/worktree revisions for child validation.
+    // A nested worktree can make the parent-root scan unavailable while its
+    // own authenticated target remains valid and independently observable.
+    try {
+      await options.observer?.snapshot()
+    } catch {
+      // Target-specific validation below remains authoritative.
     }
     const currentStatus = guard.status()
     if (!currentStatus.epoch || !currentStatus.unit) return
@@ -1883,15 +1958,12 @@ function createSessionRuntime(
       'workspace',
       parentBefore.workspaceIdentity,
     )
-    const expectedRepository = childLedger.digestIdentity(
-      'repository',
-      current.snapshot.repositoryRevisionDigest,
-    )
-    const expectedWorktree = childLedger.digestIdentity(
-      'worktree',
-      current.snapshot.worktreeRevisionDigest,
-    )
-    const candidates: Array<(typeof recovered.receipts)[number]> = []
+    let batchTargetIdentity = currentStatus.unit.pinnedOperationTargetIdentity
+    const candidates: Array<{
+      readonly receipt: (typeof recovered.receipts)[number]
+      readonly snapshot: OperationObserverSnapshot
+      readonly before?: OperationObserverSnapshot
+    }> = []
     for (const childReceipt of recovered.receipts) {
       const operation = childReceipt.canonical.operation
       if (!localOperation(operation)) continue
@@ -1899,23 +1971,105 @@ function createSessionRuntime(
         markUnavailable()
         return
       }
+
+      const targetIdentity = childReceipt.canonical.operationTargetIdentity
+      if (!targetIdentity) {
+        markUnavailable()
+        return
+      }
+      if (
+        batchTargetIdentity !== undefined &&
+        targetIdentity !== batchTargetIdentity
+      ) {
+        markUnavailable()
+        return
+      }
+      batchTargetIdentity = targetIdentity
+
+      const registration = operationObserverRegistration(targetIdentity)
+      if (!registration || !options.observer) {
+        markUnavailable()
+        return
+      }
+      let validation: RegisteredWorktreeValidationResult
+      try {
+        validation = options.observer.validateRegisteredWorktree(
+          registration.targetRoot,
+        )
+      } catch {
+        markUnavailable()
+        return
+      }
+      if (
+        validation.status === 'error' ||
+        validation.targetRoot !== registration.targetRoot ||
+        registeredWorktreeIdentity(validation) !==
+          registration.registeredWorktreeIdentity ||
+        registration.observer.targetDigest !== targetIdentity
+      ) {
+        markUnavailable()
+        return
+      }
+
+      let targetResult: OperationObserverResult
+      try {
+        targetResult = await registration.observer.snapshot()
+      } catch {
+        markUnavailable()
+        return
+      }
+      if (
+        targetResult.status === 'unavailable' ||
+        targetResult.snapshot.targetDigest !== targetIdentity
+      ) {
+        markUnavailable()
+        return
+      }
+
+      const recoveredContext = recoveredOperationContexts.get(
+        childReceipt.canonical.receiptId,
+      )
+      if (
+        (recoveredContext &&
+          recoveredContext.targetIdentity !== targetIdentity) ||
+        (targetIdentity !== options.observer.targetDigest && !recoveredContext)
+      ) {
+        markUnavailable()
+        return
+      }
+
+      const expectedRepository = childLedger.digestIdentity(
+        'repository',
+        targetResult.snapshot.repositoryRevisionDigest,
+      )
+      const expectedWorktree = childLedger.digestIdentity(
+        'worktree',
+        targetResult.snapshot.worktreeRevisionDigest,
+      )
       if (
         childReceipt.canonical.repositoryDigest !== expectedRepository ||
         childReceipt.canonical.worktreeDigest !== expectedWorktree
       ) {
-        // Stale relative to the current single observer snapshot (repository
-        // or worktree revision has moved since this receipt was minted) —
-        // skip this receipt without minting it, but keep evaluating later
+        // Stale relative to the authenticated target's current snapshot
+        // (repository or worktree revision moved since this receipt was
+        // minted) — skip without minting, but keep evaluating later
         // chronological receipts from the same child rollup.
         continue
       }
-      candidates.push(childReceipt)
+      candidates.push({
+        receipt: childReceipt,
+        snapshot: targetResult.snapshot,
+        before: recoveredContext?.before,
+      })
     }
 
     let minted = false
-    for (const childReceipt of candidates) {
+    for (const candidate of candidates) {
+      const childReceipt = candidate.receipt
+      const targetSnapshot = candidate.snapshot
       const operation = childReceipt.canonical.operation
       const parentContext = guard.currentOperationContext()
+      const beforeSnapshot = candidate.before
       const callID = `task-${host.callID}-${childReceipt.canonical.receiptId}`
       const observation = {
         callId: callID,
@@ -1925,23 +2079,23 @@ function createSessionRuntime(
           epochId: currentStatus.epoch.epochId,
           unitId: currentStatus.unit.unitId,
           workspaceIdentity: parentContext.workspaceIdentity,
-          ...(localOperation(operation)
-            ? { operationTargetIdentity: current.snapshot.targetDigest }
-            : {}),
-          ...(parentContext.repositoryIdentity
-            ? { repositoryIdentity: parentContext.repositoryIdentity }
-            : {}),
-          ...(parentContext.worktreeIdentity
-            ? { worktreeIdentity: parentContext.worktreeIdentity }
-            : {}),
+          operationTargetIdentity:
+            childReceipt.canonical.operationTargetIdentity,
+          repositoryIdentity:
+            beforeSnapshot?.repositoryRevisionDigest ??
+            parentContext.repositoryIdentity ??
+            targetSnapshot.repositoryRevisionDigest,
+          worktreeIdentity:
+            beforeSnapshot?.worktreeRevisionDigest ??
+            parentContext.worktreeIdentity ??
+            targetSnapshot.worktreeRevisionDigest,
         },
         after: {
           workspaceIdentity: parentContext.workspaceIdentity,
-          ...(localOperation(operation)
-            ? { operationTargetIdentity: current.snapshot.targetDigest }
-            : {}),
-          repositoryIdentity: current.snapshot.repositoryRevisionDigest,
-          worktreeIdentity: current.snapshot.worktreeRevisionDigest,
+          operationTargetIdentity:
+            childReceipt.canonical.operationTargetIdentity,
+          repositoryIdentity: targetSnapshot.repositoryRevisionDigest,
+          worktreeIdentity: targetSnapshot.worktreeRevisionDigest,
         },
         terminal: {
           status: 'success' as const,
@@ -2425,9 +2579,12 @@ function createSessionRuntime(
     const operationObserver =
       target.targetRoot === canonicalParentTargetRoot
         ? options.observer
-        : createOpencodeOperationObserver({
+        : ([...operationObservers.values()].find(
+            (registration) => registration.targetRoot === target.targetRoot,
+          )?.observer ??
+          createOpencodeOperationObserver({
             targetDirectory: target.targetRoot,
-          })
+          }))
     let result: OperationObserverResult
     try {
       result = await operationObserver.snapshot()
@@ -2443,6 +2600,11 @@ function createSessionRuntime(
       markUnavailable()
       return
     }
+    rememberOperationObserver({
+      targetRoot: target.targetRoot,
+      registeredWorktreeIdentity: registeredIdentity,
+      observer: operationObserver,
+    })
     const remote = await remoteIntentForOperation(host, args, operationObserver)
     pendingOperations.set(callDigest, {
       callID: host.callID,
@@ -3284,7 +3446,11 @@ function createSessionRuntime(
       return { status: 'unavailable' }
     }
     if (observed.status !== 'accepted') return { status: 'ignored' }
-    return { status: 'accepted', operation: observed.operation }
+    return {
+      status: 'accepted',
+      operation: observed.operation,
+      after: afterSnapshot,
+    }
   }
 
   function receiptForOperation(callID: string, operation: ReceiptOperation) {
@@ -3349,7 +3515,16 @@ function createSessionRuntime(
     }
     if (result.status === 'accepted') {
       const receipt = receiptForOperation(host.callID, result.operation)
-      if (receipt) mergeReceiptMarker(output, receipt)
+      if (receipt) {
+        if (localOperation(result.operation)) {
+          recoveredOperationContexts.set(receipt.canonical.receiptId, {
+            targetIdentity: pending.targetIdentity,
+            before: pending.before,
+            after: result.after,
+          })
+        }
+        mergeReceiptMarker(output, receipt)
+      }
     }
   }
 
@@ -3540,15 +3715,21 @@ export function createOpencodeWorkflowGuard(
   options: OpencodeWorkflowGuardOptions,
 ): OpencodeWorkflowGuard {
   const sessions = new Map<string, SessionRuntime>()
+  const operationObservers: OperationObserverRegistry = new Map()
+  const recoveredOperationContexts: RecoveredOperationRegistry = new Map()
 
   function sessionRuntimeFor(sessionID: string): SessionRuntime {
     const existing = sessions.get(sessionID)
     if (existing) return existing
-    const runtime = createSessionRuntime({
-      ...options,
-      registrationIdentity: options.registrationIdentity,
-      sessionSalt: options.sessionSalt,
-    })
+    const runtime = createSessionRuntime(
+      {
+        ...options,
+        registrationIdentity: options.registrationIdentity,
+        sessionSalt: options.sessionSalt,
+      },
+      operationObservers,
+      recoveredOperationContexts,
+    )
     sessions.set(sessionID, runtime)
     return runtime
   }

--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -26,6 +26,7 @@ import type {
 } from './receipt-classifier.js'
 import {
   createReceiptLedger,
+  isLocalOperation,
   type ReceiptClassification,
   type ReceiptEnvelope,
   type ReceiptLedger,
@@ -1003,11 +1004,7 @@ function terminalForOutput(
 function localOperation(
   operation: ReceiptOperation | null,
 ): operation is 'implementation' | 'verification' | 'commit' {
-  return (
-    operation === 'implementation' ||
-    operation === 'verification' ||
-    operation === 'commit'
-  )
+  return operation !== null && isLocalOperation(operation)
 }
 
 function remoteOperation(
@@ -1033,7 +1030,6 @@ function remoteReadbackInput(
     workspaceIdentity,
     repositoryIdentity: local.repositoryRevisionDigest,
     worktreeIdentity: local.worktreeRevisionDigest,
-    operationTargetIdentity: local.targetDigest,
     resourceIdentity: snapshot.resourceIdentity,
     ...(includeRevision
       ? { resourceRevisionIdentity: snapshot.resourceRevisionIdentity }
@@ -1929,7 +1925,9 @@ function createSessionRuntime(
           epochId: currentStatus.epoch.epochId,
           unitId: currentStatus.unit.unitId,
           workspaceIdentity: parentContext.workspaceIdentity,
-          operationTargetIdentity: current.snapshot.targetDigest,
+          ...(localOperation(operation)
+            ? { operationTargetIdentity: current.snapshot.targetDigest }
+            : {}),
           ...(parentContext.repositoryIdentity
             ? { repositoryIdentity: parentContext.repositoryIdentity }
             : {}),
@@ -1939,7 +1937,9 @@ function createSessionRuntime(
         },
         after: {
           workspaceIdentity: parentContext.workspaceIdentity,
-          operationTargetIdentity: current.snapshot.targetDigest,
+          ...(localOperation(operation)
+            ? { operationTargetIdentity: current.snapshot.targetDigest }
+            : {}),
           repositoryIdentity: current.snapshot.repositoryRevisionDigest,
           worktreeIdentity: current.snapshot.worktreeRevisionDigest,
         },
@@ -3111,7 +3111,9 @@ function createSessionRuntime(
         workspaceIdentity: options.workspaceIdentity,
         repositoryIdentity: pending.before.repositoryRevisionDigest,
         worktreeIdentity: pending.before.worktreeRevisionDigest,
-        operationTargetIdentity: pending.targetIdentity,
+        ...(localOperation(operation)
+          ? { operationTargetIdentity: pending.targetIdentity }
+          : {}),
         ...(pending.remoteBefore?.status === 'available'
           ? {
               resourceIdentity: pending.remoteBefore.snapshot.resourceIdentity,
@@ -3126,7 +3128,9 @@ function createSessionRuntime(
         workspaceIdentity: options.workspaceIdentity,
         repositoryIdentity: after.repositoryRevisionDigest,
         worktreeIdentity: after.worktreeRevisionDigest,
-        operationTargetIdentity: pending.targetIdentity,
+        ...(localOperation(operation)
+          ? { operationTargetIdentity: pending.targetIdentity }
+          : {}),
         commitClosure: after.commitClosure,
         ...(remoteAfter
           ? {

--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -1,4 +1,6 @@
 import { randomBytes } from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
 import type { ToolDefinition } from '@opencode-ai/plugin'
 import { z } from 'zod'
 import { INTERNAL_AGENT_SIGNATURES } from './bootstrap.js'
@@ -8,6 +10,7 @@ import type {
   OperationObserverRemoteSnapshot,
   OperationObserverResult,
   OperationObserverSnapshot,
+  RegisteredWorktreeValidationResult,
   RemoteOperation,
 } from './opencode-operation-observer.js'
 import {
@@ -466,7 +469,7 @@ function digestCall(
   return ledger.digestIdentity('call', callID)
 }
 
-type LocalOperationTool = 'write' | 'edit' | 'apply_patch' | 'bash'
+export type LocalOperationTool = 'write' | 'edit' | 'apply_patch' | 'bash'
 
 function isLocalOperationTool(tool: string): tool is LocalOperationTool {
   return (
@@ -475,6 +478,398 @@ function isLocalOperationTool(tool: string): tool is LocalOperationTool {
     tool === 'apply_patch' ||
     tool === 'bash'
   )
+}
+
+export interface OpencodeOperationTargetDerivationOptions {
+  readonly parentTargetRoot: string
+  readonly sessionLocation?: string
+  readonly validateRegisteredWorktree: (
+    candidateDirectory: string,
+  ) => RegisteredWorktreeValidationResult
+  readonly realPath?: (filePath: string) => string
+}
+
+export type OpencodeOperationTargetDerivationResult =
+  | { readonly status: 'available'; readonly targetRoot: string }
+  | {
+      readonly status: 'unavailable'
+      readonly reasonCode: 'target-unavailable'
+    }
+
+function unavailableOperationTarget(): OpencodeOperationTargetDerivationResult {
+  return { status: 'unavailable', reasonCode: 'target-unavailable' }
+}
+
+function canonicalExistingPath(
+  filePath: string,
+  realPath: (filePath: string) => string,
+): string | undefined {
+  try {
+    return realPath(filePath)
+  } catch {
+    return undefined
+  }
+}
+
+function canonicalFileTarget(
+  filePath: string,
+  realPath: (filePath: string) => string,
+): string | undefined {
+  const existing = canonicalExistingPath(filePath, realPath)
+  if (existing) return existing
+  const parent = canonicalExistingPath(path.dirname(filePath), realPath)
+  const basename = path.basename(filePath)
+  return parent && basename && basename !== '.' && basename !== '..'
+    ? path.join(parent, basename)
+    : undefined
+}
+
+function pathWithinOrEqual(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate)
+  return (
+    relative === '' ||
+    (relative !== '..' &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  )
+}
+
+function targetIsGitAdminStorage(
+  targetPath: string,
+  validation: Extract<
+    RegisteredWorktreeValidationResult,
+    { readonly status: 'ok' }
+  >,
+): boolean {
+  return (
+    pathWithinOrEqual(path.join(validation.targetRoot, '.git'), targetPath) ||
+    pathWithinOrEqual(validation.gitDir, targetPath) ||
+    pathWithinOrEqual(validation.commonDir, targetPath)
+  )
+}
+
+function targetResultFromValidation(
+  candidatePath: string,
+  validation: RegisteredWorktreeValidationResult,
+): OpencodeOperationTargetDerivationResult {
+  if (validation.status === 'error') return unavailableOperationTarget()
+  if (!pathWithinOrEqual(validation.targetRoot, candidatePath)) {
+    return unavailableOperationTarget()
+  }
+  if (targetIsGitAdminStorage(candidatePath, validation)) {
+    return unavailableOperationTarget()
+  }
+  return { status: 'available', targetRoot: validation.targetRoot }
+}
+
+function trustedParentTarget(
+  parentTargetRoot: string,
+  candidatePath: string,
+): OpencodeOperationTargetDerivationResult | undefined {
+  if (!pathWithinOrEqual(parentTargetRoot, candidatePath)) return undefined
+  if (pathWithinOrEqual(path.join(parentTargetRoot, '.git'), candidatePath)) {
+    return unavailableOperationTarget()
+  }
+  return { status: 'available', targetRoot: parentTargetRoot }
+}
+
+function validationForCandidate(
+  candidatePath: string,
+  options: OpencodeOperationTargetDerivationOptions,
+  targetPath = candidatePath,
+): OpencodeOperationTargetDerivationResult {
+  try {
+    return targetResultFromValidation(
+      targetPath,
+      options.validateRegisteredWorktree(candidatePath),
+    )
+  } catch {
+    return unavailableOperationTarget()
+  }
+}
+
+function deriveFileTarget(
+  rawPath: string,
+  baseDirectory: string,
+  parentTargetRoot: string,
+  options: OpencodeOperationTargetDerivationOptions,
+  realPath: (filePath: string) => string,
+  allowParentFastPath = true,
+): OpencodeOperationTargetDerivationResult {
+  const resolvedPath = path.resolve(baseDirectory, rawPath)
+  const canonicalPath = canonicalFileTarget(resolvedPath, realPath)
+  if (!canonicalPath) return unavailableOperationTarget()
+  const parentResult =
+    allowParentFastPath && !path.isAbsolute(rawPath)
+      ? trustedParentTarget(parentTargetRoot, canonicalPath)
+      : undefined
+  if (parentResult) return parentResult
+  return validationForCandidate(
+    path.dirname(canonicalPath),
+    options,
+    canonicalPath,
+  )
+}
+
+interface DerivedDirectoryTarget {
+  readonly targetRoot: string
+  readonly resolvedPath: string
+}
+
+function sharedTargetRoot(
+  targets: readonly OpencodeOperationTargetDerivationResult[],
+  extraRoots: readonly string[] = [],
+): string | undefined {
+  const roots = [...extraRoots]
+  for (const target of targets) {
+    if (target.status === 'unavailable') return undefined
+    roots.push(target.targetRoot)
+  }
+  const targetRoot = roots[0]
+  return targetRoot && roots.every((root) => root === targetRoot)
+    ? targetRoot
+    : undefined
+}
+
+function deriveDirectoryTarget(
+  rawPath: string,
+  baseDirectory: string,
+  parentTargetRoot: string,
+  options: OpencodeOperationTargetDerivationOptions,
+  realPath: (filePath: string) => string,
+):
+  | { readonly status: 'available'; readonly target: DerivedDirectoryTarget }
+  | { readonly status: 'unavailable' } {
+  const resolvedPath = canonicalExistingPath(
+    path.resolve(baseDirectory, rawPath),
+    realPath,
+  )
+  if (!resolvedPath) return { status: 'unavailable' }
+  const parentResult = path.isAbsolute(rawPath)
+    ? undefined
+    : trustedParentTarget(parentTargetRoot, resolvedPath)
+  if (parentResult?.status === 'unavailable') {
+    return { status: 'unavailable' }
+  }
+  if (parentResult) {
+    return {
+      status: 'available',
+      target: { targetRoot: parentResult.targetRoot, resolvedPath },
+    }
+  }
+  const validated = validationForCandidate(resolvedPath, options)
+  return validated.status === 'available'
+    ? {
+        status: 'available',
+        target: { targetRoot: validated.targetRoot, resolvedPath },
+      }
+    : { status: 'unavailable' }
+}
+
+const PATCH_FILE_PREFIXES = [
+  '*** Add File:',
+  '*** Delete File:',
+  '*** Update File:',
+  '*** Move to:',
+] as const
+
+function patchTextFileTargets(
+  patchText: string,
+): readonly string[] | undefined {
+  const paths: string[] = []
+  for (const line of patchText.split(/\r?\n/)) {
+    const prefix = PATCH_FILE_PREFIXES.find((candidate) =>
+      line.startsWith(candidate),
+    )
+    if (!prefix) continue
+    const filePath = line.slice(prefix.length).trim()
+    if (!filePath) return undefined
+    paths.push(filePath)
+  }
+  return paths
+}
+
+function hunkFileTargets(value: unknown): readonly string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const paths: string[] = []
+  for (const hunk of value) {
+    if (!isRecord(hunk) || typeof hunk.path !== 'string' || !hunk.path) {
+      return undefined
+    }
+    paths.push(hunk.path)
+    if (hunk.move_path === undefined) continue
+    if (typeof hunk.move_path !== 'string' || !hunk.move_path) return undefined
+    paths.push(hunk.move_path)
+  }
+  return paths
+}
+
+function patchFileTargets(
+  args: Record<string, unknown>,
+): readonly string[] | undefined {
+  const patchValue = args.patchText ?? args.patch
+  if (typeof patchValue === 'string') return patchTextFileTargets(patchValue)
+  if (patchValue !== undefined) return undefined
+  return args.hunks === undefined ? [] : hunkFileTargets(args.hunks)
+}
+
+function fileTargetArguments(
+  args: Record<string, unknown>,
+): string[] | undefined {
+  const paths: string[] = []
+  for (const key of ['filePath', 'path'] as const) {
+    if (!(key in args)) continue
+    if (typeof args[key] !== 'string' || args[key].length === 0) {
+      return undefined
+    }
+    paths.push(args[key])
+  }
+  return paths.length > 0 ? paths : undefined
+}
+
+function deriveFileOperationTarget(
+  args: Record<string, unknown>,
+  sessionLocation: string,
+  parentTargetRoot: string,
+  options: OpencodeOperationTargetDerivationOptions,
+  realPath: (filePath: string) => string,
+): OpencodeOperationTargetDerivationResult {
+  const paths = fileTargetArguments(args)
+  if (!paths) return unavailableOperationTarget()
+  const targets = paths.map((rawPath) =>
+    deriveFileTarget(
+      rawPath,
+      sessionLocation,
+      parentTargetRoot,
+      options,
+      realPath,
+    ),
+  )
+  const targetRoot = sharedTargetRoot(targets)
+  return targetRoot
+    ? { status: 'available', targetRoot }
+    : unavailableOperationTarget()
+}
+
+function deriveApplyPatchTarget(
+  args: Record<string, unknown>,
+  sessionLocation: string,
+  parentTargetRoot: string,
+  options: OpencodeOperationTargetDerivationOptions,
+  realPath: (filePath: string) => string,
+): OpencodeOperationTargetDerivationResult {
+  if (
+    args.workdir !== undefined &&
+    (typeof args.workdir !== 'string' || args.workdir.length === 0)
+  ) {
+    return unavailableOperationTarget()
+  }
+  const patchPaths = patchFileTargets(args)
+  if (!patchPaths) return unavailableOperationTarget()
+  const workdir =
+    args.workdir === undefined
+      ? {
+          status: 'available' as const,
+          target: {
+            targetRoot: parentTargetRoot,
+            resolvedPath: sessionLocation,
+          },
+        }
+      : deriveDirectoryTarget(
+          args.workdir,
+          sessionLocation,
+          parentTargetRoot,
+          options,
+          realPath,
+        )
+  if (workdir.status === 'unavailable') return unavailableOperationTarget()
+  const targets = patchPaths.map((rawPath) =>
+    deriveFileTarget(
+      rawPath,
+      workdir.target.resolvedPath,
+      parentTargetRoot,
+      options,
+      realPath,
+      args.workdir === undefined,
+    ),
+  )
+  const targetRoot = sharedTargetRoot(targets, [workdir.target.targetRoot])
+  return targetRoot
+    ? { status: 'available', targetRoot }
+    : unavailableOperationTarget()
+}
+
+function deriveBashTarget(
+  args: Record<string, unknown>,
+  sessionLocation: string,
+  parentTargetRoot: string,
+  options: OpencodeOperationTargetDerivationOptions,
+  realPath: (filePath: string) => string,
+): OpencodeOperationTargetDerivationResult {
+  if (args.workdir === undefined) {
+    return { status: 'available', targetRoot: parentTargetRoot }
+  }
+  if (typeof args.workdir !== 'string' || args.workdir.length === 0) {
+    return unavailableOperationTarget()
+  }
+  const candidatePath = canonicalExistingPath(
+    path.resolve(sessionLocation, args.workdir),
+    realPath,
+  )
+  if (!candidatePath) return unavailableOperationTarget()
+  const parentResult = path.isAbsolute(args.workdir)
+    ? undefined
+    : trustedParentTarget(parentTargetRoot, candidatePath)
+  return parentResult ?? validationForCandidate(candidatePath, options)
+}
+
+export function deriveOpencodeOperationTarget(
+  tool: LocalOperationTool,
+  args: unknown,
+  options: OpencodeOperationTargetDerivationOptions,
+): OpencodeOperationTargetDerivationResult {
+  const realPath = options.realPath ?? fs.realpathSync
+  const parentTargetRoot = canonicalExistingPath(
+    options.parentTargetRoot,
+    realPath,
+  )
+  if (!parentTargetRoot) return unavailableOperationTarget()
+
+  if (!isRecord(args)) return unavailableOperationTarget()
+
+  const sessionLocation = canonicalExistingPath(
+    options.sessionLocation ?? parentTargetRoot,
+    realPath,
+  )
+  if (!sessionLocation) return unavailableOperationTarget()
+
+  if (tool === 'write' || tool === 'edit') {
+    return deriveFileOperationTarget(
+      args,
+      sessionLocation,
+      parentTargetRoot,
+      options,
+      realPath,
+    )
+  }
+  if (tool === 'apply_patch') {
+    return deriveApplyPatchTarget(
+      args,
+      sessionLocation,
+      parentTargetRoot,
+      options,
+      realPath,
+    )
+  }
+  return tool === 'bash'
+    ? deriveBashTarget(
+        args,
+        sessionLocation,
+        parentTargetRoot,
+        options,
+        realPath,
+      )
+    : unavailableOperationTarget()
 }
 
 function serializeStableArray(

--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -123,6 +123,7 @@ const REASON_CODES = new Set([
   'no-active-unit',
   'no-op-operation',
   'operation-not-required',
+  'operation-target-mismatch',
   'receipt-mismatch',
   'rejected-operation',
   'resource-mismatch',

--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -2581,6 +2581,7 @@ function createSessionRuntime(
     }
   }
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: target derivation, registered-worktree validation, and observer registration must stay atomic on the before hook
   async function prepareOperation(
     host: HostToolBefore,
     args: unknown,
@@ -3078,6 +3079,7 @@ function createSessionRuntime(
     if (remember) abandonedCompletes.set(callDigest, pending.target)
   }
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: fail-closed effective-observer selection and readback bundle construction must remain a single ordered pipeline
   async function completionReadbacks(): Promise<
     | { status: 'none' }
     | { status: 'unavailable' }

--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -13,6 +13,7 @@ import type {
   RegisteredWorktreeValidationResult,
   RemoteOperation,
 } from './opencode-operation-observer.js'
+import { createOpencodeOperationObserver } from './opencode-operation-observer.js'
 import {
   classifyQuestionAnswer,
   createQuestionAttestation,
@@ -52,7 +53,7 @@ import {
 
 const MARKER_OPEN = '<SYSTEMATIC_WORKFLOW_GUARD>'
 const MARKER_CLOSE = '</SYSTEMATIC_WORKFLOW_GUARD>'
-const MARKER_PROTOCOL_VERSION = 1
+const MARKER_PROTOCOL_VERSION = 2
 const MAX_MARKER_LENGTH = 4096
 const MAX_MARKER_SOURCES = 8
 const MAX_CALL_ID_LENGTH = 256
@@ -190,6 +191,8 @@ export interface OpencodeWorkflowGuardOptions {
   hostReadback?: OpencodeWorkflowHostReadback
   readonly registrationIdentity?: string
   readonly sessionSalt?: Uint8Array
+  readonly targetDirectory?: string
+  readonly sessionLocation?: string
 }
 
 export interface OpencodeWorkflowChildSession {
@@ -281,6 +284,10 @@ interface PendingOperation {
   callID: string
   tool: 'write' | 'edit' | 'apply_patch' | 'bash'
   argsFingerprint: string
+  targetRoot: string
+  targetIdentity: string
+  registeredWorktreeIdentity: string
+  observer: OpencodeOperationObserver
   before: OperationObserverSnapshot
   remoteOperation?: RemoteOperation
   remoteBefore?: OperationObserverRemoteResult
@@ -509,6 +516,14 @@ function canonicalExistingPath(
   } catch {
     return undefined
   }
+}
+
+function registeredWorktreeIdentity(
+  validation: RegisteredWorktreeValidationResult,
+): string | undefined {
+  return validation.status === 'ok'
+    ? `${validation.gitDir}\n${validation.commonDir}`
+    : undefined
 }
 
 function canonicalFileTarget(
@@ -1018,6 +1033,7 @@ function remoteReadbackInput(
     workspaceIdentity,
     repositoryIdentity: local.repositoryRevisionDigest,
     worktreeIdentity: local.worktreeRevisionDigest,
+    operationTargetIdentity: local.targetDigest,
     resourceIdentity: snapshot.resourceIdentity,
     ...(includeRevision
       ? { resourceRevisionIdentity: snapshot.resourceRevisionIdentity }
@@ -1913,6 +1929,7 @@ function createSessionRuntime(
           epochId: currentStatus.epoch.epochId,
           unitId: currentStatus.unit.unitId,
           workspaceIdentity: parentContext.workspaceIdentity,
+          operationTargetIdentity: current.snapshot.targetDigest,
           ...(parentContext.repositoryIdentity
             ? { repositoryIdentity: parentContext.repositoryIdentity }
             : {}),
@@ -1922,6 +1939,7 @@ function createSessionRuntime(
         },
         after: {
           workspaceIdentity: parentContext.workspaceIdentity,
+          operationTargetIdentity: current.snapshot.targetDigest,
           repositoryIdentity: current.snapshot.repositoryRevisionDigest,
           worktreeIdentity: current.snapshot.worktreeRevisionDigest,
         },
@@ -2322,6 +2340,7 @@ function createSessionRuntime(
   async function remoteIntentForOperation(
     host: HostToolBefore,
     args: unknown,
+    observer: OpencodeOperationObserver,
   ): Promise<
     | {
         operation: RemoteOperation
@@ -2338,7 +2357,7 @@ function createSessionRuntime(
     )
     if (!classification || !remoteOperation(classification.category))
       return undefined
-    const remoteSnapshot = options.observer?.remoteSnapshot
+    const remoteSnapshot = observer.remoteSnapshot
     if (!remoteSnapshot) return { operation: classification.category }
     try {
       return {
@@ -2366,9 +2385,52 @@ function createSessionRuntime(
     ) {
       return
     }
+    const parentTargetRoot = options.targetDirectory ?? process.cwd()
+    const sessionLocation = options.sessionLocation ?? parentTargetRoot
+    const target = deriveOpencodeOperationTarget(host.tool, args, {
+      parentTargetRoot,
+      sessionLocation,
+      validateRegisteredWorktree: options.observer.validateRegisteredWorktree,
+    })
+    if (target.status === 'unavailable') {
+      markUnavailable()
+      return
+    }
+    let registeredTarget: RegisteredWorktreeValidationResult
+    try {
+      registeredTarget = options.observer.validateRegisteredWorktree(
+        target.targetRoot,
+      )
+    } catch {
+      markUnavailable()
+      return
+    }
+    const registeredIdentity = registeredWorktreeIdentity(registeredTarget)
+    if (
+      registeredTarget.status !== 'ok' ||
+      registeredIdentity === undefined ||
+      registeredTarget.targetRoot !== target.targetRoot
+    ) {
+      markUnavailable()
+      return
+    }
+    const canonicalParentTargetRoot = canonicalExistingPath(
+      parentTargetRoot,
+      fs.realpathSync,
+    )
+    if (!canonicalParentTargetRoot) {
+      markUnavailable()
+      return
+    }
+    const operationObserver =
+      target.targetRoot === canonicalParentTargetRoot
+        ? options.observer
+        : createOpencodeOperationObserver({
+            targetDirectory: target.targetRoot,
+          })
     let result: OperationObserverResult
     try {
-      result = await options.observer.snapshot()
+      result = await operationObserver.snapshot()
     } catch {
       markUnavailable()
       return
@@ -2377,15 +2439,19 @@ function createSessionRuntime(
       markUnavailable()
       return
     }
-    if (result.snapshot.targetDigest !== options.workspaceIdentity) {
+    if (result.snapshot.targetDigest !== operationObserver.targetDigest) {
       markUnavailable()
       return
     }
-    const remote = await remoteIntentForOperation(host, args)
+    const remote = await remoteIntentForOperation(host, args, operationObserver)
     pendingOperations.set(callDigest, {
       callID: host.callID,
       tool: host.tool,
       argsFingerprint: fingerprint,
+      targetRoot: target.targetRoot,
+      targetIdentity: operationObserver.targetDigest,
+      registeredWorktreeIdentity: registeredIdentity,
+      observer: operationObserver,
       before: result.snapshot,
       ...(remote
         ? { remoteOperation: remote.operation, remoteBefore: remote.before }
@@ -2835,6 +2901,7 @@ function createSessionRuntime(
           workspaceIdentity: options.workspaceIdentity,
           repositoryIdentity: finalResult.snapshot.repositoryRevisionDigest,
           worktreeIdentity: finalResult.snapshot.worktreeRevisionDigest,
+          operationTargetIdentity: finalResult.snapshot.targetDigest,
         },
         ...remoteReadbacks.map(({ operation, snapshot }) =>
           remoteReadbackInput(
@@ -2960,26 +3027,43 @@ function createSessionRuntime(
     return pending
   }
 
-  async function captureAfterOperation(): Promise<
-    OperationObserverSnapshot | undefined
-  > {
+  async function captureAfterOperation(
+    pending: PendingOperation,
+  ): Promise<OperationObserverSnapshot | undefined> {
     if (!options.observer) return undefined
+    let validation: RegisteredWorktreeValidationResult
+    try {
+      validation = options.observer.validateRegisteredWorktree(
+        pending.targetRoot,
+      )
+    } catch {
+      return undefined
+    }
+    if (
+      validation.status === 'error' ||
+      validation.targetRoot !== pending.targetRoot ||
+      registeredWorktreeIdentity(validation) !==
+        pending.registeredWorktreeIdentity
+    ) {
+      return undefined
+    }
     let result: OperationObserverResult
     try {
-      result = await options.observer.snapshot()
+      result = await pending.observer.snapshot()
     } catch {
       return undefined
     }
     return result.status === 'available' &&
-      result.snapshot.targetDigest === options.workspaceIdentity
+      result.snapshot.targetDigest === pending.targetIdentity
       ? result.snapshot
       : undefined
   }
 
   async function captureRemoteAfter(
     operation: RemoteOperation,
+    observer: OpencodeOperationObserver,
   ): Promise<OperationObserverRemoteSnapshot | undefined> {
-    const remoteSnapshot = options.observer?.remoteSnapshot
+    const remoteSnapshot = observer.remoteSnapshot
     if (!remoteSnapshot) return undefined
     let result: OperationObserverRemoteResult
     try {
@@ -3027,6 +3111,7 @@ function createSessionRuntime(
         workspaceIdentity: options.workspaceIdentity,
         repositoryIdentity: pending.before.repositoryRevisionDigest,
         worktreeIdentity: pending.before.worktreeRevisionDigest,
+        operationTargetIdentity: pending.targetIdentity,
         ...(pending.remoteBefore?.status === 'available'
           ? {
               resourceIdentity: pending.remoteBefore.snapshot.resourceIdentity,
@@ -3041,6 +3126,7 @@ function createSessionRuntime(
         workspaceIdentity: options.workspaceIdentity,
         repositoryIdentity: after.repositoryRevisionDigest,
         worktreeIdentity: after.worktreeRevisionDigest,
+        operationTargetIdentity: pending.targetIdentity,
         commitClosure: after.commitClosure,
         ...(remoteAfter
           ? {
@@ -3119,7 +3205,7 @@ function createSessionRuntime(
       sealOperation(callDigest, pending, true)
       return { status: 'unavailable' }
     }
-    const afterSnapshot = await captureAfterOperation()
+    const afterSnapshot = await captureAfterOperation(pending)
     if (!afterSnapshot) {
       sealOperation(callDigest, pending, true)
       return { status: 'unavailable' }
@@ -3142,7 +3228,10 @@ function createSessionRuntime(
     }
     let finalObservation = classification.observation
     if (remoteOperation(finalObservation.operation)) {
-      const remoteAfter = await captureRemoteAfter(finalObservation.operation)
+      const remoteAfter = await captureRemoteAfter(
+        finalObservation.operation,
+        pending.observer,
+      )
       if (!remoteAfter) {
         sealOperation(callDigest, pending, true)
         return { status: 'unavailable' }

--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -300,6 +300,12 @@ interface OperationObserverRegistration {
   readonly observer: OpencodeOperationObserver
 }
 
+interface EffectiveOperationObserver {
+  readonly observer: OpencodeOperationObserver
+  readonly targetIdentity: string
+  readonly pinned: boolean
+}
+
 type OperationObserverRegistry = Map<string, OperationObserverRegistration>
 
 interface RecoveredOperationContext {
@@ -1393,6 +1399,49 @@ function createSessionRuntime(
     return parentObserverRegistration()
   }
 
+  function effectiveOperationObserver():
+    | EffectiveOperationObserver
+    | undefined {
+    const parentObserver = options.observer
+    if (!parentObserver) return undefined
+    const pinnedTargetIdentity =
+      guard.status().unit?.pinnedOperationTargetIdentity
+    if (
+      pinnedTargetIdentity === undefined ||
+      pinnedTargetIdentity === options.workspaceIdentity
+    ) {
+      return {
+        observer: parentObserver,
+        targetIdentity: options.workspaceIdentity,
+        pinned: false,
+      }
+    }
+    const registration = operationObserverRegistration(pinnedTargetIdentity)
+    if (!registration) return undefined
+    let validation: RegisteredWorktreeValidationResult
+    try {
+      validation = parentObserver.validateRegisteredWorktree(
+        registration.targetRoot,
+      )
+    } catch {
+      return undefined
+    }
+    if (
+      validation.status !== 'ok' ||
+      validation.targetRoot !== registration.targetRoot ||
+      registeredWorktreeIdentity(validation) !==
+        registration.registeredWorktreeIdentity ||
+      registration.observer.targetDigest !== pinnedTargetIdentity
+    ) {
+      return undefined
+    }
+    return {
+      observer: registration.observer,
+      targetIdentity: pinnedTargetIdentity,
+      pinned: true,
+    }
+  }
+
   function questionResource(target: TransitionTarget): string {
     const status = guard.status()
     return `workflow/${target}/${status.unit?.unitId ?? status.epoch?.epochId ?? 'unknown'}`
@@ -2208,18 +2257,22 @@ function createSessionRuntime(
   async function refreshReadback(): Promise<void> {
     abandonPending()
     if (!options.observer) return
+    const effective = effectiveOperationObserver()
+    if (!effective) {
+      markUnavailable()
+      return
+    }
     let result: OperationObserverResult
     try {
-      result = await options.observer.snapshot()
+      result = await effective.observer.snapshot()
     } catch {
       markUnavailable()
       return
     }
-    if (result.status === 'unavailable') {
-      markUnavailable()
-      return
-    }
-    if (result.snapshot.targetDigest !== options.workspaceIdentity) {
+    if (
+      result.status === 'unavailable' ||
+      result.snapshot.targetDigest !== effective.targetIdentity
+    ) {
       markUnavailable()
       return
     }
@@ -2227,24 +2280,28 @@ function createSessionRuntime(
       workspaceIdentity: options.workspaceIdentity,
       repositoryIdentity: result.snapshot.repositoryRevisionDigest,
       worktreeIdentity: result.snapshot.worktreeRevisionDigest,
+      ...(effective.pinned
+        ? { operationTargetIdentity: effective.targetIdentity }
+        : {}),
     })
     if (
       (observed.status === 'rejected' &&
         observed.reasonCode === 'workspace-mismatch') ||
-      !(await refreshRemoteReadbacks(result.snapshot))
+      !(await refreshRemoteReadbacks(effective.observer, result.snapshot))
     ) {
       markUnavailable()
     }
   }
 
   async function refreshRemoteReadbacks(
+    observer: OpencodeOperationObserver,
     local: OperationObserverSnapshot,
   ): Promise<boolean> {
     const remoteOperations = guard
       .status()
       .satisfiedOperations.filter(remoteOperation)
     if (remoteOperations.length === 0) return true
-    const remoteSnapshot = options.observer?.remoteSnapshot
+    const remoteSnapshot = observer.remoteSnapshot
     if (!remoteSnapshot) return false
     for (const operation of remoteOperations) {
       const result = await readRemoteScope(remoteSnapshot, operation)
@@ -3026,49 +3083,105 @@ function createSessionRuntime(
     | { status: 'ready'; readbacks: readonly unknown[] }
   > {
     if (!options.observer) return { status: 'none' }
-    let result: OperationObserverResult
+    let parentResult: OperationObserverResult
     try {
-      result = await options.observer.snapshot()
+      parentResult = await options.observer.snapshot()
     } catch {
       return { status: 'unavailable' }
     }
     if (
-      result.status === 'unavailable' ||
-      result.snapshot.targetDigest !== options.workspaceIdentity
+      parentResult.status === 'unavailable' ||
+      parentResult.snapshot.targetDigest !== options.workspaceIdentity
     ) {
       return { status: 'unavailable' }
     }
-    const remoteReadbacks = await completionRemoteReadbacks()
+    const effective = effectiveOperationObserver()
+    if (!effective) return { status: 'unavailable' }
+    let effectiveSnapshot = parentResult.snapshot
+    if (effective.pinned) {
+      let pinnedResult: OperationObserverResult
+      try {
+        pinnedResult = await effective.observer.snapshot()
+      } catch {
+        return { status: 'unavailable' }
+      }
+      if (
+        pinnedResult.status === 'unavailable' ||
+        pinnedResult.snapshot.targetDigest !== effective.targetIdentity
+      ) {
+        return { status: 'unavailable' }
+      }
+      effectiveSnapshot = pinnedResult.snapshot
+    }
+    const initialEffectiveSnapshot = effectiveSnapshot
+    const remoteReadbacks = await completionRemoteReadbacks(effective.observer)
     if (!remoteReadbacks) return { status: 'unavailable' }
-    let finalResult: OperationObserverResult
+    let finalParentResult: OperationObserverResult
     try {
-      finalResult = await options.observer.snapshot()
+      finalParentResult = await options.observer.snapshot()
     } catch {
       return { status: 'unavailable' }
     }
     if (
-      finalResult.status === 'unavailable' ||
-      finalResult.snapshot.targetDigest !== result.snapshot.targetDigest ||
-      finalResult.snapshot.repositoryRevisionDigest !==
-        result.snapshot.repositoryRevisionDigest ||
-      finalResult.snapshot.worktreeRevisionDigest !==
-        result.snapshot.worktreeRevisionDigest
+      finalParentResult.status === 'unavailable' ||
+      finalParentResult.snapshot.targetDigest !==
+        parentResult.snapshot.targetDigest ||
+      finalParentResult.snapshot.repositoryRevisionDigest !==
+        parentResult.snapshot.repositoryRevisionDigest ||
+      finalParentResult.snapshot.worktreeRevisionDigest !==
+        parentResult.snapshot.worktreeRevisionDigest
     ) {
       return { status: 'unavailable' }
+    }
+    let finalEffective = effective
+    if (effective.pinned) {
+      const revalidated = effectiveOperationObserver()
+      if (!revalidated) return { status: 'unavailable' }
+      finalEffective = revalidated
+      if (
+        finalEffective.observer !== effective.observer ||
+        finalEffective.targetIdentity !== effective.targetIdentity ||
+        !finalEffective.pinned
+      ) {
+        return { status: 'unavailable' }
+      }
+      let pinnedResult: OperationObserverResult
+      try {
+        pinnedResult = await finalEffective.observer.snapshot()
+      } catch {
+        return { status: 'unavailable' }
+      }
+      if (
+        pinnedResult.status === 'unavailable' ||
+        pinnedResult.snapshot.targetDigest !== finalEffective.targetIdentity
+      ) {
+        return { status: 'unavailable' }
+      }
+      effectiveSnapshot = pinnedResult.snapshot
+      if (
+        effectiveSnapshot.repositoryRevisionDigest !==
+          initialEffectiveSnapshot.repositoryRevisionDigest ||
+        effectiveSnapshot.worktreeRevisionDigest !==
+          initialEffectiveSnapshot.worktreeRevisionDigest
+      ) {
+        return { status: 'unavailable' }
+      }
+    } else {
+      effectiveSnapshot = finalParentResult.snapshot
     }
     return {
       status: 'ready',
       readbacks: [
         {
           workspaceIdentity: options.workspaceIdentity,
-          repositoryIdentity: finalResult.snapshot.repositoryRevisionDigest,
-          worktreeIdentity: finalResult.snapshot.worktreeRevisionDigest,
-          operationTargetIdentity: finalResult.snapshot.targetDigest,
+          repositoryIdentity: effectiveSnapshot.repositoryRevisionDigest,
+          worktreeIdentity: effectiveSnapshot.worktreeRevisionDigest,
+          operationTargetIdentity: finalEffective.targetIdentity,
         },
         ...remoteReadbacks.map(({ operation, snapshot }) =>
           remoteReadbackInput(
             operation,
-            finalResult.snapshot,
+            effectiveSnapshot,
             options.workspaceIdentity,
             snapshot,
           ),
@@ -3077,7 +3190,9 @@ function createSessionRuntime(
     }
   }
 
-  async function completionRemoteReadbacks(): Promise<
+  async function completionRemoteReadbacks(
+    observer: OpencodeOperationObserver,
+  ): Promise<
     | readonly {
         operation: RemoteOperation
         snapshot: OperationObserverRemoteSnapshot
@@ -3088,7 +3203,7 @@ function createSessionRuntime(
       .status()
       .satisfiedOperations.filter(remoteOperation)
     if (remoteOperations.length === 0) return []
-    const remoteSnapshot = options.observer?.remoteSnapshot
+    const remoteSnapshot = observer.remoteSnapshot
     if (!remoteSnapshot) return undefined
     const readbacks: Array<{
       operation: RemoteOperation

--- a/src/lib/receipt-classifier.ts
+++ b/src/lib/receipt-classifier.ts
@@ -109,6 +109,7 @@ interface ParserClassification {
 interface ParsedOperationStateFields {
   repositoryIdentity?: string
   worktreeIdentity?: string
+  operationTargetIdentity?: string
   resourceIdentity?: string
   resourceRevisionIdentity?: string
 }
@@ -362,6 +363,7 @@ function parseOperationContext(
         'workspaceIdentity',
         'repositoryIdentity',
         'worktreeIdentity',
+        'operationTargetIdentity',
         'resourceIdentity',
         'resourceRevisionIdentity',
       ]),
@@ -401,6 +403,9 @@ function parseOperationStateFields(
     value.repositoryIdentity,
   )
   const worktreeIdentity = parseOptionalDigestIdentity(value.worktreeIdentity)
+  const operationTargetIdentity = parseOptionalDigestIdentity(
+    value.operationTargetIdentity,
+  )
   const resourceIdentity = parseOptionalDigestIdentity(value.resourceIdentity)
   const resourceRevisionIdentity = parseOptionalDigestIdentity(
     value.resourceRevisionIdentity,
@@ -408,6 +413,10 @@ function parseOperationStateFields(
   if (
     !validOptionalIdentity(value.repositoryIdentity, repositoryIdentity) ||
     !validOptionalIdentity(value.worktreeIdentity, worktreeIdentity) ||
+    !validOptionalIdentity(
+      value.operationTargetIdentity,
+      operationTargetIdentity,
+    ) ||
     !validOptionalIdentity(value.resourceIdentity, resourceIdentity) ||
     !validOptionalIdentity(
       value.resourceRevisionIdentity,
@@ -419,6 +428,7 @@ function parseOperationStateFields(
   return {
     repositoryIdentity,
     worktreeIdentity,
+    operationTargetIdentity,
     resourceIdentity,
     resourceRevisionIdentity,
   }
@@ -477,6 +487,7 @@ const OPERATION_AFTER_FIELDS = new Set([
   'workspaceIdentity',
   'repositoryIdentity',
   'worktreeIdentity',
+  'operationTargetIdentity',
   'resourceIdentity',
   'resourceRevisionIdentity',
   'pullRequest',

--- a/src/lib/receipt-ledger.ts
+++ b/src/lib/receipt-ledger.ts
@@ -348,6 +348,16 @@ function isOperation(value: unknown): value is ReceiptOperation {
   return typeof value === 'string' && OPERATION_SET.has(value)
 }
 
+export function isLocalOperation(
+  operation: ReceiptOperation,
+): operation is 'implementation' | 'verification' | 'commit' {
+  return (
+    operation === 'implementation' ||
+    operation === 'verification' ||
+    operation === 'commit'
+  )
+}
+
 function isReceiptReasonCode(value: unknown): value is ReceiptReasonCode {
   return (
     typeof value === 'string' &&
@@ -975,6 +985,9 @@ function parseEnvelope(value: unknown): ReceiptEnvelope | undefined {
     return undefined
   }
   const canonical = value.canonical
+  const operation = isOperation(canonical.operation)
+    ? canonical.operation
+    : undefined
   if (
     !isReceiptId(canonical.receiptId) ||
     !isDigest(canonical.registrationDigest) ||
@@ -988,10 +1001,15 @@ function parseEnvelope(value: unknown): ReceiptEnvelope | undefined {
       !isDigest(canonical.worktreeDigest)) ||
     (canonical.operationTargetIdentity !== undefined &&
       !isDigest(canonical.operationTargetIdentity)) ||
-    (currentVersion && !isDigest(canonical.operationTargetIdentity)) ||
+    operation === undefined ||
+    (currentVersion &&
+      isLocalOperation(operation) &&
+      !isDigest(canonical.operationTargetIdentity)) ||
+    (currentVersion &&
+      !isLocalOperation(operation) &&
+      Object.hasOwn(canonical, 'operationTargetIdentity')) ||
     (canonical.resourceDigest !== undefined &&
       !isDigest(canonical.resourceDigest)) ||
-    !isOperation(canonical.operation) ||
     canonical.result !== 'success' ||
     canonical.source !== 'runtime-verified' ||
     (canonical.consumption !== 'available' &&
@@ -1020,9 +1038,11 @@ function parseEnvelope(value: unknown): ReceiptEnvelope | undefined {
       workspaceDigest: canonical.workspaceDigest,
       repositoryDigest: canonical.repositoryDigest,
       worktreeDigest: canonical.worktreeDigest,
-      operationTargetIdentity: canonical.operationTargetIdentity,
+      ...(isLocalOperation(operation)
+        ? { operationTargetIdentity: canonical.operationTargetIdentity }
+        : {}),
       resourceDigest: canonical.resourceDigest,
-      operation: canonical.operation,
+      operation,
       result: 'success',
       source: 'runtime-verified',
       consumption: canonical.consumption,
@@ -1116,7 +1136,10 @@ export function createReceiptLedger(
     return digestReceiptIdentity(domain, normalized, sessionSaltBytes)
   }
 
-  function digestContext(context: ReceiptContext): DigestedContext {
+  function digestContext(
+    context: ReceiptContext,
+    operation: ReceiptOperation,
+  ): DigestedContext {
     return {
       epochDigest: digestIdentity('epoch', context.epochId),
       unitDigest: digestIdentity('unit', context.unitId),
@@ -1127,7 +1150,9 @@ export function createReceiptLedger(
       worktreeDigest: context.worktreeIdentity
         ? digestIdentity('worktree', context.worktreeIdentity)
         : undefined,
-      operationTargetIdentity: context.operationTargetIdentity,
+      ...(isLocalOperation(operation)
+        ? { operationTargetIdentity: context.operationTargetIdentity }
+        : {}),
       resourceDigest: context.resourceIdentity
         ? digestIdentity('resource', context.resourceIdentity)
         : undefined,
@@ -1144,7 +1169,7 @@ export function createReceiptLedger(
     if (!parsed) return prepareInvalidObservationResult(input)
 
     const callDigest = digestIdentity('call', parsed.callId)
-    const digested = digestContext(parsed.context)
+    const digested = digestContext(parsed.context, parsed.operation)
     const existing = lifecycleByCall.get(callDigest)
     if (existing) {
       return resolveExistingPrepare(existing, parsed.operation, digested)
@@ -1165,9 +1190,9 @@ export function createReceiptLedger(
     if (!parsed) return invalidObservationResult(input)
 
     const callDigest = digestIdentity('call', parsed.callId)
-    const actualContext = digestContext(parsed.context)
     const matchingEntry = lifecycleByCall.get(callDigest)
     if (!matchingEntry) return invalidObservationResult(input)
+    const actualContext = digestContext(parsed.context, matchingEntry.operation)
     const contextMismatch = compareDigestedContexts(
       matchingEntry.context,
       actualContext,
@@ -1182,7 +1207,7 @@ export function createReceiptLedger(
       return { status: 'rejected', reasonCode: entryRejection }
     }
 
-    const afterDigests = digestAfter(parsed.after)
+    const afterDigests = digestAfter(parsed.after, matchingEntry.operation)
     const noOpReason = getNoOpReason(matchingEntry, afterDigests)
     if (noOpReason) {
       sealEntry(matchingEntry)
@@ -1243,7 +1268,10 @@ export function createReceiptLedger(
     return undefined
   }
 
-  function digestAfter(after: ReceiptObservationAfter): DigestedContext {
+  function digestAfter(
+    after: ReceiptObservationAfter,
+    operation: ReceiptOperation,
+  ): DigestedContext {
     return {
       epochDigest: '',
       unitDigest: '',
@@ -1254,7 +1282,9 @@ export function createReceiptLedger(
       worktreeDigest: after.worktreeIdentity
         ? digestIdentity('worktree', after.worktreeIdentity)
         : undefined,
-      operationTargetIdentity: after.operationTargetIdentity,
+      ...(isLocalOperation(operation)
+        ? { operationTargetIdentity: after.operationTargetIdentity }
+        : {}),
       resourceDigest: after.resourceIdentity
         ? digestIdentity('resource', after.resourceIdentity)
         : undefined,
@@ -1315,7 +1345,7 @@ export function createReceiptLedger(
     callDigest: string,
     after: DigestedContext,
   ): FinalizeObservationResult {
-    if (!after.operationTargetIdentity) {
+    if (isLocalOperation(entry.operation) && !after.operationTargetIdentity) {
       entry.status = 'abandoned'
       return { status: 'rejected', reasonCode: 'invalid-observation' }
     }
@@ -1329,7 +1359,9 @@ export function createReceiptLedger(
       workspaceDigest: entry.context.workspaceDigest,
       repositoryDigest: after.repositoryDigest,
       worktreeDigest: after.worktreeDigest,
-      operationTargetIdentity: after.operationTargetIdentity,
+      ...(isLocalOperation(entry.operation)
+        ? { operationTargetIdentity: after.operationTargetIdentity }
+        : {}),
       resourceDigest: after.resourceDigest,
       operation: entry.operation,
       result: 'success',
@@ -1369,10 +1401,10 @@ export function createReceiptLedger(
     if (!callId || !context)
       return { status: 'rejected', reasonCode: 'invalid-observation' }
     const callDigest = digestIdentity('call', callId)
-    const digested = digestContext(context)
     const matchingEntry = lifecycleByCall.get(callDigest)
     if (!matchingEntry)
       return { status: 'rejected', reasonCode: 'unknown-receipt' }
+    const digested = digestContext(context, matchingEntry.operation)
     const contextMismatch = compareDigestedContexts(
       matchingEntry.context,
       digested,
@@ -1397,7 +1429,7 @@ export function createReceiptLedger(
       return { status: 'rejected', reasonCode: 'invalid-observation' }
     const stored = receipts.get(receiptId)
     if (!stored) return { status: 'rejected', reasonCode: 'unknown-receipt' }
-    const actual = digestContext(context)
+    const actual = digestContext(context, stored.envelope.canonical.operation)
     const contextMismatch = compareDigestedContexts(stored.context, actual)
     if (contextMismatch)
       return { status: 'rejected', reasonCode: contextMismatch }

--- a/src/lib/receipt-ledger.ts
+++ b/src/lib/receipt-ledger.ts
@@ -758,7 +758,9 @@ function parseContext(value: unknown): ReceiptContext | undefined {
   const operationTargetIdentity =
     value.operationTargetIdentity === undefined
       ? undefined
-      : (value.operationTargetIdentity as string)
+      : isDigest(value.operationTargetIdentity)
+        ? value.operationTargetIdentity
+        : undefined
   const resourceIdentity =
     value.resourceIdentity === undefined
       ? undefined

--- a/src/lib/receipt-ledger.ts
+++ b/src/lib/receipt-ledger.ts
@@ -12,8 +12,10 @@ import {
   validateReceiptMarker,
 } from './receipt-readback.js'
 
-export const RECEIPT_SCHEMA_VERSION = 1 as const
-export const RECEIPT_PROTOCOL_VERSION = 1 as const
+export const RECEIPT_SCHEMA_VERSION = 2 as const
+export const RECEIPT_PROTOCOL_VERSION = 2 as const
+const LEGACY_RECEIPT_SCHEMA_VERSION = 1 as const
+const LEGACY_RECEIPT_PROTOCOL_VERSION = 1 as const
 
 export type ReceiptOperation =
   | 'implementation'
@@ -92,6 +94,7 @@ export interface ReceiptContext {
   workspaceIdentity: string
   repositoryIdentity?: string
   worktreeIdentity?: string
+  operationTargetIdentity?: string
   resourceIdentity?: string
 }
 
@@ -99,6 +102,7 @@ export interface ReceiptObservationAfter {
   workspaceIdentity: string
   repositoryIdentity?: string
   worktreeIdentity?: string
+  operationTargetIdentity?: string
   resourceIdentity?: string
 }
 
@@ -130,6 +134,7 @@ export interface CanonicalReceiptFields {
   workspaceDigest: string
   repositoryDigest?: string
   worktreeDigest?: string
+  operationTargetIdentity?: string
   resourceDigest?: string
   operation: ReceiptOperation
   result: 'success'
@@ -139,8 +144,12 @@ export interface CanonicalReceiptFields {
 }
 
 export interface ReceiptEnvelope {
-  schemaVersion: typeof RECEIPT_SCHEMA_VERSION
-  protocolVersion: typeof RECEIPT_PROTOCOL_VERSION
+  schemaVersion:
+    | typeof RECEIPT_SCHEMA_VERSION
+    | typeof LEGACY_RECEIPT_SCHEMA_VERSION
+  protocolVersion:
+    | typeof RECEIPT_PROTOCOL_VERSION
+    | typeof LEGACY_RECEIPT_PROTOCOL_VERSION
   registrationDigest: string
   capabilityFlags: readonly string[]
   compatibility: 'compatible'
@@ -224,8 +233,14 @@ export interface ReceiptLedger {
   finalizeObservation(input: unknown): FinalizeObservationResult
   abandonObservation(input: unknown): AbandonObservationResult
   consumeReceipt(receiptId: unknown, context: unknown): ConsumeReceiptResult
-  recoverReceipt(input: unknown): RecoverReceiptResult
-  recoverReadback(input: readonly unknown[]): RecoverReadbackResult
+  recoverReceipt(
+    input: unknown,
+    operationTargetIdentity?: string,
+  ): RecoverReceiptResult
+  recoverReadback(
+    input: readonly unknown[],
+    operationTargetIdentity?: string,
+  ): RecoverReadbackResult
   getProgressionState(): ReceiptReadbackProgression
   validateEnvelope(input: unknown): EnvelopeValidationResult
   getEnvelope(receiptId: unknown): ReceiptEnvelope | undefined
@@ -239,6 +254,7 @@ interface DigestedContext {
   workspaceDigest: string
   repositoryDigest?: string
   worktreeDigest?: string
+  operationTargetIdentity?: string
   resourceDigest?: string
 }
 
@@ -416,6 +432,8 @@ function envelopesEqual(
     first.canonical.workspaceDigest === second.canonical.workspaceDigest &&
     first.canonical.repositoryDigest === second.canonical.repositoryDigest &&
     first.canonical.worktreeDigest === second.canonical.worktreeDigest &&
+    first.canonical.operationTargetIdentity ===
+      second.canonical.operationTargetIdentity &&
     first.canonical.resourceDigest === second.canonical.resourceDigest &&
     first.canonical.operation === second.canonical.operation &&
     first.canonical.result === second.canonical.result &&
@@ -498,6 +516,7 @@ function storedReceiptFromEnvelope(envelope: ReceiptEnvelope): StoredReceipt {
       workspaceDigest: envelope.canonical.workspaceDigest,
       repositoryDigest: envelope.canonical.repositoryDigest,
       worktreeDigest: envelope.canonical.worktreeDigest,
+      operationTargetIdentity: envelope.canonical.operationTargetIdentity,
       resourceDigest: envelope.canonical.resourceDigest,
     },
   }
@@ -726,6 +745,10 @@ function parseContext(value: unknown): ReceiptContext | undefined {
     value.worktreeIdentity === undefined
       ? undefined
       : normalizedIdentity(value.worktreeIdentity)
+  const operationTargetIdentity =
+    value.operationTargetIdentity === undefined
+      ? undefined
+      : (value.operationTargetIdentity as string)
   const resourceIdentity =
     value.resourceIdentity === undefined
       ? undefined
@@ -733,6 +756,8 @@ function parseContext(value: unknown): ReceiptContext | undefined {
   if (
     (value.repositoryIdentity !== undefined && !repositoryIdentity) ||
     (value.worktreeIdentity !== undefined && !worktreeIdentity) ||
+    (value.operationTargetIdentity !== undefined &&
+      !isDigest(operationTargetIdentity)) ||
     (value.resourceIdentity !== undefined && !resourceIdentity)
   ) {
     return undefined
@@ -744,6 +769,7 @@ function parseContext(value: unknown): ReceiptContext | undefined {
     workspaceIdentity,
     repositoryIdentity,
     worktreeIdentity,
+    operationTargetIdentity,
     resourceIdentity,
   }
 }
@@ -759,6 +785,7 @@ function parseAfter(value: unknown): ReceiptObservationAfter | undefined {
     workspaceIdentity: context.workspaceIdentity,
     repositoryIdentity: context.repositoryIdentity,
     worktreeIdentity: context.worktreeIdentity,
+    operationTargetIdentity: context.operationTargetIdentity,
     resourceIdentity: context.resourceIdentity,
   }
 }
@@ -871,6 +898,8 @@ function compareDigestedContexts(
     return 'workspace-mismatch'
   if (expected.worktreeDigest !== actual.worktreeDigest)
     return 'workspace-mismatch'
+  if (expected.operationTargetIdentity !== actual.operationTargetIdentity)
+    return 'workspace-mismatch'
   if (expected.resourceDigest !== actual.resourceDigest)
     return 'workspace-mismatch'
   return undefined
@@ -902,10 +931,13 @@ function validateEnvelopeInput(
   if (!('schemaVersion' in input) || !('protocolVersion' in input)) {
     return { compatibility: 'unavailable', reasonCode: 'incomplete-envelope' }
   }
-  if (
-    input.schemaVersion !== RECEIPT_SCHEMA_VERSION ||
-    input.protocolVersion !== RECEIPT_PROTOCOL_VERSION
-  ) {
+  const currentVersion =
+    input.schemaVersion === RECEIPT_SCHEMA_VERSION &&
+    input.protocolVersion === RECEIPT_PROTOCOL_VERSION
+  const legacyVersion =
+    input.schemaVersion === LEGACY_RECEIPT_SCHEMA_VERSION &&
+    input.protocolVersion === LEGACY_RECEIPT_PROTOCOL_VERSION
+  if (!currentVersion && !legacyVersion) {
     return { compatibility: 'unavailable', reasonCode: 'unknown-envelope' }
   }
   if (!('capabilityFlags' in input) || input.capabilityFlags === undefined) {
@@ -927,9 +959,14 @@ function isReceiptId(value: unknown): value is string {
 
 function parseEnvelope(value: unknown): ReceiptEnvelope | undefined {
   if (!isRecord(value)) return undefined
+  const currentVersion =
+    value.schemaVersion === RECEIPT_SCHEMA_VERSION &&
+    value.protocolVersion === RECEIPT_PROTOCOL_VERSION
+  const legacyVersion =
+    value.schemaVersion === LEGACY_RECEIPT_SCHEMA_VERSION &&
+    value.protocolVersion === LEGACY_RECEIPT_PROTOCOL_VERSION
   if (
-    value.schemaVersion !== RECEIPT_SCHEMA_VERSION ||
-    value.protocolVersion !== RECEIPT_PROTOCOL_VERSION ||
+    (!currentVersion && !legacyVersion) ||
     value.compatibility !== 'compatible' ||
     !isDigest(value.registrationDigest) ||
     !isBoundedCapabilityList(value.capabilityFlags) ||
@@ -949,6 +986,9 @@ function parseEnvelope(value: unknown): ReceiptEnvelope | undefined {
       !isDigest(canonical.repositoryDigest)) ||
     (canonical.worktreeDigest !== undefined &&
       !isDigest(canonical.worktreeDigest)) ||
+    (canonical.operationTargetIdentity !== undefined &&
+      !isDigest(canonical.operationTargetIdentity)) ||
+    (currentVersion && !isDigest(canonical.operationTargetIdentity)) ||
     (canonical.resourceDigest !== undefined &&
       !isDigest(canonical.resourceDigest)) ||
     !isOperation(canonical.operation) ||
@@ -962,8 +1002,12 @@ function parseEnvelope(value: unknown): ReceiptEnvelope | undefined {
     return undefined
   }
   return {
-    schemaVersion: RECEIPT_SCHEMA_VERSION,
-    protocolVersion: RECEIPT_PROTOCOL_VERSION,
+    schemaVersion: currentVersion
+      ? RECEIPT_SCHEMA_VERSION
+      : LEGACY_RECEIPT_SCHEMA_VERSION,
+    protocolVersion: currentVersion
+      ? RECEIPT_PROTOCOL_VERSION
+      : LEGACY_RECEIPT_PROTOCOL_VERSION,
     registrationDigest: value.registrationDigest,
     capabilityFlags: [...value.capabilityFlags],
     compatibility: 'compatible',
@@ -976,6 +1020,7 @@ function parseEnvelope(value: unknown): ReceiptEnvelope | undefined {
       workspaceDigest: canonical.workspaceDigest,
       repositoryDigest: canonical.repositoryDigest,
       worktreeDigest: canonical.worktreeDigest,
+      operationTargetIdentity: canonical.operationTargetIdentity,
       resourceDigest: canonical.resourceDigest,
       operation: canonical.operation,
       result: 'success',
@@ -1082,6 +1127,7 @@ export function createReceiptLedger(
       worktreeDigest: context.worktreeIdentity
         ? digestIdentity('worktree', context.worktreeIdentity)
         : undefined,
+      operationTargetIdentity: context.operationTargetIdentity,
       resourceDigest: context.resourceIdentity
         ? digestIdentity('resource', context.resourceIdentity)
         : undefined,
@@ -1208,6 +1254,7 @@ export function createReceiptLedger(
       worktreeDigest: after.worktreeIdentity
         ? digestIdentity('worktree', after.worktreeIdentity)
         : undefined,
+      operationTargetIdentity: after.operationTargetIdentity,
       resourceDigest: after.resourceIdentity
         ? digestIdentity('resource', after.resourceIdentity)
         : undefined,
@@ -1268,6 +1315,10 @@ export function createReceiptLedger(
     callDigest: string,
     after: DigestedContext,
   ): FinalizeObservationResult {
+    if (!after.operationTargetIdentity) {
+      entry.status = 'abandoned'
+      return { status: 'rejected', reasonCode: 'invalid-observation' }
+    }
     const receiptId = randomBytes(16).toString('hex')
     const canonical: CanonicalReceiptFields = {
       receiptId,
@@ -1278,6 +1329,7 @@ export function createReceiptLedger(
       workspaceDigest: entry.context.workspaceDigest,
       repositoryDigest: after.repositoryDigest,
       worktreeDigest: after.worktreeDigest,
+      operationTargetIdentity: after.operationTargetIdentity,
       resourceDigest: after.resourceDigest,
       operation: entry.operation,
       result: 'success',
@@ -1302,6 +1354,7 @@ export function createReceiptLedger(
         workspaceDigest: entry.context.workspaceDigest,
         repositoryDigest: after.repositoryDigest,
         worktreeDigest: after.worktreeDigest,
+        operationTargetIdentity: after.operationTargetIdentity,
         resourceDigest: after.resourceDigest,
       },
     })
@@ -1355,12 +1408,29 @@ export function createReceiptLedger(
     return { status: 'consumed', receipt: cloneEnvelope(stored.envelope) }
   }
 
-  function recoverReceipt(input: unknown): RecoverReceiptResult {
+  function recoverReceipt(
+    input: unknown,
+    operationTargetIdentity?: string,
+  ): RecoverReceiptResult {
     const markerResult = getMintMarker(input)
     if (markerResult.status !== 'valid') return markerResult
     const marker = markerResult.marker
     if (marker.sessionSalt !== sessionSalt)
       return { status: 'rejected', category: 'salt-mismatch' }
+    if (
+      marker.envelope.schemaVersion === 1 &&
+      operationTargetIdentity !== undefined
+    ) {
+      return { status: 'rejected', category: 'identity-digest-mismatch' }
+    }
+    if (
+      marker.envelope.schemaVersion === RECEIPT_SCHEMA_VERSION &&
+      operationTargetIdentity !== undefined &&
+      marker.envelope.canonical.operationTargetIdentity !==
+        operationTargetIdentity
+    ) {
+      return { status: 'rejected', category: 'identity-digest-mismatch' }
+    }
 
     const envelopeValidation = validateEnvelope(marker.envelope)
     const envelopeFailure = recoveryEnvelopeCategory(envelopeValidation)
@@ -1389,10 +1459,17 @@ export function createReceiptLedger(
     return { status: 'recovered', receipt: cloneEnvelope(envelope) }
   }
 
-  function recoverReadback(input: readonly unknown[]): RecoverReadbackResult {
+  function recoverReadback(
+    input: readonly unknown[],
+    operationTargetIdentity?: string,
+  ): RecoverReadbackResult {
     const folded = foldForLedgerRecovery(
       input,
-      receiptReadbackExpectationFromMetadata(metadata, sessionSaltBytes),
+      receiptReadbackExpectationFromMetadata(
+        metadata,
+        sessionSaltBytes,
+        operationTargetIdentity,
+      ),
     )
     if (folded.status !== 'reconstructed') {
       return { status: 'rejected', category: folded.category }

--- a/src/lib/receipt-readback.ts
+++ b/src/lib/receipt-readback.ts
@@ -6,6 +6,7 @@ import type {
   ReceiptLedgerMetadata,
   ReceiptOperation,
 } from './receipt-ledger.js'
+import { isLocalOperation } from './receipt-ledger.js'
 
 export const RECEIPT_READBACK_SCHEMA_VERSION = 2 as const
 export const RECEIPT_READBACK_PROTOCOL_VERSION = 2 as const
@@ -575,7 +576,9 @@ function cloneCanonical(
     workspaceDigest: canonical.workspaceDigest,
     repositoryDigest: canonical.repositoryDigest,
     worktreeDigest: canonical.worktreeDigest,
-    operationTargetIdentity: canonical.operationTargetIdentity,
+    ...(isLocalOperation(canonical.operation)
+      ? { operationTargetIdentity: canonical.operationTargetIdentity }
+      : {}),
     resourceDigest: canonical.resourceDigest,
     operation: canonical.operation,
     result: 'success',
@@ -617,6 +620,9 @@ function parseEnvelope(value: unknown): ReceiptEnvelope | undefined {
   }
 
   const canonical = value.canonical
+  const operation = isOperation(canonical.operation)
+    ? canonical.operation
+    : undefined
   if (
     !hasExactKeys(
       canonical,
@@ -635,11 +641,16 @@ function parseEnvelope(value: unknown): ReceiptEnvelope | undefined {
       !isDigest(canonical.worktreeDigest)) ||
     (canonical.operationTargetIdentity !== undefined &&
       !isDigest(canonical.operationTargetIdentity)) ||
-    (currentVersion && !Object.hasOwn(canonical, 'operationTargetIdentity')) ||
+    operation === undefined ||
+    (currentVersion &&
+      isLocalOperation(operation) &&
+      !isDigest(canonical.operationTargetIdentity)) ||
+    (currentVersion &&
+      !isLocalOperation(operation) &&
+      Object.hasOwn(canonical, 'operationTargetIdentity')) ||
     (legacyVersion && Object.hasOwn(canonical, 'operationTargetIdentity')) ||
     (canonical.resourceDigest !== undefined &&
       !isDigest(canonical.resourceDigest)) ||
-    !isOperation(canonical.operation) ||
     canonical.result !== 'success' ||
     canonical.source !== 'runtime-verified' ||
     (canonical.consumption !== 'available' &&
@@ -669,9 +680,11 @@ function parseEnvelope(value: unknown): ReceiptEnvelope | undefined {
       workspaceDigest: canonical.workspaceDigest,
       repositoryDigest: canonical.repositoryDigest,
       worktreeDigest: canonical.worktreeDigest,
-      operationTargetIdentity: canonical.operationTargetIdentity,
+      ...(isLocalOperation(operation)
+        ? { operationTargetIdentity: canonical.operationTargetIdentity }
+        : {}),
       resourceDigest: canonical.resourceDigest,
-      operation: canonical.operation,
+      operation,
       result: 'success',
       source: 'runtime-verified',
       consumption: canonical.consumption,

--- a/src/lib/receipt-readback.ts
+++ b/src/lib/receipt-readback.ts
@@ -7,8 +7,13 @@ import type {
   ReceiptOperation,
 } from './receipt-ledger.js'
 
-export const RECEIPT_READBACK_SCHEMA_VERSION = 1 as const
-export const RECEIPT_READBACK_PROTOCOL_VERSION = 1 as const
+export const RECEIPT_READBACK_SCHEMA_VERSION = 2 as const
+export const RECEIPT_READBACK_PROTOCOL_VERSION = 2 as const
+const LEGACY_RECEIPT_READBACK_SCHEMA_VERSION = 1 as const
+const LEGACY_RECEIPT_READBACK_PROTOCOL_VERSION = 1 as const
+type ReceiptReadbackVersion =
+  | typeof RECEIPT_READBACK_SCHEMA_VERSION
+  | typeof LEGACY_RECEIPT_READBACK_SCHEMA_VERSION
 
 export type ReceiptDigestDomain =
   | 'repository'
@@ -52,8 +57,8 @@ export type ReceiptReadbackFailureCategory =
 
 export interface ReceiptMintMarker {
   readonly kind: 'mint'
-  readonly schemaVersion: typeof RECEIPT_READBACK_SCHEMA_VERSION
-  readonly protocolVersion: typeof RECEIPT_READBACK_PROTOCOL_VERSION
+  readonly schemaVersion: ReceiptReadbackVersion
+  readonly protocolVersion: ReceiptReadbackVersion
   readonly envelope: ReceiptEnvelope
   readonly sessionSalt: string
   readonly integrity: string
@@ -61,8 +66,8 @@ export interface ReceiptMintMarker {
 
 export interface ReceiptConsumeMarker {
   readonly kind: 'control'
-  readonly schemaVersion: typeof RECEIPT_READBACK_SCHEMA_VERSION
-  readonly protocolVersion: typeof RECEIPT_READBACK_PROTOCOL_VERSION
+  readonly schemaVersion: ReceiptReadbackVersion
+  readonly protocolVersion: ReceiptReadbackVersion
   readonly registrationDigest: string
   readonly capabilityFlags: readonly string[]
   readonly control: 'consume'
@@ -74,8 +79,8 @@ export interface ReceiptConsumeMarker {
 
 export interface ReceiptEpochProgressionMarker {
   readonly kind: 'control'
-  readonly schemaVersion: typeof RECEIPT_READBACK_SCHEMA_VERSION
-  readonly protocolVersion: typeof RECEIPT_READBACK_PROTOCOL_VERSION
+  readonly schemaVersion: ReceiptReadbackVersion
+  readonly protocolVersion: ReceiptReadbackVersion
   readonly registrationDigest: string
   readonly capabilityFlags: readonly string[]
   readonly control: 'progression'
@@ -92,8 +97,8 @@ export interface ReceiptEpochProgressionMarker {
 
 export interface ReceiptUnitProgressionMarker {
   readonly kind: 'control'
-  readonly schemaVersion: typeof RECEIPT_READBACK_SCHEMA_VERSION
-  readonly protocolVersion: typeof RECEIPT_READBACK_PROTOCOL_VERSION
+  readonly schemaVersion: ReceiptReadbackVersion
+  readonly protocolVersion: ReceiptReadbackVersion
   readonly registrationDigest: string
   readonly capabilityFlags: readonly string[]
   readonly control: 'progression'
@@ -105,6 +110,7 @@ export interface ReceiptUnitProgressionMarker {
   readonly family: ReceiptEpochFamily
   readonly requiredOperations: readonly ReceiptOperation[]
   readonly resourceScopes: readonly ReceiptResourceScope[]
+  readonly pinnedOperationTargetIdentity?: string
   readonly state: ReceiptProgressionStateName
   readonly transitionDigest: string
   readonly timestamp: number
@@ -150,6 +156,7 @@ export type ReceiptProgressionMarkerInput =
       readonly family: ReceiptEpochFamily
       readonly requiredOperations: readonly ReceiptOperation[]
       readonly resourceScopes: readonly ReceiptResourceScope[]
+      readonly pinnedOperationTargetIdentity?: string
       readonly transitionDigest: string
       readonly timestamp?: number
     }
@@ -168,6 +175,12 @@ export interface ReceiptReadbackExpectation {
   readonly capabilityFlags: readonly string[]
   readonly sessionSalt: Uint8Array
   readonly source?: 'runtime-verified'
+  /**
+   * When present, legacy v1 mint markers are rejected because they cannot
+   * authenticate a foreign/worktree target. Absence retains the narrow v1
+   * parent-target recovery shim; callers must validate that parent separately.
+   */
+  readonly operationTargetIdentity?: string
 }
 
 export type ReceiptEpochProgressionSnapshot = {
@@ -189,6 +202,7 @@ export type ReceiptUnitProgressionSnapshot = {
   readonly family: ReceiptEpochFamily
   readonly requiredOperations: readonly ReceiptOperation[]
   readonly resourceScopes: readonly ReceiptResourceScope[]
+  readonly pinnedOperationTargetIdentity?: string
   readonly transitionDigest: string
 }
 
@@ -280,6 +294,13 @@ const CANONICAL_REQUIRED_KEYS = [
 const CANONICAL_OPTIONAL_KEYS = [
   'repositoryDigest',
   'worktreeDigest',
+  'operationTargetIdentity',
+  'resourceDigest',
+] as const
+
+const LEGACY_CANONICAL_OPTIONAL_KEYS = [
+  'repositoryDigest',
+  'worktreeDigest',
   'resourceDigest',
 ] as const
 
@@ -336,12 +357,17 @@ const UNIT_PROGRESSION_KEYS = [
   'family',
   'requiredOperations',
   'resourceScopes',
+  'pinnedOperationTargetIdentity',
   'state',
   'transitionDigest',
   'timestamp',
   'sessionSalt',
   'integrity',
 ] as const
+
+const LEGACY_UNIT_PROGRESSION_KEYS = UNIT_PROGRESSION_KEYS.filter(
+  (key) => key !== 'pinnedOperationTargetIdentity',
+)
 
 const RESOURCE_SCOPE_KEYS = ['operation', 'resourceIdentity'] as const
 
@@ -369,6 +395,26 @@ function hasExactKeys(
   return (
     required.every((key) => Object.hasOwn(value, key)) &&
     keys.every((key) => allowed.has(key))
+  )
+}
+
+function isCurrentVersionPair(
+  schemaVersion: unknown,
+  protocolVersion: unknown,
+): schemaVersion is typeof RECEIPT_READBACK_SCHEMA_VERSION {
+  return (
+    schemaVersion === RECEIPT_READBACK_SCHEMA_VERSION &&
+    protocolVersion === RECEIPT_READBACK_PROTOCOL_VERSION
+  )
+}
+
+function isLegacyVersionPair(
+  schemaVersion: unknown,
+  protocolVersion: unknown,
+): schemaVersion is typeof LEGACY_RECEIPT_READBACK_SCHEMA_VERSION {
+  return (
+    schemaVersion === LEGACY_RECEIPT_READBACK_SCHEMA_VERSION &&
+    protocolVersion === LEGACY_RECEIPT_READBACK_PROTOCOL_VERSION
   )
 }
 
@@ -529,6 +575,7 @@ function cloneCanonical(
     workspaceDigest: canonical.workspaceDigest,
     repositoryDigest: canonical.repositoryDigest,
     worktreeDigest: canonical.worktreeDigest,
+    operationTargetIdentity: canonical.operationTargetIdentity,
     resourceDigest: canonical.resourceDigest,
     operation: canonical.operation,
     result: 'success',
@@ -551,9 +598,16 @@ function cloneEnvelope(envelope: ReceiptEnvelope): ReceiptEnvelope {
 
 function parseEnvelope(value: unknown): ReceiptEnvelope | undefined {
   if (!isRecord(value) || !hasExactKeys(value, ENVELOPE_KEYS)) return undefined
+  const currentVersion = isCurrentVersionPair(
+    value.schemaVersion,
+    value.protocolVersion,
+  )
+  const legacyVersion = isLegacyVersionPair(
+    value.schemaVersion,
+    value.protocolVersion,
+  )
   if (
-    value.schemaVersion !== 1 ||
-    value.protocolVersion !== 1 ||
+    (!currentVersion && !legacyVersion) ||
     value.compatibility !== 'compatible' ||
     !isDigest(value.registrationDigest) ||
     !isCapabilityList(value.capabilityFlags) ||
@@ -567,7 +621,7 @@ function parseEnvelope(value: unknown): ReceiptEnvelope | undefined {
     !hasExactKeys(
       canonical,
       CANONICAL_REQUIRED_KEYS,
-      CANONICAL_OPTIONAL_KEYS,
+      currentVersion ? CANONICAL_OPTIONAL_KEYS : LEGACY_CANONICAL_OPTIONAL_KEYS,
     ) ||
     !isReceiptId(canonical.receiptId) ||
     !isDigest(canonical.registrationDigest) ||
@@ -579,6 +633,10 @@ function parseEnvelope(value: unknown): ReceiptEnvelope | undefined {
       !isDigest(canonical.repositoryDigest)) ||
     (canonical.worktreeDigest !== undefined &&
       !isDigest(canonical.worktreeDigest)) ||
+    (canonical.operationTargetIdentity !== undefined &&
+      !isDigest(canonical.operationTargetIdentity)) ||
+    (currentVersion && !Object.hasOwn(canonical, 'operationTargetIdentity')) ||
+    (legacyVersion && Object.hasOwn(canonical, 'operationTargetIdentity')) ||
     (canonical.resourceDigest !== undefined &&
       !isDigest(canonical.resourceDigest)) ||
     !isOperation(canonical.operation) ||
@@ -593,8 +651,12 @@ function parseEnvelope(value: unknown): ReceiptEnvelope | undefined {
   }
 
   return {
-    schemaVersion: 1,
-    protocolVersion: 1,
+    schemaVersion: currentVersion
+      ? RECEIPT_READBACK_SCHEMA_VERSION
+      : LEGACY_RECEIPT_READBACK_SCHEMA_VERSION,
+    protocolVersion: currentVersion
+      ? RECEIPT_READBACK_PROTOCOL_VERSION
+      : LEGACY_RECEIPT_READBACK_PROTOCOL_VERSION,
     registrationDigest: value.registrationDigest,
     capabilityFlags: [...value.capabilityFlags],
     compatibility: 'compatible',
@@ -607,6 +669,7 @@ function parseEnvelope(value: unknown): ReceiptEnvelope | undefined {
       workspaceDigest: canonical.workspaceDigest,
       repositoryDigest: canonical.repositoryDigest,
       worktreeDigest: canonical.worktreeDigest,
+      operationTargetIdentity: canonical.operationTargetIdentity,
       resourceDigest: canonical.resourceDigest,
       operation: canonical.operation,
       result: 'success',
@@ -623,16 +686,16 @@ function parseLedgerMetadata(
   if (
     !isRecord(value) ||
     !hasExactKeys(value, LEDGER_METADATA_KEYS) ||
-    value.schemaVersion !== 1 ||
-    value.protocolVersion !== 1 ||
+    value.schemaVersion !== RECEIPT_READBACK_SCHEMA_VERSION ||
+    value.protocolVersion !== RECEIPT_READBACK_PROTOCOL_VERSION ||
     !isDigest(value.registrationDigest) ||
     !isCapabilityList(value.capabilityFlags)
   ) {
     return undefined
   }
   return {
-    schemaVersion: 1,
-    protocolVersion: 1,
+    schemaVersion: RECEIPT_READBACK_SCHEMA_VERSION,
+    protocolVersion: RECEIPT_READBACK_PROTOCOL_VERSION,
     registrationDigest: value.registrationDigest,
     capabilityFlags: [...value.capabilityFlags],
   }
@@ -640,28 +703,32 @@ function parseLedgerMetadata(
 
 function serializeEnvelope(envelope: ReceiptEnvelope): string {
   const canonical = envelope.canonical
+  const canonicalFields = {
+    receiptId: canonical.receiptId,
+    registrationDigest: canonical.registrationDigest,
+    callDigest: canonical.callDigest,
+    epochDigest: canonical.epochDigest,
+    unitDigest: canonical.unitDigest,
+    workspaceDigest: canonical.workspaceDigest,
+    repositoryDigest: canonical.repositoryDigest ?? null,
+    worktreeDigest: canonical.worktreeDigest ?? null,
+    ...(envelope.schemaVersion === RECEIPT_READBACK_SCHEMA_VERSION
+      ? { operationTargetIdentity: canonical.operationTargetIdentity ?? null }
+      : {}),
+    resourceDigest: canonical.resourceDigest ?? null,
+    operation: canonical.operation,
+    result: canonical.result,
+    source: canonical.source,
+    consumption: canonical.consumption,
+    timestamp: canonical.timestamp,
+  }
   return JSON.stringify({
     schemaVersion: envelope.schemaVersion,
     protocolVersion: envelope.protocolVersion,
     registrationDigest: envelope.registrationDigest,
     capabilityFlags: [...envelope.capabilityFlags],
     compatibility: envelope.compatibility,
-    canonical: {
-      receiptId: canonical.receiptId,
-      registrationDigest: canonical.registrationDigest,
-      callDigest: canonical.callDigest,
-      epochDigest: canonical.epochDigest,
-      unitDigest: canonical.unitDigest,
-      workspaceDigest: canonical.workspaceDigest,
-      repositoryDigest: canonical.repositoryDigest ?? null,
-      worktreeDigest: canonical.worktreeDigest ?? null,
-      resourceDigest: canonical.resourceDigest ?? null,
-      operation: canonical.operation,
-      result: canonical.result,
-      source: canonical.source,
-      consumption: canonical.consumption,
-      timestamp: canonical.timestamp,
-    },
+    canonical: canonicalFields,
   })
 }
 
@@ -712,6 +779,12 @@ function progressionIntegrity(marker: ReceiptProgressionMarkerCore): string {
           family: marker.family,
           requiredOperations: [...marker.requiredOperations],
           resourceScopes: marker.resourceScopes.map((scope) => ({ ...scope })),
+          ...(marker.schemaVersion === RECEIPT_READBACK_SCHEMA_VERSION
+            ? {
+                pinnedOperationTargetIdentity:
+                  marker.pinnedOperationTargetIdentity ?? null,
+              }
+            : {}),
         }
   return hashIntegrity(
     'progression',
@@ -745,13 +818,32 @@ function parseMintMarker(value: unknown): ReceiptMarkerValidation {
       value.kind === 'control' ? 'unknown-kind' : 'unknown-kind',
     )
   }
-  if (value.schemaVersion !== RECEIPT_READBACK_SCHEMA_VERSION)
-    return markerResult('unknown-schema')
-  if (value.protocolVersion !== RECEIPT_READBACK_PROTOCOL_VERSION)
+  const currentVersion = isCurrentVersionPair(
+    value.schemaVersion,
+    value.protocolVersion,
+  )
+  const legacyVersion = isLegacyVersionPair(
+    value.schemaVersion,
+    value.protocolVersion,
+  )
+  if (!currentVersion && !legacyVersion) {
+    if (
+      value.schemaVersion !== RECEIPT_READBACK_SCHEMA_VERSION &&
+      value.schemaVersion !== LEGACY_RECEIPT_READBACK_SCHEMA_VERSION
+    )
+      return markerResult('unknown-schema')
     return markerResult('unknown-protocol')
+  }
   if (!hasExactKeys(value, MINT_KEYS)) return markerResult('forbidden-field')
   const envelope = parseEnvelope(value.envelope)
   if (!envelope) return markerResult('malformed')
+  if (
+    (currentVersion &&
+      envelope.schemaVersion !== RECEIPT_READBACK_SCHEMA_VERSION) ||
+    (legacyVersion && envelope.schemaVersion !== 1)
+  ) {
+    return markerResult('malformed')
+  }
   if (!isSessionSaltHex(value.sessionSalt)) return markerResult('malformed')
   if (!isDigest(value.integrity)) return markerResult('malformed')
   if (envelope.canonical.consumption !== 'available')
@@ -759,8 +851,8 @@ function parseMintMarker(value: unknown): ReceiptMarkerValidation {
 
   const marker: ReceiptMintMarker = {
     kind: 'mint',
-    schemaVersion: RECEIPT_READBACK_SCHEMA_VERSION,
-    protocolVersion: RECEIPT_READBACK_PROTOCOL_VERSION,
+    schemaVersion: value.schemaVersion as ReceiptReadbackVersion,
+    protocolVersion: value.protocolVersion as ReceiptReadbackVersion,
     envelope,
     sessionSalt: value.sessionSalt,
     integrity: value.integrity,
@@ -774,9 +866,16 @@ function parseConsumeMarker(
   value: Record<string, unknown>,
 ): ReceiptMarkerValidation {
   if (!hasExactKeys(value, CONSUME_KEYS)) return markerResult('forbidden-field')
+  const currentVersion = isCurrentVersionPair(
+    value.schemaVersion,
+    value.protocolVersion,
+  )
+  const legacyVersion = isLegacyVersionPair(
+    value.schemaVersion,
+    value.protocolVersion,
+  )
   if (
-    value.schemaVersion !== RECEIPT_READBACK_SCHEMA_VERSION ||
-    value.protocolVersion !== RECEIPT_READBACK_PROTOCOL_VERSION ||
+    (!currentVersion && !legacyVersion) ||
     value.kind !== 'control' ||
     value.control !== 'consume' ||
     !isDigest(value.registrationDigest) ||
@@ -790,8 +889,8 @@ function parseConsumeMarker(
   }
   const marker = {
     kind: 'control' as const,
-    schemaVersion: RECEIPT_READBACK_SCHEMA_VERSION,
-    protocolVersion: RECEIPT_READBACK_PROTOCOL_VERSION,
+    schemaVersion: value.schemaVersion as ReceiptReadbackVersion,
+    protocolVersion: value.protocolVersion as ReceiptReadbackVersion,
     registrationDigest: value.registrationDigest,
     capabilityFlags: [...value.capabilityFlags],
     control: 'consume' as const,
@@ -814,6 +913,8 @@ function parseProgressionMarker(
 }
 
 interface ParsedProgressionBase {
+  readonly schemaVersion: ReceiptReadbackVersion
+  readonly protocolVersion: ReceiptReadbackVersion
   readonly registrationDigest: string
   readonly capabilityFlags: readonly string[]
   readonly state: ReceiptProgressionStateName
@@ -827,8 +928,8 @@ function parseProgressionBase(
   value: Record<string, unknown>,
 ): ParsedProgressionBase | undefined {
   if (
-    value.schemaVersion === RECEIPT_READBACK_SCHEMA_VERSION &&
-    value.protocolVersion === RECEIPT_READBACK_PROTOCOL_VERSION &&
+    (isCurrentVersionPair(value.schemaVersion, value.protocolVersion) ||
+      isLegacyVersionPair(value.schemaVersion, value.protocolVersion)) &&
     value.kind === 'control' &&
     value.control === 'progression' &&
     isDigest(value.registrationDigest) &&
@@ -840,6 +941,8 @@ function parseProgressionBase(
     isDigest(value.integrity)
   ) {
     return {
+      schemaVersion: value.schemaVersion as ReceiptReadbackVersion,
+      protocolVersion: value.protocolVersion as ReceiptReadbackVersion,
       registrationDigest: value.registrationDigest,
       capabilityFlags: [...value.capabilityFlags],
       state: value.state,
@@ -873,8 +976,8 @@ function parseEpochProgressionMarker(
   }
   const marker: ReceiptEpochProgressionMarker = {
     kind: 'control',
-    schemaVersion: RECEIPT_READBACK_SCHEMA_VERSION,
-    protocolVersion: RECEIPT_READBACK_PROTOCOL_VERSION,
+    schemaVersion: base.schemaVersion,
+    protocolVersion: base.protocolVersion,
     registrationDigest: base.registrationDigest,
     capabilityFlags: [...base.capabilityFlags],
     control: 'progression',
@@ -894,7 +997,17 @@ function parseEpochProgressionMarker(
 function parseUnitProgressionMarker(
   value: Record<string, unknown>,
 ): ReceiptMarkerValidation {
-  if (!hasExactKeys(value, UNIT_PROGRESSION_KEYS)) {
+  const currentVersion = isCurrentVersionPair(
+    value.schemaVersion,
+    value.protocolVersion,
+  )
+  if (
+    !hasExactKeys(
+      value,
+      LEGACY_UNIT_PROGRESSION_KEYS,
+      currentVersion ? ['pinnedOperationTargetIdentity'] : [],
+    )
+  ) {
     return Object.hasOwn(value, 'epochId') && Object.hasOwn(value, 'unitId')
       ? markerResult('forbidden-field')
       : markerResult('missing-internal-id')
@@ -903,6 +1016,12 @@ function parseUnitProgressionMarker(
     value.requiredOperations,
   )
   const resourceScopes = canonicalResourceScopes(value.resourceScopes)
+  const pinnedOperationTargetIdentity =
+    value.pinnedOperationTargetIdentity === undefined
+      ? undefined
+      : isDigest(value.pinnedOperationTargetIdentity)
+        ? value.pinnedOperationTargetIdentity
+        : undefined
   const base = parseProgressionBase(value)
   if (
     !base ||
@@ -912,7 +1031,9 @@ function parseUnitProgressionMarker(
     !isDigest(value.unitDigest) ||
     !isFamily(value.family) ||
     !requiredOperations ||
-    !resourceScopes
+    !resourceScopes ||
+    (value.pinnedOperationTargetIdentity !== undefined &&
+      pinnedOperationTargetIdentity === undefined)
   ) {
     return value.epochId === undefined || value.unitId === undefined
       ? markerResult('missing-internal-id')
@@ -920,8 +1041,8 @@ function parseUnitProgressionMarker(
   }
   const marker: ReceiptUnitProgressionMarker = {
     kind: 'control',
-    schemaVersion: RECEIPT_READBACK_SCHEMA_VERSION,
-    protocolVersion: RECEIPT_READBACK_PROTOCOL_VERSION,
+    schemaVersion: base.schemaVersion,
+    protocolVersion: base.protocolVersion,
     registrationDigest: base.registrationDigest,
     capabilityFlags: [...base.capabilityFlags],
     control: 'progression',
@@ -933,6 +1054,7 @@ function parseUnitProgressionMarker(
     family: value.family,
     requiredOperations: [...requiredOperations],
     resourceScopes: resourceScopes.map((scope) => ({ ...scope })),
+    ...(pinnedOperationTargetIdentity ? { pinnedOperationTargetIdentity } : {}),
     state: base.state,
     transitionDigest: base.transitionDigest,
     timestamp: base.timestamp,
@@ -954,10 +1076,17 @@ export function validateReceiptMarker(input: unknown): ReceiptMarkerValidation {
   if (!isRecord(input)) return markerResult('malformed')
   if (input.kind === 'mint') return parseMintMarker(input)
   if (input.kind !== 'control') return markerResult('unknown-kind')
-  if (input.schemaVersion !== RECEIPT_READBACK_SCHEMA_VERSION)
-    return markerResult('unknown-schema')
-  if (input.protocolVersion !== RECEIPT_READBACK_PROTOCOL_VERSION)
+  if (
+    !isCurrentVersionPair(input.schemaVersion, input.protocolVersion) &&
+    !isLegacyVersionPair(input.schemaVersion, input.protocolVersion)
+  ) {
+    if (
+      input.schemaVersion !== RECEIPT_READBACK_SCHEMA_VERSION &&
+      input.schemaVersion !== LEGACY_RECEIPT_READBACK_SCHEMA_VERSION
+    )
+      return markerResult('unknown-schema')
     return markerResult('unknown-protocol')
+  }
   if (input.control === 'consume') return parseConsumeMarker(input)
   if (input.control === 'progression') return parseProgressionMarker(input)
   return markerResult('unknown-kind')
@@ -1184,7 +1313,9 @@ function projectUnitMarker(
     !isInternalId(input.unitId) ||
     !isFamily(input.family) ||
     normalizeRequiredOperations(input.requiredOperations) === undefined ||
-    normalizeResourceScopes(input.resourceScopes) === undefined
+    normalizeResourceScopes(input.resourceScopes) === undefined ||
+    (input.pinnedOperationTargetIdentity !== undefined &&
+      !isDigest(input.pinnedOperationTargetIdentity))
   ) {
     return undefined
   }
@@ -1208,6 +1339,9 @@ function projectUnitMarker(
     family: input.family,
     requiredOperations: [...requiredOperations],
     resourceScopes: resourceScopes.map((scope) => ({ ...scope })),
+    ...(input.pinnedOperationTargetIdentity
+      ? { pinnedOperationTargetIdentity: input.pinnedOperationTargetIdentity }
+      : {}),
     state: input.state,
     transitionDigest: input.transitionDigest,
     timestamp: context.timestamp,
@@ -1294,6 +1428,9 @@ function cloneMarker(marker: ReceiptMarker): ReceiptMarker {
     family: marker.family,
     requiredOperations: [...marker.requiredOperations],
     resourceScopes: marker.resourceScopes.map((scope) => ({ ...scope })),
+    ...(marker.pinnedOperationTargetIdentity
+      ? { pinnedOperationTargetIdentity: marker.pinnedOperationTargetIdentity }
+      : {}),
     state: marker.state,
     transitionDigest: marker.transitionDigest,
     timestamp: marker.timestamp,
@@ -1361,6 +1498,12 @@ function serializeMarker(marker: ReceiptMarker): string {
     family: marker.family,
     requiredOperations: [...marker.requiredOperations],
     resourceScopes: marker.resourceScopes.map((scope) => ({ ...scope })),
+    ...(marker.schemaVersion === RECEIPT_READBACK_SCHEMA_VERSION
+      ? {
+          pinnedOperationTargetIdentity:
+            marker.pinnedOperationTargetIdentity ?? null,
+        }
+      : {}),
     state: marker.state,
     transitionDigest: marker.transitionDigest,
     timestamp: marker.timestamp,
@@ -1411,6 +1554,20 @@ function foldMintMarker(
   context: FoldContext,
 ): ReceiptReadbackFailureCategory | undefined {
   if (marker.sessionSalt !== context.expectedSalt) return 'salt-mismatch'
+  if (
+    marker.envelope.schemaVersion === 1 &&
+    context.expectation.operationTargetIdentity
+  ) {
+    return 'identity-digest-mismatch'
+  }
+  if (
+    marker.envelope.schemaVersion === RECEIPT_READBACK_SCHEMA_VERSION &&
+    context.expectation.operationTargetIdentity &&
+    marker.envelope.canonical.operationTargetIdentity !==
+      context.expectation.operationTargetIdentity
+  ) {
+    return 'identity-digest-mismatch'
+  }
   const registrationMatches =
     marker.envelope.registrationDigest ===
       context.expectation.registrationDigest &&
@@ -1518,6 +1675,9 @@ function progressionSnapshot(
     family: marker.family,
     requiredOperations: [...marker.requiredOperations],
     resourceScopes: marker.resourceScopes.map((scope) => ({ ...scope })),
+    ...(marker.pinnedOperationTargetIdentity
+      ? { pinnedOperationTargetIdentity: marker.pinnedOperationTargetIdentity }
+      : {}),
     transitionDigest: marker.transitionDigest,
   }
 }
@@ -1629,12 +1789,20 @@ function applyUnitStart(
     }
     if (
       sameUnitDeclaration(current, marker) &&
-      current.transitionDigest !== marker.transitionDigest
+      current.transitionDigest !== marker.transitionDigest &&
+      current.pinnedOperationTargetIdentity ===
+        marker.pinnedOperationTargetIdentity
     ) {
       return 'conflicting-marker'
     }
     if (!unitDeclarationExtends(current, marker)) return 'conflicting-marker'
-    if (sameUnitDeclaration(current, marker)) return undefined
+    if (
+      sameUnitDeclaration(current, marker) &&
+      current.pinnedOperationTargetIdentity ===
+        marker.pinnedOperationTargetIdentity
+    ) {
+      return undefined
+    }
     context.progression = { epoch, unit: snapshot }
     return undefined
   }
@@ -1712,8 +1880,17 @@ function unitDeclarationExtends(
       scope.resourceIdentity,
     ]),
   )
-  return [...current.resourceScopes].every(
-    (scope) => nextScopes.get(scope.operation) === scope.resourceIdentity,
+  if (
+    ![...current.resourceScopes].every(
+      (scope) => nextScopes.get(scope.operation) === scope.resourceIdentity,
+    )
+  ) {
+    return false
+  }
+  return (
+    current.pinnedOperationTargetIdentity === undefined ||
+    current.pinnedOperationTargetIdentity ===
+      marker.pinnedOperationTargetIdentity
   )
 }
 
@@ -1799,11 +1976,13 @@ export function foldReceiptReadback(
 export function receiptReadbackExpectationFromMetadata(
   metadata: ReceiptLedgerMetadata,
   sessionSalt: Uint8Array,
+  operationTargetIdentity?: string,
 ): ReceiptReadbackExpectation {
   return {
     registrationDigest: metadata.registrationDigest,
     capabilityFlags: [...metadata.capabilityFlags],
     sessionSalt: new Uint8Array(sessionSalt),
     source: 'runtime-verified',
+    operationTargetIdentity,
   }
 }

--- a/src/lib/workflow-guard.ts
+++ b/src/lib/workflow-guard.ts
@@ -63,6 +63,7 @@ export type WorkflowReasonCode =
   | 'no-active-unit'
   | 'no-op-operation'
   | 'operation-not-required'
+  | 'operation-target-mismatch'
   | 'receipt-mismatch'
   | 'rejected-operation'
   | 'resource-mismatch'
@@ -115,6 +116,7 @@ export interface UnitSnapshot {
   requiredOperations: readonly ReceiptOperation[]
   requiredResourceOperations: readonly ReceiptOperation[]
   resourceScopes: readonly ReceiptResourceScope[]
+  pinnedOperationTargetIdentity?: string
 }
 
 export interface CurrentOperationContext {
@@ -242,6 +244,7 @@ interface ParsedReadback {
   workspaceIdentity: string
   repositoryIdentity?: string
   worktreeIdentity?: string
+  operationTargetIdentity?: string
   resourceIdentity?: string
   resourceRevisionIdentity?: string
   pullRequest?: ReceiptOperationAfter['pullRequest']
@@ -323,6 +326,7 @@ const RECOVERY_UNIT_KEYS = new Set([
   'family',
   'requiredOperations',
   'resourceScopes',
+  'pinnedOperationTargetIdentity',
   'transitionDigest',
 ])
 const RECOVERY_STATE_KEYS = new Set([
@@ -357,6 +361,7 @@ interface UnitState {
   requiredOperations: readonly ReceiptOperation[]
   declaredResourceOperations: readonly ReceiptOperation[]
   resourceScopes: ReadonlyMap<ReceiptOperation, string>
+  pinnedOperationTargetIdentity?: string
   evidence: Map<ReceiptOperation, ReceiptEnvelope>
   issues: Map<ReceiptOperation, Issue>
   staleReceiptIds: Set<string>
@@ -591,6 +596,12 @@ function parseRecoveryUnit(
     return undefined
   const requiredOperations = parseRecoveryOperations(value.requiredOperations)
   const resourceScopes = parseRecoveryResourceScopes(value.resourceScopes)
+  const pinnedOperationTargetIdentity =
+    value.pinnedOperationTargetIdentity === undefined
+      ? undefined
+      : isRecoveryDigest(value.pinnedOperationTargetIdentity)
+        ? value.pinnedOperationTargetIdentity
+        : undefined
   if (
     value.target !== 'unit' ||
     (value.state !== 'started' && value.state !== 'completed') ||
@@ -601,6 +612,8 @@ function parseRecoveryUnit(
     !isFamily(value.family) ||
     !requiredOperations ||
     !resourceScopes ||
+    (value.pinnedOperationTargetIdentity !== undefined &&
+      pinnedOperationTargetIdentity === undefined) ||
     !isRecoveryDigest(value.transitionDigest)
   ) {
     return undefined
@@ -615,6 +628,7 @@ function parseRecoveryUnit(
     family: value.family,
     requiredOperations,
     resourceScopes,
+    ...(pinnedOperationTargetIdentity ? { pinnedOperationTargetIdentity } : {}),
     transitionDigest: value.transitionDigest,
   }
 }
@@ -683,6 +697,9 @@ function cloneUnit(unit: UnitState): UnitSnapshot {
         resourceIdentity,
       })),
     ),
+    ...(unit.pinnedOperationTargetIdentity
+      ? { pinnedOperationTargetIdentity: unit.pinnedOperationTargetIdentity }
+      : {}),
   })
 }
 
@@ -794,6 +811,7 @@ function parseReadback(input: unknown): ParsedReadback | undefined {
         'workspaceIdentity',
         'repositoryIdentity',
         'worktreeIdentity',
+        'operationTargetIdentity',
         'resourceIdentity',
         'resourceRevisionIdentity',
         'pullRequest',
@@ -822,6 +840,7 @@ function parseReadback(input: unknown): ParsedReadback | undefined {
     workspaceIdentity: after.workspaceIdentity,
     repositoryIdentity: after.repositoryIdentity,
     worktreeIdentity: after.worktreeIdentity,
+    operationTargetIdentity: after.operationTargetIdentity,
     resourceIdentity: after.resourceIdentity,
     resourceRevisionIdentity: after.resourceRevisionIdentity,
     pullRequest: after.pullRequest,
@@ -1055,6 +1074,7 @@ function parseU4Readback(input: unknown): ParsedReadback | undefined {
         'workspaceIdentity',
         'repositoryIdentity',
         'worktreeIdentity',
+        'operationTargetIdentity',
         'resourceIdentity',
         'resourceRevisionIdentity',
         'pullRequest',
@@ -1074,6 +1094,7 @@ function parseU4Readback(input: unknown): ParsedReadback | undefined {
     workspaceIdentity: after.workspaceIdentity,
     repositoryIdentity: after.repositoryIdentity,
     worktreeIdentity: after.worktreeIdentity,
+    operationTargetIdentity: after.operationTargetIdentity,
     resourceIdentity: after.resourceIdentity,
     resourceRevisionIdentity: after.resourceRevisionIdentity,
     pullRequest: after.pullRequest,
@@ -1289,8 +1310,29 @@ export function createWorkflowGuard(
       return 'epoch-mismatch'
     if (input.context.unitId !== unit.unitId) return 'unit-mismatch'
     return (
-      currentIdentityReason(input.context) ?? resourceBeforeReason(input, unit)
+      currentIdentityReason(input.context) ??
+      operationTargetReason(input, unit) ??
+      resourceBeforeReason(input, unit)
     )
+  }
+
+  function operationTargetReason(
+    input: ParsedOperationObservation,
+    unit: UnitState,
+  ): WorkflowReasonCode | undefined {
+    if (!isPinnedLocalOperation(input.operation)) return undefined
+    if (
+      input.after &&
+      input.after.operationTargetIdentity !==
+        input.context.operationTargetIdentity
+    ) {
+      return 'operation-target-mismatch'
+    }
+    return unit.pinnedOperationTargetIdentity !== undefined &&
+      input.context.operationTargetIdentity !==
+        unit.pinnedOperationTargetIdentity
+      ? 'operation-target-mismatch'
+      : undefined
   }
 
   function currentIdentityReason(
@@ -1298,6 +1340,7 @@ export function createWorkflowGuard(
   ): WorkflowReasonCode | undefined {
     if (context.workspaceIdentity !== currentWorkspaceIdentity)
       return 'workspace-mismatch'
+    if (context.operationTargetIdentity !== undefined) return undefined
     if (context.repositoryIdentity !== currentRepositoryIdentity)
       return 'receipt-mismatch'
     return context.worktreeIdentity !== currentWorktreeIdentity
@@ -1347,7 +1390,9 @@ export function createWorkflowGuard(
     if (input.after.workspaceIdentity !== input.context.workspaceIdentity) {
       return 'workspace-mismatch'
     }
-    return resourceAfterReason(input, unit)
+    return (
+      operationTargetReason(input, unit) ?? resourceAfterReason(input, unit)
+    )
   }
 
   function resourceAfterReason(
@@ -1811,6 +1856,14 @@ export function createWorkflowGuard(
     ) {
       return 'receipt-mismatch'
     }
+    if (
+      isPinnedLocalOperation(envelope.canonical.operation) &&
+      unit.pinnedOperationTargetIdentity !== undefined &&
+      envelope.canonical.operationTargetIdentity !==
+        unit.pinnedOperationTargetIdentity
+    ) {
+      return 'operation-target-mismatch'
+    }
     const historicalImplementation =
       envelope.canonical.operation === 'implementation' &&
       unit.evidence.get('implementation')?.canonical.receiptId ===
@@ -1824,6 +1877,16 @@ export function createWorkflowGuard(
       }
     }
     return compareReceiptResources(envelope, unit)
+  }
+
+  function isPinnedLocalOperation(
+    operation: ReceiptOperation,
+  ): operation is 'implementation' | 'verification' | 'commit' {
+    return (
+      operation === 'implementation' ||
+      operation === 'verification' ||
+      operation === 'commit'
+    )
   }
 
   function compareReceiptResources(
@@ -1974,7 +2037,8 @@ export function createWorkflowGuard(
 
   function issueKind(reasonCode: WorkflowReasonCode): Issue['kind'] {
     return reasonCode === 'incompatible-receipt' ||
-      reasonCode === 'guard-unavailable'
+      reasonCode === 'guard-unavailable' ||
+      reasonCode === 'operation-target-mismatch'
       ? 'unavailable'
       : 'rejected'
   }
@@ -2205,6 +2269,7 @@ export function createWorkflowGuard(
     workspaceIdentity: string
     repositoryIdentity?: string
     worktreeIdentity?: string
+    operationTargetIdentity?: string
     resourceIdentity?: string
   } {
     const storedContext = unit.ledgerContexts.get(envelope.canonical.receiptId)
@@ -2216,6 +2281,7 @@ export function createWorkflowGuard(
       workspaceIdentity: currentWorkspaceIdentity,
       repositoryIdentity: currentRepositoryIdentity,
       worktreeIdentity: currentWorktreeIdentity,
+      operationTargetIdentity: envelope.canonical.operationTargetIdentity,
       resourceIdentity: ledgerResourceIdentity(
         operation,
         currentResource(unit, operation),
@@ -2313,6 +2379,14 @@ export function createWorkflowGuard(
       return { status: 'accepted', operation }
     }
     unit.evidence.set(operation, read.envelope)
+    if (
+      isPinnedLocalOperation(operation) &&
+      unit.pinnedOperationTargetIdentity === undefined &&
+      read.envelope.canonical.operationTargetIdentity !== undefined
+    ) {
+      unit.pinnedOperationTargetIdentity =
+        read.envelope.canonical.operationTargetIdentity
+    }
     clearIssue(unit, operation)
     globalIssue = undefined
     return { status: 'accepted', operation }
@@ -2327,6 +2401,7 @@ export function createWorkflowGuard(
       workspaceIdentity: after.workspaceIdentity,
       repositoryIdentity: after.repositoryIdentity,
       worktreeIdentity: after.worktreeIdentity,
+      operationTargetIdentity: after.operationTargetIdentity,
       resourceIdentity: after.resourceIdentity,
       resourceRevisionIdentity: after.resourceRevisionIdentity,
       pullRequest: after.pullRequest,
@@ -3007,6 +3082,29 @@ export function createWorkflowGuard(
     return undefined
   }
 
+  function recoveryTargetPinReason(
+    unit: ReceiptUnitProgressionSnapshot | null,
+    matching: readonly ReceiptEnvelope[],
+  ): WorkflowReasonCode | undefined {
+    if (!unit) return undefined
+    const localTargets = matching
+      .filter((envelope) =>
+        isPinnedLocalOperation(envelope.canonical.operation),
+      )
+      .map((envelope) => envelope.canonical.operationTargetIdentity)
+    if (unit.pinnedOperationTargetIdentity !== undefined) {
+      return localTargets.some(
+        (target) => target !== unit.pinnedOperationTargetIdentity,
+      )
+        ? 'operation-target-mismatch'
+        : undefined
+    }
+    const distinctTargets = new Set(
+      localTargets.filter((target): target is string => target !== undefined),
+    )
+    return distinctTargets.size > 1 ? 'operation-target-mismatch' : undefined
+  }
+
   function resourceScopeMatches(
     operation: ReceiptOperation,
     persisted: string,
@@ -3063,6 +3161,7 @@ export function createWorkflowGuard(
       workspaceIdentity: currentWorkspaceIdentity,
       repositoryIdentity: currentRepositoryIdentity,
       worktreeIdentity: currentWorktreeIdentity,
+      operationTargetIdentity: envelope.canonical.operationTargetIdentity,
       resourceIdentity: resourceScopes.get(envelope.canonical.operation),
     }
   }
@@ -3217,6 +3316,12 @@ export function createWorkflowGuard(
       .find((reason): reason is WorkflowReasonCode => reason !== undefined)
     if (boundaryFailure)
       return { status: 'rejected', reasonCode: boundaryFailure }
+    const targetPinFailure = recoveryTargetPinReason(
+      state.progression.unit,
+      receiptSet.matching,
+    )
+    if (targetPinFailure)
+      return { status: 'rejected', reasonCode: targetPinFailure }
     const completionFailure = recoveryCompletionReason(
       state.progression,
       receiptSet.matching,
@@ -3233,6 +3338,11 @@ export function createWorkflowGuard(
   ): UnitState | undefined {
     const snapshot = progression.unit
     if (!snapshot) return undefined
+    const inferredOperationTargetIdentity =
+      snapshot.pinnedOperationTargetIdentity ??
+      matching.find((envelope) =>
+        isPinnedLocalOperation(envelope.canonical.operation),
+      )?.canonical.operationTargetIdentity
     const unit: UnitState = {
       unitId: snapshot.unitId,
       status: snapshot.state === 'completed' ? 'completed' : 'active',
@@ -3241,6 +3351,11 @@ export function createWorkflowGuard(
         snapshot.resourceScopes.map((scope) => scope.operation),
       ),
       resourceScopes: new Map(resourceScopes),
+      ...(inferredOperationTargetIdentity
+        ? {
+            pinnedOperationTargetIdentity: inferredOperationTargetIdentity,
+          }
+        : {}),
       evidence: new Map(),
       issues: new Map(),
       staleReceiptIds: new Set(),

--- a/src/lib/workflow-guard.ts
+++ b/src/lib/workflow-guard.ts
@@ -1342,7 +1342,7 @@ export function createWorkflowGuard(
     input: ParsedOperationObservation,
     unit: UnitState,
   ): WorkflowReasonCode | undefined {
-    if (!isPinnedLocalOperation(input.operation)) return undefined
+    if (!isLocalOperation(input.operation)) return undefined
     if (
       input.after &&
       input.after.operationTargetIdentity !==
@@ -1879,7 +1879,7 @@ export function createWorkflowGuard(
       return 'receipt-mismatch'
     }
     if (
-      isPinnedLocalOperation(envelope.canonical.operation) &&
+      isLocalOperation(envelope.canonical.operation) &&
       unit.pinnedOperationTargetIdentity !== undefined &&
       envelope.canonical.operationTargetIdentity !==
         unit.pinnedOperationTargetIdentity
@@ -1899,16 +1899,6 @@ export function createWorkflowGuard(
       }
     }
     return compareReceiptResources(envelope, unit)
-  }
-
-  function isPinnedLocalOperation(
-    operation: ReceiptOperation,
-  ): operation is 'implementation' | 'verification' | 'commit' {
-    return (
-      operation === 'implementation' ||
-      operation === 'verification' ||
-      operation === 'commit'
-    )
   }
 
   function compareReceiptResources(
@@ -2402,7 +2392,7 @@ export function createWorkflowGuard(
     }
     unit.evidence.set(operation, read.envelope)
     if (
-      isPinnedLocalOperation(operation) &&
+      isLocalOperation(operation) &&
       unit.pinnedOperationTargetIdentity === undefined &&
       read.envelope.canonical.operationTargetIdentity !== undefined
     ) {
@@ -2423,7 +2413,7 @@ export function createWorkflowGuard(
       workspaceIdentity: after.workspaceIdentity,
       repositoryIdentity: after.repositoryIdentity,
       worktreeIdentity: after.worktreeIdentity,
-      ...(isPinnedLocalOperation(operation)
+      ...(isLocalOperation(operation)
         ? { operationTargetIdentity: after.operationTargetIdentity }
         : {}),
       resourceIdentity: after.resourceIdentity,
@@ -3119,9 +3109,7 @@ export function createWorkflowGuard(
   ): WorkflowReasonCode | undefined {
     if (!unit) return undefined
     const localTargets = matching
-      .filter((envelope) =>
-        isPinnedLocalOperation(envelope.canonical.operation),
-      )
+      .filter((envelope) => isLocalOperation(envelope.canonical.operation))
       .map((envelope) => envelope.canonical.operationTargetIdentity)
     if (unit.pinnedOperationTargetIdentity !== undefined) {
       return localTargets.some(
@@ -3372,7 +3360,7 @@ export function createWorkflowGuard(
     const inferredOperationTargetIdentity =
       snapshot.pinnedOperationTargetIdentity ??
       matching.find((envelope) =>
-        isPinnedLocalOperation(envelope.canonical.operation),
+        isLocalOperation(envelope.canonical.operation),
       )?.canonical.operationTargetIdentity
     const unit: UnitState = {
       unitId: snapshot.unitId,

--- a/src/lib/workflow-guard.ts
+++ b/src/lib/workflow-guard.ts
@@ -2904,6 +2904,12 @@ export function createWorkflowGuard(
     if (!global?.repositoryIdentity || !global.worktreeIdentity) {
       return 'invalid-receipt'
     }
+    if (
+      unit.pinnedOperationTargetIdentity !== undefined &&
+      global.operationTargetIdentity !== unit.pinnedOperationTargetIdentity
+    ) {
+      return 'operation-target-mismatch'
+    }
     const required = RESOURCE_FINAL_READBACK_OPERATIONS.filter((operation) =>
       unit.evidence.has(operation),
     )

--- a/src/lib/workflow-guard.ts
+++ b/src/lib/workflow-guard.ts
@@ -829,6 +829,7 @@ function parseReadback(input: unknown): ParsedReadback | undefined {
     workspaceIdentity: input.workspaceIdentity,
     repositoryIdentity: input.repositoryIdentity,
     worktreeIdentity: input.worktreeIdentity,
+    operationTargetIdentity: input.operationTargetIdentity,
     resourceIdentity: input.resourceIdentity,
     resourceRevisionIdentity: input.resourceRevisionIdentity,
     pullRequest: input.pullRequest,
@@ -860,6 +861,9 @@ function parseLegacyReadbackAfter(
     input.repositoryIdentity,
   )
   const worktreeIdentity = parseOptionalReadbackIdentity(input.worktreeIdentity)
+  const operationTargetIdentity = parseOptionalReadbackIdentity(
+    input.operationTargetIdentity,
+  )
   const resourceIdentity = parseOptionalReadbackIdentity(input.resourceIdentity)
   const resourceRevisionIdentity = parseOptionalReadbackIdentity(
     input.resourceRevisionIdentity,
@@ -867,6 +871,10 @@ function parseLegacyReadbackAfter(
   if (
     !isOptionalReadbackIdentity(input.repositoryIdentity, repositoryIdentity) ||
     !isOptionalReadbackIdentity(input.worktreeIdentity, worktreeIdentity) ||
+    !isOptionalReadbackIdentity(
+      input.operationTargetIdentity,
+      operationTargetIdentity,
+    ) ||
     !isOptionalReadbackIdentity(input.resourceIdentity, resourceIdentity) ||
     !isOptionalReadbackIdentity(
       input.resourceRevisionIdentity,
@@ -883,6 +891,7 @@ function parseLegacyReadbackAfter(
     workspaceIdentity: input.workspaceIdentity,
     ...(repositoryIdentity ? { repositoryIdentity } : {}),
     ...(worktreeIdentity ? { worktreeIdentity } : {}),
+    ...(operationTargetIdentity ? { operationTargetIdentity } : {}),
     ...(resourceIdentity ? { resourceIdentity } : {}),
     ...(resourceRevisionIdentity ? { resourceRevisionIdentity } : {}),
     ...(pullRequest ? { pullRequest } : {}),

--- a/src/lib/workflow-guard.ts
+++ b/src/lib/workflow-guard.ts
@@ -17,6 +17,7 @@ import type {
   ReceiptOperation,
   ReceiptReasonCode,
 } from './receipt-ledger.js'
+import { isLocalOperation } from './receipt-ledger.js'
 import type {
   ReceiptEpochProgressionSnapshot,
   ReceiptReadbackProgression,
@@ -968,10 +969,14 @@ function toLedgerContext(
 ): ReceiptContext {
   const {
     resourceRevisionIdentity: _resourceRevisionIdentity,
+    operationTargetIdentity: _operationTargetIdentity,
     ...ledgerContext
   } = context
   return {
     ...ledgerContext,
+    ...(isLocalOperation(operation)
+      ? { operationTargetIdentity: context.operationTargetIdentity }
+      : {}),
     resourceIdentity: ledgerResourceIdentity(
       operation,
       context.resourceIdentity,
@@ -989,10 +994,14 @@ function toLedgerAfter(
     pullRequest: _pullRequest,
     checkState: _checkState,
     reviewDecision: _reviewDecision,
+    operationTargetIdentity: _operationTargetIdentity,
     ...ledgerAfter
   } = after
   return {
     ...ledgerAfter,
+    ...(isLocalOperation(operation)
+      ? { operationTargetIdentity: after.operationTargetIdentity }
+      : {}),
     resourceIdentity: ledgerResourceIdentity(
       operation,
       after.resourceIdentity,
@@ -1082,7 +1091,11 @@ function parseU4Readback(input: unknown): ParsedReadback | undefined {
         'reviewDecision',
       ]),
     ) ||
-    (input.operation !== undefined && !isOperation(input.operation))
+    (input.operation !== undefined && !isOperation(input.operation)) ||
+    (input.operation !== undefined &&
+      isOperation(input.operation) &&
+      !isLocalOperation(input.operation) &&
+      Object.hasOwn(input, 'operationTargetIdentity'))
   ) {
     return undefined
   }
@@ -2401,7 +2414,9 @@ export function createWorkflowGuard(
       workspaceIdentity: after.workspaceIdentity,
       repositoryIdentity: after.repositoryIdentity,
       worktreeIdentity: after.worktreeIdentity,
-      operationTargetIdentity: after.operationTargetIdentity,
+      ...(isPinnedLocalOperation(operation)
+        ? { operationTargetIdentity: after.operationTargetIdentity }
+        : {}),
       resourceIdentity: after.resourceIdentity,
       resourceRevisionIdentity: after.resourceRevisionIdentity,
       pullRequest: after.pullRequest,
@@ -2855,6 +2870,7 @@ export function createWorkflowGuard(
         workspaceIdentity: parsed.after.workspaceIdentity,
         repositoryIdentity: parsed.after.repositoryIdentity,
         worktreeIdentity: parsed.after.worktreeIdentity,
+        operationTargetIdentity: parsed.after.operationTargetIdentity,
         resourceIdentity: parsed.after.resourceIdentity,
         resourceRevisionIdentity: parsed.after.resourceRevisionIdentity,
       }),

--- a/tests/integration/receipt-workflow-recovery.test.ts
+++ b/tests/integration/receipt-workflow-recovery.test.ts
@@ -537,12 +537,15 @@ async function createSession(
   return created.data.id
 }
 
-function initializeIsolatedRepository(fixture: IsolatedFixture): void {
+function initializeIsolatedRepository(
+  fixture: IsolatedFixture,
+  additionalTrackedFiles: readonly string[] = [],
+): void {
   const commands = [
     ['git', 'init', '-b', 'main'],
     ['git', 'config', 'user.email', 'u5-integration@example.invalid'],
     ['git', 'config', 'user.name', 'U5 Integration'],
-    ['git', 'add', 'package.json'],
+    ['git', 'add', 'package.json', ...additionalTrackedFiles],
     ['git', 'commit', '-m', 'initial fixture'],
   ]
   for (const command of commands) {
@@ -1690,10 +1693,21 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
     )
 
     test(
-      'rolls up implementation and commit receipts from a registered nested worktree',
+      '#678 reproduction: rolls up parent-rooted child tools targeting a registered nested worktree and completes',
       async () => {
+        // Regression guard for 3420c5c and earlier: the parent-rooted child
+        // remains in the host checkout while its bash tools target the nested
+        // worktree. The former fixed-root observer therefore saw no change,
+        // minted no parent receipts, and blocked completion.
         const localFixture = createIsolatedFixture()
-        initializeIsolatedRepository(localFixture)
+        // Mirror the real repo's gitignored .worktrees/ directory and the
+        // actual #678 dogfood worktree so the parent observer skips nested
+        // worktree contents during its untracked-file walk.
+        fs.writeFileSync(
+          path.join(localFixture.projectDir, '.gitignore'),
+          '.worktrees/\n',
+        )
+        initializeIsolatedRepository(localFixture, ['.gitignore'])
         const nestedWorktree = path.join(
           localFixture.projectDir,
           '.worktrees',
@@ -1737,7 +1751,11 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
                 id: 'u5c-parent-start',
                 name: 'systematic_workflow_start',
                 arguments: {
-                  expected_operations: ['implementation', 'commit'],
+                  expected_operations: [
+                    'implementation',
+                    'verification',
+                    'commit',
+                  ],
                 },
               },
             ],
@@ -1781,6 +1799,18 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
                 name: 'bash',
                 arguments: {
                   command: 'git apply change.patch',
+                  workdir: nestedWorktree,
+                },
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5c-child-write-verify',
+                name: 'bash',
+                arguments: {
+                  command: 'git status --short',
                   workdir: nestedWorktree,
                 },
               },
@@ -1856,7 +1886,16 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             ],
           },
           { text: 'nested worktree commit finished' },
-          { text: 'parent finished' },
+          {
+            toolCalls: [
+              {
+                id: 'u5c-parent-complete',
+                name: 'systematic_workflow_complete',
+                arguments: { target: 'unit' },
+              },
+            ],
+          },
+          { text: 'nested worktree workflow completed' },
         ])
         const configContent = buildProviderConfig(
           [localPackagedPluginUrl],
@@ -1928,8 +1967,22 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
           const parentMints = receiptMintSummaries(parentMessages.data)
           expect(parentMints.map(({ operation }) => operation)).toEqual([
             'implementation',
+            'verification',
             'commit',
           ])
+          const completionParts = completedToolParts(
+            parentMessages.data,
+            'systematic_workflow_complete',
+          )
+          expect(completionParts).toHaveLength(1)
+          const completionState = completionParts[0]?.state as Record<
+            string,
+            unknown
+          >
+          expect(completionState.output).toContain(
+            'workflow guard completed unit',
+          )
+          expect(receiptMintSummaries(parentMessages.data)).toEqual(parentMints)
           assertPrivacySafeMarkers(parentMessages.data)
         } finally {
           if (host) await host.stop()

--- a/tests/integration/receipt-workflow-recovery.test.ts
+++ b/tests/integration/receipt-workflow-recovery.test.ts
@@ -527,11 +527,12 @@ async function createSession(
   client: ReturnType<typeof createOpencodeClient>,
   directory: string,
   title: string,
+  permission = [{ permission: '*', pattern: '*', action: 'allow' as const }],
 ): Promise<string> {
   const created = await client.session.create({
     directory,
     title,
-    permission: [{ permission: '*', pattern: '*', action: 'allow' }],
+    permission,
   })
   return created.data.id
 }
@@ -1679,6 +1680,257 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
           expect(parsedStatus.reasonCode).not.toBe('guard-unavailable')
           expect(parsedStatus.satisfiedOperations).toContain('commit')
           assertPrivacySafeMarkers(afterStatusMessages.data)
+        } finally {
+          if (host) await host.stop()
+          model.stop()
+          destroyIsolatedFixture(localFixture)
+        }
+      },
+      TIMEOUT_MS * 4,
+    )
+
+    test(
+      'rolls up implementation and commit receipts from a registered nested worktree',
+      async () => {
+        const localFixture = createIsolatedFixture()
+        initializeIsolatedRepository(localFixture)
+        const nestedWorktree = path.join(
+          localFixture.projectDir,
+          '.worktrees',
+          'u5c-nested-target',
+        )
+        fs.mkdirSync(path.dirname(nestedWorktree), { recursive: true })
+        const worktreeResult = Bun.spawnSync(
+          ['git', 'worktree', 'add', '-b', 'u5c-nested-target', nestedWorktree],
+          { cwd: localFixture.projectDir },
+        )
+        if (worktreeResult.exitCode !== 0) {
+          throw new Error('isolated nested worktree setup failed')
+        }
+        fs.writeFileSync(
+          path.join(nestedWorktree, 'change.patch'),
+          'diff --git a/u5c-targeted.txt b/u5c-targeted.txt\n' +
+            'new file mode 100644\n' +
+            'index 0000000..2e4c4a1\n' +
+            '--- /dev/null\n' +
+            '+++ b/u5c-targeted.txt\n' +
+            '@@ -0,0 +1 @@\n' +
+            '+nested worktree content\n',
+        )
+
+        const localPackagedPluginUrl =
+          extractPackagedPlugin(localFixture).pluginUrl
+        const targetFile = path.join(nestedWorktree, 'u5c-targeted.txt')
+        const model = startMockModelServer([
+          {
+            toolCalls: [
+              {
+                id: 'u5c-parent-skill',
+                name: 'systematic_skill',
+                arguments: { name: 'ce:work' },
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5c-parent-start',
+                name: 'systematic_workflow_start',
+                arguments: {
+                  expected_operations: ['implementation', 'commit'],
+                },
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5c-parent-write-task',
+                name: 'task',
+                arguments: {
+                  description: 'write in the nested worktree',
+                  prompt:
+                    'Use systematic tools and write one file in the target worktree.',
+                  subagent_type: 'systematic-implementer',
+                },
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5c-child-write-skill',
+                name: 'systematic_skill',
+                arguments: { name: 'ce:work' },
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5c-child-write-start',
+                name: 'systematic_workflow_start',
+                arguments: { expected_operations: ['implementation'] },
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5c-child-write',
+                name: 'bash',
+                arguments: {
+                  command: 'git apply change.patch',
+                  workdir: nestedWorktree,
+                },
+              },
+            ],
+          },
+          { text: 'nested worktree write finished' },
+          {
+            toolCalls: [
+              {
+                id: 'u5c-parent-commit-task',
+                name: 'task',
+                arguments: {
+                  description: 'commit the nested worktree change',
+                  prompt:
+                    'Use systematic tools to commit the existing target worktree change.',
+                  subagent_type: 'systematic-implementer',
+                },
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5c-child-commit-skill',
+                name: 'systematic_skill',
+                arguments: { name: 'git-commit' },
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5c-child-commit-start',
+                name: 'systematic_workflow_start',
+                arguments: {},
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5c-child-commit-status',
+                name: 'bash',
+                arguments: {
+                  command: 'git status --short',
+                  workdir: nestedWorktree,
+                },
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5c-child-commit-add',
+                name: 'bash',
+                arguments: {
+                  command: 'git add -A',
+                  workdir: nestedWorktree,
+                },
+              },
+            ],
+          },
+          {
+            toolCalls: [
+              {
+                id: 'u5c-child-commit',
+                name: 'bash',
+                arguments: {
+                  command: 'git commit -m u5c-nested-worktree-commit',
+                  workdir: nestedWorktree,
+                },
+              },
+            ],
+          },
+          { text: 'nested worktree commit finished' },
+          { text: 'parent finished' },
+        ])
+        const configContent = buildProviderConfig(
+          [localPackagedPluginUrl],
+          model.url,
+        )
+        let host: Awaited<ReturnType<typeof startOpencodeServer>> | undefined
+        try {
+          host = await startOpencodeServer(localFixture, configContent)
+          const client = createOpencodeClient({
+            baseUrl: host.url,
+            directory: localFixture.projectDir,
+          })
+          const parentSessionID = await createSession(
+            client,
+            localFixture.projectDir,
+            'u5c nested worktree rollup',
+            [
+              { permission: '*', pattern: '*', action: 'allow' },
+              {
+                permission: 'external_directory',
+                pattern: '*',
+                action: 'allow',
+              },
+              { permission: 'edit', pattern: '*', action: 'allow' },
+            ],
+          )
+          await promptSession(
+            client,
+            parentSessionID,
+            localFixture.projectDir,
+            'Start a guarded unit, write in the nested worktree, then commit it.',
+          )
+
+          const parentMessages = await client.session.messages({
+            sessionID: parentSessionID,
+            directory: localFixture.projectDir,
+          })
+          const taskParts = completedToolParts(parentMessages.data, 'task')
+          expect(taskParts).toHaveLength(2)
+          const childSessionIDs = taskParts.map((part) => {
+            const state = part.state as Record<string, unknown>
+            const metadata = state.metadata as Record<string, unknown>
+            const childSessionID = metadata.sessionId
+            expect(typeof childSessionID).toBe('string')
+            return childSessionID as string
+          })
+
+          const children = await client.session.children({
+            sessionID: parentSessionID,
+            directory: localFixture.projectDir,
+          })
+          for (const childSessionID of childSessionIDs) {
+            const child = children.data.find(
+              (entry) => entry.id === childSessionID,
+            )
+            expect(child).toBeDefined()
+            expect(child?.parentID).toBe(parentSessionID)
+            const childMessages = await client.session.messages({
+              sessionID: childSessionID,
+              directory: localFixture.projectDir,
+            })
+            expect(
+              systematicMarkers(childMessages.data).length,
+            ).toBeGreaterThan(0)
+            assertPrivacySafeMarkers(childMessages.data)
+          }
+
+          expect(fs.existsSync(targetFile)).toBe(true)
+          const parentMints = receiptMintSummaries(parentMessages.data)
+          expect(parentMints.map(({ operation }) => operation)).toEqual([
+            'implementation',
+            'commit',
+          ])
+          assertPrivacySafeMarkers(parentMessages.data)
         } finally {
           if (host) await host.stop()
           model.stop()

--- a/tests/unit/opencode-operation-observer.test.ts
+++ b/tests/unit/opencode-operation-observer.test.ts
@@ -760,6 +760,53 @@ describe('OpenCode operation observer', () => {
     }
   })
 
+  test('keeps identical registered worktrees distinct by target digest', async () => {
+    const fixture = createRegisteredWorktreeFixture()
+    const secondLinkedWorktree = path.join(
+      path.dirname(fixture.linkedWorktree),
+      `${path.basename(fixture.linkedWorktree)}-second`,
+    )
+    try {
+      const added = runGit(fixture.parent.root, [
+        'worktree',
+        'add',
+        '--quiet',
+        '-b',
+        'linked-second',
+        secondLinkedWorktree,
+      ])
+      expect(added.status).toBe(0)
+
+      const first = await createOpencodeOperationObserver({
+        targetDirectory: fixture.linkedWorktree,
+      }).snapshot()
+      const second = await createOpencodeOperationObserver({
+        targetDirectory: secondLinkedWorktree,
+      }).snapshot()
+      expect(first.status).toBe('available')
+      expect(second.status).toBe('available')
+      if (first.status !== 'available' || second.status !== 'available') {
+        return
+      }
+
+      expect(
+        runGit(fixture.linkedWorktree, ['rev-parse', 'HEAD']).stdout.trim(),
+      ).toBe(runGit(secondLinkedWorktree, ['rev-parse', 'HEAD']).stdout.trim())
+      expect(
+        fs.readFileSync(
+          path.join(fixture.linkedWorktree, 'tracked.txt'),
+          'utf8',
+        ),
+      ).toBe(
+        fs.readFileSync(path.join(secondLinkedWorktree, 'tracked.txt'), 'utf8'),
+      )
+      expect(first.snapshot.targetDigest).not.toBe(second.snapshot.targetDigest)
+    } finally {
+      fs.rmSync(secondLinkedWorktree, { recursive: true, force: true })
+      fixture.cleanup()
+    }
+  })
+
   test('fails closed on command failure and bounded output without exposing raw facts', async () => {
     const fixture = createGitFixture()
     const secret = 'raw-observer-secret'

--- a/tests/unit/opencode-operation-observer.test.ts
+++ b/tests/unit/opencode-operation-observer.test.ts
@@ -22,6 +22,12 @@ interface SeparatedGitFixture {
   cleanup(): void
 }
 
+interface RegisteredWorktreeFixture {
+  parent: GitFixture
+  linkedWorktree: string
+  cleanup(): void
+}
+
 function runGit(
   root: string,
   args: readonly string[],
@@ -53,6 +59,34 @@ function createGitFixture(): GitFixture {
   return {
     root,
     cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  }
+}
+
+function createRegisteredWorktreeFixture(): RegisteredWorktreeFixture {
+  const parent = createGitFixture()
+  const linkedWorktree = path.join(
+    path.dirname(parent.root),
+    `${path.basename(parent.root)}-linked`,
+  )
+  const result = runGit(parent.root, [
+    'worktree',
+    'add',
+    '--quiet',
+    '-b',
+    'linked',
+    linkedWorktree,
+  ])
+  if (result.status !== 0) {
+    parent.cleanup()
+    throw new Error('git setup failed: worktree add')
+  }
+  return {
+    parent,
+    linkedWorktree,
+    cleanup: () => {
+      fs.rmSync(linkedWorktree, { recursive: true, force: true })
+      parent.cleanup()
+    },
   }
 }
 
@@ -123,6 +157,278 @@ function createSeparatedGitRemoteFixture(): SeparatedGitFixture {
 }
 
 describe('OpenCode operation observer', () => {
+  test('validates a registered linked worktree against its parent identity', () => {
+    const fixture = createRegisteredWorktreeFixture()
+    try {
+      const observer = createOpencodeOperationObserver({
+        targetDirectory: fixture.parent.root,
+      })
+
+      expect(
+        observer.validateRegisteredWorktree(fixture.linkedWorktree),
+      ).toEqual(
+        expect.objectContaining({
+          status: 'ok',
+          targetRoot: fs.realpathSync(fixture.linkedWorktree),
+        }),
+      )
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('validates the parent main checkout as a registered worktree', () => {
+    const fixture = createGitFixture()
+    try {
+      const observer = createOpencodeOperationObserver({
+        targetDirectory: fixture.root,
+      })
+
+      expect(observer.validateRegisteredWorktree(fixture.root)).toEqual(
+        expect.objectContaining({
+          status: 'ok',
+          targetRoot: fs.realpathSync(fixture.root),
+          commonDir: fs.realpathSync(path.join(fixture.root, '.git')),
+        }),
+      )
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('keeps the parent worktree membership snapshot immutable', () => {
+    const parent = createGitFixture()
+    const observer = createOpencodeOperationObserver({
+      targetDirectory: parent.root,
+    })
+    const linkedWorktree = path.join(
+      path.dirname(parent.root),
+      `${path.basename(parent.root)}-late-linked`,
+    )
+    try {
+      const added = runGit(parent.root, [
+        'worktree',
+        'add',
+        '--quiet',
+        '-b',
+        'late-linked',
+        linkedWorktree,
+      ])
+      expect(added.status).toBe(0)
+      expect(observer.validateRegisteredWorktree(linkedWorktree)).toEqual({
+        status: 'error',
+        reasonCode: 'target-unavailable',
+      })
+    } finally {
+      fs.rmSync(linkedWorktree, { recursive: true, force: true })
+      parent.cleanup()
+    }
+  })
+
+  test('canonicalizes a symlink root to the registered worktree identity', () => {
+    const fixture = createRegisteredWorktreeFixture()
+    const linkedAlias = path.join(
+      path.dirname(fixture.linkedWorktree),
+      `${path.basename(fixture.linkedWorktree)}-alias`,
+    )
+    try {
+      fs.symlinkSync(fixture.linkedWorktree, linkedAlias, 'dir')
+      const observer = createOpencodeOperationObserver({
+        targetDirectory: fixture.parent.root,
+      })
+
+      expect(observer.validateRegisteredWorktree(linkedAlias)).toEqual(
+        expect.objectContaining({
+          status: 'ok',
+          targetRoot: fs.realpathSync(fixture.linkedWorktree),
+        }),
+      )
+    } finally {
+      fs.rmSync(linkedAlias, { force: true })
+      fixture.cleanup()
+    }
+  })
+
+  test('rejects an independent unrelated repository', () => {
+    const parent = createGitFixture()
+    const unrelated = createGitFixture()
+    try {
+      const observer = createOpencodeOperationObserver({
+        targetDirectory: parent.root,
+      })
+
+      expect(observer.validateRegisteredWorktree(unrelated.root)).toEqual({
+        status: 'error',
+        reasonCode: 'target-unavailable',
+      })
+    } finally {
+      unrelated.cleanup()
+      parent.cleanup()
+    }
+  })
+
+  test('rejects an independent nested repository inside the parent checkout', () => {
+    const parent = createGitFixture()
+    const nested = path.join(parent.root, 'nested-repo')
+    fs.mkdirSync(nested)
+    runGit(nested, ['init', '--quiet'])
+    try {
+      const observer = createOpencodeOperationObserver({
+        targetDirectory: parent.root,
+      })
+
+      expect(observer.validateRegisteredWorktree(nested)).toEqual({
+        status: 'error',
+        reasonCode: 'target-unavailable',
+      })
+    } finally {
+      parent.cleanup()
+    }
+  })
+
+  test('rejects a submodule target whose common directory is under git modules', () => {
+    const parent = createGitFixture()
+    const submodule = createGitFixture()
+    try {
+      const added = runGit(parent.root, [
+        '-c',
+        'protocol.file.allow=always',
+        'submodule',
+        'add',
+        '--quiet',
+        submodule.root,
+        'submodule',
+      ])
+      expect(added.status).toBe(0)
+      runGit(parent.root, ['commit', '--quiet', '-am', 'add submodule'])
+      const observer = createOpencodeOperationObserver({
+        targetDirectory: parent.root,
+      })
+
+      expect(
+        observer.validateRegisteredWorktree(
+          path.join(parent.root, 'submodule'),
+        ),
+      ).toEqual({
+        status: 'error',
+        reasonCode: 'target-unavailable',
+      })
+    } finally {
+      submodule.cleanup()
+      parent.cleanup()
+    }
+  })
+
+  test('rejects a fake gitfile that points directly at the parent git directory', () => {
+    const parent = createGitFixture()
+    const fakeRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'systematic-observer-fake-'),
+    )
+    try {
+      fs.writeFileSync(
+        path.join(fakeRoot, '.git'),
+        `gitdir: ${path.join(parent.root, '.git')}\n`,
+      )
+      const observer = createOpencodeOperationObserver({
+        targetDirectory: parent.root,
+      })
+
+      expect(observer.validateRegisteredWorktree(fakeRoot)).toEqual({
+        status: 'error',
+        reasonCode: 'target-unavailable',
+      })
+    } finally {
+      fs.rmSync(fakeRoot, { recursive: true, force: true })
+      parent.cleanup()
+    }
+  })
+
+  test('rejects a fake gitfile that points at a registered worktree admin directory', () => {
+    const fixture = createRegisteredWorktreeFixture()
+    const fakeRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'systematic-observer-fake-'),
+    )
+    try {
+      const admin = runGit(fixture.linkedWorktree, [
+        'rev-parse',
+        '--absolute-git-dir',
+      ]).stdout.trim()
+      fs.writeFileSync(path.join(fakeRoot, '.git'), `gitdir: ${admin}\n`)
+      const observer = createOpencodeOperationObserver({
+        targetDirectory: fixture.parent.root,
+      })
+
+      expect(observer.validateRegisteredWorktree(fakeRoot)).toEqual({
+        status: 'error',
+        reasonCode: 'target-unavailable',
+      })
+    } finally {
+      fs.rmSync(fakeRoot, { recursive: true, force: true })
+      fixture.cleanup()
+    }
+  })
+
+  test('ignores poisoned ambient GIT variables in observer subprocesses', async () => {
+    const parent = createGitFixture()
+    const unrelated = createGitFixture()
+    const traceFile = path.join(parent.root, 'git-trace.log')
+    const poison = {
+      GIT_DIR: path.join(parent.root, '.git'),
+      GIT_WORK_TREE: parent.root,
+      GIT_COMMON_DIR: path.join(parent.root, '.git'),
+      GIT_INDEX_FILE: path.join(parent.root, '.git', 'index'),
+      GIT_OBJECT_DIRECTORY: path.join(parent.root, '.git', 'objects'),
+      GIT_ALTERNATE_OBJECT_DIRECTORIES: path.join(
+        parent.root,
+        '.git',
+        'objects',
+      ),
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'foo.bar',
+      GIT_CONFIG_VALUE_0: 'baz',
+      GIT_TRACE: traceFile,
+    } as const
+    try {
+      fs.writeFileSync(path.join(unrelated.root, 'tracked.txt'), 'unrelated\n')
+      runGit(unrelated.root, ['add', 'tracked.txt'])
+      runGit(unrelated.root, ['commit', '--quiet', '-m', 'unrelated'])
+
+      const child = Bun.spawnSync(
+        [
+          process.execPath,
+          '-e',
+          [
+            "import { createOpencodeOperationObserver } from './src/lib/opencode-operation-observer.ts'",
+            'const observer = createOpencodeOperationObserver({ targetDirectory: process.env.PARENT_DIRECTORY })',
+            'const result = observer.validateRegisteredWorktree(process.env.TARGET_DIRECTORY)',
+            'process.stdout.write(JSON.stringify(result))',
+          ].join(';'),
+        ],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            ...poison,
+            PARENT_DIRECTORY: parent.root,
+            TARGET_DIRECTORY: unrelated.root,
+          },
+          stdout: 'pipe',
+          stderr: 'pipe',
+        },
+      )
+      expect(child.exitCode).toBe(0)
+      const poisoned = JSON.parse(child.stdout.toString()) as unknown
+      expect(poisoned).toEqual({
+        status: 'error',
+        reasonCode: 'target-unavailable',
+      })
+      expect(fs.existsSync(traceFile)).toBe(false)
+    } finally {
+      unrelated.cleanup()
+      parent.cleanup()
+    }
+  })
+
   test('keeps target stable while repository and worktree revisions change', async () => {
     const fixture = createGitFixture()
     try {
@@ -613,7 +919,9 @@ describe('OpenCode operation observer', () => {
       const remoteTimeouts: number[] = []
       const remote = createOpencodeOperationObserver({
         targetDirectory: fixture.root,
-        limits: { maxCommandTimeoutMs: 7 } satisfies OperationObserverLimits,
+        limits: {
+          maxCommandTimeoutMs: 1_000,
+        } satisfies OperationObserverLimits,
         remoteCommandRunner: (
           executable,
           args,
@@ -650,7 +958,7 @@ describe('OpenCode operation observer', () => {
         remote.remoteSnapshot('pr-creation', 'after'),
       ).resolves.toMatchObject({ status: 'available' })
       expect(remoteTimeouts.length).toBeGreaterThan(0)
-      expect(new Set(remoteTimeouts)).toEqual(new Set([7]))
+      expect(new Set(remoteTimeouts)).toEqual(new Set([1_000]))
     } finally {
       fixture.cleanup()
     }

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -71,6 +71,7 @@ const OPERATION_SCOPE = {
   workspaceIdentity: 'a'.repeat(64),
   repositoryIdentity: 'b'.repeat(64),
   worktreeIdentity: 'c'.repeat(64),
+  operationTargetIdentity: 'a'.repeat(64),
 }
 
 interface TargetDerivationFixture {
@@ -168,6 +169,14 @@ function sequenceObserver(
   const remoteIndexes = new Map<string, number>()
   return {
     targetDigest: snapshots[0]?.targetDigest ?? 'a'.repeat(64),
+    validateRegisteredWorktree(candidateDirectory) {
+      return {
+        status: 'ok',
+        targetRoot: candidateDirectory,
+        gitDir: path.join(candidateDirectory, '.git'),
+        commonDir: path.join(candidateDirectory, '.git'),
+      }
+    },
     async snapshot() {
       const snapshot = snapshots[Math.min(index++, snapshots.length - 1)]
       if (!snapshot) {
@@ -318,6 +327,7 @@ function mintReceipt(
     unitId: currentStatus.unit.unitId,
     workspaceIdentity: scope.workspaceIdentity,
     repositoryIdentity: scope.repositoryIdentity,
+    operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
     worktreeIdentity:
       operation === 'implementation'
         ? 'worktree-before'
@@ -337,6 +347,7 @@ function mintReceipt(
       workspaceIdentity: scope.workspaceIdentity,
       repositoryIdentity: scope.repositoryIdentity,
       worktreeIdentity: scope.worktreeIdentity,
+      operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
     },
     classification: {
       outcome: 'accepted',
@@ -1779,6 +1790,7 @@ describe('OpenCode workflow guard adapter', () => {
       workspaceIdentity: SCOPE.workspaceIdentity,
       repositoryIdentity: SCOPE.repositoryIdentity,
       worktreeIdentity: SCOPE.worktreeIdentity,
+      operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
     })
 
     const sharedOutput = { title: 'pending', output: 'pending', metadata: {} }
@@ -1990,7 +2002,13 @@ describe('OpenCode workflow guard adapter', () => {
         expect(observation.context.workspaceIdentity).toBe(
           OPERATION_SCOPE.workspaceIdentity,
         )
+        expect(observation.context.operationTargetIdentity).toBe(
+          OPERATION_SCOPE.workspaceIdentity,
+        )
         expect(observation.after?.workspaceIdentity).toBe(
+          OPERATION_SCOPE.workspaceIdentity,
+        )
+        expect(observation.after?.operationTargetIdentity).toBe(
           OPERATION_SCOPE.workspaceIdentity,
         )
       }
@@ -2046,6 +2064,173 @@ describe('OpenCode workflow guard adapter', () => {
       ])
     })
   }
+
+  test('mints an implementation receipt for a write targeted at a registered worktree', async () => {
+    const fixture = createTargetDerivationFixture()
+    try {
+      const parentObserver = createOpencodeOperationObserver({
+        targetDirectory: fixture.parentRoot,
+      })
+      const initial = await parentObserver.snapshot()
+      if (initial.status !== 'available') throw new Error('parent unavailable')
+      const observations: ReceiptOperationObservation[] = []
+      const classifier = createReceiptClassifier()
+      const adapter = createOpencodeWorkflowGuard({
+        config: { mode: 'observe' },
+        workspaceIdentity: initial.snapshot.targetDigest,
+        repositoryIdentity: initial.snapshot.repositoryRevisionDigest,
+        worktreeIdentity: initial.snapshot.worktreeRevisionDigest,
+        targetDirectory: fixture.parentRoot,
+        observer: parentObserver,
+        classifier: {
+          ...classifier,
+          classifyOperation: async (input: unknown) => {
+            observations.push(input as ReceiptOperationObservation)
+            return classifier.classifyOperation?.(input)
+          },
+        },
+      })
+      await observeSkill(adapter, 'systematic_skill', 'ce:work')
+
+      const filePath = path.join(fixture.linkedRoot, 'targeted.txt')
+      const input = {
+        tool: 'write',
+        sessionID: SESSION_A,
+        callID: 'worktree-targeted-write',
+        args: { filePath, content: 'changed' },
+      }
+      await adapter.hooks['tool.execute.before'](input, { args: input.args })
+      fs.writeFileSync(filePath, 'changed')
+      await adapter.hooks['tool.execute.after'](input, {
+        title: 'write complete',
+        output: 'changed',
+        metadata: {},
+      })
+
+      const receipts = adapter.ledger(SESSION_A)?.listReceipts() ?? []
+      expect(observations).toHaveLength(2)
+      expect(observations.at(-1)).toMatchObject({
+        operation: 'implementation',
+        context: {
+          operationTargetIdentity: expect.any(String),
+        },
+        after: {
+          operationTargetIdentity: expect.any(String),
+        },
+      })
+      expect(receipts).toHaveLength(1)
+      expect(receipts[0]?.canonical.operation).toBe('implementation')
+      expect(receipts[0]?.canonical.operationTargetIdentity).toBe(
+        createOpencodeOperationObserver({
+          targetDirectory: fixture.linkedRoot,
+        }).targetDigest,
+      )
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('rejects a worktree that is removed and recreated at the same path between hooks', async () => {
+    const fixture = createTargetDerivationFixture()
+    try {
+      const parentObserver = createOpencodeOperationObserver({
+        targetDirectory: fixture.parentRoot,
+      })
+      const initial = await parentObserver.snapshot()
+      if (initial.status !== 'available') throw new Error('parent unavailable')
+      const adapter = createOpencodeWorkflowGuard({
+        config: { mode: 'observe' },
+        workspaceIdentity: initial.snapshot.targetDigest,
+        repositoryIdentity: initial.snapshot.repositoryRevisionDigest,
+        worktreeIdentity: initial.snapshot.worktreeRevisionDigest,
+        targetDirectory: fixture.parentRoot,
+        observer: parentObserver,
+        classifier: createReceiptClassifier(),
+      })
+      await observeSkill(adapter, 'systematic_skill', 'ce:work')
+
+      const input = {
+        tool: 'write',
+        sessionID: SESSION_A,
+        callID: 'recreated-worktree-write',
+        args: {
+          filePath: path.join(fixture.linkedRoot, 'targeted.txt'),
+          content: 'changed',
+        },
+      }
+      await adapter.hooks['tool.execute.before'](input, { args: input.args })
+      runTargetFixtureGit(fixture.parentRoot, [
+        'worktree',
+        'remove',
+        '--force',
+        fixture.linkedRoot,
+      ])
+      runTargetFixtureGit(fixture.parentRoot, [
+        'worktree',
+        'add',
+        '--quiet',
+        '-b',
+        'linked-recreated',
+        fixture.linkedRoot,
+      ])
+      await adapter.hooks['tool.execute.after'](input, {
+        title: 'write complete',
+        output: 'changed',
+        metadata: {},
+      })
+
+      expect(ledger(adapter).listReceipts()).toHaveLength(0)
+      expect(status(adapter).state).toBe('rejected')
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('does not fall back to a parent receipt for an invalid target after a parent change', async () => {
+    const fixture = createTargetDerivationFixture()
+    try {
+      const parentObserver = createOpencodeOperationObserver({
+        targetDirectory: fixture.parentRoot,
+      })
+      const initial = await parentObserver.snapshot()
+      if (initial.status !== 'available') throw new Error('parent unavailable')
+      const adapter = createOpencodeWorkflowGuard({
+        config: { mode: 'observe' },
+        workspaceIdentity: initial.snapshot.targetDigest,
+        repositoryIdentity: initial.snapshot.repositoryRevisionDigest,
+        worktreeIdentity: initial.snapshot.worktreeRevisionDigest,
+        targetDirectory: fixture.parentRoot,
+        observer: parentObserver,
+        classifier: createReceiptClassifier(),
+      })
+      await observeSkill(adapter, 'systematic_skill', 'ce:work')
+
+      const input = {
+        tool: 'write',
+        sessionID: SESSION_A,
+        callID: 'invalid-target-with-parent-change',
+        args: {
+          filePath: path.join(fixture.unrelatedRoot, 'targeted.txt'),
+          content: 'should not mint',
+        },
+      }
+      await adapter.hooks['tool.execute.before'](input, { args: input.args })
+      fs.appendFileSync(
+        path.join(fixture.parentRoot, 'tracked.txt'),
+        'parent\n',
+      )
+      await adapter.hooks['tool.execute.after'](input, {
+        title: 'write complete',
+        output: 'changed',
+        metadata: {},
+      })
+
+      expect(ledger(adapter).listReceipts()).toHaveLength(0)
+      expect(status(adapter).state).toBe('unavailable')
+    } finally {
+      fixture.cleanup()
+    }
+  })
 
   test('projects observer commitClosure through the operation observation', async () => {
     const observations: ReceiptOperationObservation[] = []
@@ -2840,6 +3025,7 @@ describe('OpenCode workflow guard adapter', () => {
           epochId: EPOCH_ID_A,
           unitId: UNIT_ID_A,
           workspaceIdentity: 'workspace-a',
+          operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
           worktreeIdentity: 'worktree-before',
         },
       })
@@ -2849,10 +3035,12 @@ describe('OpenCode workflow guard adapter', () => {
           epochId: EPOCH_ID_A,
           unitId: UNIT_ID_A,
           workspaceIdentity: 'workspace-a',
+          operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
           worktreeIdentity: 'worktree-before',
         },
         after: {
           workspaceIdentity: 'workspace-a',
+          operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
           worktreeIdentity: 'worktree-after',
         },
         classification: {
@@ -3244,6 +3432,7 @@ describe('OpenCode workflow guard adapter', () => {
           epochId: EPOCH_ID,
           unitId: UNIT_ID,
           workspaceIdentity: 'ws',
+          operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
           worktreeIdentity: 'before',
         },
       })
@@ -3253,9 +3442,14 @@ describe('OpenCode workflow guard adapter', () => {
           epochId: EPOCH_ID,
           unitId: UNIT_ID,
           workspaceIdentity: 'ws',
+          operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
           worktreeIdentity: 'before',
         },
-        after: { workspaceIdentity: 'ws', worktreeIdentity: 'after' },
+        after: {
+          workspaceIdentity: 'ws',
+          operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
+          worktreeIdentity: 'after',
+        },
         classification: {
           outcome: 'accepted',
           category: 'implementation',
@@ -3426,6 +3620,7 @@ describe('OpenCode workflow guard adapter', () => {
           epochId: EPOCH_ID,
           unitId: UNIT_ID,
           workspaceIdentity,
+          operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
           repositoryIdentity,
           worktreeIdentity: worktreeBeforeIdentity,
         },
@@ -3436,11 +3631,13 @@ describe('OpenCode workflow guard adapter', () => {
           epochId: EPOCH_ID,
           unitId: UNIT_ID,
           workspaceIdentity,
+          operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
           repositoryIdentity,
           worktreeIdentity: worktreeBeforeIdentity,
         },
         after: {
           workspaceIdentity,
+          operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
           repositoryIdentity,
           worktreeIdentity: worktreeAfterIdentity,
         },
@@ -3514,6 +3711,7 @@ describe('OpenCode workflow guard adapter', () => {
           epochId,
           unitId,
           workspaceIdentity: receiptWorkspaceIdentity,
+          operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
           repositoryIdentity: receipt.repositoryBeforeIdentity,
           worktreeIdentity: receipt.worktreeBeforeIdentity,
         }
@@ -3529,6 +3727,7 @@ describe('OpenCode workflow guard adapter', () => {
           context,
           after: {
             workspaceIdentity: receiptWorkspaceIdentity,
+            operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
             repositoryIdentity: receipt.repositoryAfterIdentity,
             worktreeIdentity: receipt.worktreeAfterIdentity,
             ...(receipt.operation === 'commit' ? { commitClosure: true } : {}),
@@ -3984,6 +4183,7 @@ describe('OpenCode workflow guard adapter', () => {
           epochId: EPOCH_ID,
           unitId: UNIT_ID,
           workspaceIdentity: 'ws',
+          operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
           worktreeIdentity: 'b',
         },
       })
@@ -3993,9 +4193,14 @@ describe('OpenCode workflow guard adapter', () => {
           epochId: EPOCH_ID,
           unitId: UNIT_ID,
           workspaceIdentity: 'ws',
+          operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
           worktreeIdentity: 'b',
         },
-        after: { workspaceIdentity: 'ws', worktreeIdentity: 'a' },
+        after: {
+          workspaceIdentity: 'ws',
+          operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
+          worktreeIdentity: 'a',
+        },
         classification: {
           outcome: 'accepted',
           category: 'implementation',

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -4071,6 +4071,14 @@ describe('OpenCode workflow guard adapter', () => {
         sessionSalt: ownSalt,
         observer: {
           targetDigest: OPERATION_SCOPE.workspaceIdentity,
+          validateRegisteredWorktree(candidateDirectory: string) {
+            return {
+              status: 'ok' as const,
+              targetRoot: candidateDirectory,
+              gitDir: `${candidateDirectory}/.git`,
+              commonDir: `${candidateDirectory}/.git`,
+            }
+          },
           async snapshot() {
             snapshotCalled = true
             return {
@@ -4256,6 +4264,14 @@ describe('OpenCode workflow guard adapter', () => {
         runtimeRequiredOperations,
         observer: {
           targetDigest: OPERATION_SCOPE.workspaceIdentity,
+          validateRegisteredWorktree(candidateDirectory: string) {
+            return {
+              status: 'ok' as const,
+              targetRoot: candidateDirectory,
+              gitDir: `${candidateDirectory}/.git`,
+              commonDir: `${candidateDirectory}/.git`,
+            }
+          },
           async snapshot() {
             snapshotRef.called = true
             return {
@@ -4749,6 +4765,124 @@ describe('OpenCode workflow guard adapter', () => {
       expect(
         secondOutput.metadata[SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY],
       ).toBeUndefined()
+    })
+
+    test('rolls up a child implementation from a registered worktree target', async () => {
+      const fixture = createTargetDerivationFixture()
+      try {
+        const parentObserver = createOpencodeOperationObserver({
+          targetDirectory: fixture.parentRoot,
+        })
+        const initial = await parentObserver.snapshot()
+        if (initial.status !== 'available')
+          throw new Error('parent observer unavailable')
+
+        const ownIdentity = 'rollup-registered-worktree-target'
+        const ownSalt = new Uint8Array(32).fill(128)
+        const childSessionID = 'child-registered-worktree-target'
+        const parentSessionID = SESSION_A
+        let childParts: ReadonlyArray<unknown> = []
+        const adapter = createOpencodeWorkflowGuard({
+          config: { mode: 'observe', debug: false },
+          workspaceIdentity: initial.snapshot.targetDigest,
+          repositoryIdentity: initial.snapshot.repositoryRevisionDigest,
+          worktreeIdentity: initial.snapshot.worktreeRevisionDigest,
+          targetDirectory: fixture.parentRoot,
+          registrationIdentity: ownIdentity,
+          sessionSalt: ownSalt,
+          runtimeRequiredOperations: ['implementation'],
+          observer: parentObserver,
+          classifier: createReceiptClassifier(),
+          hostReadback: {
+            readSessionParts: async (sessionID) =>
+              sessionID === parentSessionID ? [] : childParts,
+            listChildren: async (sessionID) =>
+              sessionID === parentSessionID
+                ? [{ sessionId: childSessionID, parentID: parentSessionID }]
+                : [],
+          },
+        })
+
+        await observeSkill(
+          adapter,
+          'systematic_skill',
+          'ce:work',
+          'registered-worktree-parent-skill',
+          parentSessionID,
+        )
+
+        const childSkillOutput = {
+          title: 'Loaded skill',
+          output: 'child skill result',
+          metadata: {},
+        }
+        await observeSkill(
+          adapter,
+          'systematic_skill',
+          'ce:work',
+          'registered-worktree-child-skill',
+          childSessionID,
+          childSkillOutput,
+        )
+
+        const filePath = path.join(fixture.linkedRoot, 'rollup-targeted.txt')
+        const childWriteInput = {
+          tool: 'write',
+          sessionID: childSessionID,
+          callID: 'registered-worktree-child-write',
+          args: { filePath, content: 'changed' },
+        }
+        const childWriteOutput = {
+          title: 'write complete',
+          output: 'changed',
+          metadata: {},
+        }
+        await adapter.hooks['tool.execute.before'](childWriteInput, {
+          args: childWriteInput.args,
+        })
+        fs.writeFileSync(filePath, 'changed')
+        await adapter.hooks['tool.execute.after'](
+          childWriteInput,
+          childWriteOutput,
+        )
+
+        const childSkillMarkers =
+          childSkillOutput.metadata[SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]
+        const childWriteMarker =
+          childWriteOutput.metadata[SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]
+        childParts = [
+          {
+            info: {},
+            parts: [
+              {
+                state: {
+                  metadata: {
+                    [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: [
+                      ...(Array.isArray(childSkillMarkers)
+                        ? childSkillMarkers
+                        : childSkillMarkers
+                          ? [childSkillMarkers]
+                          : []),
+                      ...(childWriteMarker ? [childWriteMarker] : []),
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+        ]
+
+        await fireTaskAfter(adapter, childSessionID, parentSessionID)
+
+        const receipts = ledger(adapter, parentSessionID).listReceipts()
+        expect(receipts).toHaveLength(1)
+        expect(receipts[0]?.canonical.operation).toBe('implementation')
+        expect(status(adapter, parentSessionID).satisfiedOperations).toContain(
+          'implementation',
+        )
+      } finally {
+        fixture.cleanup()
+      }
     })
 
     test('skips stale child receipts, mints a later current receipt, and rolls up once', async () => {

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -2168,6 +2168,42 @@ describe('OpenCode workflow guard adapter', () => {
     expect(secondPass).toContain('unavailable')
   })
 
+  test('round-trips operation-target-mismatch in prior guard marker sources', async () => {
+    const adapter = createAdapter('protected')
+    const priorSource = {
+      source: 'prior-registration',
+      state: 'rejected',
+      reasonCode: 'operation-target-mismatch',
+      enforcement: 'protected',
+      statusDigest: 'prior-status',
+    }
+    const output = {
+      system: [
+        `<SYSTEMATIC_WORKFLOW_GUARD>${JSON.stringify({
+          protocolVersion: 2,
+          sources: [priorSource],
+          aggregate: priorSource,
+        })}</SYSTEMATIC_WORKFLOW_GUARD>`,
+      ],
+    }
+
+    await adapter.hooks['experimental.chat.system.transform'](
+      { sessionID: SESSION_A },
+      output,
+    )
+
+    const body = output.system
+      .join('\n')
+      .match(
+        /<SYSTEMATIC_WORKFLOW_GUARD>(.*?)<\/SYSTEMATIC_WORKFLOW_GUARD>/s,
+      )?.[1]
+    if (!body) throw new Error('guard marker missing')
+    const document = JSON.parse(body) as {
+      sources: Array<{ source: string; reasonCode: string }>
+    }
+    expect(document.sources).toContainEqual(priorSource)
+  })
+
   test('malformed prior guard marker fails closed and internal title transforms stay untouched', async () => {
     const adapter = createAdapter('protected')
     const malformed = {

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import { z } from 'zod'
 
 import type {
@@ -7,9 +10,11 @@ import type {
   OperationObserverRemoteResult,
   OperationObserverSnapshot,
 } from '../../src/lib/opencode-operation-observer.js'
+import { createOpencodeOperationObserver } from '../../src/lib/opencode-operation-observer.js'
 import {
   createOpencodeWorkflowGuard,
   createWorkflowGuardBlockedError,
+  deriveOpencodeOperationTarget,
   isWorkflowGuardBlockedError,
   type OpencodeWorkflowGuard,
   SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY,
@@ -66,6 +71,91 @@ const OPERATION_SCOPE = {
   workspaceIdentity: 'a'.repeat(64),
   repositoryIdentity: 'b'.repeat(64),
   worktreeIdentity: 'c'.repeat(64),
+}
+
+interface TargetDerivationFixture {
+  readonly parentRoot: string
+  readonly linkedRoot: string
+  readonly secondLinkedRoot: string
+  readonly unrelatedRoot: string
+  cleanup(): void
+}
+
+function runTargetFixtureGit(
+  cwd: string,
+  args: readonly string[],
+): {
+  readonly status: number
+  readonly stdout: string
+  readonly stderr: string
+} {
+  const result = Bun.spawnSync(['git', ...args], {
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  return {
+    status: result.exitCode ?? -1,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  }
+}
+
+function createTargetDerivationFixture(): TargetDerivationFixture {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'systematic-target-'))
+  const parentRoot = path.join(root, 'parent')
+  const linkedRoot = path.join(root, 'linked')
+  const secondLinkedRoot = path.join(root, 'linked-second')
+  const unrelatedRoot = path.join(root, 'unrelated')
+  fs.mkdirSync(parentRoot)
+  fs.mkdirSync(unrelatedRoot)
+
+  const git = (cwd: string, args: readonly string[]) => {
+    const result = runTargetFixtureGit(cwd, args)
+    if (result.status !== 0) {
+      throw new Error(`target fixture git setup failed: ${args.join(' ')}`)
+    }
+  }
+  git(parentRoot, ['init', '--quiet'])
+  git(parentRoot, ['config', 'user.email', 'target@example.invalid'])
+  git(parentRoot, ['config', 'user.name', 'Target Test'])
+  fs.writeFileSync(path.join(parentRoot, 'tracked.txt'), 'parent\n')
+  fs.mkdirSync(path.join(parentRoot, 'nested'))
+  git(parentRoot, ['add', '.'])
+  git(parentRoot, ['commit', '--quiet', '-m', 'initial'])
+  git(parentRoot, ['worktree', 'add', '--quiet', '-b', 'linked', linkedRoot])
+  git(parentRoot, [
+    'worktree',
+    'add',
+    '--quiet',
+    '-b',
+    'linked-second',
+    secondLinkedRoot,
+  ])
+  git(unrelatedRoot, ['init', '--quiet'])
+
+  return {
+    parentRoot,
+    linkedRoot,
+    secondLinkedRoot,
+    unrelatedRoot,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  }
+}
+
+function deriveWithFixture(
+  fixture: TargetDerivationFixture,
+  tool: 'write' | 'edit' | 'apply_patch' | 'bash',
+  args: Record<string, unknown>,
+) {
+  const observer = createOpencodeOperationObserver({
+    targetDirectory: fixture.parentRoot,
+  })
+  return deriveOpencodeOperationTarget(tool, args, {
+    parentTargetRoot: fixture.parentRoot,
+    sessionLocation: fixture.parentRoot,
+    validateRegisteredWorktree: observer.validateRegisteredWorktree,
+  })
 }
 
 function sequenceObserver(
@@ -264,6 +354,395 @@ function mintReceipt(
 }
 
 describe('OpenCode workflow guard adapter', () => {
+  test('target derivation: registered worktree from bash workdir', () => {
+    const result = deriveOpencodeOperationTarget(
+      'bash',
+      { workdir: '../linked-worktree' },
+      {
+        parentTargetRoot: '/parent',
+        sessionLocation: '/parent',
+        realPath: (value) => value,
+        validateRegisteredWorktree: (candidate) =>
+          candidate === '/linked-worktree'
+            ? {
+                status: 'ok',
+                targetRoot: candidate,
+                gitDir: '/parent/.git/worktrees/linked',
+                commonDir: '/parent/.git',
+              }
+            : { status: 'error', reasonCode: 'target-unavailable' },
+      },
+    )
+
+    expect(result).toEqual({
+      status: 'available',
+      targetRoot: '/linked-worktree',
+    })
+  })
+
+  test('target derivation: worktree from write file path', () => {
+    const result = deriveOpencodeOperationTarget(
+      'write',
+      { path: '/linked-worktree/src/file.ts' },
+      {
+        parentTargetRoot: '/parent',
+        sessionLocation: '/parent',
+        realPath: (value) => value,
+        validateRegisteredWorktree: (candidate) =>
+          candidate === '/linked-worktree/src'
+            ? {
+                status: 'ok',
+                targetRoot: '/linked-worktree',
+                gitDir: '/parent/.git/worktrees/linked',
+                commonDir: '/parent/.git',
+              }
+            : { status: 'error', reasonCode: 'target-unavailable' },
+      },
+    )
+
+    expect(result).toEqual({
+      status: 'available',
+      targetRoot: '/linked-worktree',
+    })
+  })
+
+  test('target derivation: one apply_patch target for every file path', () => {
+    const result = deriveOpencodeOperationTarget(
+      'apply_patch',
+      {
+        workdir: '/linked-worktree',
+        patchText: [
+          '*** Begin Patch',
+          '*** Add File: src/one.ts',
+          '+one',
+          '*** Update File: nested/two.ts',
+          '@@',
+          '-two',
+          '+updated',
+          '*** End Patch',
+        ].join('\n'),
+      },
+      {
+        parentTargetRoot: '/parent',
+        sessionLocation: '/parent',
+        realPath: (value) => value,
+        validateRegisteredWorktree: (candidate) =>
+          candidate === '/linked-worktree' ||
+          candidate === '/linked-worktree/src' ||
+          candidate === '/linked-worktree/nested'
+            ? {
+                status: 'ok',
+                targetRoot: '/linked-worktree',
+                gitDir: '/parent/.git/worktrees/linked',
+                commonDir: '/parent/.git',
+              }
+            : { status: 'error', reasonCode: 'target-unavailable' },
+      },
+    )
+
+    expect(result).toEqual({
+      status: 'available',
+      targetRoot: '/linked-worktree',
+    })
+  })
+
+  test('target derivation: canonical registered worktree for real bash workdir', () => {
+    const fixture = createTargetDerivationFixture()
+    try {
+      expect(
+        deriveWithFixture(fixture, 'bash', {
+          command: 'git status --short',
+          workdir: fixture.linkedRoot,
+        }),
+      ).toEqual({
+        status: 'available',
+        targetRoot: fs.realpathSync(fixture.linkedRoot),
+      })
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('target derivation: relative bash workdir stays on parent target', () => {
+    const fixture = createTargetDerivationFixture()
+    try {
+      expect(
+        deriveWithFixture(fixture, 'bash', {
+          command: 'git status --short',
+          workdir: 'nested',
+        }),
+      ).toEqual({
+        status: 'available',
+        targetRoot: fs.realpathSync(fixture.parentRoot),
+      })
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('target derivation: absent bash workdir uses parent target', () => {
+    const fixture = createTargetDerivationFixture()
+    try {
+      expect(
+        deriveWithFixture(fixture, 'bash', { command: 'git status --short' }),
+      ).toEqual({
+        status: 'available',
+        targetRoot: fs.realpathSync(fixture.parentRoot),
+      })
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('target derivation: write and edit support filePath and path', () => {
+    const fixture = createTargetDerivationFixture()
+    try {
+      const expected = {
+        status: 'available' as const,
+        targetRoot: fs.realpathSync(fixture.linkedRoot),
+      }
+      expect(
+        deriveWithFixture(fixture, 'write', {
+          filePath: path.join(fixture.linkedRoot, 'tracked.txt'),
+        }),
+      ).toEqual(expected)
+      expect(
+        deriveWithFixture(fixture, 'edit', {
+          path: path.join(fixture.linkedRoot, 'tracked.txt'),
+        }),
+      ).toEqual(expected)
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('target derivation: new write file uses canonical existing parent', () => {
+    const fixture = createTargetDerivationFixture()
+    try {
+      const targetDirectory = path.join(fixture.linkedRoot, 'new-files')
+      fs.mkdirSync(targetDirectory)
+      expect(
+        deriveWithFixture(fixture, 'write', {
+          path: path.join(targetDirectory, 'new.ts'),
+        }),
+      ).toEqual({
+        status: 'available',
+        targetRoot: fs.realpathSync(fixture.linkedRoot),
+      })
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('target derivation: multiple apply_patch files share one worktree', () => {
+    const fixture = createTargetDerivationFixture()
+    try {
+      fs.mkdirSync(path.join(fixture.linkedRoot, 'src'), { recursive: true })
+      fs.mkdirSync(path.join(fixture.linkedRoot, 'nested'), {
+        recursive: true,
+      })
+      fs.writeFileSync(path.join(fixture.linkedRoot, 'src', 'one.ts'), 'one\n')
+      fs.writeFileSync(
+        path.join(fixture.linkedRoot, 'nested', 'two.ts'),
+        'two\n',
+      )
+
+      expect(
+        deriveWithFixture(fixture, 'apply_patch', {
+          workdir: fixture.linkedRoot,
+          patchText: [
+            '*** Begin Patch',
+            '*** Update File: src/one.ts',
+            '*** Update File: nested/two.ts',
+            '*** End Patch',
+          ].join('\n'),
+        }),
+      ).toEqual({
+        status: 'available',
+        targetRoot: fs.realpathSync(fixture.linkedRoot),
+      })
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('target derivation: apply_patch spanning worktrees fails closed', () => {
+    const fixture = createTargetDerivationFixture()
+    try {
+      expect(
+        deriveWithFixture(fixture, 'apply_patch', {
+          patchText: [
+            '*** Begin Patch',
+            `*** Update File: ${path.join(fixture.linkedRoot, 'tracked.txt')}`,
+            `*** Update File: ${path.join(fixture.secondLinkedRoot, 'tracked.txt')}`,
+            '*** End Patch',
+          ].join('\n'),
+        }),
+      ).toEqual({
+        status: 'unavailable',
+        reasonCode: 'target-unavailable',
+      })
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('target derivation: unrelated explicit bash workdir fails closed', () => {
+    const fixture = createTargetDerivationFixture()
+    try {
+      expect(
+        deriveWithFixture(fixture, 'bash', {
+          command: 'git status --short',
+          workdir: fixture.unrelatedRoot,
+        }),
+      ).toEqual({
+        status: 'unavailable',
+        reasonCode: 'target-unavailable',
+      })
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('target derivation: absolute nested repository is not parent target', () => {
+    const fixture = createTargetDerivationFixture()
+    const nestedRepository = path.join(fixture.parentRoot, 'nested-repo')
+    try {
+      fs.mkdirSync(nestedRepository)
+      const initialized = runTargetFixtureGit(nestedRepository, [
+        'init',
+        '--quiet',
+      ])
+      expect(initialized.status).toBe(0)
+      expect(
+        deriveWithFixture(fixture, 'bash', {
+          command: 'git status --short',
+          workdir: nestedRepository,
+        }),
+      ).toEqual({
+        status: 'unavailable',
+        reasonCode: 'target-unavailable',
+      })
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('target derivation: absolute nested repository file fails closed', () => {
+    const fixture = createTargetDerivationFixture()
+    const nestedRepository = path.join(fixture.parentRoot, 'nested-repo')
+    const nestedFile = path.join(nestedRepository, 'nested.ts')
+    try {
+      fs.mkdirSync(nestedRepository)
+      const initialized = runTargetFixtureGit(nestedRepository, [
+        'init',
+        '--quiet',
+      ])
+      expect(initialized.status).toBe(0)
+      fs.writeFileSync(nestedFile, 'nested\n')
+      expect(deriveWithFixture(fixture, 'write', { path: nestedFile })).toEqual(
+        {
+          status: 'unavailable',
+          reasonCode: 'target-unavailable',
+        },
+      )
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('target derivation: explicit apply workdir validates relative files', () => {
+    const fixture = createTargetDerivationFixture()
+    const nestedRepository = path.join(fixture.parentRoot, 'nested-repo')
+    const nestedFile = path.join(nestedRepository, 'nested.ts')
+    try {
+      fs.mkdirSync(nestedRepository)
+      const initialized = runTargetFixtureGit(nestedRepository, [
+        'init',
+        '--quiet',
+      ])
+      expect(initialized.status).toBe(0)
+      fs.writeFileSync(nestedFile, 'nested\n')
+      expect(
+        deriveWithFixture(fixture, 'apply_patch', {
+          workdir: fixture.parentRoot,
+          patchText: [
+            '*** Begin Patch',
+            '*** Update File: nested-repo/nested.ts',
+            '*** End Patch',
+          ].join('\n'),
+        }),
+      ).toEqual({
+        status: 'unavailable',
+        reasonCode: 'target-unavailable',
+      })
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('target derivation: invalid explicit apply workdir fails closed', () => {
+    const fixture = createTargetDerivationFixture()
+    const nestedRepository = path.join(fixture.parentRoot, 'nested-repo')
+    try {
+      fs.mkdirSync(nestedRepository)
+      const initialized = runTargetFixtureGit(nestedRepository, [
+        'init',
+        '--quiet',
+      ])
+      expect(initialized.status).toBe(0)
+      expect(
+        deriveWithFixture(fixture, 'apply_patch', {
+          workdir: nestedRepository,
+          patchText: '',
+        }),
+      ).toEqual({
+        status: 'unavailable',
+        reasonCode: 'target-unavailable',
+      })
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('target derivation: escaping file symlink is rejected', () => {
+    const fixture = createTargetDerivationFixture()
+    const outsideFile = path.join(
+      path.dirname(fixture.parentRoot),
+      'outside.ts',
+    )
+    const escapedFile = path.join(fixture.linkedRoot, 'escaped.ts')
+    try {
+      fs.writeFileSync(outsideFile, 'outside\n')
+      fs.symlinkSync(outsideFile, escapedFile)
+
+      expect(
+        deriveWithFixture(fixture, 'write', { path: escapedFile }),
+      ).toEqual({
+        status: 'unavailable',
+        reasonCode: 'target-unavailable',
+      })
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('target derivation: linked worktree gitfile is rejected', () => {
+    const fixture = createTargetDerivationFixture()
+    try {
+      expect(
+        deriveWithFixture(fixture, 'write', {
+          path: path.join(fixture.linkedRoot, '.git'),
+        }),
+      ).toEqual({
+        status: 'unavailable',
+        reasonCode: 'target-unavailable',
+      })
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
   test('does not expose the trusted recovery seam as a host/model tool', () => {
     const adapter = createAdapter('observe')
 

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -364,6 +364,310 @@ function mintReceipt(
   if (observed.status !== 'accepted') throw new Error('receipt not observed')
 }
 
+function wrapReceiptMarkers(markers: readonly unknown[]): readonly unknown[] {
+  return [
+    {
+      info: {},
+      parts: [
+        {
+          state: {
+            metadata: {
+              [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: markers,
+            },
+          },
+        },
+      ],
+    },
+  ]
+}
+
+function buildPinnedRecoveryMarkers(
+  registrationIdentity: string,
+  sessionSalt: Uint8Array,
+  workspaceIdentity: string,
+  operationTargetIdentity: string,
+  repositoryIdentity: string,
+  worktreeIdentity: string,
+): readonly unknown[] {
+  const recoveryLedger = createReceiptLedger({
+    capabilityFlags: ['workflow-guard'],
+    registrationIdentity,
+    sessionSalt,
+  })
+  const epochId = 'a'.repeat(32)
+  const unitId = 'b'.repeat(32)
+  const digestCall = (value: string) =>
+    recoveryLedger.digestIdentity('call', value)
+  const epochStart = projectReceiptProgressionMarker(recoveryLedger, {
+    target: 'epoch',
+    state: 'started',
+    epochId,
+    family: 'work',
+    transitionDigest: digestCall('epoch-start'),
+    timestamp: 1,
+  })
+  const unitStart = projectReceiptProgressionMarker(recoveryLedger, {
+    target: 'unit',
+    state: 'started',
+    epochId,
+    unitId,
+    family: 'work',
+    requiredOperations: ['verification'],
+    resourceScopes: [],
+    pinnedOperationTargetIdentity: operationTargetIdentity,
+    transitionDigest: digestCall('unit-start'),
+    timestamp: 2,
+  })
+  if (!epochStart || !unitStart) throw new Error('progression marker failed')
+
+  const context = {
+    epochId,
+    unitId,
+    workspaceIdentity,
+    operationTargetIdentity,
+    repositoryIdentity,
+    worktreeIdentity,
+  }
+  const prepared = recoveryLedger.prepareObservation({
+    callId: 'recovered-verification',
+    operation: 'verification',
+    context,
+  })
+  if (prepared.status !== 'prepared') throw new Error('receipt not prepared')
+  const finalized = recoveryLedger.finalizeObservation({
+    callId: 'recovered-verification',
+    context,
+    after: context,
+    classification: {
+      outcome: 'accepted',
+      category: 'verification',
+      attribution: 'runtime-verified',
+      result: 'success',
+      sideEffect: 'not-required',
+      reasonCode: 'recognized-command',
+    },
+    terminal: { status: 'success', output: 'non-empty', noOp: false },
+  })
+  if (finalized.status !== 'finalized') {
+    throw new Error(
+      `pinned recovery receipt not finalized: ${JSON.stringify(finalized)}`,
+    )
+  }
+  const mint = projectReceiptMintMarker(finalized.receipt, sessionSalt)
+  if (!mint) throw new Error('receipt marker failed')
+  return [epochStart, unitStart, mint]
+}
+
+async function createPinnedRecoveryAdapter(): Promise<{
+  readonly fixture: TargetDerivationFixture
+  readonly adapter: OpencodeWorkflowGuard
+  readonly targetRoot: string
+  readonly targetIdentity: string
+  setTargetValidationAvailable(value: boolean): void
+}> {
+  const fixture = createTargetDerivationFixture()
+  const targetRoot = fs.realpathSync(fixture.linkedRoot)
+  const baseObserver = createOpencodeOperationObserver({
+    targetDirectory: fixture.parentRoot,
+  })
+  const initial = await baseObserver.snapshot()
+  if (initial.status !== 'available') {
+    fixture.cleanup()
+    throw new Error('parent unavailable')
+  }
+  const targetObserver = createOpencodeOperationObserver({
+    targetDirectory: targetRoot,
+  })
+  const targetInitial = await targetObserver.snapshot()
+  if (targetInitial.status !== 'available') {
+    fixture.cleanup()
+    throw new Error('target unavailable')
+  }
+  let targetValidationAvailable = true
+  const observer: OpencodeOperationObserver = {
+    targetDigest: baseObserver.targetDigest,
+    validateRegisteredWorktree: (candidateDirectory) => {
+      if (!targetValidationAvailable && candidateDirectory === targetRoot) {
+        return { status: 'error', reasonCode: 'target-unavailable' }
+      }
+      return baseObserver.validateRegisteredWorktree(candidateDirectory)
+    },
+    snapshot: () => baseObserver.snapshot(),
+  }
+  const registrationIdentity = 'pinned-completion-registration'
+  const sessionSalt = new Uint8Array(32).fill(137)
+  let parentMarkers: readonly unknown[] = []
+  const adapter = createOpencodeWorkflowGuard({
+    config: { mode: 'observe' },
+    workspaceIdentity: initial.snapshot.targetDigest,
+    repositoryIdentity: targetInitial.snapshot.repositoryRevisionDigest,
+    worktreeIdentity: targetInitial.snapshot.worktreeRevisionDigest,
+    targetDirectory: fixture.parentRoot,
+    sessionLocation: fixture.parentRoot,
+    registrationIdentity,
+    sessionSalt,
+    observer,
+    classifier: createReceiptClassifier(),
+    hostReadback: {
+      readSessionParts: async (sessionID) =>
+        sessionID === SESSION_A ? wrapReceiptMarkers(parentMarkers) : [],
+      listChildren: async () => [],
+    },
+  })
+
+  await observeSkill(
+    adapter,
+    'systematic_skill',
+    'ce:work',
+    'pinned-recovery-setup-skill',
+    SESSION_B,
+  )
+  const input = {
+    tool: 'bash' as const,
+    sessionID: SESSION_B,
+    callID: 'pinned-recovery-setup-write',
+    args: { command: 'git status --short', workdir: targetRoot },
+  }
+  await adapter.hooks['tool.execute.before'](input, { args: input.args })
+  await adapter.hooks['tool.execute.after'](input, {
+    title: 'tests complete',
+    output: 'pass',
+    metadata: { exit: 0 },
+  })
+
+  const targetResult = await targetObserver.snapshot()
+  if (targetResult.status !== 'available') {
+    fixture.cleanup()
+    throw new Error('target unavailable')
+  }
+  parentMarkers = buildPinnedRecoveryMarkers(
+    registrationIdentity,
+    sessionSalt,
+    initial.snapshot.targetDigest,
+    targetObserver.targetDigest,
+    targetResult.snapshot.repositoryRevisionDigest,
+    targetResult.snapshot.worktreeRevisionDigest,
+  )
+  await adapter.tools.systematic_workflow_status.execute(
+    {},
+    { sessionID: SESSION_A, metadata: () => {} },
+  )
+
+  return {
+    fixture,
+    adapter,
+    targetRoot,
+    targetIdentity: targetObserver.targetDigest,
+    setTargetValidationAvailable(value) {
+      targetValidationAvailable = value
+    },
+  }
+}
+
+async function createFreshPinnedAdapter(
+  requiredOperations: readonly ReceiptOperation[] = [
+    'implementation',
+    'verification',
+  ],
+): Promise<{
+  readonly fixture: TargetDerivationFixture
+  readonly adapter: OpencodeWorkflowGuard
+  readonly parentObserver: OpencodeOperationObserver
+  readonly targetRoot: string
+  readonly targetIdentity: string
+}> {
+  const fixture = createTargetDerivationFixture()
+  const targetRoot = fs.realpathSync(fixture.linkedRoot)
+  const parentObserver = createOpencodeOperationObserver({
+    targetDirectory: fixture.parentRoot,
+  })
+  const initial = await parentObserver.snapshot()
+  const targetObserver = createOpencodeOperationObserver({
+    targetDirectory: targetRoot,
+  })
+  if (initial.status !== 'available') {
+    fixture.cleanup()
+    throw new Error('parent unavailable')
+  }
+  const adapter = createOpencodeWorkflowGuard({
+    config: { mode: 'observe' },
+    workspaceIdentity: initial.snapshot.targetDigest,
+    repositoryIdentity: initial.snapshot.repositoryRevisionDigest,
+    worktreeIdentity: initial.snapshot.worktreeRevisionDigest,
+    targetDirectory: fixture.parentRoot,
+    sessionLocation: fixture.parentRoot,
+    observer: parentObserver,
+    classifier: createReceiptClassifier(),
+    runtimeRequiredOperations: requiredOperations,
+  })
+  await observeSkill(adapter, 'systematic_skill', 'ce:work')
+  return {
+    fixture,
+    adapter,
+    parentObserver,
+    targetRoot,
+    targetIdentity: targetObserver.targetDigest,
+  }
+}
+
+async function observeFreshWrite(
+  adapter: OpencodeWorkflowGuard,
+  targetPath: string,
+  content: string,
+  callID: string,
+): Promise<void> {
+  const input = {
+    tool: 'write' as const,
+    sessionID: SESSION_A,
+    callID,
+    args: { filePath: targetPath, content },
+  }
+  await adapter.hooks['tool.execute.before'](input, { args: input.args })
+  fs.writeFileSync(targetPath, content)
+  await adapter.hooks['tool.execute.after'](input, {
+    title: 'write complete',
+    output: 'changed',
+    metadata: {},
+  })
+}
+
+async function observeFreshVerification(
+  adapter: OpencodeWorkflowGuard,
+  targetRoot: string,
+  callID: string,
+): Promise<void> {
+  await observeOperationTool(
+    adapter,
+    'bash',
+    {
+      command: 'bun test tests/unit/example.test.ts',
+      workdir: targetRoot,
+    },
+    { title: 'verification complete', output: 'pass', metadata: { exit: 0 } },
+    callID,
+  )
+}
+
+async function completeUnit(
+  adapter: OpencodeWorkflowGuard,
+  callID: string,
+): Promise<{ output: string; metadata: Record<string, unknown> }> {
+  const input = {
+    tool: 'systematic_workflow_complete' as const,
+    sessionID: SESSION_A,
+    callID,
+  }
+  await adapter.hooks['tool.execute.before'](input, {
+    args: { target: 'unit' },
+  })
+  const output = { title: 'complete', output: 'done', metadata: {} }
+  await adapter.hooks['tool.execute.after'](
+    { ...input, args: { target: 'unit' } },
+    output,
+  )
+  return output
+}
+
 describe('OpenCode workflow guard adapter', () => {
   test('target derivation: registered worktree from bash workdir', () => {
     const result = deriveOpencodeOperationTarget(
@@ -2232,6 +2536,80 @@ describe('OpenCode workflow guard adapter', () => {
     }
   })
 
+  test('fails closed when a unit switches from one registered worktree target to another', async () => {
+    const fixture = createTargetDerivationFixture()
+    try {
+      const parentObserver = createOpencodeOperationObserver({
+        targetDirectory: fixture.parentRoot,
+      })
+      const initial = await parentObserver.snapshot()
+      if (initial.status !== 'available') throw new Error('parent unavailable')
+      const adapter = createOpencodeWorkflowGuard({
+        config: { mode: 'observe' },
+        workspaceIdentity: initial.snapshot.targetDigest,
+        repositoryIdentity: initial.snapshot.repositoryRevisionDigest,
+        worktreeIdentity: initial.snapshot.worktreeRevisionDigest,
+        targetDirectory: fixture.parentRoot,
+        observer: parentObserver,
+        classifier: createReceiptClassifier(),
+      })
+      await observeSkill(adapter, 'systematic_skill', 'ce:work')
+
+      const firstPath = path.join(fixture.linkedRoot, 'first-target.txt')
+      const firstInput = {
+        tool: 'write' as const,
+        sessionID: SESSION_A,
+        callID: 'target-switch-first',
+        args: { filePath: firstPath, content: 'first' },
+      }
+      await adapter.hooks['tool.execute.before'](firstInput, {
+        args: firstInput.args,
+      })
+      fs.writeFileSync(firstPath, 'first')
+      await adapter.hooks['tool.execute.after'](firstInput, {
+        title: 'write complete',
+        output: 'changed',
+        metadata: {},
+      })
+
+      const firstTargetIdentity = createOpencodeOperationObserver({
+        targetDirectory: fixture.linkedRoot,
+      }).targetDigest
+      expect(status(adapter).unit?.pinnedOperationTargetIdentity).toBe(
+        firstTargetIdentity,
+      )
+      expect(ledger(adapter).listReceipts()).toHaveLength(1)
+
+      const secondPath = path.join(
+        fixture.secondLinkedRoot,
+        'second-target.txt',
+      )
+      const secondInput = {
+        tool: 'write' as const,
+        sessionID: SESSION_A,
+        callID: 'target-switch-second',
+        args: { filePath: secondPath, content: 'second' },
+      }
+      await adapter.hooks['tool.execute.before'](secondInput, {
+        args: secondInput.args,
+      })
+      fs.writeFileSync(secondPath, 'second')
+      await adapter.hooks['tool.execute.after'](secondInput, {
+        title: 'write complete',
+        output: 'changed',
+        metadata: {},
+      })
+
+      expect(status(adapter).state).toBe('unavailable')
+      expect(status(adapter).unit?.pinnedOperationTargetIdentity).toBe(
+        firstTargetIdentity,
+      )
+      expect(ledger(adapter).listReceipts()).toHaveLength(1)
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
   test('projects observer commitClosure through the operation observation', async () => {
     const observations: ReceiptOperationObservation[] = []
     const adapter = createAdapter(
@@ -2861,6 +3239,319 @@ describe('OpenCode workflow guard adapter', () => {
         .listReceipts()
         .some((receipt) => receipt.canonical.consumption === 'consumed'),
     ).toBe(false)
+  })
+
+  test('requalifies a pinned worktree target during completion readback', async () => {
+    const setup = await createPinnedRecoveryAdapter()
+    try {
+      const { adapter } = setup
+      expect(status(adapter).unit?.pinnedOperationTargetIdentity).toBe(
+        setup.targetIdentity,
+      )
+
+      const completeInput = {
+        tool: 'systematic_workflow_complete' as const,
+        sessionID: SESSION_A,
+        callID: 'pinned-completion',
+      }
+      await adapter.hooks['tool.execute.before'](completeInput, {
+        args: { target: 'unit' },
+      })
+      const output = { title: 'complete', output: 'done', metadata: {} }
+      await adapter.hooks['tool.execute.after'](
+        { ...completeInput, args: { target: 'unit' } },
+        output,
+      )
+
+      expect(status(adapter).unit?.status).toBe('completed')
+      expect(output.output).toContain('workflow guard completed unit')
+    } finally {
+      setup.fixture.cleanup()
+    }
+  })
+
+  test('anchors fresh pinned completion readback to the worktree target', async () => {
+    const setup = await createFreshPinnedAdapter()
+    try {
+      const { adapter, fixture } = setup
+
+      const targetPath = path.join(fixture.linkedRoot, 'fresh-target.txt')
+      await observeFreshWrite(
+        adapter,
+        targetPath,
+        'fresh target',
+        'fresh-pinned-completion-write',
+      )
+      await observeFreshVerification(
+        adapter,
+        fixture.linkedRoot,
+        'fresh-pinned-completion-verification',
+      )
+      expect(ledger(adapter).listReceipts()).toHaveLength(2)
+
+      const output = await completeUnit(adapter, 'fresh-pinned-completion')
+
+      expect(status(adapter).unit?.status).toBe('completed')
+      expect(output.output).toContain('workflow guard completed unit')
+    } finally {
+      setup.fixture.cleanup()
+    }
+  })
+
+  test('rejects completion when pinned worktree content changes after evidence', async () => {
+    const setup = await createFreshPinnedAdapter()
+    try {
+      const targetPath = path.join(setup.targetRoot, 'content-drift.txt')
+      await observeFreshWrite(
+        setup.adapter,
+        targetPath,
+        'evidence content',
+        'content-drift-write',
+      )
+      await observeFreshVerification(
+        setup.adapter,
+        setup.targetRoot,
+        'content-drift-verification',
+      )
+      fs.appendFileSync(targetPath, '\npost-evidence drift')
+
+      const contentOutput = await completeUnit(
+        setup.adapter,
+        'content-drift-completion',
+      )
+
+      expect(contentOutput.output).toContain('stale-receipt')
+      expect(status(setup.adapter).state).toBe('unavailable')
+      expect(status(setup.adapter).unit?.status).toBe('active')
+      expect(
+        ledger(setup.adapter)
+          .listReceipts()
+          .some((receipt) => receipt.canonical.consumption === 'consumed'),
+      ).toBe(false)
+    } finally {
+      setup.fixture.cleanup()
+    }
+  })
+
+  test('stales only commit when pinned HEAD advances without content changes', async () => {
+    const setup = await createFreshPinnedAdapter([
+      'implementation',
+      'verification',
+      'commit',
+    ])
+    try {
+      const targetPath = path.join(setup.targetRoot, 'tracked.txt')
+      await observeFreshWrite(
+        setup.adapter,
+        targetPath,
+        'committed content',
+        'head-drift-write',
+      )
+      await observeFreshVerification(
+        setup.adapter,
+        setup.targetRoot,
+        'head-drift-verification',
+      )
+      const commitInput = {
+        tool: 'bash' as const,
+        sessionID: SESSION_A,
+        callID: 'head-drift-commit',
+        args: {
+          command: 'git commit -m "head drift baseline"',
+          workdir: setup.targetRoot,
+        },
+      }
+      await setup.adapter.hooks['tool.execute.before'](commitInput, {
+        args: commitInput.args,
+      })
+      const stageResult = Bun.spawnSync(['git', 'add', 'tracked.txt'], {
+        cwd: setup.targetRoot,
+      })
+      if (stageResult.exitCode !== 0) throw new Error('stage failed')
+      const commitResult = Bun.spawnSync(
+        ['git', 'commit', '-m', 'head drift baseline'],
+        { cwd: setup.targetRoot },
+      )
+      if (commitResult.exitCode !== 0) throw new Error('commit failed')
+      await setup.adapter.hooks['tool.execute.after'](commitInput, {
+        title: 'commit complete',
+        output: 'committed',
+        metadata: { exit: 0 },
+      })
+      const emptyCommit = Bun.spawnSync(
+        ['git', 'commit', '--allow-empty', '-m', 'outside completion'],
+        { cwd: setup.targetRoot },
+      )
+      if (emptyCommit.exitCode !== 0) throw new Error('empty commit failed')
+
+      const output = await completeUnit(setup.adapter, 'head-drift-completion')
+
+      expect(output.output).toContain('stale-receipt')
+      expect(status(setup.adapter).state).toBe('unavailable')
+      expect(status(setup.adapter).satisfiedOperations).toEqual([
+        'implementation',
+        'verification',
+      ])
+      expect(status(setup.adapter).unit?.status).toBe('active')
+      expect(
+        ledger(setup.adapter)
+          .listReceipts()
+          .some((receipt) => receipt.canonical.consumption === 'consumed'),
+      ).toBe(false)
+    } finally {
+      setup.fixture.cleanup()
+    }
+  })
+
+  test('fails closed when the pinned target changes during completion acquisition', async () => {
+    const fixture = createTargetDerivationFixture()
+    try {
+      const realParentObserver = createOpencodeOperationObserver({
+        targetDirectory: fixture.parentRoot,
+      })
+      const initial = await realParentObserver.snapshot()
+      if (initial.status !== 'available') throw new Error('parent unavailable')
+      const targetPath = path.join(fixture.linkedRoot, 'acquisition-drift.txt')
+      let mutateDuringCompletion = false
+      let parentSnapshots = 0
+      const parentObserver: OpencodeOperationObserver = {
+        ...realParentObserver,
+        async snapshot() {
+          const result = await realParentObserver.snapshot()
+          parentSnapshots += 1
+          if (mutateDuringCompletion && parentSnapshots === 2) {
+            fs.writeFileSync(targetPath, 'changed during completion')
+          }
+          return result
+        },
+      }
+      const adapter = createOpencodeWorkflowGuard({
+        config: { mode: 'observe' },
+        workspaceIdentity: initial.snapshot.targetDigest,
+        repositoryIdentity: initial.snapshot.repositoryRevisionDigest,
+        worktreeIdentity: initial.snapshot.worktreeRevisionDigest,
+        targetDirectory: fixture.parentRoot,
+        sessionLocation: fixture.parentRoot,
+        observer: parentObserver,
+        classifier: createReceiptClassifier(),
+      })
+      await observeSkill(adapter, 'systematic_skill', 'ce:work')
+      await observeFreshWrite(
+        adapter,
+        targetPath,
+        'stable evidence',
+        'acquisition-drift-write',
+      )
+      await observeFreshVerification(
+        adapter,
+        fixture.linkedRoot,
+        'acquisition-drift-verification',
+      )
+      parentSnapshots = 0
+      mutateDuringCompletion = true
+
+      await completeUnit(adapter, 'acquisition-drift-completion')
+
+      expect(status(adapter).state).toBe('unavailable')
+      expect(status(adapter).reasonCode).toBe('guard-unavailable')
+      expect(
+        ledger(adapter)
+          .listReceipts()
+          .some((receipt) => receipt.canonical.consumption === 'consumed'),
+      ).toBe(false)
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('fails closed when the pinned registration identity changes before completion', async () => {
+    const fixture = createTargetDerivationFixture()
+    try {
+      const realParentObserver = createOpencodeOperationObserver({
+        targetDirectory: fixture.parentRoot,
+      })
+      const initial = await realParentObserver.snapshot()
+      if (initial.status !== 'available') throw new Error('parent unavailable')
+      const targetRoot = fs.realpathSync(fixture.linkedRoot)
+      let substituteRegistration = false
+      const parentObserver: OpencodeOperationObserver = {
+        ...realParentObserver,
+        validateRegisteredWorktree(candidateDirectory) {
+          const validation =
+            realParentObserver.validateRegisteredWorktree(candidateDirectory)
+          if (
+            substituteRegistration &&
+            candidateDirectory === targetRoot &&
+            validation.status === 'ok'
+          ) {
+            return { ...validation, gitDir: `${validation.gitDir}-substituted` }
+          }
+          return validation
+        },
+      }
+      const adapter = createOpencodeWorkflowGuard({
+        config: { mode: 'observe' },
+        workspaceIdentity: initial.snapshot.targetDigest,
+        repositoryIdentity: initial.snapshot.repositoryRevisionDigest,
+        worktreeIdentity: initial.snapshot.worktreeRevisionDigest,
+        targetDirectory: fixture.parentRoot,
+        sessionLocation: fixture.parentRoot,
+        observer: parentObserver,
+        classifier: createReceiptClassifier(),
+      })
+      await observeSkill(adapter, 'systematic_skill', 'ce:work')
+      const targetPath = path.join(targetRoot, 'registration-drift.txt')
+      await observeFreshWrite(
+        adapter,
+        targetPath,
+        'registered evidence',
+        'registration-drift-write',
+      )
+      await observeFreshVerification(
+        adapter,
+        targetRoot,
+        'registration-drift-verification',
+      )
+      substituteRegistration = true
+
+      await completeUnit(adapter, 'registration-drift-completion')
+
+      expect(status(adapter).state).toBe('unavailable')
+      expect(status(adapter).reasonCode).toBe('guard-unavailable')
+      expect(
+        ledger(adapter)
+          .listReceipts()
+          .some((receipt) => receipt.canonical.consumption === 'consumed'),
+      ).toBe(false)
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
+  test('fails closed when a pinned worktree target no longer validates on completion', async () => {
+    const setup = await createPinnedRecoveryAdapter()
+    try {
+      const { adapter } = setup
+      setup.setTargetValidationAvailable(false)
+
+      const completeInput = {
+        tool: 'systematic_workflow_complete' as const,
+        sessionID: SESSION_A,
+        callID: 'invalid-pinned-completion',
+      }
+      await adapter.hooks['tool.execute.before'](completeInput, {
+        args: { target: 'unit' },
+      })
+      const output = { title: 'complete', output: 'done', metadata: {} }
+      await adapter.hooks['tool.execute.after'](
+        { ...completeInput, args: { target: 'unit' } },
+        output,
+      )
+
+      expect(status(adapter).state).toBe('unavailable')
+    } finally {
+      setup.fixture.cleanup()
+    }
   })
 
   test('operation evidence remains isolated across sessions and registrations', async () => {
@@ -3671,6 +4362,7 @@ describe('OpenCode workflow guard adapter', () => {
         worktreeBeforeIdentity: string
         worktreeAfterIdentity: string
       }[],
+      operationTargetIdentity = OPERATION_SCOPE.operationTargetIdentity,
     ): unknown[] {
       const childLedger = createReceiptLedger({
         capabilityFlags: ['workflow-guard'],
@@ -3711,7 +4403,7 @@ describe('OpenCode workflow guard adapter', () => {
           epochId,
           unitId,
           workspaceIdentity: receiptWorkspaceIdentity,
-          operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
+          operationTargetIdentity,
           repositoryIdentity: receipt.repositoryBeforeIdentity,
           worktreeIdentity: receipt.worktreeBeforeIdentity,
         }
@@ -3727,7 +4419,7 @@ describe('OpenCode workflow guard adapter', () => {
           context,
           after: {
             workspaceIdentity: receiptWorkspaceIdentity,
-            operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
+            operationTargetIdentity,
             repositoryIdentity: receipt.repositoryAfterIdentity,
             worktreeIdentity: receipt.worktreeAfterIdentity,
             ...(receipt.operation === 'commit' ? { commitClosure: true } : {}),
@@ -4883,6 +5575,67 @@ describe('OpenCode workflow guard adapter', () => {
       } finally {
         fixture.cleanup()
       }
+    })
+
+    test('rejects a child receipt with an authenticated unregistered target identity', async () => {
+      const ownIdentity = 'rollup-wrong-operation-target'
+      const ownSalt = new Uint8Array(32).fill(129)
+      const childSessionID = 'child-wrong-operation-target'
+      const parentSessionID = SESSION_A
+      const wrongTargetIdentity = 'f'.repeat(64)
+      const childMarkers = buildChildMarkersWithReceipts(
+        ownIdentity,
+        ownSalt,
+        OPERATION_SCOPE.workspaceIdentity,
+        [
+          {
+            operation: 'implementation',
+            repositoryBeforeIdentity: OPERATION_SCOPE.repositoryIdentity,
+            repositoryAfterIdentity: OPERATION_SCOPE.repositoryIdentity,
+            worktreeBeforeIdentity: OPERATION_SCOPE.worktreeIdentity,
+            worktreeAfterIdentity: '1'.repeat(64),
+          },
+        ],
+        wrongTargetIdentity,
+      )
+      const childParts = [
+        {
+          info: {},
+          parts: [
+            {
+              state: {
+                metadata: {
+                  [SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]: childMarkers,
+                },
+              },
+            },
+          ],
+        },
+      ]
+      const snapshotRef = { called: false }
+      const adapter = makeRollupAdapter(
+        ownIdentity,
+        ownSalt,
+        snapshotRef,
+        childSessionID,
+        () => childParts,
+        parentSessionID,
+        ['implementation'],
+      )
+
+      await observeSkill(
+        adapter,
+        'systematic_skill',
+        'ce:work',
+        'wrong-operation-target-skill',
+        parentSessionID,
+      )
+      await fireTaskAfter(adapter, childSessionID, parentSessionID)
+
+      expect(adapter.status(parentSessionID).reasonCode).toBe(
+        'guard-unavailable',
+      )
+      expect(ledger(adapter, parentSessionID).listReceipts()).toHaveLength(0)
     })
 
     test('skips stale child receipts, mints a later current receipt, and rolls up once', async () => {

--- a/tests/unit/receipt-duplicate-replay.test.ts
+++ b/tests/unit/receipt-duplicate-replay.test.ts
@@ -22,6 +22,7 @@ const SCOPE = {
   repositoryIdentity: 'repository-current',
   worktreeIdentity: 'worktree-current',
 }
+const OPERATION_TARGET_IDENTITY = 'd'.repeat(64)
 
 function createMintedReceipt(
   registrationIdentity = 'registration-a',
@@ -41,6 +42,7 @@ function createMintedReceipt(
     workspaceIdentity: SCOPE.workspaceIdentity,
     repositoryIdentity: 'repository-before',
     worktreeIdentity: 'worktree-before',
+    operationTargetIdentity: OPERATION_TARGET_IDENTITY,
   }
   expect(
     ledger.prepareObservation({ callId, operation: 'implementation', context }),
@@ -48,7 +50,7 @@ function createMintedReceipt(
   const finalized = ledger.finalizeObservation({
     callId,
     context,
-    after: SCOPE,
+    after: { ...SCOPE, operationTargetIdentity: OPERATION_TARGET_IDENTITY },
     classification: {
       outcome: 'accepted',
       category: 'implementation',
@@ -106,6 +108,7 @@ function mintWorkflowEvidence(
       operation === 'implementation'
         ? 'worktree-before'
         : SCOPE.worktreeIdentity,
+    operationTargetIdentity: OPERATION_TARGET_IDENTITY,
   }
   const callId = `${operation}-evidence`
   expect(
@@ -114,7 +117,7 @@ function mintWorkflowEvidence(
   const finalized = ledger.finalizeObservation({
     callId,
     context,
-    after: SCOPE,
+    after: { ...SCOPE, operationTargetIdentity: OPERATION_TARGET_IDENTITY },
     classification: {
       outcome: 'accepted',
       category: operation,

--- a/tests/unit/receipt-ledger-persistence.test.ts
+++ b/tests/unit/receipt-ledger-persistence.test.ts
@@ -20,6 +20,7 @@ const SESSION_SALT = Uint8Array.from({ length: 32 }, (_, index) => index)
 const RAW_COMMAND = 'git apply private.patch'
 const RAW_OUTPUT = 'private terminal output'
 const RAW_PATH = '/private/repos/receipt-demo'
+const OPERATION_TARGET_IDENTITY = 'd'.repeat(64)
 
 interface MintedReceipt {
   ledger: ReturnType<typeof createReceiptLedger>
@@ -60,12 +61,14 @@ function createMintedReceipt(
     unitId: opaqueIdentity(unitId),
     workspaceIdentity: 'workspace-current',
     worktreeIdentity: 'worktree-before',
+    operationTargetIdentity: OPERATION_TARGET_IDENTITY,
   }
   const afterContext: ReceiptContext = {
     epochId: opaqueIdentity(epochId),
     unitId: opaqueIdentity(unitId),
     workspaceIdentity: 'workspace-current',
     worktreeIdentity: 'worktree-after',
+    operationTargetIdentity: OPERATION_TARGET_IDENTITY,
   }
   const classification: ReceiptClassification = {
     outcome: 'accepted',
@@ -89,6 +92,7 @@ function createMintedReceipt(
     after: {
       workspaceIdentity: afterContext.workspaceIdentity,
       worktreeIdentity: afterContext.worktreeIdentity,
+      operationTargetIdentity: afterContext.operationTargetIdentity,
     },
     classification,
     terminal: { status: 'success', output: 'non-empty', noOp: false },

--- a/tests/unit/receipt-ledger.test.ts
+++ b/tests/unit/receipt-ledger.test.ts
@@ -126,6 +126,23 @@ describe('receipt ledger', () => {
     )
   })
 
+  test('rejects a non-digest operation target identity in an observation context', () => {
+    const ledger = createReceiptLedger({
+      registrationIdentity: 'registration-invalid-target',
+    })
+
+    expect(
+      ledger.prepareObservation({
+        callId: 'invalid-target',
+        operation: 'implementation',
+        context: {
+          ...context(),
+          operationTargetIdentity: 'not-a-digest',
+        },
+      }),
+    ).toEqual({ status: 'rejected', reasonCode: 'invalid-observation' })
+  })
+
   test('rejects a v2 local receipt when the operation target identity is omitted', () => {
     const ledger = createReceiptLedger({
       registrationIdentity: 'registration-missing-target',

--- a/tests/unit/receipt-ledger.test.ts
+++ b/tests/unit/receipt-ledger.test.ts
@@ -11,6 +11,7 @@ const RAW_REPOSITORY = '/private/repos/receipt-demo/.git'
 const RAW_WORKTREE = '/private/repos/receipt-demo'
 const RAW_WORKSPACE_BEFORE = 'workspace-before'
 const RAW_WORKSPACE_AFTER = 'workspace-after'
+const OPERATION_TARGET_IDENTITY = 'a'.repeat(64)
 const RAW_COMMAND = 'git apply private.patch'
 const RAW_OUTPUT = 'private terminal output'
 const SUPPLIED_SALT = Uint8Array.from({ length: 32 }, (_, index) => index)
@@ -49,6 +50,7 @@ function context(
     workspaceIdentity,
     repositoryIdentity: RAW_REPOSITORY,
     worktreeIdentity: RAW_WORKTREE,
+    operationTargetIdentity: OPERATION_TARGET_IDENTITY,
     resourceIdentity: 'resource-1',
   }
 }
@@ -94,6 +96,7 @@ function finalizeLedgerObservation(
       workspaceIdentity: afterWorkspaceIdentity,
       repositoryIdentity: 'repository-after',
       worktreeIdentity: afterWorktreeIdentity,
+      operationTargetIdentity: OPERATION_TARGET_IDENTITY,
       resourceIdentity: 'resource-after',
     },
     classification: classification(operation),
@@ -106,6 +109,48 @@ function finalizeLedgerObservation(
 }
 
 describe('receipt ledger', () => {
+  test('mints a v2 receipt with its operation target identity', () => {
+    const ledger = createReceiptLedger({
+      registrationIdentity: 'registration-target-identity',
+    })
+
+    expect(prepareLedgerObservation(ledger).status).toBe('prepared')
+
+    const result = finalizeLedgerObservation(ledger)
+
+    expect(result).toMatchObject({ status: 'finalized' })
+    expect(result.receipt?.schemaVersion).toBe(2)
+    expect(result.receipt?.protocolVersion).toBe(2)
+    expect(result.receipt?.canonical.operationTargetIdentity).toBe(
+      OPERATION_TARGET_IDENTITY,
+    )
+  })
+
+  test('rejects a v2 local receipt when the operation target identity is omitted', () => {
+    const ledger = createReceiptLedger({
+      registrationIdentity: 'registration-missing-target',
+    })
+    const observationContext = context()
+
+    expect(
+      prepareLedgerObservation(ledger, 'missing-target', observationContext),
+    ).toMatchObject({ status: 'prepared' })
+
+    const result = ledger.finalizeObservation({
+      callId: 'missing-target',
+      context: observationContext,
+      after: {
+        workspaceIdentity: RAW_WORKSPACE_BEFORE,
+        repositoryIdentity: 'repository-after',
+        worktreeIdentity: 'worktree-after',
+      },
+      classification: classification(),
+      terminal: { status: 'success', output: 'non-empty', noOp: false },
+    })
+
+    expect(result).toMatchObject({ status: 'rejected' })
+  })
+
   test('mints bounded runtime-owned metadata after a changed workspace observation', () => {
     const ledger = createReceiptLedger({
       registrationIdentity: 'registration-a',
@@ -158,6 +203,7 @@ describe('receipt ledger', () => {
         workspaceIdentity: RAW_WORKSPACE_BEFORE,
         repositoryIdentity: 'repository-after',
         worktreeIdentity: 'worktree-after',
+        operationTargetIdentity: OPERATION_TARGET_IDENTITY,
         resourceIdentity: 'resource-after',
       }).status,
     ).toBe('consumed')
@@ -168,6 +214,7 @@ describe('receipt ledger', () => {
         workspaceIdentity: RAW_WORKSPACE_BEFORE,
         repositoryIdentity: 'repository-after',
         worktreeIdentity: 'worktree-after',
+        operationTargetIdentity: OPERATION_TARGET_IDENTITY,
         resourceIdentity: 'resource-after',
       }),
     ).toMatchObject({ status: 'rejected', reasonCode: 'already-consumed' })
@@ -218,6 +265,7 @@ describe('receipt ledger', () => {
     const fields: Array<keyof ReceiptContext> = [
       'repositoryIdentity',
       'worktreeIdentity',
+      'operationTargetIdentity',
       'resourceIdentity',
     ]
 
@@ -228,7 +276,10 @@ describe('receipt ledger', () => {
       const firstContext = context()
       const secondContext = {
         ...firstContext,
-        [field]: `foreign-${field}`,
+        [field]:
+          field === 'operationTargetIdentity'
+            ? 'b'.repeat(64)
+            : `foreign-${field}`,
       }
       expect(
         prepareLedgerObservation(ledger, 'same-call', firstContext).status,
@@ -282,6 +333,7 @@ describe('receipt ledger', () => {
         workspaceIdentity: RAW_WORKSPACE_BEFORE,
         repositoryIdentity: 'repository-after',
         worktreeIdentity: 'worktree-after',
+        operationTargetIdentity: OPERATION_TARGET_IDENTITY,
       },
       classification: classification(),
       terminal: { status: 'success', output: 'non-empty', noOp: false },
@@ -893,6 +945,7 @@ describe('receipt ledger', () => {
         workspaceIdentity: RAW_WORKSPACE_BEFORE,
         repositoryIdentity: 'repository-after',
         worktreeIdentity: 'worktree-after',
+        operationTargetIdentity: OPERATION_TARGET_IDENTITY,
         resourceIdentity: 'resource-after',
       }).status,
     ).toBe('consumed')
@@ -903,6 +956,7 @@ describe('receipt ledger', () => {
         workspaceIdentity: RAW_WORKSPACE_BEFORE,
         repositoryIdentity: 'repository-after',
         worktreeIdentity: 'worktree-after',
+        operationTargetIdentity: OPERATION_TARGET_IDENTITY,
         resourceIdentity: 'resource-after',
       }).status,
     ).toBe('consumed')

--- a/tests/unit/receipt-operations.test.ts
+++ b/tests/unit/receipt-operations.test.ts
@@ -359,6 +359,7 @@ function coherentFinalReadbacks(
       workspaceIdentity,
       repositoryIdentity,
       worktreeIdentity,
+      operationTargetIdentity: OPERATION_TARGET_IDENTITY,
     },
     {
       operation: 'push',
@@ -1931,6 +1932,7 @@ describe('receipt operation adapters', () => {
             workspaceIdentity: WORKSPACE_CURRENT,
             repositoryIdentity: REPOSITORY_AFTER,
             worktreeIdentity: WORKTREE_AFTER,
+            operationTargetIdentity: OPERATION_TARGET_IDENTITY,
           },
           {
             operation: 'push',
@@ -2018,6 +2020,7 @@ describe('receipt operation adapters', () => {
           workspaceIdentity: WORKSPACE_CURRENT,
           repositoryIdentity: REPOSITORY_CURRENT,
           worktreeIdentity: WORKTREE_ZERO,
+          operationTargetIdentity: OPERATION_TARGET_IDENTITY,
         },
       ],
     })
@@ -2093,6 +2096,7 @@ describe('receipt operation adapters', () => {
             workspaceIdentity: WORKSPACE_AFTER,
             repositoryIdentity: REPOSITORY_CURRENT,
             worktreeIdentity: WORKTREE_CURRENT,
+            operationTargetIdentity: OPERATION_TARGET_IDENTITY,
           },
           {
             operation: 'pr-creation',

--- a/tests/unit/receipt-operations.test.ts
+++ b/tests/unit/receipt-operations.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../../src/lib/receipt-classifier.js'
 import {
   createReceiptLedger,
+  isLocalOperation,
   type ReceiptClassification,
   type ReceiptContext,
   type ReceiptEnvelope,
@@ -70,6 +71,7 @@ const WORKTREE_ZERO =
 const WORKTREE_AFTER =
   '1616161616161616161616161616161616161616161616161616161616161616'
 const WORKTREE_INITIAL = WORKTREE_ZERO
+const OPERATION_TARGET_IDENTITY = 'd'.repeat(64)
 
 let syntheticSequence = 0
 
@@ -127,6 +129,9 @@ function operationInput(
     repositoryIdentity: REPOSITORY_CURRENT,
     worktreeIdentity:
       operation === 'implementation' ? WORKTREE_AFTER : WORKTREE_CURRENT,
+    ...(isLocalOperation(operation)
+      ? { operationTargetIdentity: OPERATION_TARGET_IDENTITY }
+      : {}),
     ...(operation === 'commit' ? { commitClosure: true } : {}),
     ...(operation === 'push'
       ? {
@@ -178,6 +183,9 @@ function operationInput(
           resourceIdentity: RESOURCE_PR,
           resourceRevisionIdentity: REVISION_B,
         }
+      : {}),
+    ...(isLocalOperation(operation)
+      ? { operationTargetIdentity: OPERATION_TARGET_IDENTITY }
       : {}),
   }
   return {
@@ -243,13 +251,24 @@ function bindOperation(
 ): Record<string, unknown> {
   const status = guard.status()
   if (!status.epoch || !status.unit) throw new Error('workflow scope missing')
+  const operation = input.operation as ReceiptOperation
+  const target = isLocalOperation(operation)
+    ? { operationTargetIdentity: OPERATION_TARGET_IDENTITY }
+    : {}
+  const after = input.after
+  const normalizedAfter =
+    after && typeof after === 'object' && !Array.isArray(after)
+      ? { ...(after as Record<string, unknown>), ...target }
+      : after
   return {
     ...input,
     context: {
       ...(input.context as Record<string, unknown>),
       epochId: status.epoch.epochId,
       unitId: status.unit.unitId,
+      ...target,
     },
+    ...(normalizedAfter !== undefined ? { after: normalizedAfter } : {}),
   }
 }
 
@@ -277,6 +296,7 @@ function mintSyntheticReceipt(
     workspaceIdentity: WORKSPACE_CURRENT,
     repositoryIdentity: REPOSITORY_CURRENT,
     worktreeIdentity: WORKTREE_CURRENT,
+    operationTargetIdentity: OPERATION_TARGET_IDENTITY,
   }
   expect(
     ledger.prepareObservation({ callId, operation, context }),
@@ -288,6 +308,7 @@ function mintSyntheticReceipt(
       workspaceIdentity: WORKSPACE_CURRENT,
       repositoryIdentity: REPOSITORY_CURRENT,
       worktreeIdentity: WORKTREE_ZERO,
+      operationTargetIdentity: OPERATION_TARGET_IDENTITY,
     },
     classification: {
       outcome: 'accepted',
@@ -886,15 +907,27 @@ describe('receipt operation adapters', () => {
   test('reports repository/worktree precondition drift as current-revision mismatch', async () => {
     const classifier = createReceiptClassifier()
     const { guard, ledger } = createScenario(classifier, ['implementation'])
+    const {
+      operationTargetIdentity: _operationTargetIdentity,
+      ...contextWithoutTarget
+    } = operationInput('implementation').context as Record<string, unknown>
     const drifted = operationInput('implementation', {
       context: {
-        ...operationInput('implementation').context,
+        ...contextWithoutTarget,
         repositoryIdentity: REPOSITORY_BEFORE,
         worktreeIdentity: WORKTREE_CURRENT,
       },
     })
+    const boundDrifted = bindOperation(guard, drifted)
+    const {
+      operationTargetIdentity: _boundOperationTargetIdentity,
+      ...boundContextWithoutTarget
+    } = boundDrifted.context as Record<string, unknown>
     expect(
-      await guard.observeOperation(bindOperation(guard, drifted)),
+      await guard.observeOperation({
+        ...boundDrifted,
+        context: boundContextWithoutTarget,
+      }),
     ).toMatchObject({
       status: 'rejected',
       reasonCode: 'receipt-mismatch',

--- a/tests/unit/receipt-privacy.test.ts
+++ b/tests/unit/receipt-privacy.test.ts
@@ -105,7 +105,7 @@ function sequenceObserver(
   let index = 0
   return {
     targetDigest: snapshots[0]?.targetDigest ?? 'a'.repeat(64),
-    validateRegisteredWorktree(candidateDirectory: string) {
+    validateRegisteredWorktree(_candidateDirectory: string) {
       const targetRoot = process.cwd()
       return {
         status: 'ok' as const,

--- a/tests/unit/receipt-privacy.test.ts
+++ b/tests/unit/receipt-privacy.test.ts
@@ -29,12 +29,13 @@ import { createWorkflowGuard } from '../../src/lib/workflow-guard.js'
 
 const SESSION_ID = 'privacy-session'
 const RESOURCE = '/Users/example/private/project'
-const SECRET_PATH = '/Users/example/private/project/.env'
+const SECRET_PATH = `${process.cwd()}/tests/unit/.privacy-fixture.env`
 const SECRET_COMMAND = 'git push origin private-branch --token=secret-value'
 const SECRET_PR_BODY = 'private pull request body with customer@example.test'
 const SECRET_ENV = 'SUPER_SECRET_ENV_VALUE'
 const SECRET_PROSE = 'private user prose must never be persisted'
 const SESSION_SALT = new Uint8Array(32).fill(7)
+const OPERATION_TARGET_IDENTITY = 'd'.repeat(64)
 
 const DIGEST = /^[0-9a-f]{64}$/
 const IDENTIFIER = /^[A-Za-z0-9_.:-]{1,256}$/
@@ -104,6 +105,15 @@ function sequenceObserver(
   let index = 0
   return {
     targetDigest: snapshots[0]?.targetDigest ?? 'a'.repeat(64),
+    validateRegisteredWorktree(candidateDirectory: string) {
+      const targetRoot = process.cwd()
+      return {
+        status: 'ok' as const,
+        targetRoot,
+        gitDir: `${targetRoot}/.git`,
+        commonDir: `${targetRoot}/.git`,
+      }
+    },
     async snapshot() {
       const snapshot = snapshots[Math.min(index++, snapshots.length - 1)]
       if (!snapshot)
@@ -143,6 +153,7 @@ function mintReceipt(): {
     workspaceIdentity: RESOURCE,
     repositoryIdentity: `${RESOURCE}/.git`,
     worktreeIdentity: `${RESOURCE}/.worktree`,
+    operationTargetIdentity: OPERATION_TARGET_IDENTITY,
     resourceIdentity: SECRET_PATH,
   }
   expect(
@@ -159,6 +170,7 @@ function mintReceipt(): {
       workspaceIdentity: RESOURCE,
       repositoryIdentity: `${RESOURCE}/.git-after`,
       worktreeIdentity: `${RESOURCE}/.worktree-after`,
+      operationTargetIdentity: OPERATION_TARGET_IDENTITY,
       resourceIdentity: SECRET_PATH,
     },
     classification: {

--- a/tests/unit/receipt-readback.test.ts
+++ b/tests/unit/receipt-readback.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { createHash } from 'node:crypto'
 
 import {
   createReceiptLedger,
@@ -24,6 +25,7 @@ const UNIT_ID = 'b'.repeat(32)
 const RAW_COMMAND = 'git apply private.patch'
 const RAW_OUTPUT = 'private terminal output'
 const RAW_PATH = '/private/repos/receipt-demo'
+const OPERATION_TARGET_IDENTITY = 'c'.repeat(64)
 
 type MintMarker = Extract<ReceiptMarker, { kind: 'mint' }>
 type ConsumeMarker = Extract<
@@ -75,6 +77,7 @@ function createFixture(options: ReceiptFixtureOptions = {}): ReceiptFixture {
     unitId: UNIT_ID,
     workspaceIdentity: RAW_PATH,
     worktreeIdentity: 'worktree-before',
+    operationTargetIdentity: OPERATION_TARGET_IDENTITY,
   }
 
   expect(
@@ -90,6 +93,7 @@ function createFixture(options: ReceiptFixtureOptions = {}): ReceiptFixture {
     after: {
       workspaceIdentity: RAW_PATH,
       worktreeIdentity: 'worktree-after',
+      operationTargetIdentity: OPERATION_TARGET_IDENTITY,
     },
     classification: {
       outcome: 'accepted',
@@ -229,7 +233,210 @@ function conflictingMint(fixture: ReceiptFixture): MintMarker {
   )
 }
 
+function legacyMintMarker(fixture: ReceiptFixture): MintMarker {
+  const canonical = fixture.receipt.canonical
+  const envelope: ReceiptEnvelope = {
+    schemaVersion: 1,
+    protocolVersion: 1,
+    registrationDigest: fixture.receipt.registrationDigest,
+    capabilityFlags: [...fixture.receipt.capabilityFlags],
+    compatibility: 'compatible',
+    canonical: {
+      receiptId: canonical.receiptId,
+      registrationDigest: canonical.registrationDigest,
+      callDigest: canonical.callDigest,
+      epochDigest: canonical.epochDigest,
+      unitDigest: canonical.unitDigest,
+      workspaceDigest: canonical.workspaceDigest,
+      repositoryDigest: canonical.repositoryDigest,
+      worktreeDigest: canonical.worktreeDigest,
+      resourceDigest: canonical.resourceDigest,
+      operation: canonical.operation,
+      result: canonical.result,
+      source: canonical.source,
+      consumption: canonical.consumption,
+      timestamp: canonical.timestamp,
+    },
+  }
+  const serialized = JSON.stringify({
+    schemaVersion: envelope.schemaVersion,
+    protocolVersion: envelope.protocolVersion,
+    registrationDigest: envelope.registrationDigest,
+    capabilityFlags: [...envelope.capabilityFlags],
+    compatibility: envelope.compatibility,
+    canonical: {
+      receiptId: envelope.canonical.receiptId,
+      registrationDigest: envelope.canonical.registrationDigest,
+      callDigest: envelope.canonical.callDigest,
+      epochDigest: envelope.canonical.epochDigest,
+      unitDigest: envelope.canonical.unitDigest,
+      workspaceDigest: envelope.canonical.workspaceDigest,
+      repositoryDigest: envelope.canonical.repositoryDigest ?? null,
+      worktreeDigest: envelope.canonical.worktreeDigest ?? null,
+      resourceDigest: envelope.canonical.resourceDigest ?? null,
+      operation: envelope.canonical.operation,
+      result: envelope.canonical.result,
+      source: envelope.canonical.source,
+      consumption: envelope.canonical.consumption,
+      timestamp: envelope.canonical.timestamp,
+    },
+  })
+  const sessionSalt = Buffer.from(fixture.sessionSalt).toString('hex')
+  return {
+    kind: 'mint',
+    schemaVersion: 1,
+    protocolVersion: 1,
+    envelope,
+    sessionSalt,
+    integrity: createHash('sha256')
+      .update(
+        `systematic/receipt-readback/mint/v1/${sessionSalt}/${serialized}`,
+      )
+      .digest('hex'),
+  }
+}
+
 describe('receipt readback', () => {
+  test('round-trips the v2 operation target identity through a mint marker', () => {
+    const fixture = createFixture()
+
+    expect(fixture.receipt.schemaVersion).toBe(2)
+    expect(fixture.mint.schemaVersion).toBe(2)
+    expect(fixture.mint.envelope.canonical.operationTargetIdentity).toBe(
+      OPERATION_TARGET_IDENTITY,
+    )
+    expect(
+      foldReceiptReadback([fixture.mint], expectationOf(fixture)),
+    ).toMatchObject({
+      status: 'reconstructed',
+      state: {
+        receipts: [
+          {
+            canonical: {
+              operationTargetIdentity: OPERATION_TARGET_IDENTITY,
+            },
+          },
+        ],
+      },
+    })
+  })
+
+  test('admits a valid v1 marker only as legacy parent-target evidence', () => {
+    const fixture = createFixture()
+    const legacy = legacyMintMarker(fixture)
+
+    const result = foldReceiptReadback([legacy], expectationOf(fixture))
+
+    expect(result).toMatchObject({
+      status: 'reconstructed',
+      state: {
+        receipts: [{ canonical: { operationTargetIdentity: undefined } }],
+      },
+    })
+
+    const recoveredLedger = createReceiptLedger({
+      registrationIdentity: 'registration-a',
+      sessionSalt: fixture.sessionSalt,
+    })
+    expect(recoveredLedger.recoverReadback([legacy])).toMatchObject({
+      status: 'recovered',
+      receipts: [{ canonical: { operationTargetIdentity: undefined } }],
+    })
+  })
+
+  test('rejects v1 evidence when recovery expects a foreign target', () => {
+    const fixture = createFixture()
+    const legacy = legacyMintMarker(fixture)
+    const foreignTarget = 'd'.repeat(64)
+
+    const result = foldReceiptReadback([legacy], {
+      ...expectationOf(fixture),
+      operationTargetIdentity: foreignTarget,
+    })
+
+    expect(result).toEqual({
+      status: 'rejected',
+      category: 'identity-digest-mismatch',
+    })
+
+    const recoveredLedger = createReceiptLedger({
+      registrationIdentity: 'registration-a',
+      sessionSalt: fixture.sessionSalt,
+    })
+    expect(recoveredLedger.recoverReadback([legacy], foreignTarget)).toEqual({
+      status: 'rejected',
+      category: 'identity-digest-mismatch',
+    })
+  })
+
+  test('rejects a v2 marker that omits the target identity', () => {
+    const fixture = createFixture()
+    const canonical = { ...fixture.mint.envelope.canonical }
+    delete canonical.operationTargetIdentity
+
+    expect(
+      validateReceiptMarker({
+        ...fixture.mint,
+        envelope: { ...fixture.mint.envelope, canonical },
+      }),
+    ).toEqual({ status: 'rejected', category: 'malformed' })
+  })
+
+  test('binds target identity changes to the mint integrity digest', () => {
+    const fixture = createFixture()
+    const tampered = {
+      ...fixture.mint,
+      envelope: {
+        ...fixture.mint.envelope,
+        canonical: {
+          ...fixture.mint.envelope.canonical,
+          operationTargetIdentity: 'd'.repeat(64),
+        },
+      },
+    }
+
+    expect(validateReceiptMarker(tampered)).toEqual({
+      status: 'rejected',
+      category: 'integrity-mismatch',
+    })
+    const reprojected = required(
+      projectReceiptMintMarker(tampered.envelope, fixture.sessionSalt),
+      'tampered-marker-not-reprojected',
+    )
+    expect(reprojected.integrity).not.toBe(fixture.mint.integrity)
+  })
+
+  test('canonical field insertion order does not change v2 serialization integrity', () => {
+    const fixture = createFixture()
+    const canonical = fixture.receipt.canonical
+    const reordered = {
+      timestamp: canonical.timestamp,
+      consumption: canonical.consumption,
+      source: canonical.source,
+      result: canonical.result,
+      operation: canonical.operation,
+      resourceDigest: canonical.resourceDigest,
+      operationTargetIdentity: canonical.operationTargetIdentity,
+      worktreeDigest: canonical.worktreeDigest,
+      repositoryDigest: canonical.repositoryDigest,
+      workspaceDigest: canonical.workspaceDigest,
+      unitDigest: canonical.unitDigest,
+      epochDigest: canonical.epochDigest,
+      callDigest: canonical.callDigest,
+      registrationDigest: canonical.registrationDigest,
+      receiptId: canonical.receiptId,
+    }
+    const reorderedMarker = required(
+      projectReceiptMintMarker(
+        { ...fixture.receipt, canonical: reordered },
+        fixture.sessionSalt,
+      ),
+      'reordered-marker-not-projected',
+    )
+
+    expect(reorderedMarker.integrity).toBe(fixture.mint.integrity)
+  })
+
   test('hashes raw identities into opaque digests and builds a defensive expectation', () => {
     const fixture = createFixture()
     const digest = digestReceiptIdentity('workspace', RAW_PATH, SESSION_SALT)
@@ -285,6 +492,43 @@ describe('receipt readback', () => {
     ).toEqual({ status: 'rejected', category: 'forbidden-field' })
   })
 
+  test('persists a pinned operation target through unit progression readback', () => {
+    const fixture = createFixture()
+    const pinned = required(
+      projectReceiptProgressionMarker(fixture.ledger, {
+        target: 'unit',
+        state: 'started',
+        epochId: EPOCH_ID,
+        unitId: UNIT_ID,
+        family: 'work',
+        requiredOperations: ['implementation'],
+        resourceScopes: [],
+        pinnedOperationTargetIdentity: OPERATION_TARGET_IDENTITY,
+        transitionDigest: fixture.ledger.digestIdentity('call', 'unit-pin'),
+        timestamp: 6,
+      }),
+      'pinned-unit-marker-not-projected',
+    )
+
+    expect(pinned).toMatchObject({
+      pinnedOperationTargetIdentity: OPERATION_TARGET_IDENTITY,
+    })
+    expect(validateReceiptMarker(pinned)).toMatchObject({ status: 'valid' })
+
+    const result = foldReceiptReadback(
+      [fixture.epochStart, fixture.unitStart, pinned],
+      expectationOf(fixture),
+    )
+    expect(result).toMatchObject({
+      status: 'reconstructed',
+      state: {
+        progression: {
+          unit: { pinnedOperationTargetIdentity: OPERATION_TARGET_IDENTITY },
+        },
+      },
+    })
+  })
+
   test('folds mint, consumption, and progression markers into ordered state', () => {
     const fixture = createFixture()
     const result = foldReceiptReadback(
@@ -316,6 +560,17 @@ describe('receipt readback', () => {
           },
         },
       },
+    })
+
+    const recoveredLedger = createReceiptLedger({
+      registrationIdentity: 'registration-a',
+      sessionSalt: fixture.sessionSalt,
+    })
+    expect(recoveredLedger.recoverReadback([fixture.mint])).toMatchObject({
+      status: 'recovered',
+      receipts: [
+        { canonical: { operationTargetIdentity: OPERATION_TARGET_IDENTITY } },
+      ],
     })
   })
 

--- a/tests/unit/receipt-readback.test.ts
+++ b/tests/unit/receipt-readback.test.ts
@@ -529,6 +529,92 @@ describe('receipt readback', () => {
     })
   })
 
+  test('round-trips a v2 remote receipt without a local operation target identity', () => {
+    const ledger = createReceiptLedger({
+      registrationIdentity: 'registration-remote-target',
+      sessionSalt: SESSION_SALT,
+    })
+    const context = {
+      epochId: EPOCH_ID,
+      unitId: UNIT_ID,
+      workspaceIdentity: RAW_PATH,
+      repositoryIdentity: 'repository-before',
+      resourceIdentity: 'remote-before',
+    }
+    expect(
+      ledger.prepareObservation({
+        callId: 'remote-push',
+        operation: 'push',
+        context,
+      }),
+    ).toMatchObject({ status: 'prepared' })
+
+    const finalized = ledger.finalizeObservation({
+      callId: 'remote-push',
+      context,
+      after: {
+        workspaceIdentity: RAW_PATH,
+        repositoryIdentity: 'repository-after',
+        resourceIdentity: 'remote-after',
+      },
+      classification: {
+        outcome: 'accepted',
+        category: 'push',
+        attribution: 'runtime-verified',
+        result: 'success',
+        sideEffect: 'required',
+        reasonCode: 'recognized-command',
+      },
+      terminal: { status: 'success', output: 'non-empty', noOp: false },
+    })
+    expect(finalized.status).toBe('finalized')
+    if (finalized.status !== 'finalized') throw new Error('remote-not-minted')
+    expect(finalized.receipt.schemaVersion).toBe(2)
+    expect(finalized.receipt.canonical.operationTargetIdentity).toBeUndefined()
+
+    const mint = required(
+      projectReceiptMintMarker(finalized.receipt, SESSION_SALT),
+      'remote-mint-marker-not-projected',
+    )
+    const result = foldReceiptReadback(
+      [mint],
+      receiptReadbackExpectationFromMetadata(ledger.metadata, SESSION_SALT),
+    )
+    expect(result).toMatchObject({
+      status: 'reconstructed',
+      state: {
+        receipts: [
+          {
+            canonical: {
+              operation: 'push',
+            },
+          },
+        ],
+      },
+    })
+    if (result.status === 'reconstructed') {
+      expect(result.state.receipts[0]?.canonical).not.toHaveProperty(
+        'operationTargetIdentity',
+      )
+    }
+  })
+
+  test('rejects a v2 local receipt marker when its operation target identity is missing', () => {
+    const fixture = createFixture()
+    const {
+      operationTargetIdentity: _operationTargetIdentity,
+      ...canonicalWithoutTarget
+    } = fixture.receipt.canonical
+    const missingTargetReceipt: ReceiptEnvelope = {
+      ...fixture.receipt,
+      canonical: canonicalWithoutTarget,
+    }
+
+    expect(
+      projectReceiptMintMarker(missingTargetReceipt, SESSION_SALT),
+    ).toBeUndefined()
+  })
+
   test('folds mint, consumption, and progression markers into ordered state', () => {
     const fixture = createFixture()
     const result = foldReceiptReadback(

--- a/tests/unit/workflow-guard-recovery.test.ts
+++ b/tests/unit/workflow-guard-recovery.test.ts
@@ -23,6 +23,7 @@ const UNIT_ID = 'b'.repeat(32)
 const WORKSPACE_ID = 'workspace-current'
 const REPOSITORY_ID = 'repository-current'
 const WORKTREE_ID = 'worktree-current'
+const OPERATION_TARGET_IDENTITY = 'd'.repeat(64)
 
 function createRecoveredFixture(
   progressionMode: 'active' | 'consumed' | 'completed' = 'active',
@@ -41,6 +42,7 @@ function createRecoveredFixture(
     epochId: EPOCH_ID,
     unitId: UNIT_ID,
     workspaceIdentity: WORKSPACE_ID,
+    operationTargetIdentity: OPERATION_TARGET_IDENTITY,
     ...(includeRepositoryBoundary
       ? {
           repositoryIdentity:
@@ -63,6 +65,7 @@ function createRecoveredFixture(
     context,
     after: {
       workspaceIdentity: WORKSPACE_ID,
+      operationTargetIdentity: OPERATION_TARGET_IDENTITY,
       ...(includeRepositoryBoundary
         ? {
             repositoryIdentity: REPOSITORY_ID,

--- a/tests/unit/workflow-guard.test.ts
+++ b/tests/unit/workflow-guard.test.ts
@@ -294,8 +294,17 @@ describe('workflow guard', () => {
         workspaceIdentity: 'workspace-next',
         repositoryIdentity: 'repository-next',
         worktreeIdentity: 'worktree-next',
+        operationTargetIdentity: SCOPE.operationTargetIdentity,
       }),
     ).toMatchObject({ status: 'accepted' })
+    expect(
+      guard.observeReadback({
+        workspaceIdentity: 'workspace-next',
+        repositoryIdentity: 'repository-next',
+        worktreeIdentity: 'worktree-next',
+        operationTargetIdentity: 42,
+      }),
+    ).toEqual({ status: 'rejected', reasonCode: 'invalid-receipt' })
     expect(guard.currentOperationContext()).toEqual({
       workspaceIdentity: 'workspace-next',
       repositoryIdentity: 'repository-next',

--- a/tests/unit/workflow-guard.test.ts
+++ b/tests/unit/workflow-guard.test.ts
@@ -7,6 +7,10 @@ import {
   type ReceiptOperation,
 } from '../../src/lib/receipt-ledger.js'
 import {
+  projectReceiptMintMarker,
+  projectReceiptProgressionMarker,
+} from '../../src/lib/receipt-readback.js'
+import {
   createWorkflowGuard,
   type WorkflowGuard,
   type WorkflowGuardOptions,
@@ -17,12 +21,18 @@ const SCOPE = {
   repositoryIdentity: 'repository-current',
   worktreeIdentity: 'worktree-current',
   resourceIdentity: 'resource-current',
+  operationTargetIdentity: 'a'.repeat(64),
 }
 
 const GUARD_SCOPE = {
   workspaceIdentity: SCOPE.workspaceIdentity,
   repositoryIdentity: SCOPE.repositoryIdentity,
   worktreeIdentity: SCOPE.worktreeIdentity,
+}
+
+const RECEIPT_AFTER_SCOPE = {
+  ...GUARD_SCOPE,
+  operationTargetIdentity: SCOPE.operationTargetIdentity,
 }
 
 let callSequence = 0
@@ -85,6 +95,7 @@ function receiptContext(
     workspaceIdentity: SCOPE.workspaceIdentity,
     repositoryIdentity: 'repository-before',
     worktreeIdentity: 'worktree-before',
+    operationTargetIdentity: SCOPE.operationTargetIdentity,
     ...(operation === 'push' || operation === 'pr-creation'
       ? { resourceIdentity: 'resource-before' }
       : {}),
@@ -95,7 +106,7 @@ function mintReceiptWithContext(
   ledger: ReturnType<typeof createReceiptLedger>,
   operation: ReceiptOperation,
   context: ReceiptContext,
-  after = GUARD_SCOPE,
+  after = RECEIPT_AFTER_SCOPE,
 ): ReceiptEnvelope {
   const callId = `host-call-${++callSequence}`
   expect(ledger.prepareObservation({ callId, operation, context }).status).toBe(
@@ -132,7 +143,9 @@ function mintReceipt(
   after = SCOPE,
 ): ReceiptEnvelope {
   const defaultAfter =
-    operation === 'push' || operation === 'pr-creation' ? SCOPE : GUARD_SCOPE
+    operation === 'push' || operation === 'pr-creation'
+      ? { ...RECEIPT_AFTER_SCOPE, resourceIdentity: SCOPE.resourceIdentity }
+      : RECEIPT_AFTER_SCOPE
   return mintReceiptWithContext(
     ledger,
     operation,
@@ -173,6 +186,99 @@ function guardWithReceipts(
 }
 
 describe('workflow guard', () => {
+  test('rejects a recovered unit operation that switches its pinned target', () => {
+    const ledger = createReceiptLedger({ registrationIdentity: 'durable-pin' })
+    const guard = createWorkflowGuard({ ledger, ...GUARD_SCOPE })
+    activateWork(guard)
+    const unit = startUnit(guard)
+    const implementation = mintReceiptWithContext(
+      ledger,
+      'implementation',
+      receiptContext(guard, 'implementation'),
+    )
+    expect(guard.observeReceipt(implementation)).toMatchObject({
+      status: 'accepted',
+    })
+    expect(guard.status().unit).toMatchObject({
+      pinnedOperationTargetIdentity: SCOPE.operationTargetIdentity,
+    })
+
+    const statusSnapshot = guard.status()
+    if (!statusSnapshot.epoch || !statusSnapshot.unit) {
+      throw new Error('workflow unit missing')
+    }
+    const transition = (identity: string) =>
+      ledger.digestIdentity('call', identity)
+    const epochMarker = projectReceiptProgressionMarker(ledger, {
+      target: 'epoch',
+      state: 'started',
+      epochId: statusSnapshot.epoch.epochId,
+      family: statusSnapshot.epoch.family,
+      transitionDigest: transition('epoch-start'),
+    })
+    const unitMarker = projectReceiptProgressionMarker(ledger, {
+      target: 'unit',
+      state: 'started',
+      epochId: statusSnapshot.epoch.epochId,
+      unitId: statusSnapshot.unit.unitId,
+      family: statusSnapshot.epoch.family,
+      requiredOperations: unit.requiredOperations,
+      resourceScopes: [],
+      pinnedOperationTargetIdentity: SCOPE.operationTargetIdentity,
+      transitionDigest: transition('unit-pin'),
+    })
+    const mintMarker = projectReceiptMintMarker(
+      implementation,
+      ledger.getSessionSalt(),
+    )
+    if (!epochMarker || !unitMarker || !mintMarker) {
+      throw new Error('recovery marker missing')
+    }
+
+    const recoveredLedger = createReceiptLedger({
+      registrationIdentity: 'durable-pin',
+      sessionSalt: ledger.getSessionSalt(),
+    })
+    const recovered = recoveredLedger.recoverReadback([
+      epochMarker,
+      unitMarker,
+      mintMarker,
+    ])
+    expect(recovered.status).toBe('recovered')
+    if (recovered.status !== 'recovered') throw new Error('recovery failed')
+
+    const recoveredGuard = createWorkflowGuard({
+      ledger: recoveredLedger,
+      ...GUARD_SCOPE,
+    })
+    expect(
+      recoveredGuard.restore({
+        provenance: 'restart',
+        state: {
+          registrationDigest: recoveredLedger.metadata.registrationDigest,
+          receipts: recovered.receipts,
+          progression: recovered.progression,
+        },
+      }),
+    ).toMatchObject({ status: 'restored' })
+
+    const foreignTarget = 'b'.repeat(64)
+    const foreignContext = {
+      ...receiptContext(recoveredGuard, 'verification'),
+      operationTargetIdentity: foreignTarget,
+    }
+    const foreignReceipt = mintReceiptWithContext(
+      recoveredLedger,
+      'verification',
+      foreignContext,
+      { ...GUARD_SCOPE, operationTargetIdentity: foreignTarget },
+    )
+    expect(recoveredGuard.observeReceipt(foreignReceipt)).toEqual({
+      status: 'unavailable',
+      reasonCode: 'operation-target-mismatch',
+    })
+  })
+
   test('exposes a frozen current operation context without mutable state', () => {
     const { guard } = createGuard()
 
@@ -554,6 +660,7 @@ describe('workflow guard', () => {
         epochId,
         unitId,
         ...GUARD_SCOPE,
+        operationTargetIdentity: SCOPE.operationTargetIdentity,
       }),
     ).toMatchObject({ status: 'consumed' })
     expect(guard.observeReceipt(implementation)).toMatchObject({
@@ -642,6 +749,7 @@ describe('workflow guard', () => {
       epochId,
       unitId,
       ...GUARD_SCOPE,
+      operationTargetIdentity: SCOPE.operationTargetIdentity,
     })
     expect(
       guard.finalizeTransition({ callId, transitionId: prepared.transitionId }),
@@ -739,6 +847,7 @@ describe('workflow guard', () => {
     first.ledger.consumeReceipt(firstReceipt.canonical.receiptId, {
       ...firstScope,
       ...GUARD_SCOPE,
+      operationTargetIdentity: SCOPE.operationTargetIdentity,
     })
 
     expect(
@@ -1312,6 +1421,7 @@ describe('workflow guard', () => {
     consumed.ledger.consumeReceipt(implementation.canonical.receiptId, {
       ...consumedScope,
       ...GUARD_SCOPE,
+      operationTargetIdentity: SCOPE.operationTargetIdentity,
     })
     expect(consumed.guard.status()).toMatchObject({
       state: 'rejected',


### PR DESCRIPTION
## What this fixes

The receipt-backed workflow guard proves that guarded operations (implementation, verification, commit) actually happened before a protected unit can complete. It observes real git state through a single operation observer pinned, at plugin init, to the parent checkout.

When a foreground `task` child stays rooted at the parent checkout but its tools target an isolated nested git worktree — via a `bash` `workdir` or absolute file paths — that fixed observer reads the unchanged parent tree. Before-state equals after-state, every operation looks like a no-op, no receipts are minted, and the parent unit ends at `waiting/missing-evidence`.

This closes that gap end to end: the guard now observes the directory a tool actually operated on, validates it as a registered worktree of the parent repository, and both mints and completes against it.

## Approach

The observed directory is derived from host tool inputs (never model or child prose), validated as a real registered worktree, and pinned to the unit through a new authenticated receipt field. The existing stable-workspace / mutable-revision trust boundary is preserved throughout.

- **Registered-worktree validation** — a candidate directory is trusted only after common-directory identity, `git worktree list` membership, and `.git` linkage all agree. `GIT_*` variables are stripped from observer subprocesses so ambient `GIT_DIR`/`GIT_WORK_TREE` can't make an unrelated directory resolve as the parent repo.
- **Host tool target derivation** — resolves the worktree a `bash`/`write`/`edit`/`apply_patch` operation acted on, failing closed on escaping, mixed-worktree, or git-admin paths.
- **`operationTargetIdentity`** — a new authenticated canonical receipt field bound into the salted integrity digest, required for local operations and absent for remote ones. Ships with a coordinated schema/protocol/marker version bump to 2 and a v1 backward-read shim: legacy receipts recover as parent-target only, and v1 foreign-target evidence is rejected.
- **Single target per unit** — the first trusted local target pins the unit in durable progression state (surviving restart); a later operation resolving to a different worktree fails closed. Mixing parent and worktree targets in one unit is intentionally rejected for now.
- **Worktree-aware rollup and completion** — foreground child receipts roll up against each receipt's authenticated target, and unit completion anchors its readback to that target's revision while keeping the workspace identity the stable parent. Target/registration mismatches are fatal; only revision staleness is skippable.

## Trust boundary

`workspaceIdentity` stays the stable parent lineage identity — the repository is not collapsed onto the workspace. Absence of the target field is never an implicit mode: a v2 local receipt that omits it is rejected rather than treated as parent-target. Every path where a target cannot be validated or observed fails closed to `unavailable`; nothing here can complete a unit on evidence that did not happen.

## Verification

- Full unit suite green (1806 tests); receipt integration suites green, including a real-host matrix across OpenCode 1.18.3 / 1.18.4 / 1.18.5 that confirms `operationTargetIdentity` in the canonical mint keys and units completing.
- A reproduction test drives a parent-rooted child whose tools target a gitignored nested worktree and asserts the parent both mints the receipts and completes the unit — failing against the pre-fix observer, passing now.
- Attack matrix covered: spoofed `.git` gitfiles, submodule and nested-repo targets, poisoned `GIT_*` env, symlink escapes, target switching mid-unit, mid-acquisition target changes, registration substitution, and content-vs-HEAD staleness.
- Typecheck, lint, content-integrity, and registry-drift all clean.

## Follow-up

Two fail-closed hardening edges found during review are tracked in #740: a marker-protocol v1 read shim, and refreshing the observer's worktree registry (plus retrying a transient capture failure) rather than freezing it at construction. Both degrade safely to `unavailable` today and are out of scope for this fix, which targets the pre-existing gitignored `.worktrees/` pattern.

Continues the delegated-receipt work from #719 on issue #678.
