### PR TITLE
fix(guard): canonicalize apply_patch paths in operation fingerprint

### DIFF
--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -977,11 +977,80 @@ function stableSerialize(
   return serializeStableRecord(value, depth, budget)
 }
 
+function canonicalPatchText(
+  patchText: string,
+  sessionLocation: string,
+): string | undefined {
+  if (patchTextFileTargets(patchText) === undefined) return undefined
+  const segments = patchText.split(/(\r?\n)/)
+  for (let index = 0; index < segments.length; index += 1) {
+    const line = segments[index]
+    if (line === '\n' || line === '\r\n') continue
+    const prefix = PATCH_FILE_PREFIXES.find((candidate) =>
+      line.startsWith(candidate),
+    )
+    if (!prefix) continue
+    const filePath = line.slice(prefix.length).trim()
+    if (!filePath) return undefined
+    segments[index] = `${prefix}${path.resolve(sessionLocation, filePath)}`
+  }
+  return segments.join('')
+}
+
+function canonicalHunks(
+  value: unknown,
+  sessionLocation: string,
+): readonly Record<string, unknown>[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const hunks: Record<string, unknown>[] = []
+  for (const hunk of value) {
+    if (!isRecord(hunk) || typeof hunk.path !== 'string' || !hunk.path) {
+      return undefined
+    }
+    const canonical: Record<string, unknown> = {
+      ...hunk,
+      path: path.resolve(sessionLocation, hunk.path),
+    }
+    if (hunk.move_path !== undefined) {
+      if (typeof hunk.move_path !== 'string' || !hunk.move_path) {
+        return undefined
+      }
+      canonical.move_path = path.resolve(sessionLocation, hunk.move_path)
+    }
+    hunks.push(canonical)
+  }
+  return hunks
+}
+
+function canonicalOperationArgs(
+  tool: LocalOperationTool,
+  args: unknown,
+  sessionLocation: string,
+): unknown {
+  if (tool !== 'apply_patch' || !isRecord(args)) return args
+  const patchPaths = patchFileTargets(args)
+  if (patchPaths === undefined) return args
+  const patchValue = args.patchText ?? args.patch
+  if (typeof patchValue === 'string') {
+    const canonical = canonicalPatchText(patchValue, sessionLocation)
+    if (canonical === undefined) return args
+    const patchKey = typeof args.patchText === 'string' ? 'patchText' : 'patch'
+    return { ...args, [patchKey]: canonical }
+  }
+  if (patchPaths.length === 0) return args
+  const hunks = canonicalHunks(args.hunks, sessionLocation)
+  return hunks === undefined ? args : { ...args, hunks }
+}
+
 function argsFingerprint(
   ledger: ReturnType<typeof createReceiptLedger>,
+  tool: LocalOperationTool,
   args: unknown,
+  sessionLocation: string,
 ): string | undefined {
-  const serialized = stableSerialize(args)
+  const serialized = stableSerialize(
+    canonicalOperationArgs(tool, args, sessionLocation),
+  )
   return serialized === undefined
     ? undefined
     : ledger.digestIdentity('call', serialized)
@@ -1360,6 +1429,17 @@ function createSessionRuntime(
   const pendingQuestionChallenges = new Map<string, PendingQuestionChallenge>()
   const blockedQuestionCalls = new Map<string, string>()
   const consumedQuestionTargets = new Set<TransitionTarget>()
+
+  function effectiveTargetContext(): {
+    parentTargetRoot: string
+    sessionLocation: string
+  } {
+    const parentTargetRoot = options.targetDirectory ?? process.cwd()
+    return {
+      parentTargetRoot,
+      sessionLocation: options.sessionLocation ?? parentTargetRoot,
+    }
+  }
 
   function rememberOperationObserver(
     registration: OperationObserverRegistration,
@@ -2597,7 +2677,13 @@ function createSessionRuntime(
     args: unknown,
   ): Promise<void> {
     if (!options.observer || !isLocalOperationTool(host.tool)) return
-    const fingerprint = argsFingerprint(ledger, args)
+    const { parentTargetRoot, sessionLocation } = effectiveTargetContext()
+    const fingerprint = argsFingerprint(
+      ledger,
+      host.tool,
+      args,
+      sessionLocation,
+    )
     if (!fingerprint) {
       markUnavailable()
       return
@@ -2608,8 +2694,6 @@ function createSessionRuntime(
     ) {
       return
     }
-    const parentTargetRoot = options.targetDirectory ?? process.cwd()
-    const sessionLocation = options.sessionLocation ?? parentTargetRoot
     const target = deriveOpencodeOperationTarget(host.tool, args, {
       parentTargetRoot,
       sessionLocation,
@@ -3627,7 +3711,13 @@ function createSessionRuntime(
   ): Promise<void> {
     if (!options.observer || !isLocalOperationTool(host.tool)) return
     const callDigest = digestCall(ledger, host.callID)
-    const fingerprint = argsFingerprint(ledger, host.args)
+    const { sessionLocation } = effectiveTargetContext()
+    const fingerprint = argsFingerprint(
+      ledger,
+      host.tool,
+      host.args,
+      sessionLocation,
+    )
     if (isSealedOperationReplay(callDigest, host, fingerprint)) return
     const pending = takePendingOperation(callDigest, host, fingerprint)
     if (!pending) return
@@ -3641,19 +3731,17 @@ function createSessionRuntime(
       markUnavailable()
       return
     }
-    if (result.status === 'accepted') {
-      const receipt = receiptForOperation(host.callID, result.operation)
-      if (receipt) {
-        if (localOperation(result.operation)) {
-          recoveredOperationContexts.set(receipt.canonical.receiptId, {
-            targetIdentity: pending.targetIdentity,
-            before: pending.before,
-            after: result.after,
-          })
-        }
-        mergeReceiptMarker(output, receipt)
-      }
+    if (result.status !== 'accepted') return
+    const receipt = receiptForOperation(host.callID, result.operation)
+    if (!receipt) return
+    if (localOperation(result.operation)) {
+      recoveredOperationContexts.set(receipt.canonical.receiptId, {
+        targetIdentity: pending.targetIdentity,
+        before: pending.before,
+        after: result.after,
+      })
     }
+    mergeReceiptMarker(output, receipt)
   }
 
   async function after(input: unknown, output: unknown): Promise<void> {

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -2498,6 +2498,72 @@ describe('OpenCode workflow guard adapter', () => {
     }
   })
 
+  test('canonicalizes relative-before and absolute-after apply_patch hunks into one implementation receipt', async () => {
+    const cleanup = prepareApplyPatchTargetDirectory()
+    try {
+      const absolutePath = path.resolve(process.cwd(), 'sub/x.ts')
+      const absoluteMovePath = path.resolve(process.cwd(), 'sub/y.ts')
+      const adapter = createAdapter(
+        'observe',
+        false,
+        sequenceObserver([
+          operationSnapshot(),
+          operationSnapshot('b'.repeat(64), 'd'.repeat(64)),
+        ]),
+      )
+      await observeSkill(adapter, 'systematic_skill', 'ce:work')
+
+      await observeOperationToolWithArgs(
+        adapter,
+        { hunks: [{ path: 'sub/x.ts', move_path: 'sub/y.ts' }] },
+        {
+          hunks: [{ path: absolutePath, move_path: absoluteMovePath }],
+        },
+        { title: 'apply_patch complete', output: 'local result', metadata: {} },
+        'apply-patch-canonical-hunks',
+      )
+
+      expect(ledger(adapter).listReceipts()).toHaveLength(1)
+      expect(ledger(adapter).listReceipts()[0]?.canonical.operation).toBe(
+        'implementation',
+      )
+      expect(status(adapter).state).not.toBe('unavailable')
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('fails closed without throwing for an apply_patch empty file-target path', async () => {
+    const malformedPatch = [
+      '*** Begin Patch',
+      '*** Add File: ',
+      '+content',
+      '*** End Patch',
+    ].join('\n')
+    const adapter = createAdapter(
+      'observe',
+      false,
+      sequenceObserver([
+        operationSnapshot(),
+        operationSnapshot('b'.repeat(64), 'd'.repeat(64)),
+      ]),
+    )
+    await observeSkill(adapter, 'systematic_skill', 'ce:work')
+
+    await expect(
+      observeOperationToolWithArgs(
+        adapter,
+        { patchText: malformedPatch },
+        { patchText: malformedPatch },
+        { title: 'apply_patch complete', output: 'local result', metadata: {} },
+        'apply-patch-empty-file-target',
+      ),
+    ).resolves.toBeUndefined()
+
+    expect(ledger(adapter).listReceipts()).toHaveLength(0)
+    expect(status(adapter).state).toBe('unavailable')
+  })
+
   test('keeps apply_patch fingerprints different when the patch body changes', async () => {
     const cleanup = prepareApplyPatchTargetDirectory()
     try {

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -281,6 +281,33 @@ async function observeOperationTool(
   )
 }
 
+async function observeOperationToolWithArgs(
+  adapter: OpencodeWorkflowGuard,
+  beforeArgs: Record<string, unknown>,
+  afterArgs: Record<string, unknown>,
+  output: Record<string, unknown>,
+  callID = 'apply_patch-operation',
+  sessionID = SESSION_A,
+): Promise<void> {
+  await adapter.hooks['tool.execute.before'](
+    { tool: 'apply_patch', sessionID, callID },
+    { args: beforeArgs },
+  )
+  await adapter.hooks['tool.execute.after'](
+    { tool: 'apply_patch', sessionID, callID, args: afterArgs },
+    output,
+  )
+}
+
+function prepareApplyPatchTargetDirectory(): () => void {
+  const targetDirectory = path.resolve(process.cwd(), 'sub')
+  const existed = fs.existsSync(targetDirectory)
+  fs.mkdirSync(targetDirectory, { recursive: true })
+  return () => {
+    if (!existed) fs.rmSync(targetDirectory, { recursive: true, force: true })
+  }
+}
+
 async function observeSkill(
   adapter: OpencodeWorkflowGuard,
   tool: 'systematic_skill' | 'skill',
@@ -2424,6 +2451,195 @@ describe('OpenCode workflow guard adapter', () => {
       ])
     })
   }
+
+  test('canonicalizes relative-before and absolute-after apply_patch paths into one implementation receipt', async () => {
+    const cleanup = prepareApplyPatchTargetDirectory()
+    try {
+      const absolutePath = path.resolve(process.cwd(), 'sub/x.ts')
+      const adapter = createAdapter(
+        'observe',
+        false,
+        sequenceObserver([
+          operationSnapshot(),
+          operationSnapshot('b'.repeat(64), 'd'.repeat(64)),
+        ]),
+      )
+      await observeSkill(adapter, 'systematic_skill', 'ce:work')
+
+      await observeOperationToolWithArgs(
+        adapter,
+        {
+          patchText: [
+            '*** Begin Patch',
+            '*** Add File: sub/x.ts',
+            '+content',
+            '*** End Patch',
+          ].join('\n'),
+        },
+        {
+          patchText: [
+            '*** Begin Patch',
+            `*** Add File: ${absolutePath}`,
+            '+content',
+            '*** End Patch',
+          ].join('\n'),
+        },
+        { title: 'apply_patch complete', output: 'local result', metadata: {} },
+        'apply-patch-canonical-path',
+      )
+
+      expect(ledger(adapter).listReceipts()).toHaveLength(1)
+      expect(ledger(adapter).listReceipts()[0]?.canonical.operation).toBe(
+        'implementation',
+      )
+      expect(status(adapter).state).not.toBe('unavailable')
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('keeps apply_patch fingerprints different when the patch body changes', async () => {
+    const cleanup = prepareApplyPatchTargetDirectory()
+    try {
+      const adapter = createAdapter(
+        'observe',
+        false,
+        sequenceObserver([
+          operationSnapshot(),
+          operationSnapshot('b'.repeat(64), 'd'.repeat(64)),
+        ]),
+      )
+      await observeSkill(adapter, 'systematic_skill', 'ce:work')
+
+      await observeOperationToolWithArgs(
+        adapter,
+        {
+          patchText: [
+            '*** Begin Patch',
+            '*** Add File: sub/x.ts',
+            '+before',
+            '*** End Patch',
+          ].join('\n'),
+        },
+        {
+          patchText: [
+            '*** Begin Patch',
+            '*** Add File: sub/x.ts',
+            '+after',
+            '*** End Patch',
+          ].join('\n'),
+        },
+        { title: 'apply_patch complete', output: 'local result', metadata: {} },
+        'apply-patch-changed-body',
+      )
+
+      expect(ledger(adapter).listReceipts()).toHaveLength(0)
+      expect(status(adapter).state).toBe('unavailable')
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('keeps apply_patch fingerprints different when the target file changes', async () => {
+    const cleanup = prepareApplyPatchTargetDirectory()
+    try {
+      const adapter = createAdapter(
+        'observe',
+        false,
+        sequenceObserver([
+          operationSnapshot(),
+          operationSnapshot('b'.repeat(64), 'd'.repeat(64)),
+        ]),
+      )
+      await observeSkill(adapter, 'systematic_skill', 'ce:work')
+
+      await observeOperationToolWithArgs(
+        adapter,
+        {
+          patchText: [
+            '*** Begin Patch',
+            '*** Add File: sub/x.ts',
+            '+content',
+            '*** End Patch',
+          ].join('\n'),
+        },
+        {
+          patchText: [
+            '*** Begin Patch',
+            '*** Add File: sub/y.ts',
+            '+content',
+            '*** End Patch',
+          ].join('\n'),
+        },
+        { title: 'apply_patch complete', output: 'local result', metadata: {} },
+        'apply-patch-changed-file',
+      )
+
+      expect(ledger(adapter).listReceipts()).toHaveLength(0)
+      expect(status(adapter).state).toBe('unavailable')
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('treats an equivalent duplicate apply_patch after event as a replay', async () => {
+    const cleanup = prepareApplyPatchTargetDirectory()
+    try {
+      const absolutePath = path.resolve(process.cwd(), 'sub/x.ts')
+      const adapter = createAdapter(
+        'observe',
+        false,
+        sequenceObserver([
+          operationSnapshot(),
+          operationSnapshot('b'.repeat(64), 'd'.repeat(64)),
+        ]),
+      )
+      await observeSkill(adapter, 'systematic_skill', 'ce:work')
+
+      await observeOperationToolWithArgs(
+        adapter,
+        {
+          patchText: [
+            '*** Begin Patch',
+            '*** Add File: sub/x.ts',
+            '+content',
+            '*** End Patch',
+          ].join('\n'),
+        },
+        {
+          patchText: [
+            '*** Begin Patch',
+            `*** Add File: ${absolutePath}`,
+            '+content',
+            '*** End Patch',
+          ].join('\n'),
+        },
+        { title: 'apply_patch complete', output: 'local result', metadata: {} },
+        'apply-patch-replay',
+      )
+      await adapter.hooks['tool.execute.after'](
+        {
+          tool: 'apply_patch',
+          sessionID: SESSION_A,
+          callID: 'apply-patch-replay',
+          args: {
+            patchText: [
+              '*** Begin Patch',
+              '*** Add File: sub/x.ts',
+              '+content',
+              '*** End Patch',
+            ].join('\n'),
+          },
+        },
+        { title: 'apply_patch replay', output: 'local result', metadata: {} },
+      )
+
+      expect(ledger(adapter).listReceipts()).toHaveLength(1)
+      expect(status(adapter).state).not.toBe('unavailable')
+    } finally {
+      cleanup()
+    }
+  })
 
   test('mints an implementation receipt for a write targeted at a registered worktree', async () => {
     const fixture = createTargetDerivationFixture()


### PR DESCRIPTION
## What

An `apply_patch` operation failed closed to `guard-unavailable` — minting no implementation receipt — when a co-installed plugin's `tool.execute.before` hook rewrote the patch file path (absolute↔relative) before the receipt guard observed it.

## Why

The guard fingerprints `apply_patch` arguments over the raw `patchText` string. When an upstream before-hook rewrites the path and assigns a new `output.args`, the before-hook fingerprints the rewritten form while the after-hook fingerprints the original `input.args`. The two digests diverge, so `takePendingOperation` seals the operation abandoned and marks the guard unavailable.

Target derivation itself succeeds (the pending operation is created) — this mismatch is strictly downstream, and distinct from #743.

## Fix

Canonicalize `apply_patch` path targets to their lexical absolute form (`path.resolve` against the effective session location — not `realpath`) before fingerprinting, at both `prepareOperation` and `finishOperation`. A shared `effectiveTargetContext()` helper computes the session location identically at both sites.

The patch body, target ordering, move destinations, and every non-path argument stay in the hash, so a changed patch body or a different target file still changes the fingerprint. Ambiguous or unparseable patches fail closed (args left unchanged).

## Tests

Four regression tests covering the before/after args divergence — a path the unit and integration suites never exercised, because they feed fixed args directly to the guard:

1. Relative-path before / equivalent absolute-path after → mints exactly one implementation receipt.
2. Same path, changed patch body → `guard-unavailable`.
3. Different target file, same root → `guard-unavailable`.
4. Equivalent duplicate after event → treated as replay (no double mint, no unavailable transition).

Full unit suite (1811 tests) green; typecheck, lint (no new warnings), and build clean.

Closes #746.