### PR TITLE
feat(cli): add read-only capability diagnostics

### DIFF
--- a/docs/plans/2026-08-13-001-refactor-bitter-lesson-harness-plan.md
+++ b/docs/plans/2026-08-13-001-refactor-bitter-lesson-harness-plan.md
@@ -1,0 +1,672 @@
+---
+title: 'refactor: Bitter Lesson Engineering program for Systematic'
+type: refactor
+status: active
+date: 2026-08-13
+deepened: 2026-08-13
+---
+
+# refactor: Bitter Lesson Engineering Program for Systematic
+
+## Overview
+
+Run a dependency-ordered simplification program that measures where Systematic's opinionated compound-engineering guidance helps, selectively removes policy that obstructs improving models, and preserves the product's useful identity and non-negotiable trust boundaries. Each architecture area receives its own focused child plan before implementation; this document owns the program thesis, audit, sequencing, promotion gates, and deletion criteria.
+
+---
+
+## Problem Frame
+
+Richard Sutton's *The Bitter Lesson* argues that methods built around general search and learning ultimately outperform systems that encode increasingly detailed human knowledge. Human-authored structure often helps immediately, but it tends to plateau, accumulate exceptions, and obstruct methods that can exploit improving computation. The engineering translation for an AI coding harness is not “remove all deterministic code.” It is: keep deterministic mechanisms where the external world requires exactness, and stop encoding our current beliefs about how capable models must think, route, delegate, review, and sequence work.
+
+Systematic currently has strong foundations: runtime skill discovery, shared repository state, generated harness adapters, typed configuration, observable host integration, and evidence-backed operation readback. The audit nevertheless found that these primitives are surrounded by a much larger policy layer:
+
+- mandatory skill invocation based on a one-percent applicability rule;
+- fixed brainstorm → plan → work → review choreography;
+- dozens of specialized reviewer and workflow personas selected through handcrafted thresholds;
+- provider- and model-specific category defaults tied to the current model market;
+- large bootstrap catalogs and repeated procedural instructions injected before the model knows whether they matter;
+- harness adapters that translate fixed names, fields, and tool mappings rather than publishing structured capability facts;
+- a workflow guard whose receipt, parser, attestation, readback, and state machinery proves a fixed workflow protocol rather than offering smaller generic evidence and authorization primitives.
+
+The sharpest symptom is structural. The OpenCode workflow-guard adapter is over 4,000 lines, its core session runtime is roughly 2,400 lines, and the surrounding receipt/readback/classifier stack contains thousands more. Historical fixes around worktree targeting, duplicate registrations, path canonicalization, marker versions, hook mutation, recovery, and readback show that each new handcrafted distinction expands the compatibility surface. The same pattern appears at a smaller scale in prompt workflows, persona catalogs, model defaults, and cross-harness translation.
+
+This program treats every deterministic rule as challengeable, not presumptively wrong. Systematic's opinionated compound-engineering loops are part of its product identity and remain when evidence shows they improve task success, review quality, safety, or operator confidence. A rule is removed only when rule-specific counterexample and ablation evals show that its benefit can be preserved by a simpler mechanism across the supported model and harness cohorts. Authorization, secret isolation, atomic writes, provenance, compatibility, and irreversible side-effect boundaries form the initial minimum safety kernel; a focused child plan may narrow one only after a threat model and adversarial suite prove the replacement.
+
+---
+
+## Bitter Lesson Engineering Rubric
+
+Every retained or introduced mechanism must pass these tests:
+
+1. **Capability, not preference:** does it enable an outcome the model otherwise cannot perform, or merely prescribe how a human expects the model to work?
+2. **Outcome, not choreography:** is success judged from observable state rather than a required internal sequence?
+3. **Open solution space:** can materially different valid approaches pass?
+4. **Scales with models and compute:** does a stronger model gain freedom and performance, or remain trapped behind assumptions made for weaker models?
+5. **Search and feedback:** can the model inspect alternatives, act, observe results, and revise?
+6. **Measured heuristic:** if a heuristic remains, is its benefit demonstrated by evals and is its cost visible?
+7. **Progressive disclosure:** is context loaded when useful rather than injected globally?
+8. **Structured evidence:** are capabilities, state, freshness, trust, and failures machine-readable rather than blended into prose?
+9. **Narrow safeguard:** does deterministic enforcement correspond to a concrete threat or irreversible action?
+10. **Deletability:** can the rule, persona, adapter, or compatibility shim be removed without redesigning the whole system?
+
+Disposition vocabulary used throughout the migration:
+
+- **Keep:** an external contract or trust boundary that remains deterministic.
+- **Narrow:** a justified mechanism whose current scope is broader than the risk it controls.
+- **Replace:** a handcrafted decision system that should become a capability, eval, search, or feedback loop.
+- **Delete:** duplicated, obsolete, or preference-only machinery with no demonstrated outcome benefit.
+
+---
+
+## Current-State Audit
+
+### Scorecard
+
+| Dimension | Audit result | Interpretation |
+|---|---:|---|
+| Capability discovery | 8/10 | Strong runtime discovery, weakened by static documentation and no unified live diagnostic surface. |
+| Context injection | 8/8 categories present | Complete but over-injected; inventory and policy compete with task context. |
+| Host/UI visibility | 7/8 action classes | Strong OpenCode/Pi feedback; Claude Code remains more build-time and indirect. |
+| Shared authoritative workspace | 4/5 | Source ownership is sound; generated projections create deliberate drift and sync debt. |
+| Cross-harness action parity | 8/12 outcomes | Honest gaps exist, but Systematic-specific abstractions encourage lowest-common-denominator ceremony. |
+| Primitive-to-policy ratio | 4/13 primitive | Small capability surface surrounded by a substantially larger policy surface. |
+| Prompt-native behavior | 6/18 | Most consequential behavior is fixed by code or rigid prompt workflows. |
+| Lifecycle completeness | 2/7 entity classes | Discovery is strong; composition and mutation remain packaging- or filesystem-bound. |
+
+### Keep / Narrow / Replace / Delete Inventory
+
+| Area | Current examples | Disposition | Target direction |
+|---|---|---|---|
+| Authorization and trust | `SECURITY_OVERLAY_FIELDS`, project/user trust precedence, child-session tool isolation | Keep | Schema-owned, explicit trust metadata with the smallest protected field set. |
+| Atomic/idempotent writes | harness setup, Pi exports, generated bundles | Keep | Shared generated-projection contract with ownership and drift metadata. |
+| Evidence and provenance | repository/worktree snapshots, remote PR/check readback, privacy-safe receipt integrity | Narrow | Generic evidence records independent of a prescribed workflow lifecycle. |
+| Workflow guard | epochs, units, required operations, operation parsers, question attestation, progression markers | Replace substantially | Capability/evidence/authorization kernel; model owns workflow selection and sequencing. |
+| Shell command classification | command grammar, operation allowlists, command-shape inference | Replace | Observe effects through typed host tools and state snapshots; use a minimal shell-risk boundary only where unavoidable. |
+| Bootstrap | full `using-systematic` body, profiles, verbose catalog, usage rules | Replace | Small structured session facts plus queryable discovery handles. |
+| Skill invocation policy | mandatory one-percent rule and skill-first routing | Delete | Model may discover and load skills when useful; eval outcomes determine whether guidance helps. |
+| Workflow skills | rigid brainstorm/plan/work/review ladders and stopping points | Narrow/replace | Outcome contracts, optional strategy references, and adaptive execution. |
+| Persona catalog | fixed reviewer taxonomy and conditional dispatch thresholds | Replace | Fewer generalists plus composable capability/lens descriptors selected dynamically. |
+| Model defaults | provider-specific category chains and static rationale | Replace | Inherit-first routing with capability constraints and eval-informed local preferences. |
+| Tool translation | fixed OpenCode-to-Pi mappings and namespace translation | Narrow/replace | Runtime capability descriptors and schema-driven projections; fail closed only at execution edges. |
+| Ownership detection | description regexes, path-prefix ownership, internal-agent signature strings | Delete/replace | Explicit source IDs, ownership metadata, and host flags. |
+| Compatibility shims | marker versions, removed-name lists, legacy read paths | Delete by policy | Time-bounded compatibility with usage evidence and scheduled removal. |
+| Content integrity | source-shape bans and duplicated prose rules | Narrow | Validate externally meaningful contracts and generated/runtime parity, not preferred wording. |
+| Tests | extensive unit/contract coverage, sparse model-behavior evals | Expand | Outcome eval corpus spanning models, harnesses, cost, latency, safety, and alternative valid strategies. |
+
+---
+
+## Requirements Trace
+
+### Evaluation and adaptability
+
+- R1. Establish a versioned, reproducible eval corpus before simplifying production behavior. It must measure task success, safety, intervention rate, cost, latency, and robustness without requiring one prescribed reasoning trace.
+- R2. Run representative evals across multiple model capability tiers and all three supported harnesses; distinguish model failures, harness failures, and adapter failures.
+- R3. Record raw task inputs, structured tool events, terminal outcomes, grader evidence, and bounded metadata while excluding secrets and unnecessary user-authored content.
+- R4. Every policy removal or routing change must state its baseline, expected gain, regression budget, and rollback condition.
+- R33. Every rule proposed for removal must have a rule-specific ablation and counterexample suite that tests both visible task outcome and hidden safety/provenance degradation.
+- R25. Every eval run must execute inside a deterministic isolation boundary with a disposable workspace, bounded filesystem scope, explicit environment and network policy, no ambient credentials by default, per-run artifacts, and cleanup/readback evidence.
+- R26. Eval and shadow artifacts must follow a defined data-classification, redaction, retention, and sharing policy; redaction failure fails closed before persistence.
+
+### Thin capability kernel
+
+- R5. Publish one structured, source-tagged capability snapshot covering tools, skills, agents/lenses, model availability, workflow protection, config sources, trust level, and freshness.
+- R6. Replace global catalog and procedural bootstrap text with progressive discovery; initial context must contain only stable facts needed for the current session.
+- R7. Keep deterministic code limited to capability execution, authorization, evidence collection, atomic projection, compatibility, and externally enforced invariants.
+- R8. Unsupported capabilities must be explicit and queryable, with native-harness fallbacks preferred over Systematic emulation.
+- R34. OpenCode, Pi, and Claude Code must preserve one minimum user-visible contract for core workflows: the same intended outcome, approval boundary, evidence meaning, unsupported-state semantics, and failure visibility, even when native mechanisms differ.
+
+### Model-owned workflow
+
+- R9. Replace mandatory skill invocation and fixed workflow phases with outcome-oriented task contracts. The model may choose direct action, skills, delegation, search, and review according to task evidence.
+- R10. Preserve user approval for irreversible public, destructive, security-sensitive, or cost-bearing actions without requiring a specific internal planning ceremony.
+- R11. Skills must become optional strategy modules whose value can be independently evaluated and whose full instructions load only on demand.
+- R35. Systematic retains opinionated compound-engineering guidance wherever cohort evals show it improves user outcomes; “thin” and “generic” are not independent product goals.
+- R12. Persona selection must move from fixed names and thresholds toward composable capabilities/lenses with a small compatibility layer for existing public agent names.
+
+### Model and harness evolution
+
+- R13. Default model behavior must inherit the user's active model unless an explicit user policy or eval-backed capability requirement justifies an override.
+- R14. No production source list may assume a closed provider or model catalog. Availability and capability facts must come from the host or user configuration.
+- R15. Harness adapters must project one canonical capability/evidence schema and preserve native strengths instead of enforcing artificial parity.
+- R16. Generated Pi and Claude Code artifacts must expose source identity, generation version, freshness, and ownership so drift is observable and repairable.
+
+### Evidence and enforcement
+
+- R17. Replace workflow-specific receipt progression with generic evidence assertions: what changed, which host observed it, what authorization applied, and how fresh the observation is.
+- R18. Models and prompts cannot mint trusted evidence or expand authorization. Deterministic host adapters remain the authority for side effects and user approvals.
+- R19. Evidence checks must validate outcomes rather than command spelling wherever the host can observe the resulting state.
+- R20. Workflow protection must degrade by capability: unavailable evidence blocks only the protected transition that needs it, not unrelated work or the whole session.
+- R27. Trusted evidence must be issued by deterministic host adapters and structurally bound to its issuer, host/adapter identity, subject, observation method, source snapshot, session/run, freshness, and verification result. Model prose may reference evidence but cannot create it.
+- R28. Approval for a protected action must bind to the exact action, resource, repository/workspace/commit snapshot, actor/session, host channel, expiry, and single-use consumption; execution revalidates the binding against current state.
+- R29. Every evidence predicate must declare its invalidation inputs and freshness rule. Mutable-state transitions perform final readback or exact subject comparison immediately before execution.
+- R30. Each harness must publish a deterministic degradation matrix mapping unavailable observation/approval capabilities to allowed work, blocked predicates, and recovery paths.
+
+### Deletion and operational discipline
+
+- R21. Compatibility code must have an owner, usage signal, removal version/date, and test proving the legacy path; unmeasured indefinite shims are prohibited.
+- R22. Documentation, registry profiles, bootstrap text, and generated bundles must derive counts and capability claims from one authoritative source.
+- R23. The migration must preserve clean rollback points and allow old and new behavior to run in shadow or comparison mode before deletion.
+- R24. The final architecture must materially reduce prompt tokens, fixed persona count, policy-bearing code, workflow-guard complexity, and model/provider literals while meeting the eval regression budget.
+- R31. Every migration phase must define versioned state, old/new authority, clean-install and upgrade behavior, rollback behavior, generated-artifact ownership, and mixed-version rejection rules.
+- R32. Every behavior-changing subsystem must run behind a documented shadow/opt-in/default-on gate lifecycle; shadow output remains local and non-authoritative until explicit promotion evidence exists.
+- R36. No more than two behavior-changing migration surfaces may be active simultaneously. Each child plan must close or freeze its compatibility obligations before the program opens another surface beyond that cap.
+
+---
+
+## Scope Boundaries
+
+- This program audits the entire Systematic product: OpenCode runtime, Pi extension/export, Claude Code bundle, CLI, configuration, skills, agents, registry profiles, tests/evals, CI/build scripts, documentation, and the workflow guard.
+- This artifact is not directly implementable and does not authorize a repository-wide rewrite. Each initiative below requires a focused child plan grounded against then-current code, exact interfaces, threat boundaries, migration mechanics, tests, and release scope.
+- At most two behavior-changing initiatives may be active concurrently. Measurement and read-only diagnostics do not count toward the cap; shadow implementations do.
+- Existing public skill and agent names may remain as temporary aliases, but they cannot dictate the target architecture.
+- Security boundaries are not automatically preserved in their current form. They are re-derived from threats and external invariants, then reduced to the smallest mechanism that enforces them.
+- Model prompts are not trusted as enforcement. Better models receive broader decision freedom only inside deterministic authorization and evidence boundaries.
+- Config authority remains explicit: user/custom security policy overrides project policy; project config cannot set or widen `model`, `variant`, `skills`, or `permission`; generated projections cannot become a higher-trust config source.
+- The eval system must remain local/self-hostable by default. Versioned local eval fixtures and redacted run artifacts are not product telemetry; no automatic external transmission or collection is introduced.
+- Adding production dependencies, changing release/CI workflows, or changing the default protection mode remains separately approval-gated during implementation.
+
+### Deferred to Separate Tasks
+
+- Training or fine-tuning a routing model: defer until the local eval corpus proves that a learned router would outperform direct model choice or simple capability constraints.
+- Automatic model escalation from eval scorecards: defer until inherit-first routing and capability incompatibility detection are proven. Any future escalation requires separate approval, explicit user opt-in, freshness, cost/latency limits, and a visible reason.
+- Organization-wide shared eval infrastructure: defer until the repository-local runner and schema stabilize.
+- Support for additional harnesses: defer until the canonical capability schema and adapter conformance suite are proven on OpenCode, Pi, and Claude Code.
+- Durable cloud audit storage: defer; the default remains local, bounded, and privacy-minimized.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/index.ts` and `src/pi.ts` are the runtime composition roots. They should become thin adapters over canonical capabilities rather than policy aggregators.
+- `src/lib/bootstrap.ts` mixes marker management, full workflow policy, profiles, and catalogs. Its marker/idempotency behavior is useful; its payload should shrink radically.
+- `src/lib/skill-catalog.ts`, `src/lib/discovered-skills.ts`, `src/lib/agents.ts`, and `src/lib/agent-resolver.ts` already provide the discovery substrate needed for progressive disclosure.
+- `src/lib/source-model-defaults.ts` and `src/lib/model-availability.ts` demonstrate the current split between adaptive availability discovery and static human-authored routing.
+- `src/lib/config.ts`, `src/lib/config-schema.ts`, and `src/lib/config-handler.ts` contain both justified trust boundaries and heuristic ownership/projection policy.
+- `src/lib/workflow-guard.ts`, `src/lib/opencode-workflow-guard.ts`, `src/lib/receipt-ledger.ts`, `src/lib/receipt-readback.ts`, `src/lib/receipt-classifier.ts`, `src/lib/opencode-operation-observer.ts`, and `src/lib/question-attestation.ts` form the current evidence and enforcement control plane.
+- `scripts/build-claude-code-plugin.ts`, `src/lib/pi-subagents-export.ts`, and `registry/` are generated-projection precedents; their source-owned output and drift checks should generalize into one projection contract.
+- `tests/integration/opencode.test.ts`, `tests/integration/pi.test.ts`, and `tests/integration/claude-code.test.ts` provide real or packaged harness seams but do not yet form a cross-model outcome eval platform.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md` establishes that validation must mirror runtime semantics rather than check an idealized source shape.
+- `docs/solutions/best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md` establishes that shared-core tests do not prove adapter parity.
+- `docs/solutions/workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md` establishes that source correctness does not prove installed runtime correctness.
+- `docs/solutions/logic-errors/pi-chained-bootstrap-composition-2026-07-14.md` demonstrates the fragility of prompt composition and the need to preserve foreign host context.
+- `docs/solutions/integration-issues/opencode-plugin-hook-silent-defect-swallow-2026-05-19.md` shows why host-hook observability must be explicit.
+- `docs/plans/2026-07-21-002-test-receipt-workflow-capabilities-plan.md` and the receipt integration tests establish the correct anti-vibes posture: real-host observations, bounded evidence, and explicit unsupported states.
+- The #743/#746 incident chain demonstrates the cost of reasoning over transformed command text across plugin boundaries. Path normalization, hook argument mutation, duplicate registrations, cached plugin versions, and worktree registration all became independent confounders around one operation fingerprint.
+
+### External References
+
+- Richard Sutton, [The Bitter Lesson](http://www.incompleteideas.net/IncIdeas/BitterLesson.html), 2019 — general methods that scale through search and learning outperform accumulated human domain encoding.
+- Anthropic, [Demystifying evals for AI agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents) — outcome-oriented agent evals, multiple graders, transcript inspection, and eval maintenance.
+- OpenAI, [Evals](https://github.com/openai/evals) and [evaluation guidance](https://developers.openai.com/api/docs/guides/evals) — structured regression, model comparison, and continuous evaluation.
+- Google Research, [Towards a science of scaling agent systems](https://research.google/blog/towards-a-science-of-scaling-agent-systems-when-and-why-agent-systems-work/) — orchestration benefit depends on task decomposability, tool density, and coordination cost rather than a universal multi-agent advantage.
+
+---
+
+## Key Technical Decisions
+
+- KTD-1 — **Evals precede simplification.** Existing rules are not retained because they feel safe, and they are not deleted because they feel overengineered. Shadow comparisons establish whether each rule improves outcomes, reduces risk, or merely constrains solution space.
+- KTD-1a — **Ablate rules, not just systems.** A candidate architecture cannot earn deletion through aggregate green scores alone. Every removed rule needs counterexamples that detect equal visible output with weaker provenance, authorization, recovery, or safety margin.
+- KTD-2 — **One canonical capability schema.** Runtime facts, not prose conventions, describe available tools, skills, lenses, models, guard capabilities, config sources, trust, ownership, and freshness. Harness-specific adapters project this schema into native mechanisms.
+- KTD-2a — **The capability schema is descriptive, not prescriptive.** It may expose host affordances, invocation handles, availability, provenance, trust, freshness, and limits. It cannot encode routing thresholds, required workflow sequences, preferred skill order, persona-selection policy, or provider/model preference. Avoid one recursive “everything manifest”; every field must name its consumer and failure consequence.
+- KTD-3 — **The model owns reversible workflow decisions.** Search order, skill use, delegation, planning depth, reviewer selection, and iteration strategy are model choices. Deterministic code owns only authorization, evidence, compatibility, and irreversible side-effect boundaries.
+- KTD-4 — **Outcome contracts replace phase scripts.** Core workflows state goals, required evidence, user gates, and terminal conditions. Strategy references may suggest tactics but cannot require one trace unless the trace itself is externally required.
+- KTD-5 — **Progressive disclosure replaces bootstrap completeness.** Session start carries a compact capability summary and discovery handles. Full catalogs, skills, profiles, and historical guidance load only when requested or task-relevant.
+- KTD-6 — **Generalists plus lenses replace persona proliferation.** Lenses are small review perspectives or constraints, not autonomous personas or runtime routing rules by default. A small set of execution/research/review capabilities may compose security, correctness, product, performance, design, and other lenses. Dispatch remains a model decision unless permissions, isolation, or concurrency change the execution boundary. Compatibility aliases map old persona names during migration.
+- KTD-7 — **Model inheritance is the default and only baseline router.** Static provider/model chains are deleted. Explicit user policy wins; otherwise the active model handles the task. Eval scorecards may inform local diagnostics or opt-in recommendations but cannot silently override the invoking model.
+- KTD-8 — **Evidence and authorization are separate.** Evidence records describe host-observed facts such as workspace deltas, passing checks, commits, pushes, and PR state. Authorization records describe user/host permission for an exact risky action and snapshot. A policy check may require both, but neither subsystem owns workflow phases or the other's lifecycle.
+- KTD-9 — **Effects beat command parsing.** Typed tools and post-action state observations are preferred. Shell parsing remains only as a narrow risk classifier where the host provides no safer execution boundary; it is not the primary source of operation truth.
+- KTD-10 — **Native harness strengths remain native.** Systematic does not emulate background tasks, blocking questions, task lists, or workflow controls solely to make all harnesses look alike. The canonical schema reports capabilities and honest fallbacks.
+- KTD-10a — **One minimum user contract remains portable.** Core workflows keep equivalent outcomes, approval semantics, evidence meaning, unsupported-state behavior, and visible failure across OpenCode, Pi, and Claude Code. Native mechanisms may differ; trust meaning may not silently drift.
+- KTD-11 — **Generated projections carry provenance.** Every generated profile, persona export, or plugin bundle declares its source identity, generation version, ownership, and freshness. User-owned content remains separate.
+- KTD-11a — **Generated output is never source authority.** Projection manifests bind source identity, generator identity/version, content digest, ownership, and freshness. Installers and rollback paths verify those bindings and reject stale, tampered, or ambiguous mixed-version output.
+- KTD-12 — **Compatibility expires.** Aliases, marker readers, namespace translations, and legacy config paths require measured use and an explicit removal release. Absence of evidence is not a reason to keep them forever.
+- KTD-13 — **Replacement and deletion travel together.** Each behavior-changing initiative names the legacy surface it narrows or removes, its comparison window, promotion gate, and rollback. I8 completes compatibility cleanup; it is not the first deletion phase.
+- KTD-14 — **This is a program, not a mega-implementation.** The initiatives below define dependencies and child-plan acceptance. No initiative starts implementation from this document alone, and no more than two behavior-changing surfaces run concurrently.
+
+---
+
+## High-Level Technical Design
+
+> This illustrates the intended approach and is directional guidance for review, not implementation specification.
+
+```mermaid
+flowchart TB
+  USER[User goal and constraints] --> MODEL[Active model]
+  FACTS[Compact session capability facts] --> MODEL
+  MODEL --> DISCOVER[Queryable skill / lens / tool discovery]
+  DISCOVER --> MODEL
+  MODEL --> ACT[Native harness tools and bounded capabilities]
+  ACT --> OBSERVE[Host evidence adapters]
+  OBSERVE --> EVIDENCE[Canonical evidence records]
+  EVIDENCE --> MODEL
+  EVIDENCE --> POLICY[Authorization and irreversible-action policy]
+  POLICY --> ACT
+  MODEL --> RESULT[Outcome]
+  RESULT --> EVAL[Cross-model / cross-harness graders]
+  EVAL --> ROUTING[Local scorecards and policy deletion decisions]
+  ROUTING --> FACTS
+```
+
+The target has four layers:
+
+1. **Capability layer:** discovers and executes native tools, skills, lenses, config, and generated projections.
+2. **Evidence layer:** observes side effects and external state without assuming a Systematic workflow.
+3. **Authorization layer:** enforces user, repository, and host trust boundaries for risky transitions.
+4. **Evaluation layer:** compares outcomes across models, harnesses, strategies, and policy variants.
+
+Prompt workflows become optional policy packages above these layers, not the control plane beneath them.
+
+---
+
+## Acceptance Examples
+
+- A strong model receives a coding task, inspects capabilities, chooses a direct execution path without loading `ce:work`, passes the same behavior and safety evals, and is not penalized for skipping the historical phase sequence.
+- A weaker model chooses a planning or TDD strategy skill, uses more steps, and succeeds against the same outcome graders. Both traces are valid.
+- A user upgrades or changes providers. Systematic inherits the active model without requiring a source release that edits provider literals.
+- A security-sensitive change triggers an authorization requirement because of the affected action/resource, not because a named workflow happened to be active.
+- A write performed through a typed edit tool produces workspace-delta evidence. An equivalent safe write through another host-native tool can produce the same evidence without adding another command-shape allowlist entry.
+- A shell command succeeds but causes no relevant state change. It cannot satisfy an outcome requiring a changed workspace, commit, push, or PR.
+- OpenCode supports rich background delegation while Pi supports only sequential delegation. Each model sees the native capability truth and can still satisfy the same task-level eval.
+- Claude Code loads a generated plugin whose provenance and source version are queryable; drift from the source bundle fails conformance even if the build itself succeeds.
+- A removed reviewer persona name resolves through a compatibility alias during the migration, emits a deprecation signal, and maps to a general reviewer plus the equivalent lens.
+- A legacy receipt marker is observed after its supported window. The system reports the required upgrade/readback path rather than carrying another indefinite parser branch.
+- A bootstrap without a full skill catalog remains sufficient because the model can query discovery. Measured task success stays within the regression budget while prompt tokens materially decrease.
+- A new model materially outperforms the current preferred workflow using an unexpected strategy. The eval accepts the outcome and provides evidence to delete or narrow the obsolete policy.
+
+---
+
+## Phased Delivery
+
+### Phase 1 — Measure and expose
+
+Create focused child plans for the eval foundation and read-only capability diagnostic. Ship only measurement and introspection in this phase; default runtime behavior remains unchanged.
+
+### Phase 2 — Selectively simplify product policy
+
+Use evidence from Phase 1 to choose narrow wedges in bootstrap, workflow guidance, personas, and model inheritance. Preserve opinionated guidance where it improves user outcomes. No more than two behavior-changing wedges run concurrently.
+
+### Phase 3 — Revisit adapters and trust machinery
+
+Create separate child plans for generated adapters and for evidence/authorization only if earlier measurements show those migrations are warranted. OpenCode remains the first comparison host; Pi and Claude Code follow only after the minimum cross-harness user contract is proven.
+
+### Phase 4 — Complete proven deletions
+
+Complete compatibility removals already started by earlier initiatives. Phase 4 is not the first deletion point and does not reopen unresolved migrations.
+
+### Shadow / comparison mode contract
+
+- Legacy behavior remains authoritative until the candidate subsystem passes its promotion gate.
+- Each comparison record is local and versioned and identifies the subsystem, harness, install mode, source/package identity, old result, candidate result, equivalence classification, redacted evidence pointer, and timestamp.
+- Allowed classifications are equivalent, safer, less safe, intentional behavior change, unsupported, and error. Unclassified drift is a release blocker.
+- Shadow execution cannot mint authoritative evidence, consume approvals, mutate generated ownership state, or affect the user-visible outcome.
+- Every subsystem gate declares owner, supported harnesses, current default, evidence location, promotion criteria, rollback action, and removal release/date.
+
+### Install, release, and rollback contract
+
+Every migration release verifies source checkout, packed and installed npm artifacts, generated Pi exports, generated Claude Code bundles, and registry outputs across clean install, upgrade from latest stable, upgrade from the previous migration release, and rollback to latest stable where the surface applies.
+
+The release evidence packet includes source/package identity, gate defaults, compatibility-ledger changes, eval comparison, safety results, clean/upgrade/rollback results, generated provenance, unsupported capabilities, privacy confirmation, and deletion candidates. New local state is versioned; old runtimes ignore or explicitly reject unknown evidence rather than misinterpreting it. Rollback never requires deleting or overwriting user-owned files.
+
+### Compatibility deletion entry criteria
+
+A compatibility path may be deleted only after its replacement and deprecation have shipped in stable releases; clean installs no longer depend on it; supported upgrades migrate or fail clearly; generated artifacts and docs no longer emit it; rollback remains documented; and local/operator evidence supports deletion. Unknown usage requires either more evidence or an explicit major-release breaking decision—it is not silently treated as zero.
+
+---
+
+## Program Initiative Contract
+
+The sections below are architecture initiatives, not implementation-ready units. Before implementation, each initiative must produce and pass review on a focused child plan that defines:
+
+- the verified user or operator pain and the do-nothing baseline;
+- the exact current interfaces, call sites, generated surfaces, and trust boundaries involved;
+- a narrow first wedge, paired deletion or narrowing slice, and explicit non-goals;
+- baseline and candidate eval cases, including rule-specific ablations and counterexamples;
+- the authoritative old/new behavior, gate lifecycle, compatibility window, and rollback mechanics;
+- clean-install, upgrade, installed-artifact, and harness-specific verification where applicable;
+- privacy classification, evidence provenance, and degraded-capability behavior when trust data is involved;
+- a release evidence packet and stop condition.
+
+An initiative cannot enter implementation while two other behavior-changing surfaces are active. If a compatibility obligation misses its removal deadline, the program either makes an explicit major-version breaking decision or freezes it as supported debt; it does not extend an indefinite proof loop.
+
+---
+
+## Program Initiatives
+
+### I1. Establish the outcome-evaluation foundation
+
+- [ ] **Goal:** Create the measurement system that decides which current rules help and which obstruct model improvement.
+- **Requirements:** R1-R4, R23-R26, R33, R36.
+- **Dependencies:** None.
+- **Files:**
+  - Create: `evals/` with versioned task cases, fixtures, graders, model/harness matrices, and result schemas.
+  - Create: `scripts/run-evals.ts` and focused eval support modules under `scripts/lib/` or `src/lib/` according to runtime ownership.
+  - Modify: `package.json` scripts only after approval if new named commands are needed.
+  - Extend: `tests/integration/` harness fixtures for deterministic replay and installed-artifact execution.
+  - Create: `docs/src/content/docs/guides/evaluations.mdx`.
+  - Modify: `HARNESSES.md` evidence expectations.
+- **Approach:**
+  - Run each case in a fresh disposable worktree or temporary repository with bounded filesystem scope, an explicit environment allowlist, controlled network access, no ambient credentials by default, separate artifacts, and mandatory cleanup/readback. Cases needing credentials receive explicit scoped fixtures.
+  - Define outcome cases spanning atomic edits, ambiguous bugs, broad refactors, research, planning, review, worktrees, delegation, recovery, public-action approval, and adversarial prompt content.
+  - Separate deterministic graders (tests, diffs, file state, git/GitHub state, policy violations) from rubric graders (quality, maintainability, plan usefulness). Use multiple graders where subjective assessment is unavoidable.
+  - Record strategy-neutral transcripts and tool events so alternative successful traces remain valid.
+  - Add A/B variants for current policy, thinner policy, and no-policy baselines. Report confidence intervals or repeated-run variance rather than treating one run as truth.
+  - Define prohibited, fixture-only, derived-only, and allowed-by-default artifact fields. Apply deterministic redaction before persistence, document retention, and fail closed if redaction cannot complete. Raw output, absolute paths, repository content, and user prose are not persisted unless the versioned case explicitly owns them.
+  - Establish regression budgets per task class instead of one global score; safety-critical cases remain zero-tolerance.
+- **Patterns to follow:** existing isolated OpenCode/Pi/Claude fixtures, receipt real-host tests, installed-artifact verification learning.
+- **Test scenarios:**
+  - Happy path: the same case runs against at least two models and two harnesses and produces comparable structured results.
+  - Alternative strategy: two different valid traces receive equivalent success credit.
+  - Grader disagreement: deterministic and rubric graders disagree without silently collapsing to pass/fail.
+  - Privacy: injected secrets and user-authored prose do not appear in persisted eval artifacts beyond approved fixtures.
+  - Reproducibility: pinned case/version/model configuration can be rerun and compared.
+  - Isolation: an attempted out-of-workspace write or undeclared credential access fails the case and leaves the primary checkout unchanged.
+  - Crash cleanup: an interrupted case records cleanup status and cannot contaminate the next run.
+- **Child-plan entry gate:** specify the repository entrypoint, runner ownership, installed-artifact selection, harness setup/teardown, artifact schema, access/retention rules, and cost envelope before implementation.
+- **Verification:** current Systematic behavior has a local baseline; policy changes cannot proceed without a linked eval delta. This initiative is its own implementation program and may ship incrementally rather than blocking harmless read-only diagnostics.
+
+### I2. Introduce a read-only capability snapshot, then test progressive discovery
+
+- [ ] **Goal:** Give models concise, structured, current facts and move large catalogs/policies out of global context.
+- **Requirements:** R5-R8, R15, R22-R24, R31-R32, R34, R36.
+- **Dependencies:** A minimal I1 harness establishes token/discovery baselines. The read-only diagnostic may ship before the full corpus; behavior-changing progressive disclosure waits for representative eval evidence.
+- **Files:**
+  - Create: `src/lib/capability-schema.ts` and `src/lib/capability-snapshot.ts`.
+  - Modify: `src/lib/bootstrap.ts`, `src/lib/skill-catalog.ts`, `src/lib/discovered-skills.ts`, `src/lib/agent-resolver.ts`, `src/index.ts`, `src/pi.ts`.
+  - Modify: `scripts/build-claude-code-plugin.ts` to emit the same fact model through native Claude Code surfaces.
+  - Modify: `src/cli.ts` with a live capability/diagnostic view and “why unavailable” explanations.
+  - Test: new capability schema/snapshot tests plus all harness integration suites.
+- **Approach:**
+  - First ship a read-only snapshot and CLI diagnostic with no routing or bootstrap behavior change. Then gate progressive disclosure separately.
+  - Keep the schema small and descriptive. Separate capability, source, availability, trust boundary, and projection facts rather than creating a recursive universal manifest. Every field names its runtime consumer and consequence if stale or wrong.
+  - Represent each capability with stable ID, kind, source, native binding, trust level, freshness, availability, limitations, and discovery handle; do not include activation thresholds, preferred order, model/provider recommendations, or workflow sequences.
+  - Keep session-start content declarative and small. Include only harness identity, high-level capability classes, safety/approval boundaries, and how to query details.
+  - Remove verbose skill/agent catalogs from bootstrap once evals prove query-based discovery works.
+  - Generate documentation counts and profile inventories from the same schema.
+  - Replace internal-agent prompt signatures, description-based ownership, and path-prefix ownership heuristics with explicit host/source metadata where available; report unsupported host metadata honestly.
+  - Keep the current bootstrap authoritative while the read-only snapshot ships. A focused child plan must name the first OpenCode/Pi consumer, marker coexistence behavior, Claude Code projection path, and the exact payload section removed at promotion.
+- **Test scenarios:**
+  - Freshness: model/provider/tool changes update the snapshot without a source edit.
+  - Discovery: disabled, missing, invalid, unsupported, and available entries are distinguishable.
+  - Token budget: bootstrap size falls materially while outcome scores stay within budget.
+  - Duplicate registration: multiple sources retain explicit identities without prompt sniffing.
+  - Cross-harness: the same canonical fact has a native projection or explicit unsupported result in each harness.
+  - Paired deletion: after query-based discovery passes its gate, remove at least one verbose bootstrap catalog section rather than maintaining a full duplicate path.
+- **Child-plan entry gate:** define the minimal schema fields and their consumers, bootstrap coexistence sequence, cross-harness minimum contract, generated-projection versioning, and first paired deletion.
+- **Verification:** one diagnostic surface explains the active harness, config sources, discovered assets, available models, protection capabilities, and projection freshness; the first promoted discovery slice deletes its superseded bootstrap payload.
+
+### I3. Test outcome contracts on one workflow family
+
+- [ ] **Goal:** Let models choose how much process they need while preserving user constraints, evidence requirements, and irreversible-action gates.
+- **Requirements:** R9-R11, R24, R33, R35-R36.
+- **Dependencies:** I1 baselines and I2 progressive discovery.
+- **Files:**
+  - Candidate scope only: choose one workflow family from `skills/ce-work/SKILL.md`, `skills/ce-plan/SKILL.md`, `skills/ce-review/SKILL.md`, or `skills/test-driven-development/SKILL.md` in the child plan. Do not rewrite all core skills in one release.
+  - Treat `skills/using-systematic/SKILL.md` and `skills/orchestrating-subagents/SKILL.md` as separate follow-on surfaces unless the selected wedge requires a narrowly scoped compatibility edit.
+  - Review and rationalize: remaining skill definitions under `skills/` and their references.
+  - Modify: `scripts/content-integrity.ts` to enforce outcome/safety metadata and source references rather than wording bans.
+  - Update: generated docs and registry artifacts.
+  - Test: skill loading, content integrity, harness payload, and eval comparisons.
+- **Approach:**
+  - Define a compact contract for each skill: intended outcomes, entry signals, required evidence, user gates, failure/stop conditions, and optional strategy references.
+  - Delete mandatory skill invocation, one-percent applicability, unconditional planning/review/TDD, fixed stopping-point choreography, and harness-specific syntax from global instructions.
+  - Keep strict requirements only where skipping them creates an externally demonstrated risk. Encode those requirements in deterministic checks when possible.
+  - Move detailed tactics into short references the model can load selectively.
+  - Compare current and compact variants across weak and strong models; preserve guidance that measurably helps weaker models without constraining stronger ones by making it optional or capability-tiered.
+  - Pair the first promoted contract with deletion of the mandatory one-percent skill-invocation rule; do not retain it as a hidden compatibility default.
+- **Test scenarios:**
+  - Direct path: an atomic change completes safely without loading a workflow skill.
+  - Assisted path: a complex change loads planning/TDD/review guidance and benefits measurably.
+  - Strong-model path: a valid unanticipated workflow passes all outcome graders.
+  - User-gate path: public/destructive action still pauses for explicit approval independent of workflow choice.
+  - Portability: no skill assumes an unavailable harness mechanism.
+- **Child-plan entry gate:** identify the first workflow family, measured user pain, weak/strong-model cohorts, fallback guidance for high-risk tasks, and the exact rule removed or narrowed.
+- **Verification:** the selected workflow's token footprint and mandatory procedural rules decrease materially with no safety regression and an improved or neutral task-success frontier. Broader skill migration requires another reviewed child plan.
+
+### I4. Collapse one redundant persona cluster before considering lenses
+
+- [ ] **Goal:** Preserve specialized scrutiny without hardcoding dozens of permanent agent identities and dispatch thresholds.
+- **Requirements:** R5, R9, R12, R15, R24, R33, R35-R36.
+- **Dependencies:** I1 evals and I2 capability schema.
+- **Files:**
+  - Create: canonical lens/capability metadata under `agents/` or a generated manifest owned by source content.
+  - Modify: `src/lib/agents.ts`, `src/lib/agent-resolver.ts`, `src/lib/agent-overlays.ts`, `src/lib/config-handler.ts`, `src/lib/pi-delegate-tool.ts`.
+  - Rationalize: `agents/review/`, `agents/document-review/`, `agents/workflow/`, `agents/research/`, and `agents/design/`.
+  - Modify: registry generation, Pi export, and Claude Code flattening.
+  - Test: compatibility aliases, lens composition, dynamic selection, and review eval coverage.
+- **Approach:**
+  - Start by identifying and collapsing one cluster whose members differ only by prose framing. Do not introduce a general lens runtime merely to rename today's persona router.
+  - Only if the cluster eval demonstrates a real need, define a small set of execution modes such as explore, implement, research, review, and design, then test compact review perspectives such as correctness or security.
+  - Store lenses as small prompt fragments and descriptive metadata: stable ID, purpose, required permissions, incompatibilities, and evidence expectations. Production metadata contains no default activation thresholds.
+  - Let the active model discover and select lenses from task evidence. Threshold and router experiments live only in eval configuration unless a later plan proves a narrow optional hint.
+  - Keep old public names as generated aliases for one major-version window; measure use and publish mappings.
+  - Collapse personas whose only distinction is prose framing and retain separate agents only where tool permissions or execution environments genuinely differ.
+  - Allow a single capable model to apply multiple lenses serially when multi-agent coordination does not improve eval outcomes.
+- **Test scenarios:**
+  - Review recall: composed lenses find the same or more seeded defects than the current persona swarm with acceptable false positives.
+  - Coordination cost: simple diffs avoid unnecessary multi-agent dispatch.
+  - Compatibility: old names resolve to equivalent capabilities during the migration window.
+  - Permission boundary: design/write-capable and read-only review capabilities remain distinct where needed.
+  - Unknown lens: fail with a discoverable explanation, not a fixed translation-table crash.
+  - No-router regression: strong-model cohorts remain within review budget when all automatic lens routing is disabled.
+  - Paired deletion: collapse at least one redundant persona cluster into temporary aliases during this unit.
+- **Child-plan entry gate:** name the exact cluster, compatibility aliases, seeded defects, permission distinctions, coordination baseline, and proof that a new lens abstraction pays rent.
+- **Verification:** fewer canonical personas, no loss of review coverage, and lower median coordination cost on evals. A general lens system is optional follow-on work, not the default result.
+
+### I5. Remove one static model-routing assumption at a time
+
+- [ ] **Goal:** Make Systematic improve automatically as users adopt better models instead of pinning tasks to the model market of August 2026.
+- **Requirements:** R2, R4, R13-R14, R24, R31-R33, R36.
+- **Dependencies:** I1 eval scorecards and I2 capability snapshot.
+- **Files:**
+  - Retire or radically narrow: `src/lib/source-model-defaults.ts`.
+  - Modify: `src/lib/model-availability.ts`, `src/lib/config-handler.ts`, `src/lib/agent-overlays.ts`, `src/lib/config-schema.ts`.
+  - Modify: generated configuration docs and OMO/standalone registry profiles.
+  - Test: model inheritance, explicit user overrides, unavailable capability handling, and eval-backed optional escalation.
+- **Approach:**
+  - Default every bundled agent/capability to the invoking model.
+  - Preserve explicit user configuration as the only unconditional model override.
+  - Describe task needs as capabilities or constraints such as context size, tool use, vision, cost ceiling, latency preference, and reasoning strength, without naming a provider in the canonical policy.
+  - Do not implement automatic escalation in this migration. Capability incompatibility may explain why the active model cannot perform a task, but changing models remains explicit user policy.
+  - Remove provider frequency lore and hardcoded provider unions from runtime policy; validate identifiers structurally rather than against a closed commercial catalog.
+  - Remove fallback-to-first-provider behavior as the first deletion slice; unknown availability inherits rather than guesses.
+- **Test scenarios:**
+  - New provider/model: becomes usable without a Systematic release.
+  - Active-model improvement: stronger invoking model receives full workflow freedom rather than being downgraded by category defaults.
+  - User override: remains authoritative and trust-protected.
+  - Unknown availability: inherits safely instead of guessing a model.
+  - Scorecard drift: stale eval data is visible and cannot silently route.
+- **Child-plan entry gate:** inventory each current default's consumer and fallback behavior, select one deletion wedge, and define config precedence and rollback without introducing scorecard-driven routing.
+- **Verification:** each promoted wedge removes a source-owned market assumption without reducing task success or overriding explicit user policy. Final zero-literal cleanup is a later deletion decision.
+
+### I6. Unify generated projection facts without flattening native behavior
+
+- [ ] **Goal:** Reduce translation policy and generated drift while preserving each host's native capabilities.
+- **Requirements:** R5-R8, R14-R16, R22-R24, R31-R32, R34, R36.
+- **Dependencies:** I2 canonical schema; promoted slices from I3/I4/I5 only where they change projected content.
+- **Files:**
+  - Modify: `src/index.ts`, `src/pi.ts`, `src/lib/config-handler.ts`, `src/lib/agent-resolver.ts`, `src/lib/pi-subagents-export.ts`, `scripts/build-claude-code-plugin.ts`.
+  - Consolidate: harness profile and registry generation inputs.
+  - Modify: `HARNESSES.md`, installation/configuration guides, registry docs.
+  - Test: direct adapter conformance comparisons and installed-artifact scenarios.
+- **Approach:**
+  - Define an adapter contract that accepts canonical capabilities/content and returns native bindings, unsupported facts, provenance, and drift state.
+  - Discover host tools and supported fields at runtime or build time where authoritative schemas exist; keep narrow fail-closed fallbacks for unknown execution capabilities.
+  - Stop flattening identity unless a host requires it. When flattening is required, generate stable IDs and reversible aliases rather than relying on filename stems or namespace string surgery.
+  - Unify generated-artifact ownership semantics across Pi exports, Claude Code bundles, and registry profiles.
+  - Generated artifacts are non-authoritative projections. Their manifests bind source identity, generator version, content digest, ownership, and freshness; installs reject ambiguous mixed versions rather than inferring precedence.
+  - Preserve direct boundary tests for each adapter; do not infer parity from shared-core tests.
+- **Test scenarios:**
+  - Host adds a tool or field: discovery exposes it without a hardcoded translation-table edit where the host schema permits.
+  - Host removes or changes a field: adapter reports incompatibility with source/freshness context.
+  - Generated artifact drift: detected before publication and explainable to operators.
+  - User-owned output: never overwritten by projection refresh.
+  - Mixed installation sources: ownership and precedence remain explicit.
+- **Child-plan entry gate:** specify per-artifact versioning, source/generated authority, tamper/staleness validation, clean/upgrade/rollback installation paths, and mixed-install rejection behavior.
+- **Verification:** adapters contain binding code rather than workflow policy; every capability has conformance evidence or an explicit unsupported status.
+
+### I7. Threat-model and narrow workflow protection before any replacement
+
+- [ ] **Goal:** Preserve trustworthy operation evidence while deleting the assumption that Systematic must prescribe and attest one development workflow.
+- **Requirements:** R7, R10, R17-R20, R23-R24, R27-R32, R33-R34, R36.
+- **Dependencies:** I1 evidence evals, I2 capability schema, and I6 adapter contract.
+- **Files:**
+  - Candidate only after child-plan approval: separate evidence-record, authorization-boundary, and thin host-adapter modules under `src/lib/`.
+  - Refactor or retire: `src/lib/workflow-guard.ts`, `src/lib/opencode-workflow-guard.ts`, `src/lib/receipt-ledger.ts`, `src/lib/receipt-readback.ts`, `src/lib/receipt-classifier.ts`, `src/lib/question-attestation.ts`.
+  - Reuse narrowly: `src/lib/opencode-operation-observer.ts` state observation and remote readback primitives.
+  - Modify: `src/index.ts`, config schema/loading, capability snapshot, and workflow tools.
+  - Replace/extend: receipt unit/integration tests with generic evidence, authorization, replay, privacy, and real-host cases.
+- **Approach:**
+  - Define evidence as adapter-issued host observations with type, issuer, host/adapter identity and version, subject/resource, observation method, source snapshot, before/after identities, result, run/session, freshness, verification status, and privacy-bounded integrity. Models may reference evidence IDs but cannot create records.
+  - Define an issuer trust policy mapping each adapter identity/version to the evidence classes it may issue. Compromised, unknown, downgraded, or stale issuers cannot satisfy protected predicates.
+  - Define authorization separately as a single-use, expiring grant bound to action, resource, actor/session, host channel, and exact workspace/commit snapshot. Revalidate immediately before execution.
+  - Remove epochs, units, skill-activation detection, fixed required-operation sequences, and completion attestation from the trusted core.
+  - Let workflows or models request evidence predicates such as “workspace changed,” “verification passed after the latest change,” “commit contains current workspace,” “remote branch contains commit,” “PR checks are green,” or “user approved this publication.”
+  - Prefer typed tool events and direct state comparisons. Replace shell command grammar as the primary classifier; retain only a small execution-risk parser if needed to decide whether a raw shell action itself requires authorization.
+  - Evaluate predicates as pure functions over evidence records and authorization grants. Do not create a generic workflow state machine, pending predicate lifecycle, or monolithic module owning collection, authorization, readback, projection, and progression.
+  - Use native host authorization/question channels directly when possible. Preserve one-time binding and replay protection only for approvals that cross a real trust boundary.
+  - Require each predicate to declare invalidation inputs and freshness. Perform final readback or exact subject comparison immediately before a protected transition.
+  - Run the new kernel in shadow mode beside receipt progression. Compare false accept, false reject, unavailability, latency, and recovery behavior before enforcement changes.
+  - Publish a capability-to-predicate degradation matrix. Missing GitHub readback must not disable local editing; missing worktree identity must not fabricate local evidence; unavailable approval channels block only the risky action requiring consent.
+  - Preserve the minimum safety kernel until rule-specific threat models and adversarial counterexamples justify narrowing: project-config privilege boundaries, approval binding/replay resistance, operation provenance, current-state freshness, worktree/repository identity, atomic writes, and user-owned-file protection.
+  - Pair promotion with retirement of at least one workflow-specific receipt/progression requirement proven equivalent by shadow evidence.
+- **Test scenarios:**
+  - Equivalent effects: multiple tool paths produce the same valid workspace-delta evidence.
+  - No-op/false claim: successful text or tool return without observed effect produces no effect evidence.
+  - Freshness: verification before a later change cannot satisfy a current-state predicate.
+  - Replay/cross-session: evidence and approvals cannot be transplanted or consumed twice.
+  - Authorization binding: approval for one branch/resource/snapshot cannot authorize another or survive a relevant state change.
+  - Forgery: model-authored or hand-edited evidence fails provenance validation.
+  - Partial capability: unsupported remote readback blocks only remote-state assertions.
+  - Duplicate registrations: source identities coexist without selecting ownership through marker-seed heuristics.
+  - Recovery: installed runtime reconstructs only from host-owned evidence or performs fresh readback.
+  - Privacy: raw commands, outputs, paths, repository contents, and user prose are not persisted unless a specific local eval fixture requires them.
+- **Child-plan entry gate:** map every public `WorkflowGuard` call site, define the minimum safety kernel, exact candidate API, shadow-authority boundary, issuer trust policy, config precedence, degradation matrix, mixed-version state behavior, and first workflow-specific rule eligible for ablation.
+- **Verification:** outcome and security evals meet the regression budget; the selected workflow-specific rule is narrowed or deleted without weakening provenance or authorization; no replacement module combines evidence, authorization, readback, projection, and workflow lifecycle. A universal evidence platform is explicitly out of scope.
+
+### I8. Complete compatibility expiry for already-proven migrations
+
+- [ ] **Goal:** Complete the architecture change by removing shadowed policy, aliases, and generated duplication once evidence supports deletion.
+- **Requirements:** R21-R24, R31-R33, R36.
+- **Dependencies:** relevant I1-I7 child plans have shipped stable replacements, deprecations, and comparison evidence.
+- **Files:**
+  - Delete or simplify superseded workflow-guard, model-default, routing, persona, bootstrap, translation, removed-name, and legacy marker code.
+  - Modify: configuration schema and migrations, package exports, docs, registry profiles, content-integrity rules, and release notes.
+  - Update: `ARCHITECTURE.md`, `STRUCTURE.md`, `AGENTS.md`, `HARNESSES.md`, onboarding, and generated references.
+  - Test: package/runtime compatibility, migration warnings, clean-install behavior, and absence of deleted names/paths.
+- **Approach:**
+  - Maintain a compatibility ledger with feature, owner, measured use, introduced release, removal release/date, and replacement.
+  - Delete code at the scheduled boundary rather than converting deprecation warnings into permanent infrastructure.
+  - Use a major release for removals that affect public names, config, or workflow-control tools.
+  - Keep migration documentation concise and outcome-oriented; do not expose internal agent/process taxonomy in public artifacts.
+  - Re-run the complete eval matrix on clean installs and upgraded installs across all three harnesses.
+  - Require the release evidence packet and compatibility deletion entry criteria defined above; I8 completes only aliases/shims that earlier initiatives have already narrowed.
+- **Test scenarios:**
+  - Clean install: contains only the target architecture and no dormant compatibility branches.
+  - Upgrade: supported old config/names produce a clear bounded migration path before removal; after removal they fail explicitly.
+  - Installed artifacts: npm, Pi, Claude Code, and registry outputs reflect the same source version and capability claims.
+  - Deletion proof: removed provider literals, persona files, workflow markers, and bootstrap rules are absent from source and generated outputs.
+  - Rollback: previous stable major version remains installable without shared-state corruption.
+- **Child-plan entry gate:** list only deletion candidates that already satisfy stable replacement, deprecation, usage, clean-install, upgrade, generated-artifact, and rollback evidence. This initiative cannot invent replacements.
+- **Verification:** the ledger is empty only for the completed migration scope, and cross-harness evals pass on published artifacts. Unproven shims are frozen as explicit supported debt or removed through a declared major-version decision.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `src/index.ts` and `src/pi.ts` become adapter composition roots over capability, evidence, and authorization services. Skills and agents stop activating trusted workflow state. Generated bundles consume the same canonical manifests.
+- **Error propagation:** capability and evidence failures become typed, scoped, source-tagged results. Host-hook exceptions must produce an observable degraded capability instead of disappearing behind best-effort catches.
+- **State lifecycle risks:** shadow mode temporarily duplicates observations; comparison state must remain bounded, local, and clearly non-authoritative. Compatibility aliases and legacy readers require expiry from the start.
+- **API surface parity:** OpenCode, Pi, Claude Code, CLI, registry profiles, docs, and generated artifacts all consume the canonical capability schema but retain native differences.
+- **Integration coverage:** source tests are insufficient. Each phase requires installed-artifact and real-host evidence plus cross-model evals.
+- **Unchanged invariants:** `src/index.ts` keeps a single default export; project config cannot escalate sensitive capabilities; generated writes remain atomic/idempotent; user-owned files are not overwritten; secrets and user data are minimized; public/destructive actions still require explicit authorization.
+
+---
+
+## Success Metrics
+
+Baseline exact values are captured in I1. User outcomes are promotion gates; structural reductions are secondary evidence that the architecture actually simplified rather than merely moved complexity.
+
+- Task success is non-inferior overall and improves on at least one strong-model cohort without reducing weak-model safety.
+- Median time-to-completion, user intervention rate, and regression/rework rate are non-inferior by task cohort.
+- Review and plan usefulness remain non-inferior under rubric and deterministic graders, with no loss of operator-visible evidence or failure clarity.
+- Systematic's opinionated guidance is retained wherever its ablation worsens task success, safety, review quality, or operator confidence.
+- Safety-critical eval cases retain zero unauthorized destructive/public/security-sensitive transitions.
+- The minimum cross-harness user contract passes on OpenCode, Pi, and Claude Code for representative core workflows.
+- Every deleted rule passes its own counterexample and ablation gate; aggregate suite scores cannot mask a safety/provenance regression.
+- Structural targets below cannot promote a change whose user-outcome gate fails.
+- Median bootstrap tokens fall by at least 70%, with full catalogs absent from initial context.
+- Mandatory procedural instruction count falls by at least 80% in the core workflow skills.
+- Canonical bundled persona count falls by at least 60% while seeded-defect review recall remains non-inferior.
+- Production provider/model preference literals fall to zero outside tests, examples, and explicit user configuration.
+- Workflow/evidence policy-bearing source lines fall by at least 50%; further reduction is preferred if security evals permit it.
+- New host capabilities can appear in the capability snapshot without a Systematic release when the host exposes an authoritative schema.
+- Every retained heuristic has a linked eval and every compatibility shim has an expiry.
+- Installed npm, Pi, Claude Code, and registry artifacts pass the same capability/evidence conformance suite.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Evals overfit current tasks or models | High | High | Version broad task families, preserve hidden/held-out cases, compare multiple models, inspect transcripts, and rotate seeded failures. |
+| Eval execution mutates real workspaces or leaks credentials | Medium | Critical | Disposable isolated workspaces, bounded environment/network policy, no ambient secrets, cleanup/readback evidence, and isolation adversarial cases. |
+| Simplification removes guidance that weaker models need | High | Medium | Keep guidance optional and progressively disclosed; compare by model tier before deleting it. |
+| “Model freedom” weakens authorization | Medium | Critical | Separate reversible workflow freedom from deterministic side-effect authorization; zero-tolerance safety evals. |
+| New evidence kernel recreates the old guard under new names | Medium | High | Prohibit workflow-phase concepts in the trusted core; review every field against an external evidence or authorization need. |
+| Cross-harness schema becomes a lowest-common denominator | Medium | High | Represent native extensions and explicit unsupported facts; do not emulate parity by default. |
+| Model routing evals become stale | High | Medium | Inherit by default, attach freshness to scorecards, and require opt-in for automatic escalation. |
+| Compatibility migration never ends | High | High | Removal release/date required when each shim is added; CI reports expired entries. |
+| Eval cost becomes operationally excessive | Medium | Medium | Tier suites into fast deterministic gates, scheduled model matrices, and pre-release full runs; measure value per case. |
+| Generated artifacts diverge during staged rollout | Medium | High | Canonical provenance/freshness metadata and direct installed-artifact conformance tests. |
+| Host APIs lack structured identity/capability metadata | High | Medium | Use explicit `unsupported` and narrow local fallbacks; upstream missing primitives rather than expanding prompt sniffing. |
+| Shadow mode becomes a permanent dual stack | High | High | Old/new authority contract, named gates, local comparison records, paired deletion slices, promotion criteria, and expiry in every behavior-changing initiative. |
+| Program becomes an endless architecture initiative | High | High | Two-surface concurrency cap, focused child plans, narrow first wedges, explicit stop conditions, and freeze-as-supported-debt decisions when deletion proof misses its deadline. |
+| Simplification erases Systematic's useful product identity | Medium | High | Treat opinionated guidance as an ablatable product feature, not presumed debt; promote only when user-outcome cohorts stay non-inferior. |
+
+---
+
+## Alternative Approaches Considered
+
+- **Delete the workflow guard immediately:** rejected. It would confuse justified evidence boundaries with unnecessary workflow policy and discard hard-won security behavior without a comparative replacement.
+- **Keep the architecture and merely shorten prompts:** rejected. Prompt bloat is a symptom; static routing, persona taxonomy, model defaults, adapter mappings, and workflow progression would remain.
+- **Replace deterministic checks with an LLM judge:** rejected for authorization, provenance, and objective side effects. Model graders complement but do not replace verifiable state.
+- **Build a learned router first:** rejected. Without a task corpus and stable capability schema, it would learn current taxonomy and encode the same assumptions less transparently.
+- **Standardize all harnesses behind Systematic abstractions:** rejected. This suppresses native host progress and increases adapter burden. The target standardizes facts and evidence, not UI/tool mechanics.
+- **Preserve every public persona indefinitely:** rejected. Compatibility aliases are temporary; permanent persona accumulation is the exact control-plane growth this plan addresses.
+
+---
+
+## Documentation / Operational Notes
+
+- Publish the Bitter Lesson Engineering rubric as an architectural decision guide after the first phase validates its terminology.
+- Add a generated capability reference and remove hand-maintained catalog counts from public documentation.
+- Document eval scope, privacy, local storage, model/harness versions, and known blind spots with every published comparison.
+- Report model-specific findings as dated evidence, not permanent claims about providers.
+- Maintain a public compatibility ledger during the migration and remove it when the target major version no longer carries shims.
+- Each child plan should ship independently with before/after eval evidence and exact installed-artifact verification where its surface applies.
+
+---
+
+## Sources & References
+
+- Richard Sutton, [The Bitter Lesson](http://www.incompleteideas.net/IncIdeas/BitterLesson.html)
+- Anthropic, [Demystifying evals for AI agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)
+- OpenAI, [Evals](https://github.com/openai/evals)
+- Google Research, [Towards a science of scaling agent systems](https://research.google/blog/towards-a-science-of-scaling-agent-systems-when-and-why-agent-systems-work/)
+- `ARCHITECTURE.md`
+- `STRUCTURE.md`
+- `HARNESSES.md`
+- `docs/plans/2026-07-21-002-test-receipt-workflow-capabilities-plan.md`
+- `docs/plans/2026-07-25-001-feat-receipt-backed-workflow-guard-plan.md`
+- `docs/plans/2026-07-16-001-feat-harness-portable-skills-plan.md`
+- `docs/solutions/best-practices/content-integrity-mirror-runtime-drop-rules-2026-05-17.md`
+- `docs/solutions/best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md`
+- `docs/solutions/workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md`
+- `docs/solutions/logic-errors/pi-chained-bootstrap-composition-2026-07-14.md`
+- `docs/solutions/integration-issues/opencode-plugin-hook-silent-defect-swallow-2026-05-19.md`

--- a/docs/plans/2026-08-13-002-feat-read-only-capability-diagnostic-plan.md
+++ b/docs/plans/2026-08-13-002-feat-read-only-capability-diagnostic-plan.md
@@ -1,0 +1,348 @@
+---
+title: 'feat: Add a read-only capability diagnostic'
+type: feat
+status: completed
+date: 2026-08-13
+origin: docs/plans/2026-08-13-001-refactor-bitter-lesson-harness-plan.md
+---
+
+# feat: Add a Read-Only Capability Diagnostic
+
+## Overview
+
+Add the first I2a slice from the Bitter Lesson Engineering program: a CLI-specific,
+versioned, machine-readable `systematic capabilities` diagnostic. It reports only
+what the standalone CLI can directly observe about the package, configuration
+sources, and discovered skills and agents.
+
+This output is not the canonical registry or control plane for capability truth.
+Existing bootstrap and config-handler behavior remains authoritative, and the
+diagnostic is never consumed by runtime composition, routing, setup, or workflow
+protection. Schema generalization waits until a second consumer demonstrates reuse.
+
+## Problem Frame
+
+Operators need a read-only answer to named standalone-CLI questions: which command
+and package ran, which configuration sources are present, which source currently
+wins for a provable field or path, what discovery roots and winning summaries were
+observed, and what the CLI cannot observe. The facts are currently spread across
+CLI, config, and discovery code.
+
+The standalone CLI has no authoritative loaded OpenCode, Pi, or Claude Code runtime.
+It must not infer host identity, live model availability, setup state, or capability
+truth from filenames, generated artifacts, or cached values.
+
+## Requirements Trace
+
+- R1. Emit one CLI-specific, versioned JSON diagnostic for `systematic capabilities`;
+  it is not a canonical capability registry or runtime control plane.
+- R2. Limit v1 facts to command/schema identity, package/version, configuration
+  source presence, effective per-field/path authority only where current merge code
+  can prove it, observed discovery roots and winning skill/agent summaries/counts,
+  and explicit limitations.
+- R3. Report source presence separately from effective authority. Do not invent a
+  universal user/project/custom precedence ladder or infer authority from filenames.
+- R4. Define `unknown`, `unavailable`, and explicit `absent` semantics; do not use
+  either status for an absent source or for an intentionally unobservable host fact.
+- R5. Preserve current config merge and protected project-field semantics. A small
+  read-only config metadata API may expose source kind, proven precedence, and
+  loaded/absent/invalid state; otherwise the CLI reports only facts already proven.
+- R6. Preserve current discovery semantics. Skills report only winners returned by
+  `discoverSkills()`; duplicate losers are not rediscovered or exposed.
+- R7. Treat duplicate-agent catalog collisions as a hard agent-section failure:
+  suppress the agent summary and emit one structural-invalid fact.
+- R8. Emit an allowlisted, privacy-safe JSON object with redacted/relative source
+  IDs, bounded enums/counts, sanitized error codes, and no arbitrary values.
+- R9. Sort every emitted collection and key deterministically. The output builder
+  accepts an injected clock and output sink for tests and a testable CLI entrypoint.
+- R10. Keep the command read-only: no persistence, config mutation, setup/export
+  call, provider API call, generated-artifact access, or runtime consumer.
+- R11. Prove non-interference: existing bootstrap/config-handler output remains
+  unchanged for frozen inputs, and existing runtime code remains authoritative.
+
+## Anti-Goals and Scope Boundaries
+
+- This is not a canonical registry, policy engine, control plane, or broad capability
+  ontology. Generalization is deferred until a second consumer proves reuse.
+- No setup/projection inventory, host identity, live model availability, model cache
+  interpretation, generated-artifact facts, registry facts, or docs/reference page.
+- No per-item duplicate-skill visibility, second discovery pass, or alternate
+  discovery/control path.
+- No prompt/body content, config values, arbitrary overlay values, absolute local
+  paths, stacks, raw parser errors, nested unknown keys, cache, telemetry, or file
+  output.
+- No runtime plugin hook, Pi extension, Claude Code session, bootstrap, routing,
+  model-selection, workflow-guard, setup, export, or provider integration.
+
+### Deferred to Separate Tasks
+
+- A second consumer may justify a generalized schema or shared fact model.
+- Host-native observations may be added only by a consumer that can directly observe
+  the relevant runtime.
+- Generated-artifact provenance and drift belong to a separate child plan.
+- Snapshot persistence, comparison history, human rendering, and docs-site work wait
+  for a concrete operator workflow.
+
+## Context and Research
+
+### Relevant Code and Patterns
+
+- `src/cli.ts` is the narrow first consumer and already has read-only commands.
+- `src/lib/config.ts` and `loadConfigWithSources` are the current config authority.
+- `src/lib/discovered-skills.ts` defines observed skill winners and root order.
+- `src/lib/agent-resolver.ts` builds the flattened catalog and rejects duplicate names.
+- `src/lib/bootstrap.ts` and the config handler remain runtime authorities and are not
+  consumers of this diagnostic.
+- Existing CLI, config, discovery, bootstrap, and config-handler tests provide real
+  temporary-directory and non-interference fixtures.
+
+### Institutional Learnings
+
+- `docs/plans/2026-07-21-002-test-receipt-workflow-capabilities-plan.md` separates
+  classified observation from runtime behavior.
+- `docs/solutions/workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md`
+  requires observed state rather than build inference.
+- `docs/solutions/best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md`
+  favors boundary-level observable contracts.
+- `docs/solutions/integration-issues/opencode-plugin-hook-silent-defect-swallow-2026-05-19.md`
+  requires visible typed collector failures.
+
+## Key Technical Decisions
+
+- **CLI-specific contract:** The schema answers named `systematic capabilities`
+  operator questions. It is not a registry and has no control-plane authority.
+- **Source facts before authority facts:** Emit source presence independently. Emit
+  an effective winner for a field/path only when the current merge implementation or
+  a narrow metadata API proves it.
+- **No filename trust:** The CLI never infers precedence or trust from source names,
+  paths, or the existence of generated files.
+- **Display versus canonical paths:** Canonicalized/real paths are used internally
+  for comparison and deduplication only. Default output uses bounded relative source
+  IDs; canonical paths never appear in default JSON.
+- **Closed privacy allowlist:** Config facts are limited to source IDs, presence,
+  bounded source kinds, proven effective source IDs, and protected-field outcomes.
+  No config values or nested arbitrary overlays are serialized.
+- **Existing discovery only:** Skills use the winners already returned by
+  `discoverSkills()`. Agents use the existing catalog; a duplicate collision yields
+  one invalid fact and no valid-looking agent count or summary.
+- **Deterministic test seam:** The builder receives clock, filesystem roots, argv, and
+  an output sink. The CLI entrypoint is callable in tests without process globals.
+- **Runtime separation:** Existing bootstrap and config-handler functions remain
+  authoritative and never import or consume the diagnostic.
+
+## Observation Semantics
+
+Every fact answers one named standalone-CLI question. The status vocabulary is:
+
+| Condition | Representation |
+|---|---|
+| A source is not present | `presence: absent`; not `unknown` or `unavailable` |
+| The CLI intentionally cannot observe the fact | `status: unknown` plus a bounded limitation code |
+| An intended collector/source exists but failed or is malformed | `status: unavailable` plus source ID and sanitized error code |
+| The fact was directly observed successfully | `status: available` |
+
+`unavailable` is forbidden for host-runtime facts that the standalone CLI cannot
+observe by design. Those facts remain an explicit `unknown` limitation, not a failed
+collector.
+
+## High-Level Technical Design
+
+> This illustrates the intended approach and is directional guidance for review, not
+> an implementation specification.
+
+```mermaid
+flowchart LR
+  CLI[systematic capabilities] --> BUILD[CLI diagnostic builder]
+  BUILD --> ID[Command/schema/package identity]
+  BUILD --> CFG[Source presence and proven config authority]
+  BUILD --> DISC[Observed discovery roots and summaries]
+  BUILD --> LIMITS[Explicit observation limitations]
+  BUILD --> JSON[Allowlisted deterministic JSON stdout]
+
+  JSON -. never feeds .-> BOOTSTRAP[Runtime bootstrap]
+  JSON -. never feeds .-> HANDLER[Runtime config handler]
+  JSON -. never feeds .-> RUNTIME[Host runtime/control plane]
+```
+
+The output has four bounded areas:
+
+1. **Identity:** command identity, diagnostic schema version, package name/version,
+   and injected observation time.
+2. **Sources:** redacted source IDs, source kind only when provable, and explicit
+   `present`/`absent`/`invalid` presence state.
+3. **Effective facts:** allowlisted field/path winners only when current merge
+   semantics prove them; discovery roots and winning skill/agent counts/summaries.
+4. **Limitations/errors:** bounded `unknown` limitations or `unavailable` errors with
+   code, source ID, and a short sanitized reason.
+
+## Implementation Units
+
+- [x] **Unit 1: Define the CLI diagnostic contract and deterministic builder**
+
+  **Goal:** Define the smallest versioned JSON object for named standalone-CLI
+  observations, with injectable clock, roots, argv, and output sink.
+
+  **Files:**
+  - Create: `src/lib/capability-snapshot.ts`
+  - Create: `tests/unit/capability-snapshot.test.ts`
+
+  **Approach:**
+  - Use closed enums and allowlists for fact kinds, source IDs, presence, status,
+    limitation codes, and sanitized error codes.
+  - Reject unknown output keys and arbitrary nested values.
+  - Lexically normalize injected roots before comparison; the standalone CLI resolves
+    filesystem identity before injection. Derive only relative display IDs.
+  - Sort every object key and collection before serialization.
+
+  **Tests:** Pure contract/parsing tests, JSON round-trip tests, privacy allowlist
+  tests, injected-clock determinism tests, and absence-versus-unknown semantics.
+
+  **Verification:** The builder has no writes or runtime imports from bootstrap or
+  config handling and produces deterministic output for identical injected inputs.
+
+- [x] **Unit 2: Collect only proven config facts**
+
+  **Goal:** Report source presence and effective per-field/path authority without
+  reimplementing config merge semantics.
+
+  **Requirements:** R3, R5, R8, R10.
+
+  **Files:**
+  - Create: `src/lib/capability-snapshot.ts`
+  - Modify only if required: `src/lib/config.ts` for a narrow read-only config
+    metadata return exposing source kind, proven precedence, and loaded/absent/invalid
+    state
+  - Create: `tests/unit/capability-snapshot.test.ts`
+  - Reference: `src/lib/config-schema.ts`
+
+  **Approach:**
+  - First use the metadata already exposed by current loading code. If it cannot
+    prove a requested field/path, narrow the diagnostic rather than infer from
+    filenames. Add no generalized trust classes.
+  - Keep source presence separate from effective winners. Never emit config values,
+    prompt bodies, arbitrary overlays, stacks, or canonical paths.
+  - Preserve project config protected-field blocking exactly as current semantics.
+  - Use a closed allowlist of emitted config facts. Include a nested secret/overlay
+    fixture to prove no leakage.
+
+  **Tests:** Present, absent, malformed, and protected-field fixtures; proven winner
+  per field/path; unprovable authority omitted with a limitation; canonical-path
+  dedupe with relative display IDs; secret/nested-overlay non-leakage.
+
+- [x] **Unit 3: Summarize existing discovery and add the CLI surface**
+
+  **Goal:** Add `systematic capabilities` without a second discovery pass or runtime
+  consumer.
+
+  **Requirements:** R1, R2, R4, R6-R9.
+
+  **Files:**
+  - Create: `src/lib/capability-snapshot.ts`
+  - Modify: `src/cli.ts`
+  - Create: `tests/unit/capability-snapshot.test.ts`
+  - Test: `tests/unit/cli.test.ts`
+  - Reference: `src/lib/discovered-skills.ts`, `src/lib/agent-resolver.ts`
+
+  **Approach:**
+  - Report only winning skill roots and bounded skill counts returned by
+    `discoverSkills()`; do not expose discarded duplicate skills.
+  - Use the existing agent catalog. On duplicate-name collision, suppress its
+    summary/count and emit exactly one structural-invalid fact for that section.
+  - Keep JSON output deterministic, read-only, and on stdout; invocation errors go to
+    stderr. The testable entrypoint accepts the injected clock and output sink.
+
+  **Tests:** CLI JSON contract, help text, invalid invocation, stable sorting, real
+  temp-directory no-write behavior, duplicate-agent hard section failure, and frozen
+  argv/env/temp-root determinism.
+
+- [x] **Unit 4: Prove non-interference and keep documentation minimal**
+
+  **Goal:** Show that the diagnostic is observation-only and does not alter existing
+  runtime behavior.
+
+  **Requirements:** R7, R9-R11.
+
+  **Files:**
+  - Modify: `tests/unit/bootstrap.test.ts`
+  - Modify: `tests/unit/config-handler.test.ts`
+  - Modify: `tests/unit/cli.test.ts`
+
+  **Approach:**
+  - Add targeted regression coverage with frozen inputs proving existing bootstrap
+    and config-handler output is unchanged.
+  - Prove no persistence, config mutation, setup/export call, provider call, or
+    generated-artifact read/write.
+  - Keep user-facing documentation to CLI help and plan acceptance; do not add a
+    docs/reference page or broad parity campaign in v1.
+
+  **Verification:** Existing runtime tests remain authoritative; snapshot disagreement
+  never changes runtime behavior.
+
+## System-Wide Impact
+
+- **Interaction graph:** The standalone CLI calls one diagnostic builder. Bootstrap,
+  config handling, setup, export, provider access, and workflow protection do not
+  consume it.
+- **Error propagation:** A malformed intended source is an `unavailable` fact; an
+  intentionally unobservable fact is `unknown`; an absent source is explicitly absent.
+  Duplicate-agent catalog invalidity fails only that section and suppresses its
+  summary.
+- **State lifecycle:** No files, config, caches, generated artifacts, or telemetry
+  are written.
+- **Authority:** Existing config merge, protected fields, discovery winners,
+  bootstrap, and config-handler behavior remain authoritative.
+- **Determinism:** Identical injected inputs and observed discovery sets produce
+  deterministically ordered output.
+
+## Risks and Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| The diagnostic becomes a second policy engine | CLI-specific named facts, closed allowlists, no runtime consumer, and a second-consumer gate for generalization. |
+| Authority is inferred from filenames | Use current merge metadata or omit the effective fact; never infer from paths. |
+| Config values or paths leak | Allowlisted fields, relative source IDs, internal-only canonical paths, and secret/overlay fixtures. |
+| A duplicate agent catalog looks valid | Hard section failure, one structural-invalid fact, and no summary/count. |
+| `unknown` and `unavailable` are conflated | Explicit truth table and separate absence representation. |
+| Output becomes nondeterministic | Canonical realpath comparison, sorted keys/collections, injected clock, and frozen-input tests. |
+| Snapshot disagreement changes runtime behavior | Bootstrap and config handler remain authorities and receive no snapshot input. |
+
+## Success Metrics
+
+- `systematic capabilities` answers only the named v1 operator questions with a
+  versioned, parseable, deterministic JSON object.
+- Source presence and proven effective authority are separate and privacy-safe.
+- Discovery summaries match existing winner semantics; duplicate-agent collisions do
+  not produce a valid-looking summary.
+- Default output contains no absolute local paths, config values, prompt/body text,
+  arbitrary overlay values, stacks, raw parser errors, or nested unknown keys.
+- The command performs no persistence or mutation, and frozen-input bootstrap and
+  config-handler output remains unchanged.
+
+## Documentation and Operational Notes
+
+- CLI help is the only planned user-facing note in v1: invocation, read-only scope,
+  and the fact that this is not a host-runtime or canonical-registry view.
+- Keep examples fixture-based and privacy-safe.
+- Defer docs/reference pages, generated artifacts, persistence, and schema reuse until
+  a second consumer establishes a real contract need.
+
+## Sources and References
+
+- **Origin program:** `docs/plans/2026-08-13-001-refactor-bitter-lesson-harness-plan.md`
+- `src/cli.ts`
+- `src/lib/config.ts`
+- `src/lib/config-schema.ts`
+- `src/lib/discovered-skills.ts`
+- `src/lib/agent-resolver.ts`
+- `src/lib/bootstrap.ts`
+- `tests/unit/cli.test.ts`
+- `tests/unit/discovered-skills.test.ts`
+- `tests/unit/agent-resolver.test.ts`
+- `tests/unit/config.test.ts`
+- `docs/plans/2026-07-21-002-test-receipt-workflow-capabilities-plan.md`
+- `docs/solutions/workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md`
+- `docs/solutions/best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md`
+- `docs/solutions/integration-issues/opencode-plugin-hook-silent-defect-swallow-2026-05-19.md`
+
+The `origin:` field points directly to the parent plan above; no `.origin.md`
+companion is expected or created.

--- a/docs/plans/2026-08-13-003-feat-local-opencode-eval-foundation-plan.md
+++ b/docs/plans/2026-08-13-003-feat-local-opencode-eval-foundation-plan.md
@@ -1,0 +1,493 @@
+---
+title: 'feat: Establish a local OpenCode eval foundation'
+type: feat
+status: active
+date: 2026-08-13
+origin: docs/plans/2026-08-13-001-refactor-bitter-lesson-harness-plan.md
+---
+
+# feat: Establish a Local OpenCode Eval Foundation
+
+## Overview
+
+Implement the first I1 child plan from the Bitter Lesson Engineering program: a
+local, deterministic runner for exactly two OpenCode cases. Each selected case can
+run against the Systematic source checkout or a packed installed package and emits a
+privacy-minimized result bundle.
+
+This is a narrow measurement seam, not a reusable evaluation platform or a model
+benchmark. Privacy, cleanup, provenance, sanity, and reproducibility are assertions
+around the two cases, not additional corpus cases. Cross-model comparisons,
+subjective grading, other harnesses, CI integration, and routing decisions remain
+separate work.
+
+## Problem Frame
+
+Existing probes demonstrate useful OpenCode behavior but do not share one small
+contract for artifact provenance, fixture-scoped local isolation, deterministic
+grading, privacy-safe persistence, and cleanup. The first runner must answer one
+question reliably: given a selected case, mode, fixture seed, and injected clock,
+did the expected observable state occur?
+
+The runner uses child-process environment allowlisting, canonical-path checks, and
+primary-checkout readback. It provides no OS-level sandbox or containment and does
+not make arbitrary untrusted model code safe.
+
+## Requirements Trace
+
+- R1. Provide the future direct local entrypoint `scripts/run-evals.ts`; no package or CI
+  command is added in v1.
+- R2. Run exactly two corpus cases: `bootstrap-loading` and `fixture-local-write`.
+  Sanity, privacy, cleanup, provenance, and reproducibility are assertions around
+  those cases, never separate cases.
+- R3. Support explicit `source` and `installed` modes with no fallback or blending.
+- R4. Create unique fixture-scoped local roots for project, home, OpenCode config,
+  XDG state, probe, and mode-specific package/provenance paths.
+- R5. Build child environments from a concrete deny-by-default policy. Representative
+  fake credential/auth values are seeded in tests and proven absent from children.
+- R6. Pin runtime identity and run the sanity gate before task grading. Identity drift,
+  artifact mismatch, isolation escape, or unhealthy probe is `infra_failure`.
+- R7. Use exactly four primary outcomes: `success`, `infra_failure`, `task_failure`,
+  and `privacy_cleanup_failure`. Lower-level causes are bounded subcodes.
+- R8. Define shared result fields plus mode-specific provenance fields, including
+  OpenCode/probe/fixture/case/result/artifact identity, seed, and normalized clock.
+- R9. Harden packed mode against unsafe archive entries, links, and module resolution;
+  installed execution must not resolve through checkout or workspace-hoisted paths.
+- R10. Persist an allowlisted result only after full serialized-output validation.
+  Raw stdout/stderr, transcripts, environment, repository content, and user prose are
+  banned by default.
+- R11. Always attempt cleanup for started cases. Residue or quarantine is non-successful
+  and nonzero, and quarantine failures remain `privacy_cleanup_failure`.
+- R12. Accumulate independent case/mode results when safe, aborting later work only
+  after a runner-wide identity/isolation failure invalidates it. Exit zero only when
+  every selected case/mode is `success`; the manifest records partial completion.
+- R13. Keep pure parsing/redaction tests in unit tests and fixture, environment,
+  artifact, and runner behavior in integration tests. Add no manual tests.
+- R14. Preserve the source-vs-packed-installed boundary without generalized dependency
+  or provenance infrastructure.
+
+## Scope Boundaries
+
+- OpenCode only; no Pi or Claude Code runner.
+- Exactly two deterministic cases:
+  - `bootstrap-loading`: plugin/bootstrap loading is observable through the probe.
+  - `fixture-local-write`: a controlled write lands under the fixture project with
+    the expected bounded content/state.
+- No third sanity/privacy/cleanup/provenance case. Those are assertions around both
+  cases.
+- No full reusable platform is created. The future directory `scripts/lib/evals/` is
+  explicitly rejected/deferred. Keep implementation in the future entrypoint
+  `scripts/run-evals.ts`, with at most a few case-local helpers if readability or a
+  genuinely separate case boundary requires them. Generalization waits for a second
+  harness or a demonstrated third use.
+- No cross-model matrix, ranking, subjective LLM grader, transcript-quality judge,
+  browser UI, hosted service, database, remote upload, CI gate, or policy deletion.
+- No credentialed or network-enabled task. Tests use synthetic values only; no real
+  credentials are included.
+- No direct `dist/` mode. Installed mode must exercise the packed package boundary.
+- No production dependency, lockfile, package-script, release-workflow, or origin
+  program-plan change.
+
+### Deferred to Separate Tasks
+
+- A second harness or a demonstrated third case may justify shared runner helpers.
+- Multi-model cohorts and repeated-run variance require a later measurement plan.
+- Credentialed/network-enabled tasks require a separate security review.
+- CI scheduling, published comparisons, human reports, and migration of existing
+  manual probes wait for evidence that this narrow runner is useful.
+
+## Context and Research
+
+### Relevant Code and Patterns
+
+- `tests/integration/fixtures/receipt-workflow-host.ts` provides tested disposable
+  roots, child environment handling, probe capture, cleanup, redaction, and package
+  extraction patterns.
+- `tests/integration/opencode.test.ts` checks source/installed configuration and
+  parent npm configuration non-interference.
+- `tests/unit/package-exports.test.ts` verifies tarball contents and installed runtime
+  behavior rather than trusting build output.
+- `tests/manual/subagent-stop-sanity.ts` provides a sanity-gate precedent; it is not
+  migrated or used as a new manual test.
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md`
+  establishes isolated subprocess roots and environment hygiene.
+- `docs/solutions/workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md`
+  requires exercising the packed artifact in situ.
+- `docs/solutions/best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md`
+  favors boundary-first observable contracts.
+- `docs/solutions/integration-issues/opencode-plugin-hook-silent-defect-swallow-2026-05-19.md`
+  requires probe-health checks before interpreting missing host evidence.
+
+## Key Technical Decisions
+
+- **Narrow implementation surface:** Start with the future entrypoint
+  `scripts/run-evals.ts`. A helper may be added only when the two cases genuinely need
+  separation; the future directory `scripts/lib/evals/` is explicitly
+  rejected/deferred, and no generalized dependency/provenance layer is created.
+- **Exactly two cases:** Case IDs are `bootstrap-loading` and `fixture-local-write`.
+  All trust assertions execute around each selected case/mode.
+- **Four primary outcomes:** Only the table below supplies public top-level outcomes;
+  subcodes are bounded implementation causes.
+- **Fixture-scoped local isolation:** Trust comes from a child-env allowlist,
+  canonical-path validation of every runner-controlled path, pre/post primary-checkout
+  status/readback, and failure on detected escape. There is no OS-level sandbox or
+  containment, and arbitrary untrusted model code remains out of scope.
+- **Explicit modes:** `source` points at the checkout source entry. `installed` packs,
+  validates, extracts, and executes the package from its fixture-local package root.
+  Neither mode falls back to the other.
+- **Deterministic grading:** Grade only probe events, process outcome, and exact
+  fixture filesystem state. Do not grade model reasoning or prose.
+- **Local evidence only:** Persist an allowlisted run manifest and bounded results in
+  the future gitignored run-output directory `evals/runs/`; no telemetry, remote
+  upload, or raw transcript collection.
+
+## Primary Outcomes and Subcodes
+
+| Primary outcome | Meaning | Example bounded subcodes |
+|---|---|---|
+| `success` | Identity, sanity, isolation, case assertions, cleanup/residue checks, and privacy-safe write all pass. | `none` |
+| `infra_failure` | Runner, identity, artifact, probe, fixture, OpenCode invocation, or isolation state is not trustworthy for task grading. | `identity_drift`, `probe_unhealthy`, `artifact_resolution`, `opencode_unavailable`, `path_escape`, `primary_checkout_delta`, `case_setup` |
+| `task_failure` | The runner is healthy, but the selected deterministic case does not produce the expected observable result. | `bootstrap_not_observed`, `write_missing`, `write_mismatch`, `unexpected_exit` |
+| `privacy_cleanup_failure` | Redaction/serialized-output validation, cleanup, residue handling, quarantine, retention, or atomic result write fails. | `redaction_failed`, `residue_detected`, `quarantine_failed`, `atomic_write_failed` |
+
+Lower-level causes never become additional public outcome classes. Identity or
+isolation failure is classified as `infra_failure` before task grading; residue or
+quarantine is never `success` and always causes a nonzero run exit.
+
+## Result Contract
+
+Every per-case/mode result shares these fields:
+
+- `resultSchemaVersion`, `caseSchemaVersion`, `caseId`, `harness: opencode`, `mode`,
+  `outcome`, and optional bounded `subcode`.
+- Opaque `runId`, `fixtureSeed`, normalized/injected clock, and selected assertion
+  IDs; physical absolute paths are not persisted.
+- Runtime identity captured before classification: OpenCode version/build identity,
+  probe-plugin identity/hash, fixture contract version/hash, case/result schema
+  versions, and artifact identity.
+- Bounded sanity/assertion evidence, cleanup/residue state, privacy-validation state,
+  and safe artifact references.
+
+Mode-specific provenance is explicit:
+
+- **Source:** checkout-relative source identity, commit/worktree readback identity,
+  canonical source entry validation, and the source OpenCode config entry ID.
+- **Installed:** package name/version, packed tarball digest, extracted package-root
+  identity, canonical resolved module entry ID, and the installed OpenCode config
+  entry ID.
+
+Identity drift, an unhealthy probe, or a mismatch between recorded and resolved
+  artifact identity is a hard `infra_failure` before any task verdict.
+
+## Child Environment Policy
+
+The child environment is an explicit allowlist, not a filtered copy of the parent.
+The runner supplies only fixed execution values such as its controlled `PATH`, locale,
+timezone, `TERM`/`NO_COLOR` where needed, fixture-scoped `HOME`, and fixture-scoped
+XDG/npm/OpenCode paths. Parent values are not forwarded for:
+
+- GitHub/GH tokens and configuration (`GITHUB_*`, `GH_*`, and token-bearing config).
+- npm auth/config/cache/prefix (`NPM_*`, `npm_config_*`, `.npmrc`, and parent cache).
+- OpenAI/provider and cloud credentials (`OPENAI_*`, provider token variables,
+  `AWS_*`, `AZURE_*`, `GOOGLE_*`, `CLOUDSDK_*`, and equivalent auth files).
+- CI credentials and service tokens.
+- SSH agent/socket and Git auth/config helpers (`SSH_AUTH_SOCK`, `GIT_ASKPASS`,
+  `GIT_SSH_COMMAND`, credential helpers, inherited Git config, and credential files).
+- OpenCode auth/cache state and inherited `HOME`, XDG, or npm configuration.
+
+Tests seed representative fake values in each category, including fake files and
+socket paths, then prove that children cannot observe them. Synthetic denial markers
+are runner-owned, case-specific, and never persisted. No real credential is placed in
+the fixture or test environment.
+
+## Artifact and Config Boundaries
+
+The runner creates and owns these mode-specific config entries for every case:
+
+- Source mode: `<fixtureRoot>/opencode/source/opencode.json`, whose plugin entry
+  resolves to the validated checkout source entry.
+- Installed mode: `<fixtureRoot>/opencode/installed/opencode.json`, whose plugin
+  entry resolves only inside `<fixtureRoot>/package-root/`.
+
+For both modes the runner creates a probe plugin at
+`<fixtureRoot>/probe/<mode>/probe-plugin.ts`, records its identity/hash, attaches it
+to the mode-specific config, verifies probe health, and tears it down during cleanup.
+Probe creation, attachment, and teardown are runner-owned operations, not corpus
+cases.
+
+Installed mode must:
+
+- Reject archive entries that are absolute or contain `..` traversal components.
+- Reject hardlinks and symlinks whose targets are unsafe; any permitted symlink must
+  resolve canonically inside the extracted package root, with no escaping link chain.
+- Reject every extracted or resolved module path whose canonical path is outside the
+  package root.
+- Refuse resolution through the primary checkout, workspace-hoisted modules, or any
+  other path outside the extracted package root. Missing package content is a hard
+  `infra_failure`; source mode is never used as fallback.
+
+Source and installed paths are canonicalized before use. Persisted provenance contains
+only bounded relative/package IDs, never sensitive absolute paths.
+
+## Isolation and Out-of-Root Detection
+
+For each case/mode, assert canonical containment for every runner-controlled path:
+run root, case root, fixture root, project, home/XDG roots, config entries, probe,
+package extraction, resolved module entry, temporary result files, quarantine root,
+and retention target.
+
+Before and after each started case, capture primary-checkout repository status and
+read back the runner-selected checkout inputs. A detected primary-checkout delta or a
+canonical path escape is `infra_failure`. This detector is intentionally limited: it
+does not claim general filesystem escape detection or make arbitrary child code safe.
+
+## Identity and Determinism Budget
+
+Identity is captured and validated before classification. The expected OpenCode
+version/build, probe-plugin hash, fixture contract version/hash, case/result schema
+versions, artifact identity, fixture seed, and injected/normalized clock must remain
+stable for the result. Drift or unhealthy probe state aborts task grading as
+`infra_failure`.
+
+The determinism budget is deliberately small:
+
+- Freeze argv, allowlisted environment, fixture seed, package/checkout identity,
+  observed discovery set, temp-root layout, and injected clock for comparisons.
+- Allow only opaque run IDs, physical temp-root names, and non-persisted process
+  duration to vary. Normalize those fields out of comparison.
+- Sort all persisted keys, collections, assertion IDs, subcodes, and provenance
+  identifiers. Any other difference is a failed reproducibility assertion around the
+  selected case, not a new outcome class.
+
+## Cleanup, Quarantine, and Privacy
+
+The exact lifecycle is:
+
+1. Execute the selected case.
+2. Attempt cleanup, including probe teardown.
+3. Read back for residue.
+4. Attempt quarantine/retention if residue remains.
+5. Build, validate, and atomically write the privacy-safe result/manifest.
+
+Every started case reaches cleanup even after child failure or interruption. Any
+residue or quarantine is non-successful and nonzero. Quarantine roots use unique,
+run-owned names, are never reused, and are rejected by later runs if discovered.
+If quarantine fails, the result remains `privacy_cleanup_failure`; persisted output
+contains no absolute sensitive path, only a bounded status/code.
+
+Persistence is allowlist-only. Raw stdout, stderr, transcripts, environment values,
+repository content, user-authored prose, arbitrary paths, and secrets are banned by
+default. The runner redacts the candidate object, serializes it fully, then runs a
+second-pass validator over the complete serialized bytes before the atomic rename.
+Redaction or validation failure writes no unsafe artifact and returns
+`privacy_cleanup_failure` nonzero; only a separately validated minimal safe status
+may be retained.
+
+## High-Level Technical Design
+
+> This illustrates the intended approach and is directional guidance for review, not
+> an implementation specification.
+
+```mermaid
+flowchart TB
+  ENTRY[scripts/run-evals.ts] --> SELECT[Validate two case IDs and explicit mode]
+  SELECT --> ID[Capture identity and deterministic inputs]
+  ID --> FIXTURE[Create fixture-scoped local roots]
+  FIXTURE --> ENV[Build child-env allowlist]
+  ENV --> ARTIFACT{source or installed}
+  ARTIFACT --> SOURCE[Validate checkout source + source config]
+  ARTIFACT --> PACK[Pack, validate, extract + installed config]
+  SOURCE --> PROBE[Create/attach/health-check runner probe]
+  PACK --> PROBE
+  PROBE --> SANITY{Identity/isolation/sanity healthy?}
+  SANITY -->|no| INFRA[infra_failure]
+  SANITY -->|yes| CASES[Run bootstrap-loading or fixture-local-write]
+  CASES --> GRADE[Deterministic observable assertions]
+  INFRA --> CLEAN[Cleanup -> residue readback -> quarantine attempt]
+  GRADE --> CLEAN
+  CLEAN --> PRIV[Redact -> serialize -> second-pass validate]
+  PRIV --> WRITE[Atomic privacy-safe result + manifest]
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Define the narrow case and result contracts**
+
+  **Goal:** Define the two case manifests and the shared result contract without
+  creating a reusable eval platform.
+
+  **Files:**
+  - Create: `scripts/run-evals.ts`
+  - Create: `evals/cases/opencode/bootstrap-loading.json`
+  - Create: `evals/cases/opencode/fixture-local-write.json`
+  - Create: `tests/unit/eval-contract.test.ts`
+  - Create: `tests/unit/eval-redaction.test.ts`
+
+  **Approach:**
+  - Reject unknown case fields and permit only the two stable case IDs.
+  - Define the four primary outcomes and one bounded subcode table.
+  - Define shared fields and source/installed provenance fields listed above.
+  - Keep pure parsing, normalization, allowlist, and redaction helpers unit-testable;
+    do not add a generic schema or platform directory.
+
+  **Tests:** Pure parsing and redaction tests cover unknown fields, outcome mapping,
+  full serialized-output validation, seeded fake secrets, path minimization, and
+  deterministic sorting.
+
+- [ ] **Unit 2: Implement fixture-scoped execution and environment policy**
+
+  **Goal:** Run either case in unique local roots with explicit child-env denial and
+  honest out-of-root detection.
+
+  **Requirements:** R2, R4-R8, R11-R12.
+
+  **Files:**
+  - Create: `scripts/run-evals.ts`
+  - Create only if genuinely needed: `scripts/eval-cases/opencode.ts` for case-local
+    OpenCode probe/setup logic; it is not a reusable runner API
+  - Create: `tests/integration/eval-fixture.test.ts`
+  - Create: `tests/integration/eval-runner.test.ts`
+
+  **Approach:**
+  - Create unique project/home/XDG/config/probe roots for every case/mode.
+  - Apply the concrete child environment policy and synthetic denial fixtures.
+  - Create, attach, health-check, and later tear down the probe for both modes.
+  - Assert canonical containment of runner-controlled paths and compare pre/post
+    primary-checkout status/readback. Do not claim general filesystem monitoring.
+  - Run `bootstrap-loading` and `fixture-local-write` only; their privacy, cleanup,
+    provenance, sanity, and reproducibility checks remain assertions around them.
+
+  **Tests:** Integration fixtures prove fake credential absence, unique roots,
+  no-write behavior outside allowed run artifacts, primary-checkout preservation,
+  probe health, child interruption cleanup, and both deterministic case outcomes.
+
+- [ ] **Unit 3: Harden source and packed-installed modes**
+
+  **Goal:** Prove distinct source and installed execution boundaries with mode-specific
+  config entries and provenance, without generalized dependency infrastructure.
+
+  **Requirements:** R3, R6, R8-R9, R14.
+
+  **Files:**
+  - Create: `scripts/run-evals.ts`
+  - Test: `tests/integration/eval-artifact.test.ts`
+
+  **Approach:**
+  - Source mode validates the checkout source entry and records bounded checkout
+    identity plus pre/post readback.
+  - Installed mode packs once per run, records package/version/tarball digest, rejects
+    unsafe archive entries and links, extracts under the fixture package root, and
+    verifies every canonical module resolution stays inside that root.
+  - Refuse checkout or workspace-hoisted resolution in installed mode. Never fall
+    back between modes.
+  - Verify the exact source and installed OpenCode config entry paths and probe
+    attachment for both modes.
+
+  **Tests:** A checkout-only sentinel is unavailable in installed mode; source and
+  installed results have distinct provenance; malformed archives, unsafe links,
+  outside-root module resolution, and missing package content yield `infra_failure`.
+
+- [ ] **Unit 4: Implement cleanup, privacy-safe persistence, and exit semantics**
+
+  **Goal:** Produce bounded local evidence and correct run-level behavior for partial,
+  failed, and successful selections.
+
+  **Requirements:** R1, R7, R10-R13.
+
+  **Files:**
+  - Create: `scripts/run-evals.ts`
+  - Modify: `.gitignore`
+  - Create: `evals/README.md`
+  - Test: `tests/integration/eval-runner.test.ts`
+  - Test: `tests/unit/eval-redaction.test.ts`
+
+  **Approach:**
+  - Persist one allowlisted manifest and bounded per-case/mode results under the
+    future run-output directory `evals/runs/` using temporary file plus atomic rename.
+  - Apply the exact cleanup/residue/quarantine/privacy ordering above.
+  - Accumulate independent results when safe. If a runner-wide identity/isolation
+    failure invalidates later work, abort remaining selections, clean started cases,
+    and mark the manifest partial.
+  - Exit zero only when every selected case/mode is `success`; every other primary
+    outcome, partial completion, residue, or quarantine is nonzero.
+
+  **Tests:** Seeded-secret scans cover the entire serialized output, unsafe-write
+  rejection leaves no unsafe artifact, quarantine names are unique/non-reused,
+  cleanup always runs, partial manifests are explicit, and source/installed repeated
+  runs preserve normalized result evidence under frozen inputs.
+
+  **Documentation:** The future `evals/README.md` stays minimal: invocation, result location,
+  the four outcomes, privacy boundary, and unsupported scope. It does not describe an
+  operator policy or a reusable platform.
+
+## System-Wide Impact
+
+- **Interaction graph:** The future entrypoint `scripts/run-evals.ts` invokes OpenCode through existing
+  subprocess/probe boundaries. Production plugin, CLI, Pi, Claude, config, bootstrap,
+  generated assets, package exports, CI, and release workflows do not consume it.
+- **Outcome propagation:** Every result uses exactly one of the four primary outcomes;
+  bounded subcodes explain lower-level causes.
+- **Lifecycle:** Fixtures and probes are run-owned and disposable. Cleanup is always
+  attempted; residue/quarantine is visible, non-successful, and nonzero.
+- **Provenance:** Source and installed modes have distinct, validated identities and
+  config entries. Installed mode cannot resolve through checkout/workspace paths.
+- **Boundary honesty:** Canonical path checks and primary-checkout readback detect the
+  specified runner-controlled escapes only; no general filesystem containment claim.
+
+## Risks and Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| The runner becomes a reusable platform too early | One entrypoint, exactly two cases, optional case-local helper only when needed, and a second-harness/third-use gate. |
+| Isolation is overstated | Use “fixture-scoped local isolation,” explicit no-OS-containment language, canonical checks, and primary-checkout readback. |
+| Ambient auth or config leaks | Deny-by-default child environment, fixture-scoped HOME/XDG/npm/OpenCode paths, and seeded fake-value integration tests. |
+| Identity drift hides an invalid result | Capture and validate all required identities before task grading; classify drift as `infra_failure`. |
+| Installed mode exercises source or hoisted modules | Harden archive entries/links, canonical package-root resolution, mode-specific config, and no fallback. |
+| Artifacts leak private data | Closed persistence allowlist, full serialized second-pass validation, atomic write, and fail-closed privacy outcome. |
+| Cleanup contaminates later runs | Unique roots, ordered residue readback/quarantine, never-reused quarantine names, and nonzero failure semantics. |
+| Partial results are misread as a complete suite | Manifest records selected, completed, aborted, and per-case/mode outcomes. |
+
+## Success Metrics
+
+- One direct entrypoint runs exactly the two deterministic cases in explicit source or
+  packed-installed mode.
+- Every selected case/mode has identity, sanity, assertion, provenance, privacy, and
+  cleanup evidence under the shared result contract.
+- All public outcomes use exactly `success`, `infra_failure`, `task_failure`, or
+  `privacy_cleanup_failure`; lower-level causes are bounded subcodes.
+- Fake credential/auth values do not reach children or persisted artifacts.
+- The primary checkout remains unchanged according to the specified pre/post status
+  and readback checks.
+- Installed results prove execution from the extracted package root and never from
+  checkout/workspace-hoisted paths.
+- No production code path, package script, CI workflow, dependency, or origin plan is
+  changed.
+
+## Documentation and Operational Notes
+
+- Future documentation path: `evals/README.md` documents only invocation, result location, the four outcomes,
+  privacy boundary, and unsupported scope.
+- Do not publish result bundles or paste raw artifacts into issues or PRs without a
+  separate privacy review.
+- Result manifests record OpenCode, probe, fixture, case/result schema, artifact,
+  fixture-seed, and normalized-clock identities in bounded form.
+- The `origin:` field points directly to the parent plan above; no `.origin.md`
+  companion is expected or created.
+
+## Sources and References
+
+- **Origin program:** `docs/plans/2026-08-13-001-refactor-bitter-lesson-harness-plan.md`
+- `package.json`
+- `.gitignore`
+- `tests/integration/fixtures/receipt-workflow-host.ts`
+- `tests/integration/opencode.test.ts`
+- `tests/unit/package-exports.test.ts`
+- `tests/manual/subagent-stop-sanity.ts`
+- `docs/plans/2026-07-21-002-test-receipt-workflow-capabilities-plan.md`
+- `docs/solutions/integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md`
+- `docs/solutions/workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md`
+- `docs/solutions/integration-issues/opencode-plugin-hook-silent-defect-swallow-2026-05-19.md`
+- `docs/solutions/best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,22 @@
 #!/usr/bin/env node
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
+import { buildAgentCatalog } from './lib/agent-resolver.js'
 import * as agents from './lib/agents.js'
+import {
+  buildCapabilitySnapshot,
+  type CapabilityClock,
+  type CapabilityFactInput,
+  type CapabilityOutputSink,
+  type ConfigObservationMetadata,
+} from './lib/capability-snapshot.js'
 import * as commands from './lib/commands.js'
-import { getConfigPaths } from './lib/config.js'
+import { getConfigPaths, loadConfigWithSources } from './lib/config.js'
+import {
+  discoverSkills,
+  type SkillDiscoveryIssueCode,
+} from './lib/discovered-skills.js'
 import {
   cleanup,
   exportPersonas,
@@ -15,23 +28,38 @@ import {
 import { type Harness, setupHarness } from './lib/setup.js'
 import * as skills from './lib/skills.js'
 
-const getPackageVersion = (): string => {
+interface PackageMetadata {
+  readonly name?: string
+  readonly version?: string
+}
+
+function readPackageMetadata(packageRoot: string): PackageMetadata {
   try {
-    const packageJsonPath = path.resolve(
-      import.meta.dirname,
-      '..',
-      'package.json',
-    )
-    if (!fs.existsSync(packageJsonPath)) return 'unknown'
+    const packageJsonPath = path.join(packageRoot, 'package.json')
+    if (!fs.existsSync(packageJsonPath)) return {}
     const content = fs.readFileSync(packageJsonPath, 'utf8')
-    const parsed = JSON.parse(content) as { version?: string }
-    return parsed.version ?? 'unknown'
+    const parsed = JSON.parse(content) as unknown
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed)
+    ) {
+      return {}
+    }
+    const record = parsed as Record<string, unknown>
+    return {
+      ...(typeof record.name === 'string' ? { name: record.name } : {}),
+      ...(typeof record.version === 'string'
+        ? { version: record.version }
+        : {}),
+    }
   } catch {
-    return 'unknown'
+    return {}
   }
 }
 
-const VERSION = getPackageVersion()
+const PACKAGE_ROOT = path.resolve(import.meta.dirname, '..')
+const VERSION = readPackageMetadata(PACKAGE_ROOT).version ?? 'unknown'
 
 const HELP = `
 systematic - OpenCode plugin for systematic engineering workflows
@@ -41,6 +69,7 @@ Usage:
 
 Commands:
   list [type]                  List available skills, agents, or commands
+  capabilities                 Read-only standalone-CLI observation; not a host-runtime or canonical-registry view
   config [subcommand]          Configuration management
     show                       Show configuration
     path                       Print config file locations
@@ -57,6 +86,7 @@ Options:
 
 Examples:
   systematic list skills
+  systematic capabilities
   systematic list agents
   systematic config show
   systematic setup --harness opencode
@@ -80,6 +110,222 @@ Scope:
   project   <cwd>/.pi/agents (default)
   global    $PI_CODING_AGENT_DIR/agents or ~/.pi/agent/agents
 `
+
+interface CapabilityCliRoots {
+  readonly agentsRoot: string
+  readonly cwd: string
+  readonly homeDir: string
+  readonly packageRoot: string
+  readonly configDir?: string
+  readonly opencodeConfigDirOverride?: string
+}
+
+interface CapabilityCliOptions {
+  readonly argv: readonly string[]
+  readonly roots: CapabilityCliRoots
+  readonly clock?: CapabilityClock
+  readonly config?: ConfigObservationMetadata
+  readonly outputSink?: CapabilityOutputSink
+  readonly errorSink?: (message: string) => void
+}
+
+function defaultCapabilityRoots(): CapabilityCliRoots {
+  const configDir = process.env.XDG_CONFIG_HOME
+    ? path.join(process.env.XDG_CONFIG_HOME, 'opencode')
+    : path.join(os.homedir(), '.config/opencode')
+  return {
+    agentsRoot: path.join(PACKAGE_ROOT, 'agents'),
+    configDir,
+    cwd: process.cwd(),
+    homeDir: os.homedir(),
+    opencodeConfigDirOverride:
+      process.env.OPENCODE_CONFIG_DIR?.trim() || undefined,
+    packageRoot: PACKAGE_ROOT,
+  }
+}
+
+function sourceErrorForSkillIssue(
+  issue: SkillDiscoveryIssueCode,
+): 'source-malformed' | 'source-read-failed' {
+  return issue === 'read-failed' ? 'source-read-failed' : 'source-malformed'
+}
+
+function discoverySummaryFact(
+  discoveryId: 'agents' | 'skills',
+  count: number,
+  winningRoots: readonly string[],
+): CapabilityFactInput {
+  return {
+    count,
+    discoveryId,
+    factId: 'discovery-summary',
+    kind: 'discovery',
+    sourceId: `discovery:${discoveryId}`,
+    status: 'available',
+    winningRoots,
+  }
+}
+
+function unavailableDiscoveryFact(
+  discoveryId: 'agents' | 'skills',
+  errorCode: 'source-malformed' | 'source-read-failed' | 'structural-invalid',
+): CapabilityFactInput {
+  return {
+    errorCode,
+    factId: 'discovery-summary',
+    sourceId: `discovery:${discoveryId}`,
+    status: 'unavailable',
+  }
+}
+
+function discoverySourceIssueFact(
+  errorCode: 'source-malformed' | 'source-read-failed',
+): CapabilityFactInput {
+  return {
+    errorCode,
+    factId: 'discovery-source-issue',
+    kind: 'status',
+    sourceId: 'discovery:skills',
+    status: 'unavailable',
+  }
+}
+
+function collectSkillFacts(roots: CapabilityCliRoots): CapabilityFactInput[] {
+  let issue: SkillDiscoveryIssueCode | undefined
+  try {
+    const skills = discoverSkills({
+      configDir: roots.configDir,
+      homeDir: roots.homeDir,
+      onIssue: (nextIssue) => {
+        issue ??= nextIssue
+      },
+      opencodeConfigDirOverride: roots.opencodeConfigDirOverride,
+      startDir: roots.cwd,
+    })
+    const winningRoots = [...new Set(skills.map((skill) => skill.root))].sort()
+    const facts = [discoverySummaryFact('skills', skills.length, winningRoots)]
+    if (issue !== undefined) {
+      facts.push(discoverySourceIssueFact(sourceErrorForSkillIssue(issue)))
+    }
+    return facts
+  } catch {
+    return [discoverySourceIssueFact('source-malformed')]
+  }
+}
+
+function collectAgentFact(agentsRoot: string): CapabilityFactInput {
+  try {
+    const catalog = buildAgentCatalog(agentsRoot)
+    return discoverySummaryFact('agents', catalog.length, ['agents'])
+  } catch {
+    return unavailableDiscoveryFact('agents', 'structural-invalid')
+  }
+}
+
+function collectDiscoveryFacts(
+  roots: CapabilityCliRoots,
+): CapabilityFactInput[] {
+  return [
+    {
+      factId: 'host-runtime',
+      limitationCode: 'host-runtime-unobservable',
+      status: 'unknown',
+    },
+    ...collectSkillFacts(roots),
+    collectAgentFact(roots.agentsRoot),
+  ]
+}
+
+function collectConfigMetadata(
+  roots: CapabilityCliRoots,
+  injected?: ConfigObservationMetadata,
+): ConfigObservationMetadata | undefined {
+  if (injected !== undefined) return injected
+  try {
+    return loadConfigWithSources(roots.cwd, {
+      customConfigDir: roots.opencodeConfigDirOverride ?? null,
+      homeDir: roots.homeDir,
+      invalidSource: 'report',
+      userConfigDir: roots.configDir,
+      warningSink: () => undefined,
+    }).metadata
+  } catch {
+    return undefined
+  }
+}
+
+function resolveCapabilityRootPath(root: string): string {
+  try {
+    return fs.realpathSync(root)
+  } catch {
+    return path.resolve(root)
+  }
+}
+
+function capabilityRoots(roots: CapabilityCliRoots): readonly {
+  id: 'agents' | 'cwd' | 'package' | 'skills' | 'user'
+  path: string
+}[] {
+  return [
+    { id: 'agents', path: resolveCapabilityRootPath(roots.agentsRoot) },
+    { id: 'cwd', path: resolveCapabilityRootPath(roots.cwd) },
+    { id: 'package', path: resolveCapabilityRootPath(roots.packageRoot) },
+    {
+      id: 'skills',
+      path: resolveCapabilityRootPath(path.join(roots.packageRoot, 'skills')),
+    },
+    { id: 'user', path: resolveCapabilityRootPath(roots.homeDir) },
+  ]
+}
+
+function capabilityPackage(packageRoot: string): {
+  readonly name: string
+  readonly version: string
+} {
+  const metadata = readPackageMetadata(packageRoot)
+  return {
+    name: metadata.name ?? 'unknown',
+    version: metadata.version ?? 'unknown',
+  }
+}
+
+function runCapabilities(options: CapabilityCliOptions): number {
+  const outputSink =
+    options.outputSink ?? ((value: string) => console.log(value))
+  const errorSink =
+    options.errorSink ?? ((message: string) => console.error(message))
+  const isFullArgv =
+    options.argv.length === 2 &&
+    options.argv[0] === 'systematic' &&
+    options.argv[1] === 'capabilities'
+  const isCommandOnlyArgv =
+    options.argv.length === 1 && options.argv[0] === 'capabilities'
+  if (!isFullArgv && !isCommandOnlyArgv) {
+    errorSink('Usage: systematic capabilities')
+    return 2
+  }
+  const builderArgv = isFullArgv ? options.argv : ['systematic', 'capabilities']
+
+  try {
+    buildCapabilitySnapshot({
+      argv: builderArgv,
+      clock: options.clock,
+      config: collectConfigMetadata(options.roots, options.config),
+      facts: collectDiscoveryFacts(options.roots),
+      outputSink,
+      package: capabilityPackage(options.roots.packageRoot),
+      roots: capabilityRoots(options.roots),
+    })
+    return 0
+  } catch {
+    errorSink('Capabilities diagnostic unavailable')
+    return 1
+  }
+}
+
+export function runCapabilitiesCli(options: CapabilityCliOptions): number {
+  return runCapabilities(options)
+}
 
 function isHarness(value: string): value is Harness {
   return value === 'opencode' || value === 'pi'
@@ -370,47 +616,62 @@ function piSubagentsCommand(rest: string[]): void {
   }
 }
 
-const args = process.argv.slice(2)
-const command = args[0]
+function runLegacyCli(args: string[]): void {
+  const command = args[0]
 
-switch (command) {
-  case 'list':
-    listItems(args[1] || 'skills')
-    break
-  case 'setup':
-    setupCommand(args.slice(1))
-    break
-  case 'pi-subagents':
-    piSubagentsCommand(args.slice(1))
-    break
-  case 'config':
-    switch (args[1]) {
-      case 'show':
-      case undefined:
-        configShow()
-        break
-      case 'path':
-        configPath()
-        break
-      default:
-        console.error(`Unknown config subcommand: ${args[1]}`)
-        console.log('Available: show, path')
-        process.exit(1)
+  switch (command) {
+    case 'list':
+      listItems(args[1] || 'skills')
+      break
+    case 'capabilities': {
+      const status = runCapabilitiesCli({
+        argv: ['systematic', ...args],
+        errorSink: console.error,
+        outputSink: console.log,
+        roots: defaultCapabilityRoots(),
+      })
+      if (status !== 0) process.exit(status)
+      break
     }
-    break
-  case 'version':
-  case '--version':
-  case '-v':
-    console.log(`systematic v${VERSION}`)
-    break
-  case 'help':
-  case '--help':
-  case '-h':
-  case undefined:
-    console.log(HELP)
-    break
-  default:
-    console.error(`Unknown command: ${command}`)
-    console.log(HELP)
-    process.exit(1)
+    case 'setup':
+      setupCommand(args.slice(1))
+      break
+    case 'pi-subagents':
+      piSubagentsCommand(args.slice(1))
+      break
+    case 'config':
+      switch (args[1]) {
+        case 'show':
+        case undefined:
+          configShow()
+          break
+        case 'path':
+          configPath()
+          break
+        default:
+          console.error(`Unknown config subcommand: ${args[1]}`)
+          console.log('Available: show, path')
+          process.exit(1)
+      }
+      break
+    case 'version':
+    case '--version':
+    case '-v':
+      console.log(`systematic v${VERSION}`)
+      break
+    case 'help':
+    case '--help':
+    case '-h':
+    case undefined:
+      console.log(HELP)
+      break
+    default:
+      console.error(`Unknown command: ${command}`)
+      console.log(HELP)
+      process.exit(1)
+  }
+}
+
+if (import.meta.main) {
+  runLegacyCli(process.argv.slice(2))
 }

--- a/src/lib/capability-snapshot.ts
+++ b/src/lib/capability-snapshot.ts
@@ -1,0 +1,1230 @@
+const CAPABILITY_SNAPSHOT_SCHEMA_VERSION = 'cli-capabilities.v1' as const
+const CAPABILITY_SNAPSHOT_COMMAND = 'systematic capabilities' as const
+
+const CAPABILITY_SOURCE_IDS = [
+  'config:custom',
+  'config:global',
+  'config:project',
+  'config:user',
+  'discovery:agents',
+  'discovery:skills',
+  'host:runtime',
+  'package',
+] as const
+
+const CONFIG_SOURCE_KINDS = ['custom', 'project', 'user'] as const
+
+const CONFIG_AUTHORITY_FIELD_PATHS = [
+  'bootstrap.enabled',
+  'bootstrap.file',
+  'skills_as_commands',
+  'workflow_guard.debug',
+  'workflow_guard.mode',
+] as const
+
+const CONFIG_PROTECTED_FIELD_PATHS = [
+  'workflow_guard',
+  'agents.*.model',
+  'agents.*.permission',
+  'agents.*.skills',
+  'agents.*.variant',
+  'categories.*.model',
+  'categories.*.permission',
+  'categories.*.skills',
+  'categories.*.variant',
+] as const
+
+const CONFIG_SOURCE_ERROR_CODES = [
+  'parse-failed',
+  'read-failed',
+  'schema-invalid',
+  'source-invalid',
+] as const
+
+const CONFIG_SOURCE_KIND_SET = new Set<string>(CONFIG_SOURCE_KINDS)
+const CONFIG_AUTHORITY_FIELD_PATH_SET = new Set<string>(
+  CONFIG_AUTHORITY_FIELD_PATHS,
+)
+const CONFIG_PROTECTED_FIELD_PATH_SET = new Set<string>(
+  CONFIG_PROTECTED_FIELD_PATHS,
+)
+const CONFIG_SOURCE_ERROR_CODE_SET = new Set<string>(CONFIG_SOURCE_ERROR_CODES)
+
+const CAPABILITY_SOURCE_PRESENCE = ['absent', 'invalid', 'present'] as const
+
+const CAPABILITY_STATUSES = ['available', 'unknown', 'unavailable'] as const
+
+const CAPABILITY_FACT_IDS = [
+  'config-authority',
+  'config-field-authority',
+  'config-protected-field',
+  'discovery-summary',
+  'discovery-source-issue',
+  'host-runtime',
+] as const
+
+const CAPABILITY_DISCOVERY_IDS = ['agents', 'skills'] as const
+
+const CAPABILITY_LIMITATION_CODES = [
+  'authority-unproven',
+  'discovery-not-collected',
+  'host-runtime-unobservable',
+] as const
+
+const CAPABILITY_ERROR_CODES = [
+  'source-malformed',
+  'source-read-failed',
+  'source-unsupported',
+  'structural-invalid',
+] as const
+
+const CAPABILITY_ROOT_IDS = [
+  'agents',
+  'cwd',
+  'global',
+  'package',
+  'project',
+  'skills',
+  'user',
+  'workspace',
+] as const
+
+type CapabilitySourceId = (typeof CAPABILITY_SOURCE_IDS)[number]
+type ConfigSourceKind = (typeof CONFIG_SOURCE_KINDS)[number]
+type ConfigAuthorityFieldPath = (typeof CONFIG_AUTHORITY_FIELD_PATHS)[number]
+type ConfigProtectedFieldPath = (typeof CONFIG_PROTECTED_FIELD_PATHS)[number]
+type ConfigSourceErrorCode = (typeof CONFIG_SOURCE_ERROR_CODES)[number]
+type CapabilitySourcePresence = (typeof CAPABILITY_SOURCE_PRESENCE)[number]
+type CapabilityStatus = (typeof CAPABILITY_STATUSES)[number]
+type CapabilityFactId = (typeof CAPABILITY_FACT_IDS)[number]
+type CapabilityStatusFactId = Exclude<
+  CapabilityFactId,
+  'discovery-source-issue' | 'discovery-summary'
+>
+type CapabilityDiscoveryIssueErrorCode = Extract<
+  CapabilityErrorCode,
+  'source-malformed' | 'source-read-failed'
+>
+type CapabilityDiscoveryId = (typeof CAPABILITY_DISCOVERY_IDS)[number]
+type CapabilityLimitationCode = (typeof CAPABILITY_LIMITATION_CODES)[number]
+type CapabilityErrorCode = (typeof CAPABILITY_ERROR_CODES)[number]
+type CapabilityRootId = (typeof CAPABILITY_ROOT_IDS)[number] | string
+
+interface CapabilityPackageIdentity {
+  readonly name: string
+  readonly version: string
+}
+
+interface CapabilityRootInput {
+  readonly id: CapabilityRootId
+  readonly path: string
+}
+
+interface CapabilitySourceInput {
+  readonly sourceId: CapabilitySourceId
+  readonly presence: CapabilitySourcePresence
+  readonly sourceKind?: ConfigSourceKind
+  readonly path?: string
+  readonly errorCode?: CapabilityErrorCode
+}
+
+export type CapabilityFactInput =
+  | {
+      readonly factId: Exclude<
+        CapabilityFactId,
+        | 'config-field-authority'
+        | 'config-protected-field'
+        | 'discovery-source-issue'
+        | 'discovery-summary'
+      >
+      readonly status: CapabilityStatus
+      readonly sourceId?: CapabilitySourceId
+      readonly limitationCode?: CapabilityLimitationCode
+      readonly errorCode?: CapabilityErrorCode
+    }
+  | {
+      readonly factId: 'config-field-authority'
+      readonly fieldPath: ConfigAuthorityFieldPath
+      readonly kind: 'authority'
+      readonly sourceId: CapabilitySourceId
+      readonly status: 'available'
+    }
+  | {
+      readonly errorCode: CapabilityDiscoveryIssueErrorCode
+      readonly factId: 'discovery-source-issue'
+      readonly kind: 'status'
+      readonly sourceId: 'discovery:skills'
+      readonly status: 'unavailable'
+    }
+  | {
+      readonly errorCode: CapabilityErrorCode
+      readonly factId: 'discovery-summary'
+      readonly kind?: 'status'
+      readonly sourceId: CapabilitySourceId
+      readonly status: 'unavailable'
+    }
+  | {
+      readonly factId: 'config-protected-field'
+      readonly fieldPath: ConfigProtectedFieldPath
+      readonly kind: 'protection'
+      readonly outcome: 'blocked'
+      readonly sourceId: CapabilitySourceId
+      readonly status: 'available'
+    }
+  | {
+      readonly count: number
+      readonly discoveryId: CapabilityDiscoveryId
+      readonly factId: 'discovery-summary'
+      readonly kind: 'discovery'
+      readonly sourceId: CapabilitySourceId
+      readonly status: 'available'
+      readonly winningRoots: readonly string[]
+    }
+
+interface ConfigSourceMetadata {
+  readonly errorCode?: ConfigSourceErrorCode
+  readonly kind: ConfigSourceKind
+  readonly path?: string
+  readonly presence: CapabilitySourcePresence
+}
+
+interface ConfigAuthorityMetadata {
+  readonly fieldPath: ConfigAuthorityFieldPath
+  readonly sourceKind: ConfigSourceKind
+}
+
+interface ConfigProtectedFieldMetadata {
+  readonly fieldPath: ConfigProtectedFieldPath
+  readonly outcome: 'blocked'
+  readonly sourceKind: ConfigSourceKind
+}
+
+export interface ConfigObservationMetadata {
+  readonly authorities: readonly ConfigAuthorityMetadata[]
+  readonly protectedFields: readonly ConfigProtectedFieldMetadata[]
+  readonly sources: readonly ConfigSourceMetadata[]
+}
+
+export type CapabilityClock = () => number | Date
+export type CapabilityOutputSink = (serialized: string) => void
+
+interface CapabilitySnapshotBuilderOptions {
+  readonly argv: readonly string[]
+  readonly package: CapabilityPackageIdentity
+  readonly roots: readonly CapabilityRootInput[]
+  readonly sources?: readonly CapabilitySourceInput[]
+  readonly facts?: readonly CapabilityFactInput[]
+  readonly config?: ConfigObservationMetadata
+  readonly observedAt?: string
+  readonly clock?: CapabilityClock
+  readonly outputSink?: CapabilityOutputSink
+}
+
+interface CapabilitySnapshotArgvIdentity {
+  readonly executable: string
+  readonly subcommand: 'capabilities'
+}
+
+interface CapabilitySnapshotIdentity {
+  readonly argv: CapabilitySnapshotArgvIdentity
+  readonly package: CapabilityPackageIdentity
+}
+
+interface CapabilitySnapshotRoot {
+  readonly id: string
+}
+
+interface CapabilitySnapshotSource {
+  readonly errorCode?: CapabilityErrorCode
+  readonly kind: 'source'
+  readonly presence: CapabilitySourcePresence
+  readonly sourceId: CapabilitySourceId
+  readonly sourceKind?: ConfigSourceKind
+}
+
+type CapabilitySnapshotFact =
+  | {
+      readonly factId: CapabilityStatusFactId
+      readonly kind: 'status'
+      readonly status: 'available'
+    }
+  | {
+      readonly factId: CapabilityStatusFactId
+      readonly kind: 'status'
+      readonly limitationCode: CapabilityLimitationCode
+      readonly status: 'unknown'
+    }
+  | {
+      readonly errorCode: CapabilityErrorCode
+      readonly factId: CapabilityStatusFactId
+      readonly kind: 'status'
+      readonly sourceId?: CapabilitySourceId
+      readonly status: 'unavailable'
+    }
+  | {
+      readonly errorCode: CapabilityErrorCode
+      readonly factId: 'discovery-summary'
+      readonly kind: 'status'
+      readonly sourceId: CapabilitySourceId
+      readonly status: 'unavailable'
+    }
+  | {
+      readonly errorCode: CapabilityDiscoveryIssueErrorCode
+      readonly factId: 'discovery-source-issue'
+      readonly kind: 'status'
+      readonly sourceId: 'discovery:skills'
+      readonly status: 'unavailable'
+    }
+  | {
+      readonly factId: 'config-field-authority'
+      readonly fieldPath: ConfigAuthorityFieldPath
+      readonly kind: 'authority'
+      readonly sourceId: CapabilitySourceId
+      readonly status: 'available'
+    }
+  | {
+      readonly factId: 'config-protected-field'
+      readonly fieldPath: ConfigProtectedFieldPath
+      readonly kind: 'protection'
+      readonly outcome: 'blocked'
+      readonly sourceId: CapabilitySourceId
+      readonly status: 'available'
+    }
+  | {
+      readonly count: number
+      readonly discoveryId: CapabilityDiscoveryId
+      readonly factId: 'discovery-summary'
+      readonly kind: 'discovery'
+      readonly sourceId: CapabilitySourceId
+      readonly status: 'available'
+      readonly winningRoots: readonly string[]
+    }
+
+interface CapabilitySnapshot {
+  readonly command: typeof CAPABILITY_SNAPSHOT_COMMAND
+  readonly facts: readonly CapabilitySnapshotFact[]
+  readonly identity: CapabilitySnapshotIdentity
+  readonly observedAt: string
+  readonly roots: readonly CapabilitySnapshotRoot[]
+  readonly schemaVersion: typeof CAPABILITY_SNAPSHOT_SCHEMA_VERSION
+  readonly sources: readonly CapabilitySnapshotSource[]
+}
+
+const CAPABILITY_SOURCE_ID_SET = new Set<string>(CAPABILITY_SOURCE_IDS)
+const CAPABILITY_SOURCE_PRESENCE_SET = new Set<string>(
+  CAPABILITY_SOURCE_PRESENCE,
+)
+const CAPABILITY_STATUS_SET = new Set<string>(CAPABILITY_STATUSES)
+const CAPABILITY_FACT_ID_SET = new Set<string>(CAPABILITY_FACT_IDS)
+const CAPABILITY_DISCOVERY_ID_SET = new Set<string>(CAPABILITY_DISCOVERY_IDS)
+const CAPABILITY_LIMITATION_CODE_SET = new Set<string>(
+  CAPABILITY_LIMITATION_CODES,
+)
+const CAPABILITY_ERROR_CODE_SET = new Set<string>(CAPABILITY_ERROR_CODES)
+
+const MAX_DISPLAY_ID_LENGTH = 128
+const MAX_PACKAGE_NAME_LENGTH = 128
+const MAX_PACKAGE_VERSION_LENGTH = 64
+const MAX_DISCOVERY_COUNT = 100_000
+const MAX_DISCOVERY_ROOTS = 32
+
+function compareText(left: string, right: string): number {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function assertRecord(
+  value: unknown,
+  label: string,
+): asserts value is Record<string, unknown> {
+  if (!isRecord(value)) throw new TypeError(`${label} must be an object`)
+}
+
+function assertAllowedKeys(
+  value: Record<string, unknown>,
+  allowedKeys: readonly string[],
+  label: string,
+): void {
+  const allowed = new Set(allowedKeys)
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key))
+      throw new TypeError(`${label} has unknown key ${key}`)
+  }
+}
+
+function assertString(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new TypeError(`${label} must be a non-empty string`)
+  }
+}
+
+function assertEnum<T extends string>(
+  value: unknown,
+  values: ReadonlySet<string>,
+  label: string,
+): asserts value is T {
+  if (typeof value !== 'string' || !values.has(value)) {
+    throw new TypeError(`${label} is not an allowed value`)
+  }
+}
+
+function normalizeDisplayId(value: string, label: string): string {
+  assertString(value, label)
+  const normalized = value.replaceAll('\\', '/').replace(/^\.\//, '')
+  if (
+    normalized.length > MAX_DISPLAY_ID_LENGTH ||
+    normalized.startsWith('/') ||
+    normalized.includes('..') ||
+    !/^[A-Za-z0-9._:-]+(?:\/[A-Za-z0-9._:-]+)*$/.test(normalized)
+  ) {
+    throw new TypeError(`${label} must be a bounded relative display ID`)
+  }
+  return normalized
+}
+
+function normalizePackageName(value: string): string {
+  assertString(value, 'package.name')
+  if (
+    value.length > MAX_PACKAGE_NAME_LENGTH ||
+    !/^@?[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)?$/.test(value)
+  ) {
+    throw new TypeError('package.name is not an allowed package identity')
+  }
+  return value
+}
+
+function normalizePackageVersion(value: string): string {
+  assertString(value, 'package.version')
+  if (
+    value.length > MAX_PACKAGE_VERSION_LENGTH ||
+    !/^[A-Za-z0-9][A-Za-z0-9.+_-]*$/.test(value)
+  ) {
+    throw new TypeError('package.version is not an allowed version identity')
+  }
+  return value
+}
+
+function normalizeExecutable(value: string): string {
+  assertString(value, 'argv[0]')
+  const segments = value.replaceAll('\\', '/').split('/')
+  const executable = segments.at(-1) ?? ''
+  if (
+    executable.length === 0 ||
+    executable.length > MAX_DISPLAY_ID_LENGTH ||
+    !/^[A-Za-z0-9._:-]+$/.test(executable)
+  ) {
+    throw new TypeError('argv[0] is not an allowed executable identity')
+  }
+  return executable
+}
+
+function normalizeArgv(
+  argv: readonly string[],
+): CapabilitySnapshotArgvIdentity {
+  if (argv.length < 2) {
+    throw new TypeError(
+      'argv must include an executable and capabilities command',
+    )
+  }
+  const executable = normalizeExecutable(argv[0] ?? '')
+  if (argv[1] !== 'capabilities') {
+    throw new TypeError('argv must identify the capabilities command')
+  }
+  return {
+    executable,
+    subcommand: 'capabilities',
+  }
+}
+
+function canonicalizePath(value: string): string {
+  assertString(value, 'root.path')
+  const normalizedSeparators = value.replaceAll('\\', '/')
+  const absolute = normalizedSeparators.startsWith('/')
+  const segments: string[] = []
+  for (const segment of normalizedSeparators.split('/')) {
+    if (segment === '' || segment === '.') continue
+    if (segment === '..') {
+      if (segments.length > 0 && segments.at(-1) !== '..') segments.pop()
+      else if (!absolute) segments.push(segment)
+      continue
+    }
+    segments.push(segment)
+  }
+  const joined = segments.join('/')
+  return absolute ? `/${joined}` : joined
+}
+
+function normalizeObservedAt(
+  options: CapabilitySnapshotBuilderOptions,
+): string {
+  const observedAt = options.observedAt
+  if (observedAt !== undefined) {
+    assertString(observedAt, 'observedAt')
+    const parsed = new Date(observedAt)
+    if (Number.isNaN(parsed.getTime())) {
+      throw new TypeError('observedAt must be a valid timestamp')
+    }
+    return parsed.toISOString()
+  }
+
+  const now = options.clock?.() ?? Date.now()
+  const timestamp = now instanceof Date ? now : new Date(now)
+  if (Number.isNaN(timestamp.getTime())) {
+    throw new TypeError('clock must return a valid timestamp')
+  }
+  return timestamp.toISOString()
+}
+
+function normalizePackage(
+  value: CapabilityPackageIdentity,
+): CapabilityPackageIdentity {
+  assertRecord(value, 'package')
+  assertAllowedKeys(value, ['name', 'version'], 'package')
+  return {
+    name: normalizePackageName(value.name),
+    version: normalizePackageVersion(value.version),
+  }
+}
+
+function normalizeRoots(
+  roots: readonly CapabilityRootInput[],
+): readonly CapabilitySnapshotRoot[] {
+  const normalized = roots.map((root, index) => {
+    assertRecord(root, `roots[${index}]`)
+    assertAllowedKeys(root, ['id', 'path'], `roots[${index}]`)
+    const id = normalizeDisplayId(root.id, `roots[${index}].id`)
+    const path = canonicalizePath(root.path)
+    return { id, path }
+  })
+
+  normalized.sort((left, right) => {
+    const pathOrder = compareText(left.path, right.path)
+    return pathOrder !== 0 ? pathOrder : compareText(left.id, right.id)
+  })
+
+  const unique: CapabilitySnapshotRoot[] = []
+  let previousPath: string | undefined
+  for (const root of normalized) {
+    if (root.path === previousPath) continue
+    previousPath = root.path
+    unique.push({ id: root.id })
+  }
+  unique.sort((left, right) => compareText(left.id, right.id))
+  return unique
+}
+
+function normalizeSources(
+  sources: readonly CapabilitySourceInput[],
+): readonly CapabilitySnapshotSource[] {
+  const normalized = sources.map(normalizeSource)
+
+  normalized.sort(compareSources)
+
+  const unique: Array<
+    CapabilitySnapshotSource & { readonly canonicalPath?: string }
+  > = []
+  const seen = new Set<string>()
+  for (const source of normalized) {
+    const key = source.canonicalPath ?? `source:${source.sourceId}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    unique.push(source)
+  }
+  unique.sort((left, right) => compareText(left.sourceId, right.sourceId))
+  return unique.map(({ canonicalPath: _canonicalPath, ...source }) => source)
+}
+
+function compareSources(
+  left: CapabilitySnapshotSource & { readonly canonicalPath?: string },
+  right: CapabilitySnapshotSource & { readonly canonicalPath?: string },
+): number {
+  const pathOrder = compareText(
+    left.canonicalPath ?? '',
+    right.canonicalPath ?? '',
+  )
+  if (pathOrder !== 0) return pathOrder
+  const sourceOrder = compareText(left.sourceId, right.sourceId)
+  if (sourceOrder !== 0) return sourceOrder
+  return compareText(left.presence, right.presence)
+}
+
+function normalizeSource(
+  source: CapabilitySourceInput,
+  index: number,
+): CapabilitySnapshotSource & { readonly canonicalPath?: string } {
+  assertRecord(source, `sources[${index}]`)
+  assertAllowedKeys(
+    source,
+    ['errorCode', 'path', 'presence', 'sourceId', 'sourceKind'],
+    `sources[${index}]`,
+  )
+  assertEnum<CapabilitySourceId>(
+    source.sourceId,
+    CAPABILITY_SOURCE_ID_SET,
+    `sources[${index}].sourceId`,
+  )
+  assertEnum<CapabilitySourcePresence>(
+    source.presence,
+    CAPABILITY_SOURCE_PRESENCE_SET,
+    `sources[${index}].presence`,
+  )
+  assertSourceKind(source, index)
+  const canonicalPath =
+    source.path === undefined ? undefined : canonicalizePath(source.path)
+  if (source.presence === 'invalid') {
+    assertEnum<CapabilityErrorCode>(
+      source.errorCode,
+      CAPABILITY_ERROR_CODE_SET,
+      `sources[${index}].errorCode`,
+    )
+    return {
+      errorCode: source.errorCode,
+      kind: 'source',
+      presence: source.presence,
+      sourceId: source.sourceId,
+      ...(source.sourceKind === undefined
+        ? {}
+        : { sourceKind: source.sourceKind }),
+      canonicalPath,
+    }
+  }
+  if (source.errorCode !== undefined) {
+    throw new TypeError(
+      `sources[${index}].errorCode is only valid for invalid sources`,
+    )
+  }
+  return {
+    kind: 'source',
+    presence: source.presence,
+    sourceId: source.sourceId,
+    ...(source.sourceKind === undefined
+      ? {}
+      : { sourceKind: source.sourceKind }),
+    canonicalPath,
+  }
+}
+
+function assertSourceKind(source: CapabilitySourceInput, index: number): void {
+  if (source.sourceKind === undefined) return
+  assertEnum<ConfigSourceKind>(
+    source.sourceKind,
+    CONFIG_SOURCE_KIND_SET,
+    `sources[${index}].sourceKind`,
+  )
+  if (source.sourceId !== configSourceId(source.sourceKind)) {
+    throw new TypeError(`sources[${index}].sourceKind does not match sourceId`)
+  }
+}
+
+function configSourceId(sourceKind: ConfigSourceKind): CapabilitySourceId {
+  return `config:${sourceKind}` as CapabilitySourceId
+}
+
+function configErrorCode(
+  errorCode: ConfigSourceErrorCode,
+): CapabilityErrorCode {
+  return errorCode === 'read-failed' ? 'source-read-failed' : 'source-malformed'
+}
+
+function normalizeConfigObservation(config: ConfigObservationMetadata): {
+  readonly facts: readonly CapabilityFactInput[]
+  readonly sources: readonly CapabilitySourceInput[]
+} {
+  assertRecord(config, 'config')
+  assertAllowedKeys(
+    config,
+    ['authorities', 'protectedFields', 'sources'],
+    'config',
+  )
+  if (!Array.isArray(config.sources)) {
+    throw new TypeError('config.sources must be an array')
+  }
+  if (!Array.isArray(config.authorities)) {
+    throw new TypeError('config.authorities must be an array')
+  }
+  if (!Array.isArray(config.protectedFields)) {
+    throw new TypeError('config.protectedFields must be an array')
+  }
+
+  const sources = config.sources.map((source, index) => {
+    assertRecord(source, `config.sources[${index}]`)
+    assertAllowedKeys(
+      source,
+      ['errorCode', 'kind', 'path', 'presence'],
+      `config.sources[${index}]`,
+    )
+    assertEnum<ConfigSourceKind>(
+      source.kind,
+      CONFIG_SOURCE_KIND_SET,
+      `config.sources[${index}].kind`,
+    )
+    assertEnum<CapabilitySourcePresence>(
+      source.presence,
+      CAPABILITY_SOURCE_PRESENCE_SET,
+      `config.sources[${index}].presence`,
+    )
+    const pathValue = source.path
+    if (pathValue !== undefined) {
+      assertString(pathValue, `config.sources[${index}].path`)
+      canonicalizePath(pathValue)
+    }
+    if (source.errorCode !== undefined) {
+      assertEnum<ConfigSourceErrorCode>(
+        source.errorCode,
+        CONFIG_SOURCE_ERROR_CODE_SET,
+        `config.sources[${index}].errorCode`,
+      )
+    }
+    return {
+      ...(source.errorCode === undefined
+        ? {}
+        : { errorCode: configErrorCode(source.errorCode) }),
+      ...(pathValue === undefined ? {} : { path: pathValue }),
+      presence: source.presence,
+      sourceId: configSourceId(source.kind),
+      sourceKind: source.kind,
+    }
+  })
+
+  const facts: CapabilityFactInput[] = []
+  for (const source of sources) {
+    if (source.presence !== 'invalid' || source.errorCode === undefined)
+      continue
+    facts.push({
+      errorCode: source.errorCode,
+      factId: 'config-authority',
+      sourceId: source.sourceId,
+      status: 'unavailable',
+    })
+  }
+  config.authorities.forEach((authority, index) => {
+    assertRecord(authority, `config.authorities[${index}]`)
+    assertAllowedKeys(
+      authority,
+      ['fieldPath', 'sourceKind'],
+      `config.authorities[${index}]`,
+    )
+    assertEnum<ConfigAuthorityFieldPath>(
+      authority.fieldPath,
+      CONFIG_AUTHORITY_FIELD_PATH_SET,
+      `config.authorities[${index}].fieldPath`,
+    )
+    assertEnum<ConfigSourceKind>(
+      authority.sourceKind,
+      CONFIG_SOURCE_KIND_SET,
+      `config.authorities[${index}].sourceKind`,
+    )
+    facts.push({
+      factId: 'config-field-authority',
+      fieldPath: authority.fieldPath,
+      kind: 'authority',
+      sourceId: configSourceId(authority.sourceKind),
+      status: 'available',
+    })
+  })
+
+  config.protectedFields.forEach((protectedField, index) => {
+    assertRecord(protectedField, `config.protectedFields[${index}]`)
+    assertAllowedKeys(
+      protectedField,
+      ['fieldPath', 'outcome', 'sourceKind'],
+      `config.protectedFields[${index}]`,
+    )
+    assertEnum<ConfigProtectedFieldPath>(
+      protectedField.fieldPath,
+      CONFIG_PROTECTED_FIELD_PATH_SET,
+      `config.protectedFields[${index}].fieldPath`,
+    )
+    assertEnum<ConfigSourceKind>(
+      protectedField.sourceKind,
+      CONFIG_SOURCE_KIND_SET,
+      `config.protectedFields[${index}].sourceKind`,
+    )
+    if (protectedField.outcome !== 'blocked') {
+      throw new TypeError(
+        `config.protectedFields[${index}].outcome must be blocked`,
+      )
+    }
+    facts.push({
+      factId: 'config-protected-field',
+      fieldPath: protectedField.fieldPath,
+      kind: 'protection',
+      outcome: 'blocked',
+      sourceId: configSourceId(protectedField.sourceKind),
+      status: 'available',
+    })
+  })
+
+  return { facts, sources }
+}
+
+function normalizeFact(value: unknown, label: string): CapabilitySnapshotFact {
+  assertRecord(value, label)
+  assertAllowedKeys(
+    value,
+    [
+      'errorCode',
+      'factId',
+      'fieldPath',
+      'kind',
+      'limitationCode',
+      'outcome',
+      'sourceId',
+      'status',
+      'count',
+      'discoveryId',
+      'winningRoots',
+    ],
+    label,
+  )
+  assertEnum<CapabilityFactId>(
+    value.factId,
+    CAPABILITY_FACT_ID_SET,
+    `${label}.factId`,
+  )
+
+  if (value.factId === 'config-field-authority') {
+    return normalizeAuthorityFact(value, label)
+  }
+  if (value.factId === 'config-protected-field') {
+    return normalizeProtectionFact(value, label)
+  }
+  if (value.factId === 'discovery-summary') {
+    return normalizeDiscoveryFact(value, label)
+  }
+  if (value.factId === 'discovery-source-issue') {
+    return normalizeDiscoverySourceIssueFact(value, label)
+  }
+  return normalizeStatusFact(value, label)
+}
+
+function normalizeAuthorityFact(
+  value: Record<string, unknown>,
+  label: string,
+): CapabilitySnapshotFact {
+  assertNoDiscoveryFields(value, label)
+  assertEnum<ConfigAuthorityFieldPath>(
+    value.fieldPath,
+    CONFIG_AUTHORITY_FIELD_PATH_SET,
+    `${label}.fieldPath`,
+  )
+  if (value.kind !== 'authority') {
+    throw new TypeError(`${label}.kind must be authority`)
+  }
+  assertAvailableFactSource(value, label)
+  return {
+    factId: 'config-field-authority',
+    fieldPath: value.fieldPath,
+    kind: 'authority',
+    sourceId: value.sourceId,
+    status: 'available',
+  }
+}
+
+function normalizeProtectionFact(
+  value: Record<string, unknown>,
+  label: string,
+): CapabilitySnapshotFact {
+  assertNoDiscoveryFields(value, label)
+  assertEnum<ConfigProtectedFieldPath>(
+    value.fieldPath,
+    CONFIG_PROTECTED_FIELD_PATH_SET,
+    `${label}.fieldPath`,
+  )
+  if (value.kind !== 'protection') {
+    throw new TypeError(`${label}.kind must be protection`)
+  }
+  if (value.outcome !== 'blocked') {
+    throw new TypeError(`${label}.outcome must be blocked`)
+  }
+  assertAvailableFactSource(value, label)
+  return {
+    factId: 'config-protected-field',
+    fieldPath: value.fieldPath,
+    kind: 'protection',
+    outcome: 'blocked',
+    sourceId: value.sourceId,
+    status: 'available',
+  }
+}
+
+function assertAvailableFactSource(
+  value: Record<string, unknown>,
+  label: string,
+): asserts value is Record<string, unknown> & {
+  readonly sourceId: CapabilitySourceId
+} {
+  assertEnum<CapabilitySourceId>(
+    value.sourceId,
+    CAPABILITY_SOURCE_ID_SET,
+    `${label}.sourceId`,
+  )
+  if (value.status !== 'available') {
+    throw new TypeError(`${label}.status must be available`)
+  }
+}
+
+function normalizeStatusFact(
+  value: Record<string, unknown>,
+  label: string,
+): CapabilitySnapshotFact {
+  assertNoDiscoveryFields(value, label)
+  if (value.kind !== undefined && value.kind !== 'status') {
+    throw new TypeError(`${label}.kind must be status`)
+  }
+  assertEnum<CapabilityStatus>(
+    value.status,
+    CAPABILITY_STATUS_SET,
+    `${label}.status`,
+  )
+  if (value.sourceId !== undefined) {
+    assertEnum<CapabilitySourceId>(
+      value.sourceId,
+      CAPABILITY_SOURCE_ID_SET,
+      `${label}.sourceId`,
+    )
+  }
+
+  switch (value.status) {
+    case 'available':
+      return normalizeAvailableFact(value, label)
+    case 'unknown':
+      return normalizeUnknownFact(value, label)
+    case 'unavailable':
+      return normalizeUnavailableFact(value, label)
+  }
+}
+
+function assertNoDiscoveryFields(
+  value: Record<string, unknown>,
+  label: string,
+): void {
+  if (
+    value.count !== undefined ||
+    value.discoveryId !== undefined ||
+    value.winningRoots !== undefined
+  ) {
+    throw new TypeError(`${label} discovery fields require discovery kind`)
+  }
+}
+
+function normalizeDiscoveryFact(
+  value: Record<string, unknown>,
+  label: string,
+): CapabilitySnapshotFact {
+  if (value.status === 'unavailable') {
+    return normalizeUnavailableDiscoveryFact(value, label)
+  }
+
+  if (value.status !== 'available') {
+    throw new TypeError(`${label}.status must be available or unavailable`)
+  }
+  assertAvailableDiscoveryFact(value, label)
+  assertEnum<CapabilityDiscoveryId>(
+    value.discoveryId,
+    CAPABILITY_DISCOVERY_ID_SET,
+    `${label}.discoveryId`,
+  )
+  const expectedSourceId = `discovery:${value.discoveryId}`
+  if (value.sourceId !== expectedSourceId) {
+    throw new TypeError(`${label}.sourceId does not match discoveryId`)
+  }
+  assertEnum<CapabilitySourceId>(
+    value.sourceId,
+    CAPABILITY_SOURCE_ID_SET,
+    `${label}.sourceId`,
+  )
+  const count = value.count
+  if (
+    typeof count !== 'number' ||
+    !Number.isSafeInteger(count) ||
+    count < 0 ||
+    count > MAX_DISCOVERY_COUNT
+  ) {
+    throw new TypeError(`${label}.count must be a bounded integer`)
+  }
+  if (!Array.isArray(value.winningRoots)) {
+    throw new TypeError(`${label}.winningRoots must be an array`)
+  }
+  if (value.winningRoots.length > MAX_DISCOVERY_ROOTS) {
+    throw new TypeError(`${label}.winningRoots exceeds the bounded limit`)
+  }
+  const winningRoots = value.winningRoots.map((root, index) => {
+    assertString(root, `${label}.winningRoots[${index}]`)
+    return normalizeDisplayId(root, `${label}.winningRoots[${index}]`)
+  })
+  winningRoots.sort(compareText)
+  return {
+    count,
+    discoveryId: value.discoveryId,
+    factId: 'discovery-summary',
+    kind: 'discovery',
+    sourceId: value.sourceId,
+    status: 'available',
+    winningRoots: [...new Set(winningRoots)],
+  }
+}
+
+function normalizeDiscoverySourceIssueFact(
+  value: Record<string, unknown>,
+  label: string,
+): CapabilitySnapshotFact {
+  if (value.kind !== 'status') {
+    throw new TypeError(`${label}.kind must be status`)
+  }
+  if (value.status !== 'unavailable') {
+    throw new TypeError(`${label}.status must be unavailable`)
+  }
+  if (value.sourceId !== 'discovery:skills') {
+    throw new TypeError(`${label}.sourceId must be discovery:skills`)
+  }
+  if (
+    value.errorCode !== 'source-malformed' &&
+    value.errorCode !== 'source-read-failed'
+  ) {
+    throw new TypeError(`${label}.errorCode is not a discovery source error`)
+  }
+  if (
+    value.count !== undefined ||
+    value.discoveryId !== undefined ||
+    value.fieldPath !== undefined ||
+    value.limitationCode !== undefined ||
+    value.outcome !== undefined ||
+    value.winningRoots !== undefined
+  ) {
+    throw new TypeError(`${label} has invalid discovery source issue fields`)
+  }
+  return {
+    errorCode: value.errorCode,
+    factId: 'discovery-source-issue',
+    kind: 'status',
+    sourceId: 'discovery:skills',
+    status: 'unavailable',
+  }
+}
+
+function normalizeUnavailableDiscoveryFact(
+  value: Record<string, unknown>,
+  label: string,
+): CapabilitySnapshotFact {
+  if (value.kind !== undefined && value.kind !== 'status') {
+    throw new TypeError(`${label}.kind must be status`)
+  }
+  if (value.sourceId === undefined) {
+    throw new TypeError(`${label}.sourceId is required`)
+  }
+  if (
+    value.count !== undefined ||
+    value.discoveryId !== undefined ||
+    value.winningRoots !== undefined
+  ) {
+    throw new TypeError(`${label} unavailable discovery fields are invalid`)
+  }
+  assertEnum<CapabilitySourceId>(
+    value.sourceId,
+    CAPABILITY_SOURCE_ID_SET,
+    `${label}.sourceId`,
+  )
+  return normalizeUnavailableFact(value, label)
+}
+
+function assertAvailableDiscoveryFact(
+  value: Record<string, unknown>,
+  label: string,
+): void {
+  if (value.kind !== 'discovery') {
+    throw new TypeError(`${label}.kind must be discovery`)
+  }
+  if (
+    value.errorCode !== undefined ||
+    value.limitationCode !== undefined ||
+    value.outcome !== undefined
+  ) {
+    throw new TypeError(`${label} available discovery fields are invalid`)
+  }
+}
+
+function normalizeAvailableFact(
+  value: Record<string, unknown>,
+  label: string,
+): CapabilitySnapshotFact {
+  if (value.sourceId !== undefined || value.errorCode !== undefined) {
+    throw new TypeError(
+      `${label} available facts cannot include source or error metadata`,
+    )
+  }
+  if (value.limitationCode !== undefined) {
+    throw new TypeError(`${label} available facts cannot include a limitation`)
+  }
+  return {
+    factId: value.factId as CapabilityStatusFactId,
+    kind: 'status',
+    status: 'available',
+  }
+}
+
+function normalizeUnknownFact(
+  value: Record<string, unknown>,
+  label: string,
+): CapabilitySnapshotFact {
+  assertEnum<CapabilityLimitationCode>(
+    value.limitationCode,
+    CAPABILITY_LIMITATION_CODE_SET,
+    `${label}.limitationCode`,
+  )
+  if (value.sourceId !== undefined || value.errorCode !== undefined) {
+    throw new TypeError(
+      `${label} unknown facts cannot include source or error metadata`,
+    )
+  }
+  return {
+    factId: value.factId as CapabilityStatusFactId,
+    kind: 'status',
+    limitationCode: value.limitationCode,
+    status: 'unknown',
+  }
+}
+
+function normalizeUnavailableFact(
+  value: Record<string, unknown>,
+  label: string,
+): CapabilitySnapshotFact {
+  assertEnum<CapabilityErrorCode>(
+    value.errorCode,
+    CAPABILITY_ERROR_CODE_SET,
+    `${label}.errorCode`,
+  )
+  if (value.limitationCode !== undefined) {
+    throw new TypeError(
+      `${label} unavailable facts cannot include a limitation`,
+    )
+  }
+  return {
+    errorCode: value.errorCode,
+    factId: value.factId as CapabilityStatusFactId,
+    kind: 'status',
+    ...(value.sourceId === undefined
+      ? {}
+      : { sourceId: value.sourceId as CapabilitySourceId }),
+    status: 'unavailable',
+  }
+}
+
+function normalizeFacts(
+  facts: readonly unknown[],
+): readonly CapabilitySnapshotFact[] {
+  const normalized = facts.map((fact, index) =>
+    normalizeFact(fact, `facts[${index}]`),
+  )
+
+  normalized.sort(compareFacts)
+  return normalized
+}
+
+function compareFacts(
+  left: CapabilitySnapshotFact,
+  right: CapabilitySnapshotFact,
+): number {
+  const factOrder = compareText(left.factId, right.factId)
+  if (factOrder !== 0) return factOrder
+  const fieldOrder = compareText(
+    factField(left, 'fieldPath'),
+    factField(right, 'fieldPath'),
+  )
+  if (fieldOrder !== 0) return fieldOrder
+  const statusOrder = compareText(left.status, right.status)
+  if (statusOrder !== 0) return statusOrder
+  const sourceOrder = compareText(
+    factField(left, 'sourceId'),
+    factField(right, 'sourceId'),
+  )
+  if (sourceOrder !== 0) return sourceOrder
+  const discoveryOrder = compareText(
+    factField(left, 'discoveryId'),
+    factField(right, 'discoveryId'),
+  )
+  if (discoveryOrder !== 0) return discoveryOrder
+  return compareText(
+    factField(left, 'errorCode'),
+    factField(right, 'errorCode'),
+  )
+}
+
+function factField(
+  fact: CapabilitySnapshotFact,
+  field: 'discoveryId' | 'errorCode' | 'fieldPath' | 'sourceId',
+): string {
+  if (field === 'discoveryId' && 'discoveryId' in fact) return fact.discoveryId
+  if (field === 'errorCode' && 'errorCode' in fact) return fact.errorCode
+  if (field === 'fieldPath' && 'fieldPath' in fact) return fact.fieldPath
+  if (field === 'sourceId' && 'sourceId' in fact) return fact.sourceId ?? ''
+  return ''
+}
+
+export function buildCapabilitySnapshot(
+  options: CapabilitySnapshotBuilderOptions,
+): CapabilitySnapshot {
+  assertRecord(options, 'options')
+  assertAllowedKeys(
+    options,
+    [
+      'argv',
+      'clock',
+      'config',
+      'facts',
+      'observedAt',
+      'outputSink',
+      'package',
+      'roots',
+      'sources',
+    ],
+    'options',
+  )
+  if (!Array.isArray(options.argv)) throw new TypeError('argv must be an array')
+  if (!Array.isArray(options.roots))
+    throw new TypeError('roots must be an array')
+  if (options.sources !== undefined && !Array.isArray(options.sources)) {
+    throw new TypeError('sources must be an array')
+  }
+  if (options.facts !== undefined && !Array.isArray(options.facts)) {
+    throw new TypeError('facts must be an array')
+  }
+
+  const configObservation = options.config
+    ? normalizeConfigObservation(options.config)
+    : { facts: [], sources: [] }
+
+  const snapshot: CapabilitySnapshot = {
+    command: CAPABILITY_SNAPSHOT_COMMAND,
+    facts: normalizeFacts([
+      ...(options.facts ?? []),
+      ...configObservation.facts,
+    ]),
+    identity: {
+      argv: normalizeArgv(options.argv),
+      package: normalizePackage(options.package),
+    },
+    observedAt: normalizeObservedAt(options),
+    roots: normalizeRoots(options.roots),
+    schemaVersion: CAPABILITY_SNAPSHOT_SCHEMA_VERSION,
+    sources: normalizeSources([
+      ...(options.sources ?? []),
+      ...configObservation.sources,
+    ]),
+  }
+
+  const serialized = JSON.stringify(snapshot)
+  options.outputSink?.(serialized)
+  return snapshot
+}
+
+export function serializeCapabilitySnapshot(
+  snapshot: CapabilitySnapshot,
+): string {
+  return JSON.stringify(snapshot)
+}

--- a/src/lib/config-schema.ts
+++ b/src/lib/config-schema.ts
@@ -558,7 +558,7 @@ export function validateConfig(input: unknown): ValidationResult {
  *
  * Matches the hand-coded `SECURITY_OVERLAY_FIELDS` set in `src/lib/config.ts`.
  */
-export const SECURITY_OVERLAY_FIELDS: readonly string[] = [
+export const SECURITY_OVERLAY_FIELDS = [
   'model',
   'variant',
   'skills',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -14,7 +14,7 @@ import {
 } from './bundled-names.js'
 import {
   PI_SUBAGENTS_PROTECTED_FIELDS,
-  SECURITY_OVERLAY_FIELDS as SCHEMA_SECURITY_OVERLAY_FIELDS,
+  SECURITY_OVERLAY_FIELDS,
   SystematicConfigSchema,
 } from './config-schema.js'
 import { REMOVED_BUNDLED_AGENT_CATEGORIES } from './removed-names.js'
@@ -46,8 +46,64 @@ export interface SourcedOverlayConfigMap {
   categories: Record<string, SourcedOverlayConfig>
 }
 
+export const CONFIG_AUTHORITY_FIELD_PATHS = [
+  'bootstrap.enabled',
+  'bootstrap.file',
+  'skills_as_commands',
+  'workflow_guard.debug',
+  'workflow_guard.mode',
+] as const
+
+export const CONFIG_PROTECTED_FIELD_PATHS = [
+  'workflow_guard',
+  'agents.*.model',
+  'agents.*.permission',
+  'agents.*.skills',
+  'agents.*.variant',
+  'categories.*.model',
+  'categories.*.permission',
+  'categories.*.skills',
+  'categories.*.variant',
+] as const
+
+export type ConfigSourceKind = 'custom' | 'project' | 'user'
+export type ConfigSourcePresence = 'absent' | 'invalid' | 'present'
+export type ConfigSourceErrorCode =
+  | 'parse-failed'
+  | 'read-failed'
+  | 'schema-invalid'
+  | 'source-invalid'
+export type ConfigAuthorityFieldPath =
+  (typeof CONFIG_AUTHORITY_FIELD_PATHS)[number]
+export type ConfigProtectedFieldPath =
+  (typeof CONFIG_PROTECTED_FIELD_PATHS)[number]
+
+export interface ConfigSourceMetadata {
+  readonly errorCode?: ConfigSourceErrorCode
+  readonly kind: ConfigSourceKind
+  readonly presence: ConfigSourcePresence
+}
+
+export interface ConfigAuthorityMetadata {
+  readonly fieldPath: ConfigAuthorityFieldPath
+  readonly sourceKind: ConfigSourceKind
+}
+
+export interface ConfigProtectedFieldMetadata {
+  readonly fieldPath: ConfigProtectedFieldPath
+  readonly outcome: 'blocked'
+  readonly sourceKind: ConfigSourceKind
+}
+
+export interface ConfigObservationMetadata {
+  readonly authorities: readonly ConfigAuthorityMetadata[]
+  readonly protectedFields: readonly ConfigProtectedFieldMetadata[]
+  readonly sources: readonly ConfigSourceMetadata[]
+}
+
 export interface SourceAwareConfigResult {
   config: SystematicConfig
+  metadata: ConfigObservationMetadata
   overlays: SourcedOverlayConfigMap
 }
 
@@ -102,12 +158,32 @@ interface RawSystematicConfig
 }
 
 interface ConfigSource {
+  canonicalPath: string
   path: string
   config: RawSystematicConfig
-  trust: 'user' | 'project' | 'custom'
+  protectedFields: readonly ConfigProtectedFieldMetadata[]
+  trust: ConfigSourceKind
 }
 
-const SECURITY_OVERLAY_FIELDS = new Set(SCHEMA_SECURITY_OVERLAY_FIELDS)
+type SecurityOverlayField = (typeof SECURITY_OVERLAY_FIELDS)[number]
+
+const PROTECTED_OVERLAY_FIELD_PATHS = {
+  agents: {
+    model: 'agents.*.model',
+    permission: 'agents.*.permission',
+    skills: 'agents.*.skills',
+    variant: 'agents.*.variant',
+  },
+  categories: {
+    model: 'categories.*.model',
+    permission: 'categories.*.permission',
+    skills: 'categories.*.skills',
+    variant: 'categories.*.variant',
+  },
+} satisfies Record<
+  'agents' | 'categories',
+  Record<SecurityOverlayField, ConfigProtectedFieldPath>
+>
 
 const PROJECT_PROTECTED_FIELDS = new Set(['workflow_guard'])
 
@@ -159,6 +235,7 @@ export function warnDroppedNames(
   field: string,
   warned: Set<string>,
   removalVersion?: string,
+  warningSink: (message: string) => void = console.warn,
 ): void {
   for (const name of dropped) {
     if (warned.has(name)) continue
@@ -167,7 +244,7 @@ export function warnDroppedNames(
     const removalNote = removalVersion
       ? ` It was removed in ${removalVersion}.`
       : ''
-    console.warn(
+    warningSink(
       `[systematic] "${displayName}" in \`${field}\` is no longer a bundled name and will be ignored.${removalNote} Remove it from your config to silence this warning. See ${MIGRATION_DOCS_URL} for migration guidance.`,
     )
   }
@@ -378,24 +455,123 @@ function throwTopLevelConfigSchemaError(
 function loadConfigSource(
   filePath: string,
   trust: ConfigSource['trust'],
-): ConfigSource | null {
-  const rawConfig = loadJsoncFile(filePath)
-  if (!rawConfig) return null
+  invalidSource: 'throw' | 'report',
+): { metadata: ConfigSourceMetadata; source: ConfigSource | null } {
+  try {
+    const rawConfig = loadJsoncFile(filePath)
+    if (!rawConfig) {
+      return {
+        metadata: { kind: trust, presence: 'absent' },
+        source: null,
+      }
+    }
 
-  const config =
-    trust === 'project' ? stripProjectProtectedFields(rawConfig) : rawConfig
+    const protectedFields = collectProjectProtectedFields(rawConfig, trust)
+    const config =
+      trust === 'project' ? stripProjectProtectedFields(rawConfig) : rawConfig
 
-  const result = SystematicConfigSchema.safeParse(config)
-  if (!result.success) {
-    throwTopLevelConfigSchemaError(filePath, trust, result.error.issues, config)
+    const result = SystematicConfigSchema.safeParse(config)
+    if (!result.success) {
+      throwTopLevelConfigSchemaError(
+        filePath,
+        trust,
+        result.error.issues,
+        config,
+      )
+    }
+
+    // Validation succeeded; propagate raw parsed JSONC so the merge layer
+    // sees undefined for unset fields (preserves merge semantics where a
+    // higher-priority empty config does NOT override a lower-priority explicit
+    // setting). The schema's defaults are applied by the merge layer via
+    // DEFAULT_CONFIG at the top of the spread chain.
+    return {
+      metadata: { kind: trust, presence: 'present' },
+      source: {
+        canonicalPath: resolveConfigSourcePath(filePath),
+        config,
+        path: filePath,
+        protectedFields,
+        trust,
+      },
+    }
+  } catch (error) {
+    if (invalidSource === 'throw') throw error
+    return {
+      metadata: {
+        errorCode: classifyConfigSourceError(error),
+        kind: trust,
+        presence: 'invalid',
+      },
+      source: null,
+    }
   }
+}
 
-  // Validation succeeded; propagate raw parsed JSONC so the merge layer
-  // sees undefined for unset fields (preserves merge semantics where a
-  // higher-priority empty config does NOT override a lower-priority explicit
-  // setting). The schema's defaults are applied by the merge layer via
-  // DEFAULT_CONFIG at the top of the spread chain.
-  return { path: filePath, config, trust }
+function classifyConfigSourceError(error: unknown): ConfigSourceErrorCode {
+  if (isConfigSchemaError(error)) return 'schema-invalid'
+  if (!(error instanceof Error)) return 'source-invalid'
+  if (error.message.includes('JSONC parse error')) return 'parse-failed'
+  if (error.message.includes('unable to read file')) return 'read-failed'
+  return 'source-invalid'
+}
+
+function isConfigSchemaError(
+  error: unknown,
+): error is Error & { readonly _tag: 'ConfigSchemaError' } {
+  return isRecord(error) && error._tag === 'ConfigSchemaError'
+}
+
+function resolveConfigSourcePath(filePath: string): string {
+  try {
+    return fs.realpathSync(filePath)
+  } catch {
+    return path.resolve(filePath)
+  }
+}
+
+function collectProjectProtectedFields(
+  rawConfig: RawSystematicConfig,
+  trust: ConfigSource['trust'],
+): readonly ConfigProtectedFieldMetadata[] {
+  if (trust !== 'project') return []
+
+  return [
+    ...(Object.hasOwn(rawConfig, 'workflow_guard')
+      ? [
+          {
+            fieldPath: 'workflow_guard' as const,
+            outcome: 'blocked' as const,
+            sourceKind: 'project' as const,
+          },
+        ]
+      : []),
+    ...collectOverlayProtectedFields(rawConfig.agents, 'agents'),
+    ...collectOverlayProtectedFields(rawConfig.categories, 'categories'),
+  ]
+}
+
+function collectOverlayProtectedFields(
+  overlayMap: unknown,
+  mapKey: 'agents' | 'categories',
+): readonly ConfigProtectedFieldMetadata[] {
+  if (!isRecord(overlayMap)) return []
+  return Object.values(overlayMap).flatMap((value) =>
+    isRecord(value) ? collectProtectedOverlayValue(value, mapKey) : [],
+  )
+}
+
+function collectProtectedOverlayValue(
+  value: Record<string, unknown>,
+  mapKey: 'agents' | 'categories',
+): readonly ConfigProtectedFieldMetadata[] {
+  return [...SECURITY_OVERLAY_FIELDS]
+    .filter((field) => Object.hasOwn(value, field))
+    .map((field) => ({
+      fieldPath: PROTECTED_OVERLAY_FIELD_PATHS[mapKey][field],
+      outcome: 'blocked' as const,
+      sourceKind: 'project' as const,
+    }))
 }
 
 function stripProjectProtectedFields(
@@ -430,6 +606,11 @@ export interface LoadConfigOptions {
    * absorbs cwd project overlays (plan R7/R19). Defaults to true.
    */
   includeProject?: boolean
+  invalidSource?: 'throw' | 'report'
+  homeDir?: string
+  userConfigDir?: string
+  customConfigDir?: string | null
+  warningSink?: (message: string) => void
 }
 
 export function loadConfig(
@@ -444,15 +625,26 @@ export function loadConfigWithSources(
   options?: LoadConfigOptions,
 ): SourceAwareConfigResult {
   const includeProject = options?.includeProject ?? true
-  const paths = getConfigPaths(projectDir)
+  const invalidSource = options?.invalidSource ?? 'throw'
+  const paths = getConfigPaths(projectDir, options)
+  const warningSink = options?.warningSink ?? console.warn
 
-  const userSource = loadConfigSource(paths.userConfig, 'user')
-  const projectSource = includeProject
-    ? loadConfigSource(paths.projectConfig, 'project')
-    : null
-  const customSource = paths.customConfig
-    ? loadConfigSource(paths.customConfig, 'custom')
-    : null
+  const user = loadConfigSource(paths.userConfig, 'user', invalidSource)
+  const project = includeProject
+    ? loadConfigSource(paths.projectConfig, 'project', invalidSource)
+    : {
+        metadata: { kind: 'project' as const, presence: 'absent' as const },
+        source: null,
+      }
+  const custom = paths.customConfig
+    ? loadConfigSource(paths.customConfig, 'custom', invalidSource)
+    : {
+        metadata: { kind: 'custom' as const, presence: 'absent' as const },
+        source: null,
+      }
+  const userSource = user.source
+  const projectSource = project.source
+  const customSource = custom.source
   const sources = [userSource, projectSource, customSource].filter(
     (source): source is ConfigSource => source !== null,
   )
@@ -463,7 +655,13 @@ export function loadConfigWithSources(
     (name) => REMOVED_AGENT_CATEGORIES_SET.has(name),
   )
   const warned = new Set<string>()
-  warnDroppedNames(droppedCategories, 'categories', warned, 'v3.0.0')
+  warnDroppedNames(
+    droppedCategories,
+    'categories',
+    warned,
+    'v3.0.0',
+    warningSink,
+  )
   const droppedCategorySet = new Set(droppedCategories)
   const overlays: SourcedOverlayConfigMap =
     droppedCategorySet.size === 0
@@ -544,13 +742,25 @@ export function loadConfigWithSources(
     result.disabled_skills,
     CURRENT_SKILL_NAMES_SET,
   )
-  warnDroppedNames(droppedSkills, 'disabled_skills', warned)
+  warnDroppedNames(
+    droppedSkills,
+    'disabled_skills',
+    warned,
+    undefined,
+    warningSink,
+  )
 
   const droppedAgents = computeDroppedNames(
     result.disabled_agents,
     CURRENT_AGENT_NAMES_SET,
   )
-  warnDroppedNames(droppedAgents, 'disabled_agents', warned)
+  warnDroppedNames(
+    droppedAgents,
+    'disabled_agents',
+    warned,
+    undefined,
+    warningSink,
+  )
 
   const droppedSkillSet = new Set(droppedSkills)
   const droppedAgentSet = new Set(droppedAgents)
@@ -568,7 +778,119 @@ export function loadConfigWithSources(
           ),
         }
 
-  return { config: effectiveConfig, overlays }
+  return {
+    config: effectiveConfig,
+    metadata: buildConfigObservationMetadata({
+      custom: custom.metadata,
+      project: project.metadata,
+      sources,
+      user: user.metadata,
+    }),
+    overlays,
+  }
+}
+
+interface ConfigSourceLoadSummary {
+  readonly custom: ConfigSourceMetadata
+  readonly project: ConfigSourceMetadata
+  readonly sources: readonly ConfigSource[]
+  readonly user: ConfigSourceMetadata
+}
+
+function buildConfigObservationMetadata(
+  summary: ConfigSourceLoadSummary,
+): ConfigObservationMetadata {
+  const authorities: ConfigAuthorityMetadata[] = []
+  const sourceConfigs = new Map<ConfigSourceKind, RawSystematicConfig>()
+  const sourcePaths = new Map<ConfigSourceKind, string>()
+  for (const source of summary.sources) {
+    sourceConfigs.set(source.trust, source.config)
+    sourcePaths.set(source.trust, source.canonicalPath)
+  }
+
+  const firstDefinedSource = (
+    fieldPath: ConfigAuthorityFieldPath,
+    candidates: readonly ConfigSourceKind[],
+  ): ConfigAuthorityMetadata | undefined => {
+    for (const sourceKind of candidates) {
+      const config = sourceConfigs.get(sourceKind)
+      if (config && hasConfigField(config, fieldPath)) {
+        return { fieldPath, sourceKind }
+      }
+    }
+    return undefined
+  }
+
+  const fieldCandidates: Readonly<
+    Record<ConfigAuthorityFieldPath, readonly ConfigSourceKind[]>
+  > = {
+    'bootstrap.enabled': ['custom', 'project', 'user'],
+    'bootstrap.file': ['custom', 'project', 'user'],
+    skills_as_commands: ['custom', 'project', 'user'],
+    'workflow_guard.debug': ['custom', 'user'],
+    'workflow_guard.mode': ['custom', 'user'],
+  }
+  for (const fieldPath of CONFIG_AUTHORITY_FIELD_PATHS) {
+    const authority = firstDefinedSource(fieldPath, fieldCandidates[fieldPath])
+    if (authority) authorities.push(authority)
+  }
+
+  const protectedFields = summary.sources.flatMap(
+    (source) => source.protectedFields,
+  )
+  const sources = dedupeSourceMetadata(
+    [summary.custom, summary.project, summary.user],
+    sourcePaths,
+  )
+  return {
+    authorities: sortAuthorities(authorities),
+    protectedFields: sortProtectedFields(protectedFields),
+    sources,
+  }
+}
+
+function dedupeSourceMetadata(
+  metadata: readonly ConfigSourceMetadata[],
+  sourcePaths: ReadonlyMap<ConfigSourceKind, string>,
+): readonly ConfigSourceMetadata[] {
+  const seen = new Set<string>()
+  return metadata.filter((source) => {
+    const identity = sourcePaths.get(source.kind) ?? `missing:${source.kind}`
+    if (seen.has(identity)) return false
+    seen.add(identity)
+    return true
+  })
+}
+
+function hasConfigField(
+  config: RawSystematicConfig,
+  fieldPath: ConfigAuthorityFieldPath,
+): boolean {
+  const [topLevel, nested] = fieldPath.split('.')
+  if (nested === undefined)
+    return config[topLevel as keyof RawSystematicConfig] !== undefined
+  const value = config[topLevel as keyof RawSystematicConfig]
+  return isRecord(value) && value[nested] !== undefined
+}
+
+function sortAuthorities(
+  authorities: readonly ConfigAuthorityMetadata[],
+): readonly ConfigAuthorityMetadata[] {
+  return [...authorities].sort((left, right) =>
+    left.fieldPath === right.fieldPath
+      ? left.sourceKind.localeCompare(right.sourceKind)
+      : left.fieldPath.localeCompare(right.fieldPath),
+  )
+}
+
+function sortProtectedFields(
+  fields: readonly ConfigProtectedFieldMetadata[],
+): readonly ConfigProtectedFieldMetadata[] {
+  return [...fields].sort((left, right) =>
+    left.fieldPath === right.fieldPath
+      ? left.sourceKind.localeCompare(right.sourceKind)
+      : left.fieldPath.localeCompare(right.fieldPath),
+  )
 }
 
 function mergeOverlaySources(sources: ConfigSource[]): SourcedOverlayConfigMap {
@@ -760,15 +1082,26 @@ function throwInvalidOverlay(sourcePath: string, keyPath: string): never {
   )
 }
 
-export function getConfigPaths(projectDir: string) {
-  const homeDir = os.homedir()
-  const customConfigDir = process.env.OPENCODE_CONFIG_DIR?.trim()
+interface ConfigPathOptions {
+  readonly homeDir?: string
+  readonly userConfigDir?: string
+  readonly customConfigDir?: string | null
+}
+
+export function getConfigPaths(
+  projectDir: string,
+  options?: ConfigPathOptions,
+) {
+  const homeDir = options?.homeDir ?? os.homedir()
+  const userConfigDir =
+    options?.userConfigDir ?? path.join(homeDir, '.config/opencode')
+  const customConfigDir =
+    options !== undefined && Object.hasOwn(options, 'customConfigDir')
+      ? options.customConfigDir?.trim()
+      : process.env.OPENCODE_CONFIG_DIR?.trim()
 
   const result = {
-    userConfig: resolveConfigPath(
-      path.join(homeDir, '.config/opencode'),
-      'systematic',
-    ),
+    userConfig: resolveConfigPath(userConfigDir, 'systematic'),
     projectConfig: resolveConfigPath(
       path.join(projectDir, '.opencode'),
       'systematic',

--- a/src/lib/discovered-skills.ts
+++ b/src/lib/discovered-skills.ts
@@ -26,6 +26,8 @@ type DiscoveryRootId =
   | 'project-opencode'
   | 'global-opencode-config'
 
+export type SkillDiscoveryIssueCode = 'read-failed' | 'source-invalid'
+
 export interface DiscoveredSkill {
   name: string
   description: string
@@ -56,6 +58,8 @@ export interface DiscoverSkillsOptions {
    * discovery pure and testable.
    */
   opencodeConfigDirOverride?: string
+  /** Optional bounded issue sink; discovery winners and precedence are unchanged. */
+  onIssue?: (issue: SkillDiscoveryIssueCode) => void
 }
 
 /** Upstream skill-name regex: lowercase alphanumeric segments joined by single hyphens, 1-64 chars. */
@@ -164,7 +168,7 @@ function globSkillFiles(rootDir: string, subdirNames: string[]): string[] {
       if (!fs.existsSync(scanRoot)) continue
       const entries = walkDir(scanRoot, {
         maxDepth: 10,
-        filter: (entry) => !entry.isDirectory && entry.name === 'SKILL.md',
+        filter: (entry) => entry.name === 'SKILL.md',
       })
       for (const entry of entries) {
         results.push(entry.path)
@@ -189,17 +193,26 @@ function globSkillFiles(rootDir: string, subdirNames: string[]): string[] {
 function toDiscoveredSkill(
   skillPath: string,
   rootId: DiscoveryRootId,
+  onIssue?: (issue: SkillDiscoveryIssueCode) => void,
 ): DiscoveredSkill | undefined {
   let content: string
   try {
     content = fs.readFileSync(skillPath, 'utf8')
   } catch {
+    onIssue?.('read-failed')
     return undefined // missing, unreadable, or a directory: skip
   }
 
+  if (parseFrontmatter<Record<string, unknown>>(content).parseError) {
+    onIssue?.('source-invalid')
+    return undefined
+  }
   const frontmatter = extractFrontmatterFromContent(content)
   const name = frontmatter.name
-  if (!name || !isValidSkillName(name)) return undefined
+  if (!name || !isValidSkillName(name)) {
+    onIssue?.('source-invalid')
+    return undefined
+  }
 
   return {
     name,
@@ -239,7 +252,8 @@ function toDiscoveredSkill(
 export function discoverSkills(
   options: DiscoverSkillsOptions,
 ): DiscoveredSkill[] {
-  const { startDir, homeDir, configDir, opencodeConfigDirOverride } = options
+  const { startDir, homeDir, configDir, onIssue, opencodeConfigDirOverride } =
+    options
   const globalConfigDir = configDir ?? path.join(homeDir, '.config/opencode')
   const gitRoot = findGitWorktreeRoot(startDir)
 
@@ -247,7 +261,7 @@ export function discoverSkills(
 
   function upsertAll(skillPaths: string[], rootId: DiscoveryRootId): void {
     for (const skillPath of skillPaths) {
-      const skill = toDiscoveredSkill(skillPath, rootId)
+      const skill = toDiscoveredSkill(skillPath, rootId, onIssue)
       if (skill) byName.set(skill.name, skill)
     }
   }

--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -10,6 +10,10 @@ import {
   INTERNAL_AGENT_SIGNATURES,
   readHarnessProfile,
 } from '../../src/lib/bootstrap.ts'
+import {
+  buildCapabilitySnapshot,
+  serializeCapabilitySnapshot,
+} from '../../src/lib/capability-snapshot.ts'
 
 /**
  * Reconstruct the production skip predicate from src/index.ts:91-97 using the
@@ -325,6 +329,62 @@ describe('getBootstrapContent', () => {
       </available_skills>
       </SYSTEMATIC_WORKFLOWS>"
     `)
+  })
+
+  test('keeps bootstrap and system-prompt bytes unchanged after capability observation', () => {
+    const skillsDir = makeBundledSkillsDir(
+      '---\nname: using-systematic\ndescription: fixture\n---\nFixture bootstrap body',
+    )
+    const config = {
+      bootstrap: { enabled: true },
+      disabled_skills: [],
+    }
+    const deps = {
+      bundledSkillsDir: skillsDir,
+      profileBlock: 'Frozen profile block',
+      usageTemplate: 'Frozen usage template',
+    }
+
+    const before = getBootstrapContent(config, deps)
+    const promptBefore = composeSystemPromptWithBootstrap(
+      'Frozen system prompt',
+      before,
+    )
+    const snapshot = buildCapabilitySnapshot({
+      argv: ['systematic', 'capabilities'],
+      clock: () => Date.parse('2026-08-13T12:34:56.000Z'),
+      facts: [
+        {
+          factId: 'config-field-authority',
+          fieldPath: 'bootstrap.enabled',
+          kind: 'authority',
+          sourceId: 'config:custom',
+          status: 'available',
+        },
+      ],
+      package: { name: '@fixture/systematic', version: '1.0.0' },
+      roots: [{ id: 'cwd', path: testDir }],
+      outputSink: () => undefined,
+    })
+    expect(serializeCapabilitySnapshot(snapshot)).toContain('config:custom')
+
+    const after = getBootstrapContent(config, deps)
+    const promptAfter = composeSystemPromptWithBootstrap(
+      'Frozen system prompt',
+      after,
+    )
+
+    expect(after).toBe(before)
+    expect(promptAfter).toBe(promptBefore)
+  })
+
+  test('bootstrap source does not import capability snapshot data', () => {
+    const source = fs.readFileSync(
+      new URL('../../src/lib/bootstrap.ts', import.meta.url),
+      'utf8',
+    )
+
+    expect(source).not.toContain('capability-snapshot')
   })
 
   test('default config returns content with SYSTEMATIC_WORKFLOWS wrapper', () => {

--- a/tests/unit/capability-snapshot.test.ts
+++ b/tests/unit/capability-snapshot.test.ts
@@ -1,0 +1,510 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+
+import {
+  buildCapabilitySnapshot,
+  type ConfigObservationMetadata,
+} from '../../src/lib/capability-snapshot.js'
+
+const OBSERVED_AT = '2026-08-13T12:34:56.000Z'
+const ABSOLUTE_ROOT = '/Users/marcus/private/project'
+const SECRET = 'customer-token-and-private-stack'
+const USER_CONFIG_PATH = `${ABSOLUTE_ROOT}/user/systematic.json`
+const PROJECT_CONFIG_PATH = `${ABSOLUTE_ROOT}/project/systematic.json`
+const CUSTOM_CONFIG_PATH = `${ABSOLUTE_ROOT}/custom/systematic.json`
+
+type CapabilitySnapshotBuilderOptions = Parameters<
+  typeof buildCapabilitySnapshot
+>[0]
+type CapabilitySnapshot = ReturnType<typeof buildCapabilitySnapshot>
+
+function baseOptions(
+  overrides: Partial<CapabilitySnapshotBuilderOptions> = {},
+): CapabilitySnapshotBuilderOptions {
+  return {
+    argv: ['systematic', 'capabilities'],
+    package: {
+      name: '@fro.bot/systematic',
+      version: '1.2.3',
+    },
+    roots: [],
+    clock: () => Date.parse(OBSERVED_AT),
+    ...overrides,
+  }
+}
+
+function expectSortedKeys(value: unknown): void {
+  if (Array.isArray(value)) {
+    for (const item of value) expectSortedKeys(item)
+    return
+  }
+
+  if (value === null || typeof value !== 'object') return
+
+  const record = value as Record<string, unknown>
+  expect(Object.keys(record)).toEqual([...Object.keys(record)].sort())
+  for (const nested of Object.values(record)) expectSortedKeys(nested)
+}
+
+describe('capability snapshot contract', () => {
+  test('builds the minimal versioned identity shape', () => {
+    const snapshot = buildCapabilitySnapshot(baseOptions())
+
+    expect(snapshot).toEqual({
+      command: 'systematic capabilities',
+      facts: [],
+      identity: {
+        argv: {
+          executable: 'systematic',
+          subcommand: 'capabilities',
+        },
+        package: {
+          name: '@fro.bot/systematic',
+          version: '1.2.3',
+        },
+      },
+      observedAt: OBSERVED_AT,
+      roots: [],
+      schemaVersion: 'cli-capabilities.v1',
+      sources: [],
+    })
+  })
+
+  test('serializes identically for identical inputs and a frozen clock', () => {
+    const options = baseOptions({
+      roots: [{ id: 'cwd', path: ABSOLUTE_ROOT }],
+      sources: [
+        {
+          sourceId: 'config:project',
+          presence: 'present',
+          path: `${ABSOLUTE_ROOT}/.config/systematic.json`,
+        },
+      ],
+      facts: [
+        {
+          factId: 'host-runtime',
+          status: 'unknown',
+          limitationCode: 'host-runtime-unobservable',
+        },
+      ],
+    })
+
+    const first = JSON.stringify(buildCapabilitySnapshot(options))
+    const second = JSON.stringify(buildCapabilitySnapshot(options))
+
+    expect(first).toBe(second)
+  })
+
+  test('sorts roots, facts, sources, collections, and object keys deterministically', () => {
+    const snapshot = buildCapabilitySnapshot(
+      baseOptions({
+        roots: [
+          { id: 'project', path: `${ABSOLUTE_ROOT}/project` },
+          { id: 'cwd', path: ABSOLUTE_ROOT },
+        ],
+        sources: [
+          { sourceId: 'config:user', presence: 'absent' },
+          {
+            sourceId: 'config:project',
+            presence: 'present',
+            path: `${ABSOLUTE_ROOT}/project/systematic.json`,
+          },
+        ],
+        facts: [
+          {
+            factId: 'host-runtime',
+            status: 'unknown',
+            limitationCode: 'host-runtime-unobservable',
+          },
+          { factId: 'config-authority', status: 'available' },
+        ],
+      }),
+    )
+
+    const parsed = JSON.parse(JSON.stringify(snapshot)) as unknown
+    expectSortedKeys(parsed)
+    expect(snapshot.roots.map((root) => root.id)).toEqual(['cwd', 'project'])
+    expect(snapshot.sources.map((source) => source.sourceId)).toEqual([
+      'config:project',
+      'config:user',
+    ])
+    expect(snapshot.facts.map((fact) => fact.factId)).toEqual([
+      'config-authority',
+      'host-runtime',
+    ])
+  })
+
+  test('keeps absent, unknown, and unavailable semantics distinct', () => {
+    const snapshot = buildCapabilitySnapshot(
+      baseOptions({
+        sources: [
+          { sourceId: 'config:project', presence: 'absent' },
+          {
+            sourceId: 'config:user',
+            presence: 'invalid',
+            errorCode: 'source-malformed',
+          },
+        ],
+        facts: [
+          {
+            factId: 'host-runtime',
+            status: 'unknown',
+            limitationCode: 'host-runtime-unobservable',
+          },
+          {
+            factId: 'config-authority',
+            status: 'unavailable',
+            sourceId: 'config:user',
+            errorCode: 'source-read-failed',
+          },
+        ],
+      }),
+    )
+
+    expect(snapshot.sources).toEqual([
+      {
+        kind: 'source',
+        presence: 'absent',
+        sourceId: 'config:project',
+      },
+      {
+        errorCode: 'source-malformed',
+        kind: 'source',
+        presence: 'invalid',
+        sourceId: 'config:user',
+      },
+    ])
+    expect(snapshot.facts).toEqual([
+      {
+        factId: 'config-authority',
+        kind: 'status',
+        errorCode: 'source-read-failed',
+        sourceId: 'config:user',
+        status: 'unavailable',
+      },
+      {
+        factId: 'host-runtime',
+        kind: 'status',
+        limitationCode: 'host-runtime-unobservable',
+        status: 'unknown',
+      },
+    ])
+  })
+
+  test('rejects incomplete available discovery summaries', () => {
+    expect(() =>
+      buildCapabilitySnapshot(
+        baseOptions({
+          facts: [{ factId: 'discovery-summary', status: 'available' }],
+        }),
+      ),
+    ).toThrow(/discovery/i)
+  })
+
+  test('rejects impossible discovery source issue states', () => {
+    const invalidFacts: readonly unknown[] = [
+      {
+        factId: 'discovery-source-issue',
+        status: 'available',
+      },
+      {
+        factId: 'discovery-source-issue',
+        limitationCode: 'authority-unproven',
+        status: 'unknown',
+      },
+      {
+        errorCode: 'source-malformed',
+        factId: 'discovery-source-issue',
+        status: 'unavailable',
+      },
+      {
+        errorCode: 'source-malformed',
+        factId: 'discovery-source-issue',
+        sourceId: 'discovery:agents',
+        status: 'unavailable',
+      },
+    ]
+
+    for (const fact of invalidFacts) {
+      expect(() =>
+        buildCapabilitySnapshot(baseOptions({ facts: [fact as never] })),
+      ).toThrow(/discovery-source-issue|sourceId|status/i)
+    }
+  })
+
+  test('projects bounded config source presence and proven field authority', () => {
+    const config: ConfigObservationMetadata = {
+      authorities: [
+        { fieldPath: 'bootstrap.enabled', sourceKind: 'project' },
+        { fieldPath: 'workflow_guard.mode', sourceKind: 'user' },
+        { fieldPath: 'skills_as_commands', sourceKind: 'custom' },
+      ],
+      protectedFields: [
+        {
+          fieldPath: 'workflow_guard',
+          outcome: 'blocked',
+          sourceKind: 'project',
+        },
+      ],
+      sources: [
+        {
+          kind: 'custom',
+          path: CUSTOM_CONFIG_PATH,
+          presence: 'present',
+        },
+        {
+          kind: 'project',
+          path: PROJECT_CONFIG_PATH,
+          presence: 'absent',
+        },
+        {
+          kind: 'user',
+          path: USER_CONFIG_PATH,
+          presence: 'present',
+        },
+      ],
+    }
+
+    const snapshot = buildCapabilitySnapshot(baseOptions({ config }))
+
+    expect(snapshot.sources).toEqual([
+      {
+        kind: 'source',
+        presence: 'present',
+        sourceId: 'config:custom',
+        sourceKind: 'custom',
+      },
+      {
+        kind: 'source',
+        presence: 'absent',
+        sourceId: 'config:project',
+        sourceKind: 'project',
+      },
+      {
+        kind: 'source',
+        presence: 'present',
+        sourceId: 'config:user',
+        sourceKind: 'user',
+      },
+    ])
+    expect(snapshot.facts).toContainEqual({
+      factId: 'config-field-authority',
+      fieldPath: 'bootstrap.enabled',
+      kind: 'authority',
+      sourceId: 'config:project',
+      status: 'available',
+    })
+    expect(snapshot.facts).toContainEqual({
+      factId: 'config-field-authority',
+      fieldPath: 'workflow_guard.mode',
+      kind: 'authority',
+      sourceId: 'config:user',
+      status: 'available',
+    })
+    expect(snapshot.facts).toContainEqual({
+      factId: 'config-field-authority',
+      fieldPath: 'skills_as_commands',
+      kind: 'authority',
+      sourceId: 'config:custom',
+      status: 'available',
+    })
+    expect(snapshot.facts).toContainEqual({
+      factId: 'config-protected-field',
+      fieldPath: 'workflow_guard',
+      kind: 'protection',
+      outcome: 'blocked',
+      sourceId: 'config:project',
+      status: 'available',
+    })
+  })
+
+  test('maps invalid config sources to sanitized unavailable metadata', () => {
+    const snapshot = buildCapabilitySnapshot(
+      baseOptions({
+        config: {
+          authorities: [],
+          protectedFields: [],
+          sources: [
+            {
+              errorCode: 'parse-failed',
+              kind: 'project',
+              path: `${ABSOLUTE_ROOT}/project/systematic.json`,
+              presence: 'invalid',
+            },
+          ],
+        },
+      }),
+    )
+
+    expect(snapshot.sources).toEqual([
+      {
+        errorCode: 'source-malformed',
+        kind: 'source',
+        presence: 'invalid',
+        sourceId: 'config:project',
+        sourceKind: 'project',
+      },
+    ])
+    expect(JSON.stringify(snapshot)).not.toContain(ABSOLUTE_ROOT)
+    expect(JSON.stringify(snapshot)).not.toContain(SECRET)
+  })
+
+  test('deduplicates canonical and symlink-equivalent config source paths', () => {
+    const snapshot = buildCapabilitySnapshot(
+      baseOptions({
+        config: {
+          authorities: [],
+          protectedFields: [],
+          sources: [
+            {
+              kind: 'custom',
+              path: `${ABSOLUTE_ROOT}/config/../config/systematic.json`,
+              presence: 'present',
+            },
+            {
+              kind: 'user',
+              path: `${ABSOLUTE_ROOT}/config/systematic.json`,
+              presence: 'present',
+            },
+          ],
+        },
+      }),
+    )
+
+    expect(snapshot.sources).toHaveLength(1)
+    expect(snapshot.sources[0]).toEqual({
+      kind: 'source',
+      presence: 'present',
+      sourceId: 'config:custom',
+      sourceKind: 'custom',
+    })
+  })
+
+  test('rejects privacy-sensitive arbitrary values and unknown keys', () => {
+    for (const [key, value] of [
+      ['overlay', { nested: { token: SECRET } }],
+      ['rawError', { message: SECRET, stack: SECRET }],
+      ['unknownOutputKey', SECRET],
+    ] as const) {
+      const unsafeInput = {
+        ...baseOptions(),
+        [key]: value,
+      } as unknown as CapabilitySnapshotBuilderOptions
+
+      expect(() => buildCapabilitySnapshot(unsafeInput)).toThrow(
+        `options has unknown key ${key}`,
+      )
+    }
+
+    const unsafeConfig = {
+      authorities: [],
+      protectedFields: [],
+      rawError: { message: SECRET, stack: SECRET },
+      sources: [],
+    } as unknown as ConfigObservationMetadata
+    expect(() =>
+      buildCapabilitySnapshot(baseOptions({ config: unsafeConfig })),
+    ).toThrow('config has unknown key rawError')
+
+    const serialized = JSON.stringify(
+      buildCapabilitySnapshot(
+        baseOptions({
+          roots: [{ id: 'cwd', path: ABSOLUTE_ROOT }],
+          sources: [
+            {
+              sourceId: 'config:project',
+              presence: 'present',
+              path: `${ABSOLUTE_ROOT}/systematic.json`,
+            },
+          ],
+        }),
+      ),
+    )
+    expect(serialized).not.toContain(ABSOLUTE_ROOT)
+    expect(serialized).not.toContain(SECRET)
+  })
+
+  test('keeps a JSON round trip stable', () => {
+    const snapshot = buildCapabilitySnapshot(
+      baseOptions({
+        roots: [{ id: 'cwd', path: ABSOLUTE_ROOT }],
+        sources: [
+          {
+            sourceId: 'config:project',
+            presence: 'present',
+            path: `${ABSOLUTE_ROOT}/systematic.json`,
+          },
+        ],
+        facts: [
+          {
+            count: 0,
+            discoveryId: 'skills',
+            factId: 'discovery-summary',
+            kind: 'discovery',
+            sourceId: 'discovery:skills',
+            status: 'available',
+            winningRoots: [],
+          },
+        ],
+      }),
+    )
+    const serialized = JSON.stringify(snapshot)
+    const roundTripped = JSON.parse(serialized) as CapabilitySnapshot
+
+    expect(roundTripped).toEqual(snapshot)
+    expect(JSON.stringify(roundTripped)).toBe(serialized)
+  })
+
+  test('serializes an allowlisted discovery summary with bounded winners', () => {
+    const snapshot = buildCapabilitySnapshot(
+      baseOptions({
+        facts: [
+          {
+            count: 2,
+            discoveryId: 'skills',
+            factId: 'discovery-summary',
+            kind: 'discovery',
+            sourceId: 'discovery:skills',
+            status: 'available',
+            winningRoots: ['global-opencode-config', 'project-opencode'],
+          },
+        ],
+      }),
+    )
+
+    expect(snapshot.facts).toEqual([
+      {
+        count: 2,
+        discoveryId: 'skills',
+        factId: 'discovery-summary',
+        kind: 'discovery',
+        sourceId: 'discovery:skills',
+        status: 'available',
+        winningRoots: ['global-opencode-config', 'project-opencode'],
+      },
+    ])
+  })
+
+  test('accepts an output sink without performing filesystem writes', () => {
+    let emitted = ''
+    const snapshot = buildCapabilitySnapshot(
+      baseOptions({ outputSink: (value) => (emitted = value) }),
+    )
+
+    expect(emitted).toBe(JSON.stringify(snapshot))
+  })
+
+  test('does not import runtime collectors or write to the filesystem', () => {
+    const source = readFileSync(
+      new URL('../../src/lib/capability-snapshot.ts', import.meta.url),
+      'utf8',
+    )
+
+    expect(source).not.toMatch(
+      /from ['"][^'"]*(bootstrap|config-handler|runtime)/,
+    )
+    expect(source).not.toMatch(
+      /from ['"]node:fs['"]|writeFile|mkdir|rmSync|unlink/,
+    )
+  })
+})

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -24,6 +24,14 @@ function snapshotTree(root: string): string {
       .sort((left, right) => left.name.localeCompare(right.name))
 
     for (const child of children) {
+      // Bun writes its own runtime module-resolution cache under a `.bun`
+      // directory inside $HOME as a side effect of spawning the CLI
+      // subprocess. That cache is Bun's own artifact, not something the
+      // CLI under test writes, so it must not count as an unexpected file
+      // when a fixture directory is used as HOME.
+      if (child.name === '.bun') {
+        continue
+      }
       const childRelative = path.join(relative, child.name)
       const childPath = path.join(directory, child.name)
       if (child.isDirectory()) {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -4,6 +4,8 @@ import * as crypto from 'node:crypto'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { runCapabilitiesCli as runTestableCli } from '../../src/cli.js'
+import type { ConfigObservationMetadata } from '../../src/lib/capability-snapshot.js'
 import { MANIFEST_FILENAME } from '../../src/lib/pi-subagents-export.js'
 
 const ROOT_DIR = path.resolve(import.meta.dirname, '../..')
@@ -11,6 +13,30 @@ const CLI_PATH = path.join(ROOT_DIR, 'src/cli.ts')
 
 function mkTempCwd(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'systematic-cli-test-'))
+}
+
+function snapshotTree(root: string): string {
+  const entries: string[] = []
+
+  function visit(directory: string, relative = ''): void {
+    const children = fs
+      .readdirSync(directory, { withFileTypes: true })
+      .sort((left, right) => left.name.localeCompare(right.name))
+
+    for (const child of children) {
+      const childRelative = path.join(relative, child.name)
+      const childPath = path.join(directory, child.name)
+      if (child.isDirectory()) {
+        entries.push(`${childRelative}/`)
+        visit(childPath, childRelative)
+      } else {
+        entries.push(`${childRelative}:${fs.readFileSync(childPath, 'utf8')}`)
+      }
+    }
+  }
+
+  visit(root)
+  return entries.join('\n')
 }
 
 function runCli(
@@ -30,6 +56,72 @@ function runCli(
     stderr: result.stderr ?? '',
     exitCode: result.status ?? -1,
   }
+}
+
+const OBSERVED_AT = '2026-08-13T12:34:56.000Z'
+
+type CapabilityCliRoots = Parameters<typeof runTestableCli>[0]['roots']
+
+function makeCapabilityRoots(root: string): CapabilityCliRoots {
+  const cwd = path.join(root, 'project')
+  const homeDir = path.join(root, 'home')
+  const packageRoot = path.join(root, 'package')
+  const agentsRoot = path.join(packageRoot, 'agents')
+  fs.mkdirSync(path.join(cwd, '.git'), { recursive: true })
+  fs.mkdirSync(homeDir, { recursive: true })
+  fs.mkdirSync(agentsRoot, { recursive: true })
+  fs.writeFileSync(
+    path.join(packageRoot, 'package.json'),
+    JSON.stringify({ name: '@fixture/systematic', version: '9.8.7' }),
+  )
+  return { agentsRoot, cwd, homeDir, packageRoot }
+}
+
+function emptyConfig(): ConfigObservationMetadata {
+  return {
+    authorities: [],
+    protectedFields: [],
+    sources: [
+      { kind: 'custom', presence: 'absent' },
+      { kind: 'project', presence: 'absent' },
+      { kind: 'user', presence: 'absent' },
+    ],
+  }
+}
+
+function runTestableCapabilities(
+  roots: CapabilityCliRoots,
+  args: string[] = ['capabilities'],
+  config: ConfigObservationMetadata = emptyConfig(),
+): { stdout: string; stderr: string; status: number } {
+  const stdout: string[] = []
+  const stderr: string[] = []
+  const status = runTestableCli({
+    argv: ['systematic', ...args],
+    clock: () => Date.parse(OBSERVED_AT),
+    config,
+    errorSink: (message) => stderr.push(message),
+    outputSink: (value) => stdout.push(value),
+    roots,
+  })
+  return { status, stderr: stderr.join('\n'), stdout: stdout.join('\n') }
+}
+
+function runObservedCapabilities(
+  roots: CapabilityCliRoots,
+  config?: ConfigObservationMetadata,
+): { status: number; stderr: string; stdout: string } {
+  const stdout: string[] = []
+  const stderr: string[] = []
+  const status = runTestableCli({
+    argv: ['systematic', 'capabilities'],
+    clock: () => Date.parse(OBSERVED_AT),
+    errorSink: (message) => stderr.push(message),
+    outputSink: (value) => stdout.push(value),
+    roots,
+    ...(config === undefined ? {} : { config }),
+  })
+  return { status, stderr: stderr.join('\n'), stdout: stdout.join('\n') }
 }
 
 describe('cli setup --harness', () => {
@@ -187,6 +279,273 @@ describe('cli setup --harness', () => {
       expect(fs.readdirSync(cwd)).toEqual([])
     } finally {
       fs.rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('cli capabilities', () => {
+  it('emits a read-only versioned JSON diagnostic without writing to cwd', () => {
+    const cwd = mkTempCwd()
+    try {
+      const before = fs.readdirSync(cwd)
+      const result = runCli(['capabilities'], cwd)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stderr).toBe('')
+      const parsed = JSON.parse(result.stdout) as {
+        command?: string
+        schemaVersion?: string
+        identity?: { argv?: { subcommand?: string } }
+      }
+      expect(parsed.command).toBe('systematic capabilities')
+      expect(parsed.schemaVersion).toBe('cli-capabilities.v1')
+      expect(parsed.identity?.argv?.subcommand).toBe('capabilities')
+      expect(JSON.stringify(parsed)).not.toContain(cwd)
+      expect(fs.readdirSync(cwd)).toEqual(before)
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('documents read-only standalone observation and non-runtime scope in help', () => {
+    const cwd = mkTempCwd()
+    try {
+      const result = runCli(['--help'], cwd)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toMatch(/capabilities.*read-only/i)
+      expect(result.stdout).toMatch(/standalone-cli/i)
+      expect(result.stdout).toMatch(/host-runtime|canonical-registry/i)
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('reports invalid capabilities invocation through stderr', () => {
+    const cwd = mkTempCwd()
+    try {
+      const result = runCli(['capabilities', '--unexpected'], cwd)
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stdout).toBe('')
+      expect(result.stderr).toMatch(/usage:.*capabilities/i)
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('does not mutate the full diagnostic fixture tree or create generated artifacts', () => {
+    const root = mkTempCwd()
+    try {
+      const roots = makeCapabilityRoots(root)
+      fs.writeFileSync(path.join(roots.cwd, 'fixture-secret.json'), 'secret')
+      const before = snapshotTree(root)
+
+      const result = runTestableCapabilities(roots)
+
+      expect(result.status).toBe(0)
+      expect(snapshotTree(root)).toBe(before)
+      expect(result.stdout).not.toContain('fixture-secret')
+      expect(result.stdout).not.toContain(MANIFEST_FILENAME)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps setup/export/provider operations outside the capability path', () => {
+    const source = fs.readFileSync(CLI_PATH, 'utf8')
+    const start = source.indexOf('function runCapabilities')
+    const end = source.indexOf('function isHarness', start)
+    const capabilityPath = source.slice(start, end)
+
+    expect(capabilityPath).not.toMatch(/setupHarness|exportPersonas|refresh\(/)
+    expect(capabilityPath).not.toMatch(/provider|generated|manifest/i)
+  })
+})
+
+describe('testable capabilities entrypoint', () => {
+  it('is deterministic, bounded, and read-only for frozen roots and clock', () => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'systematic-capabilities-'),
+    )
+    try {
+      const roots = makeCapabilityRoots(root)
+      const before = fs.readdirSync(root)
+      const first = runTestableCapabilities(roots)
+      const second = runTestableCapabilities(roots)
+
+      expect(first.status).toBe(0)
+      expect(first.stderr).toBe('')
+      expect(first.stdout).toBe(second.stdout)
+      const parsed = JSON.parse(first.stdout) as {
+        facts: Array<Record<string, unknown>>
+        identity: { package: { name: string; version: string } }
+      }
+      expect(parsed.identity.package).toEqual({
+        name: '@fixture/systematic',
+        version: '9.8.7',
+      })
+      expect(parsed.facts).toContainEqual({
+        factId: 'host-runtime',
+        kind: 'status',
+        limitationCode: 'host-runtime-unobservable',
+        status: 'unknown',
+      })
+      expect(first.stdout).not.toContain(root)
+      expect(fs.readdirSync(root)).toEqual(before)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('summarizes only winning skill entries and roots', () => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'systematic-capabilities-'),
+    )
+    try {
+      const roots = makeCapabilityRoots(root)
+      const winnerDir = path.join(roots.cwd, '.opencode/skills/dupe')
+      const loserDir = path.join(roots.homeDir, '.claude/skills/dupe')
+      fs.mkdirSync(winnerDir, { recursive: true })
+      fs.mkdirSync(loserDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(winnerDir, 'SKILL.md'),
+        '---\nname: dupe\ndescription: winner\n---\nWinner body',
+      )
+      fs.writeFileSync(
+        path.join(loserDir, 'SKILL.md'),
+        '---\nname: dupe\ndescription: loser-secret\n---\nLoser secret body',
+      )
+
+      const result = runTestableCapabilities(roots)
+      const parsed = JSON.parse(result.stdout) as {
+        facts: Array<Record<string, unknown>>
+      }
+      expect(parsed.facts).toContainEqual({
+        count: 1,
+        discoveryId: 'skills',
+        factId: 'discovery-summary',
+        kind: 'discovery',
+        sourceId: 'discovery:skills',
+        status: 'available',
+        winningRoots: ['project-opencode'],
+      })
+      expect(result.stdout).not.toContain('loser-secret')
+      expect(result.stdout).not.toContain('Loser secret body')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('suppresses the agent summary on duplicate flat names', () => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'systematic-capabilities-'),
+    )
+    try {
+      const roots = makeCapabilityRoots(root)
+      for (const category of ['research', 'review']) {
+        const dir = path.join(roots.agentsRoot, category)
+        fs.mkdirSync(dir, { recursive: true })
+        fs.writeFileSync(
+          path.join(dir, 'duplicate.md'),
+          `---\nname: duplicate\ndescription: ${category}\n---\n${category} body`,
+        )
+      }
+
+      const result = runTestableCapabilities(roots)
+      const parsed = JSON.parse(result.stdout) as {
+        facts: Array<Record<string, unknown>>
+      }
+      const agentFacts = parsed.facts.filter(
+        (fact) => fact.sourceId === 'discovery:agents',
+      )
+      expect(agentFacts).toEqual([
+        {
+          errorCode: 'structural-invalid',
+          factId: 'discovery-summary',
+          kind: 'status',
+          sourceId: 'discovery:agents',
+          status: 'unavailable',
+        },
+      ])
+      expect(JSON.stringify(agentFacts)).not.toContain('count')
+      expect(result.stdout).not.toContain(roots.agentsRoot)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('reports malformed skill and agent sources without leaking content or paths', () => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'systematic-capabilities-'),
+    )
+    try {
+      const roots = makeCapabilityRoots(root)
+      const brokenSkill = path.join(
+        roots.cwd,
+        '.opencode/skills/broken/SKILL.md',
+      )
+      fs.mkdirSync(brokenSkill, { recursive: true })
+      const brokenAgent = path.join(roots.agentsRoot, 'broken.md')
+      fs.writeFileSync(
+        brokenAgent,
+        '---\nname: broken\ndescription: secret-agent-description\n---\nAgent body',
+      )
+      fs.writeFileSync(
+        brokenAgent,
+        '---\nname: [broken\n---\nsecret-agent-body',
+      )
+
+      const result = runTestableCapabilities(roots)
+      const parsed = JSON.parse(result.stdout) as {
+        facts: Array<Record<string, unknown>>
+      }
+      expect(parsed.facts).toContainEqual({
+        errorCode: 'source-read-failed',
+        factId: 'discovery-source-issue',
+        kind: 'status',
+        sourceId: 'discovery:skills',
+        status: 'unavailable',
+      })
+      expect(parsed.facts).toContainEqual({
+        count: 0,
+        discoveryId: 'skills',
+        factId: 'discovery-summary',
+        kind: 'discovery',
+        sourceId: 'discovery:skills',
+        status: 'available',
+        winningRoots: [],
+      })
+      expect(parsed.facts).toContainEqual({
+        errorCode: 'structural-invalid',
+        factId: 'discovery-summary',
+        kind: 'status',
+        sourceId: 'discovery:agents',
+        status: 'unavailable',
+      })
+      expect(result.stdout).not.toContain(root)
+      expect(result.stdout).not.toContain('secret-agent')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('returns bounded stderr and nonzero status for invalid invocation', () => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'systematic-capabilities-'),
+    )
+    try {
+      const roots = makeCapabilityRoots(root)
+      const result = runTestableCapabilities(roots, [
+        'capabilities',
+        '--unexpected',
+      ])
+
+      expect(result.status).toBe(2)
+      expect(result.stdout).toBe('')
+      expect(result.stderr).toBe('Usage: systematic capabilities')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
     }
   })
 })
@@ -522,6 +881,278 @@ describe('cli pi-subagents', () => {
       )
     } finally {
       fs.rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('uses injected config roots instead of process-global config locations', () => {
+    const root = mkTempCwd()
+    const globalCustomDir = path.join(root, 'global-custom')
+    const previousCustomDir = process.env.OPENCODE_CONFIG_DIR
+    try {
+      fs.mkdirSync(globalCustomDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(globalCustomDir, 'systematic.json'),
+        JSON.stringify({
+          bootstrap: { file: '/private/global-secret-path' },
+          skills_as_commands: false,
+        }),
+      )
+      const roots = {
+        ...makeCapabilityRoots(root),
+        configDir: path.join(root, 'injected-config'),
+        opencodeConfigDirOverride: undefined,
+      }
+      process.env.OPENCODE_CONFIG_DIR = globalCustomDir
+
+      const result = runObservedCapabilities(roots)
+      const parsed = JSON.parse(result.stdout) as {
+        facts: Array<Record<string, unknown>>
+        sources: Array<Record<string, unknown>>
+      }
+
+      expect(result.status).toBe(0)
+      expect(parsed.sources).not.toContainEqual(
+        expect.objectContaining({
+          sourceId: 'config:custom',
+          presence: 'present',
+        }),
+      )
+      expect(parsed.facts).not.toContainEqual(
+        expect.objectContaining({
+          fieldPath: 'skills_as_commands',
+          sourceId: 'config:custom',
+        }),
+      )
+      expect(result.stdout).not.toContain(globalCustomDir)
+      expect(result.stdout).not.toContain('global-secret')
+    } finally {
+      if (previousCustomDir === undefined) {
+        delete process.env.OPENCODE_CONFIG_DIR
+      } else {
+        process.env.OPENCODE_CONFIG_DIR = previousCustomDir
+      }
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps successful capabilities stderr empty when config drops removed names', () => {
+    const root = mkTempCwd()
+    const home = path.join(root, 'home')
+    const xdg = path.join(root, 'xdg')
+    const custom = path.join(root, 'custom')
+    const project = path.join(root, 'project')
+    try {
+      fs.mkdirSync(path.join(project, '.opencode'), { recursive: true })
+      fs.mkdirSync(home, { recursive: true })
+      fs.mkdirSync(xdg, { recursive: true })
+      fs.mkdirSync(custom, { recursive: true })
+      fs.writeFileSync(
+        path.join(project, '.opencode/systematic.json'),
+        JSON.stringify({ categories: { docs: {} } }),
+      )
+
+      const result = runCli(['capabilities'], project, {
+        HOME: home,
+        OPENCODE_CONFIG_DIR: custom,
+        XDG_CONFIG_HOME: xdg,
+      })
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stderr).toBe('')
+      expect(() => JSON.parse(result.stdout)).not.toThrow()
+      expect(result.stderr).not.toContain('docs')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps valid skill winners while reporting a separate malformed-source fact', () => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'systematic-capabilities-'),
+    )
+    try {
+      const roots = makeCapabilityRoots(root)
+      const winnerDir = path.join(roots.cwd, '.opencode/skills/good')
+      const brokenDir = path.join(roots.cwd, '.opencode/skills/broken')
+      fs.mkdirSync(winnerDir, { recursive: true })
+      fs.mkdirSync(brokenDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(winnerDir, 'SKILL.md'),
+        '---\nname: good\ndescription: winner\n---\nWinner body',
+      )
+      fs.writeFileSync(path.join(brokenDir, 'SKILL.md'), '---\nname: [broken')
+
+      const result = runTestableCapabilities(roots)
+      const parsed = JSON.parse(result.stdout) as {
+        facts: Array<Record<string, unknown>>
+      }
+
+      expect(parsed.facts).toContainEqual({
+        count: 1,
+        discoveryId: 'skills',
+        factId: 'discovery-summary',
+        kind: 'discovery',
+        sourceId: 'discovery:skills',
+        status: 'available',
+        winningRoots: ['project-opencode'],
+      })
+      expect(parsed.facts).toContainEqual({
+        errorCode: 'source-malformed',
+        factId: 'discovery-source-issue',
+        kind: 'status',
+        sourceId: 'discovery:skills',
+        status: 'unavailable',
+      })
+      expect(
+        parsed.facts.filter((fact) => fact.sourceId === 'discovery:skills'),
+      ).toHaveLength(2)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('deduplicates symlink-equivalent capability roots at the CLI boundary', () => {
+    const root = mkTempCwd()
+    try {
+      const roots = makeCapabilityRoots(root)
+      const realRoot = path.join(root, 'real-root')
+      const aliasRoot = path.join(root, 'alias-root')
+      fs.mkdirSync(path.join(realRoot, 'agents'), { recursive: true })
+      fs.writeFileSync(
+        path.join(realRoot, 'package.json'),
+        JSON.stringify({ name: '@fixture/systematic', version: '1.0.0' }),
+      )
+      fs.symlinkSync(realRoot, aliasRoot, 'dir')
+
+      const result = runTestableCapabilities({
+        ...roots,
+        agentsRoot: path.join(realRoot, 'agents'),
+        cwd: realRoot,
+        packageRoot: aliasRoot,
+      })
+      const parsed = JSON.parse(result.stdout) as {
+        roots: Array<{ id: string }>
+      }
+
+      expect(
+        parsed.roots.filter(({ id }) => id === 'cwd' || id === 'package'),
+      ).toHaveLength(1)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('observes isolated valid and malformed config fixtures in a real subprocess', () => {
+    const cases = [
+      {
+        name: 'valid',
+        project: JSON.stringify({
+          bootstrap: { enabled: false },
+          workflow_guard: { mode: 'protected' },
+        }),
+        assert: (parsed: Record<string, unknown>) => {
+          const facts = parsed.facts as Array<Record<string, unknown>>
+          expect(facts).toContainEqual({
+            factId: 'config-field-authority',
+            fieldPath: 'bootstrap.enabled',
+            kind: 'authority',
+            sourceId: 'config:project',
+            status: 'available',
+          })
+          expect(facts).toContainEqual({
+            factId: 'config-field-authority',
+            fieldPath: 'skills_as_commands',
+            kind: 'authority',
+            sourceId: 'config:custom',
+            status: 'available',
+          })
+          expect(facts).toContainEqual({
+            factId: 'config-protected-field',
+            fieldPath: 'workflow_guard',
+            kind: 'protection',
+            outcome: 'blocked',
+            sourceId: 'config:project',
+            status: 'available',
+          })
+        },
+      },
+      {
+        name: 'malformed-jsonc',
+        project: '{ malformed secret }',
+        assert: (parsed: Record<string, unknown>) => {
+          expect(parsed.sources).toContainEqual({
+            errorCode: 'source-malformed',
+            kind: 'source',
+            presence: 'invalid',
+            sourceId: 'config:project',
+            sourceKind: 'project',
+          })
+        },
+      },
+      {
+        name: 'schema-invalid',
+        project: JSON.stringify({ unknown_key: 'schema-secret' }),
+        assert: (parsed: Record<string, unknown>) => {
+          expect(parsed.sources).toContainEqual({
+            errorCode: 'source-malformed',
+            kind: 'source',
+            presence: 'invalid',
+            sourceId: 'config:project',
+            sourceKind: 'project',
+          })
+        },
+      },
+    ] as const
+
+    for (const fixture of cases) {
+      const root = mkTempCwd()
+      const home = path.join(root, 'home')
+      const xdg = path.join(root, 'xdg')
+      const custom = path.join(root, 'custom')
+      const project = path.join(root, 'project')
+      try {
+        fs.mkdirSync(path.join(project, '.opencode'), { recursive: true })
+        fs.mkdirSync(path.join(home, '.config/opencode'), {
+          recursive: true,
+        })
+        fs.mkdirSync(path.join(xdg, 'opencode'), { recursive: true })
+        fs.mkdirSync(custom, { recursive: true })
+        fs.mkdirSync(xdg, { recursive: true })
+        const userConfig = JSON.stringify({ workflow_guard: { debug: true } })
+        fs.writeFileSync(
+          path.join(home, '.config/opencode/systematic.json'),
+          userConfig,
+        )
+        fs.writeFileSync(path.join(xdg, 'opencode/systematic.json'), userConfig)
+        fs.writeFileSync(
+          path.join(custom, 'systematic.json'),
+          JSON.stringify({
+            bootstrap: { file: '/private/custom-secret-path' },
+            skills_as_commands: false,
+          }),
+        )
+        fs.writeFileSync(
+          path.join(project, '.opencode/systematic.json'),
+          fixture.project,
+        )
+        const before = snapshotTree(root)
+        const result = runCli(['capabilities'], project, {
+          HOME: home,
+          OPENCODE_CONFIG_DIR: custom,
+          XDG_CONFIG_HOME: xdg,
+        })
+        const parsed = JSON.parse(result.stdout) as Record<string, unknown>
+
+        expect(result.exitCode).toBe(0)
+        expect(result.stderr).toBe('')
+        expect(parsed.command).toBe('systematic capabilities')
+        fixture.assert(parsed)
+        expect(result.stdout).not.toContain(root)
+        expect(result.stdout).not.toContain('secret')
+        expect(snapshotTree(root)).toBe(before)
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true })
+      }
     }
   })
 })

--- a/tests/unit/config-handler.test.ts
+++ b/tests/unit/config-handler.test.ts
@@ -4,7 +4,10 @@ import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { Config } from '@opencode-ai/sdk'
+import type { CapabilityCliRoots } from '../../src/cli.js'
+import { runCapabilitiesCli as runTestableCli } from '../../src/cli.js'
 import { extractAgentFrontmatter } from '../../src/lib/agents.js'
+import type { ConfigObservationMetadata } from '../../src/lib/capability-snapshot.js'
 import {
   createConfigHandler,
   formatAgentDescription,
@@ -192,6 +195,106 @@ Command template for ${name}.`,
         bundledCommandsDir: path.join(bundledDir, 'commands'),
       })
       expect(typeof handler).toBe('function')
+    })
+
+    test('keeps emitted runtime config bytes unchanged after capability observation', async () => {
+      createAgent(
+        path.join(bundledDir, 'agents'),
+        'fixture-agent',
+        'Fixture agent',
+      )
+      createSkill(
+        path.join(bundledDir, 'skills'),
+        'fixture-skill',
+        'Fixture skill',
+      )
+      createCommand(
+        path.join(bundledDir, 'commands'),
+        'fixture-command',
+        'Fixture command',
+      )
+
+      const handler = createConfigHandler({
+        directory: projectDir,
+        bundledSkillsDir: path.join(bundledDir, 'skills'),
+        bundledAgentsDir: path.join(bundledDir, 'agents'),
+        bundledCommandsDir: path.join(bundledDir, 'commands'),
+      })
+      const makeConfig = (): Config => ({
+        agent: {
+          'native-agent': {
+            description: 'Native agent',
+            prompt: 'Native prompt',
+          },
+        },
+        command: {
+          'native-command': {
+            description: 'Native command',
+            template: 'Native template',
+          },
+        },
+      })
+
+      const before = makeConfig()
+      await handler(before)
+      const beforeSerialized = JSON.stringify(before)
+
+      const diagnosticRoot = path.join(testDir, 'diagnostic')
+      const packageRoot = path.join(diagnosticRoot, 'package')
+      const agentsRoot = path.join(packageRoot, 'agents')
+      fs.mkdirSync(agentsRoot, { recursive: true })
+      fs.writeFileSync(
+        path.join(packageRoot, 'package.json'),
+        JSON.stringify({ name: '@fixture/systematic', version: '1.0.0' }),
+      )
+      const roots: CapabilityCliRoots = {
+        agentsRoot,
+        cwd: projectDir,
+        homeDir: path.join(diagnosticRoot, 'home'),
+        packageRoot,
+      }
+      const conflictingConfig: ConfigObservationMetadata = {
+        authorities: [
+          { fieldPath: 'skills_as_commands', sourceKind: 'custom' },
+        ],
+        protectedFields: [
+          {
+            fieldPath: 'workflow_guard',
+            outcome: 'blocked',
+            sourceKind: 'project',
+          },
+        ],
+        sources: [
+          { kind: 'custom', presence: 'present' },
+          { kind: 'project', presence: 'absent' },
+          { kind: 'user', presence: 'absent' },
+        ],
+      }
+      const diagnosticOutput: string[] = []
+      expect(
+        runTestableCli({
+          argv: ['systematic', 'capabilities'],
+          clock: () => Date.parse('2026-08-13T12:34:56.000Z'),
+          config: conflictingConfig,
+          outputSink: (value) => diagnosticOutput.push(value),
+          roots,
+        }),
+      ).toBe(0)
+
+      const after = makeConfig()
+      await handler(after)
+
+      expect(JSON.stringify(after)).toBe(beforeSerialized)
+      expect(diagnosticOutput).toHaveLength(1)
+    })
+
+    test('config-handler source does not import capability snapshot data', () => {
+      const source = fs.readFileSync(
+        new URL('../../src/lib/config-handler.ts', import.meta.url),
+        'utf8',
+      )
+
+      expect(source).not.toContain('capability-snapshot')
     })
 
     test('collects bundled agents into config', async () => {

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -6,6 +6,10 @@ import { fileURLToPath } from 'node:url'
 
 import { BUNDLED_SKILL_NAMES } from '../../src/lib/bundled-names.js'
 import {
+  buildCapabilitySnapshot,
+  serializeCapabilitySnapshot,
+} from '../../src/lib/capability-snapshot.js'
+import {
   computeDroppedNames,
   DEFAULT_CONFIG,
   getConfigPaths,
@@ -13,6 +17,8 @@ import {
   loadConfigWithSources,
   warnDroppedNames,
 } from '../../src/lib/config.js'
+
+const OBSERVED_AT = '2026-08-13T12:34:56.000Z'
 
 describe('config', () => {
   let testDir: string
@@ -156,6 +162,139 @@ describe('config', () => {
 
         const result = loadConfig(testDir)
         expect(result.bootstrap.enabled).toBe(false)
+      })
+    })
+
+    describe('read-only observation metadata', () => {
+      test('reports source presence and field-specific authority without values', () => {
+        writeUserConfig({
+          bootstrap: { enabled: false },
+          workflow_guard: { mode: 'protected' },
+          skills_as_commands: false,
+          agents: {
+            'correctness-reviewer': {
+              model: 'openai/secret-model',
+              permission: { bash: 'deny' },
+            },
+          },
+        })
+
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        fs.writeFileSync(
+          path.join(projectConfigDir, 'systematic.json'),
+          JSON.stringify({
+            bootstrap: { enabled: true },
+            workflow_guard: { mode: 'disabled' },
+            skills_as_commands: true,
+            agents: {
+              'correctness-reviewer': { temperature: 0.4 },
+            },
+          }),
+        )
+
+        const customDir = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'systematic-custom-'),
+        )
+        process.env.OPENCODE_CONFIG_DIR = customDir
+        fs.writeFileSync(
+          path.join(customDir, 'systematic.json'),
+          JSON.stringify({
+            skills_as_commands: false,
+            categories: { review: { temperature: 0.7 } },
+          }),
+        )
+
+        try {
+          const result = loadConfigWithSources(testDir)
+
+          expect(result.metadata.sources).toEqual([
+            { kind: 'custom', presence: 'present' },
+            { kind: 'project', presence: 'present' },
+            { kind: 'user', presence: 'present' },
+          ])
+          expect(result.metadata.authorities).toEqual(
+            expect.arrayContaining([
+              { fieldPath: 'bootstrap.enabled', sourceKind: 'project' },
+              { fieldPath: 'skills_as_commands', sourceKind: 'custom' },
+              { fieldPath: 'workflow_guard.mode', sourceKind: 'user' },
+            ]),
+          )
+          expect(result.metadata.authorities).not.toContainEqual({
+            fieldPath: 'workflow_guard.mode',
+            sourceKind: 'project',
+          })
+          expect(result.metadata.protectedFields).toContainEqual({
+            fieldPath: 'workflow_guard',
+            outcome: 'blocked',
+            sourceKind: 'project',
+          })
+          expect(JSON.stringify(result.metadata)).not.toContain('secret-model')
+          expect(JSON.stringify(result.metadata)).not.toContain('permission')
+          expect(result.config.skills_as_commands).toBe(false)
+          expect(result.config.bootstrap.enabled).toBe(true)
+          expect(result.config.workflow_guard.mode).toBe('protected')
+        } finally {
+          delete process.env.OPENCODE_CONFIG_DIR
+          fs.rmSync(customDir, { recursive: true, force: true })
+        }
+      })
+
+      test('reports malformed source metadata only in opt-in mode', () => {
+        const projectConfigDir = path.join(testDir, '.opencode')
+        fs.mkdirSync(projectConfigDir)
+        const projectConfigPath = path.join(projectConfigDir, 'systematic.json')
+        fs.writeFileSync(projectConfigPath, '{invalid json')
+
+        const result = loadConfigWithSources(testDir, {
+          invalidSource: 'report',
+        })
+
+        expect(result.metadata.sources).toContainEqual({
+          errorCode: 'parse-failed',
+          kind: 'project',
+          presence: 'invalid',
+        })
+        expect(JSON.stringify(result.metadata)).not.toContain(projectConfigPath)
+        expect(() => loadConfig(testDir)).toThrow(projectConfigPath)
+      })
+
+      test('deduplicates symlink-equivalent config sources without leaking paths', () => {
+        const realProjectDir = path.join(testDir, 'real-project')
+        const realConfigDir = path.join(realProjectDir, '.opencode')
+        const aliasedProjectDir = path.join(testDir, 'aliased-project')
+        const aliasedCustomDir = path.join(testDir, 'aliased-custom')
+        fs.mkdirSync(realConfigDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(realConfigDir, 'systematic.json'),
+          JSON.stringify({ skills_as_commands: false }),
+        )
+        fs.symlinkSync(realProjectDir, aliasedProjectDir, 'dir')
+        fs.symlinkSync(realConfigDir, aliasedCustomDir, 'dir')
+        process.env.OPENCODE_CONFIG_DIR = aliasedCustomDir
+
+        try {
+          const result = loadConfigWithSources(aliasedProjectDir)
+          expect(result.metadata.sources).toEqual([
+            { kind: 'custom', presence: 'present' },
+            { kind: 'user', presence: 'absent' },
+          ])
+
+          const serialized = serializeCapabilitySnapshot(
+            buildCapabilitySnapshot({
+              argv: ['systematic', 'capabilities'],
+              clock: () => Date.parse(OBSERVED_AT),
+              config: result.metadata,
+              package: { name: '@fro.bot/systematic', version: '1.2.3' },
+              roots: [],
+            }),
+          )
+          expect(serialized).not.toContain(realProjectDir)
+          expect(serialized).not.toContain(aliasedProjectDir)
+          expect(serialized).not.toContain(aliasedCustomDir)
+        } finally {
+          delete process.env.OPENCODE_CONFIG_DIR
+        }
       })
     })
 

--- a/tests/unit/discovered-skills.test.ts
+++ b/tests/unit/discovered-skills.test.ts
@@ -215,6 +215,22 @@ describe('discoverSkills', () => {
     expect(result.map((s) => s.name)).toEqual(['ok'])
   })
 
+  test('reports bounded source issues without changing winning discovery results', () => {
+    const skillDir = path.join(projectDir, '.opencode/skills/broken')
+    fs.mkdirSync(skillDir, { recursive: true })
+    fs.mkdirSync(path.join(skillDir, 'SKILL.md'), { recursive: true })
+
+    const issues: string[] = []
+    const result = discoverSkills({
+      startDir: projectDir,
+      homeDir,
+      onIssue: (issue) => issues.push(issue),
+    })
+
+    expect(result).toEqual([])
+    expect(issues).toEqual(['read-failed'])
+  })
+
   test('configDir override: skills discovered from custom OpenCode config dir', () => {
     const configDir = path.join(root, 'custom-config')
     writeSkill(path.join(configDir, 'skills/customcfg'), 'customcfg')


### PR DESCRIPTION
## Summary
- Add `systematic capabilities`, a versioned deterministic JSON diagnostic for standalone CLI-observable package/config/discovery state.
- Separate config source presence from proven per-field authority while preserving project protected-field blocking.
- Report winning skills/agents and bounded discovery failures without exposing discarded entries or local paths.

## Why
- Replace static assumptions about current harness capability with directly observed, machine-readable facts.
- Keep the diagnostic strictly read-only and non-authoritative: bootstrap, config handling, setup, routing, and workflow protection remain unchanged.

## Implementation
- Add the privacy-allowlisted `cli-capabilities.v1` snapshot builder and capabilities-only CLI seam.
- Extend config loading with read-only observation metadata, injectable roots, and warning sinks while preserving default behavior.
- Preserve discovery winner semantics, fail closed on agent collisions, and model malformed skill sources as bounded issue facts.
- Add the Bitter Lesson migration program, completed capability-diagnostic plan, and focused local eval-foundation child plan.

## Verification
- `bun test tests/unit` — 1,865 passed
- `bun test tests/integration/release-notes-ci.test.ts` — 20 passed
- `bun test tests/unit/fro-bot-workflow.test.ts` — 14 passed
- `bun run lint` — 17-warning baseline, no regression
- `bun run typecheck`
- `bun run build`
- `bun run registry:drift`
- `bun run schema:drift`
- Source and built CLI smoke tests: one JSON document, empty stderr, no writes, no absolute-path/config-value leakage
