### PR TITLE
fix(guard): derive apply_patch target from patch files when workdir absent

### DIFF
--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -836,7 +836,17 @@ function deriveApplyPatchTarget(
       args.workdir === undefined,
     ),
   )
-  const targetRoot = sharedTargetRoot(targets, [workdir.target.targetRoot])
+  // When workdir is absent and the patch names files, those targets alone
+  // determine the shared root (consistent with deriveFileOperationTarget).
+  // Seeding the parent root here would reject absolute paths into a registered
+  // worktree (#743). An explicit workdir — or a patch with no file targets —
+  // still contributes the workdir root, preserving the spanning guard and the
+  // parent fallback for fileless patches.
+  const seedWorkdirRoot = args.workdir !== undefined || targets.length === 0
+  const targetRoot = sharedTargetRoot(
+    targets,
+    seedWorkdirRoot ? [workdir.target.targetRoot] : [],
+  )
   return targetRoot
     ? { status: 'available', targetRoot }
     : unavailableOperationTarget()

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -902,6 +902,26 @@ describe('OpenCode workflow guard adapter', () => {
     }
   })
 
+  test('target derivation: apply_patch absolute worktree path without workdir resolves to worktree', () => {
+    const fixture = createTargetDerivationFixture()
+    try {
+      expect(
+        deriveWithFixture(fixture, 'apply_patch', {
+          patchText: [
+            '*** Begin Patch',
+            `*** Update File: ${path.join(fixture.linkedRoot, 'tracked.txt')}`,
+            '*** End Patch',
+          ].join('\n'),
+        }),
+      ).toEqual({
+        status: 'available',
+        targetRoot: fs.realpathSync(fixture.linkedRoot),
+      })
+    } finally {
+      fixture.cleanup()
+    }
+  })
+
   test('target derivation: unrelated explicit bash workdir fails closed', () => {
     const fixture = createTargetDerivationFixture()
     try {


### PR DESCRIPTION
## What

An `apply_patch` targeting an absolute path inside a registered nested worktree — with no `workdir` argument — failed closed to `guard-unavailable` instead of minting an implementation receipt. The equivalent change via `write`/`edit`, or via `apply_patch` **with** `workdir`, already worked.

## Why

In `deriveApplyPatchTarget`, when `workdir` is absent the workdir root defaulted to the parent checkout. Each per-file target resolved correctly to the worktree, but `sharedTargetRoot(targets, [parentRoot])` then mixed the parent root into the shared-root set — parent ≠ worktree, so it returned `undefined` and the guard degraded to `guard-unavailable`.

This blocks any agent whose only file-mutation tool is `apply_patch` (patchText-only schema, no `workdir`) from producing an implementation receipt against a nested worktree.

## Fix

When `workdir` is absent and the patch names files, derive the shared root from the patch-file targets alone — the same trust path `write`/`edit` use via `deriveFileOperationTarget`. An explicit `workdir`, or a patch with no file targets, still seeds the workdir root, so:

- the multi-worktree spanning guard still fails closed on distinct roots, and
- fileless patches still fall back to the parent root.

## Test

Adds a unit test: an absolute worktree path in `patchText` with no `workdir` now resolves to that worktree. Covers the gap noted in #743 — the existing suite only exercised spanning-worktree and explicit-`workdir` cases.

Full unit suite (1807 tests) green; typecheck, lint, and build clean.

Closes #743.