### PR TITLE
feat(evals): add local OpenCode outcome runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,8 @@ cep-guide.md
 # Eval debug logs (verbose opencode run logs; JSONL transcripts are kept)
 tests/manual/with-without-eval/**/*.log
 
+# Local eval run artifacts
+/evals/runs/
+
 # Generated Claude Code plugin (built in CI, published to the claude-code-plugin branch; never committed)
 claude-code/

--- a/docs/plans/2026-08-13-003-feat-local-opencode-eval-foundation-plan.md
+++ b/docs/plans/2026-08-13-003-feat-local-opencode-eval-foundation-plan.md
@@ -314,7 +314,7 @@ flowchart TB
 
 ## Implementation Units
 
-- [ ] **Unit 1: Define the narrow case and result contracts**
+- [x] **Unit 1: Define the narrow case and result contracts**
 
   **Goal:** Define the two case manifests and the shared result contract without
   creating a reusable eval platform.
@@ -337,7 +337,7 @@ flowchart TB
   full serialized-output validation, seeded fake secrets, path minimization, and
   deterministic sorting.
 
-- [ ] **Unit 2: Implement fixture-scoped execution and environment policy**
+- [x] **Unit 2: Implement fixture-scoped execution and environment policy**
 
   **Goal:** Run either case in unique local roots with explicit child-env denial and
   honest out-of-root detection.
@@ -364,7 +364,7 @@ flowchart TB
   no-write behavior outside allowed run artifacts, primary-checkout preservation,
   probe health, child interruption cleanup, and both deterministic case outcomes.
 
-- [ ] **Unit 3: Harden source and packed-installed modes**
+- [x] **Unit 3: Harden source and packed-installed modes**
 
   **Goal:** Prove distinct source and installed execution boundaries with mode-specific
   config entries and provenance, without generalized dependency infrastructure.
@@ -390,7 +390,7 @@ flowchart TB
   installed results have distinct provenance; malformed archives, unsafe links,
   outside-root module resolution, and missing package content yield `infra_failure`.
 
-- [ ] **Unit 4: Implement cleanup, privacy-safe persistence, and exit semantics**
+- [x] **Unit 4: Implement cleanup, privacy-safe persistence, and exit semantics**
 
   **Goal:** Produce bounded local evidence and correct run-level behavior for partial,
   failed, and successful selections.

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,35 @@
+# Local OpenCode evals
+
+Direct invocation:
+
+```sh
+bun scripts/run-evals.ts \
+  --case bootstrap-loading \
+  --case fixture-local-write \
+  --mode source \
+  --mode installed \
+  --seed local-seed-001 \
+  --clock 2026-08-14T00:00:00.000Z
+```
+
+`--case` and `--mode` are repeatable. Valid cases are `bootstrap-loading` and
+`fixture-local-write`; valid modes are `source` and `installed`. Seeds match
+`[A-Za-z0-9][A-Za-z0-9._-]{0,127}` and clocks are exact UTC timestamps in
+`YYYY-MM-DDTHH:mm:ss.sssZ` form. Use `--help` for the concise CLI contract.
+
+Local output is written under `evals/runs/<runId>/`.
+`manifest.json` is written last and is the completion marker. Exit code `0`
+means every requested selection succeeded, `1` means a completed or partial
+run contains a non-success outcome, and `2` means invalid CLI arguments.
+
+The four primary outcomes are `success`, `infra_failure`, `task_failure`, and
+`privacy_cleanup_failure`.
+
+Persisted output is allowlisted and privacy-checked. Raw stdout, stderr,
+transcripts, environment values, repository content, user prose, secrets, and
+absolute paths are outside the persistence boundary.
+
+Isolation is fixture-scoped local isolation, not operating-system isolation.
+
+Unsupported scope includes Pi or Claude Code, additional cases, networked or
+credentialed tasks, hosted execution, and CI orchestration.

--- a/evals/cases/opencode/bootstrap-loading.json
+++ b/evals/cases/opencode/bootstrap-loading.json
@@ -1,0 +1,6 @@
+{
+  "caseSchemaVersion": 1,
+  "caseId": "bootstrap-loading",
+  "harness": "opencode",
+  "assertionIds": ["bootstrap-observed"]
+}

--- a/evals/cases/opencode/fixture-local-write.json
+++ b/evals/cases/opencode/fixture-local-write.json
@@ -1,0 +1,8 @@
+{
+  "caseSchemaVersion": 1,
+  "caseId": "fixture-local-write",
+  "harness": "opencode",
+  "assertionIds": ["fixture-file-content", "fixture-file-created"],
+  "expectedArtifactId": "fixture/output.txt",
+  "expectedContentId": "fixture-local-write-v1"
+}

--- a/scripts/eval-cases/opencode.ts
+++ b/scripts/eval-cases/opencode.ts
@@ -1,0 +1,745 @@
+import { type ChildProcess, spawn } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { createOpencodeClient } from '@opencode-ai/sdk/v2'
+
+import {
+  buildEvalChildEnv,
+  type EvalCaseExecution,
+  type EvalCaseManifest,
+  type EvalFixture,
+  EXPECTED_OPENCODE_VERSION,
+} from '../run-evals.ts'
+
+const MODEL_PROVIDER_ID = 'systematic-eval-local-provider'
+const MODEL_ID = 'systematic-eval-local-model'
+const EXPECTED_WRITE_CONTENT = 'fixture-local-write-v1'
+const PROBE_FAKE_VALUE_MARKER = 'eval-parent-fake-value'
+const PROBE_DIGEST = createHash('sha256')
+  .update('systematic-eval-probe-v1')
+  .digest('hex')
+
+export interface ScriptedToolCall {
+  id: string
+  name: string
+  arguments: Record<string, unknown>
+}
+
+export interface ScriptedResponse {
+  text?: string
+  toolCalls?: ScriptedToolCall[]
+}
+
+export interface ScriptedModelServer {
+  url: string
+  stop(): Promise<void>
+}
+
+export type BoundedProbeEvent =
+  | { type: 'loaded'; status: 'ok' | 'unhealthy' }
+  | {
+      type: 'transform'
+      kind: 'chat'
+      status: 'healthy' | 'unhealthy'
+      blockCount: number
+    }
+  | { type: 'tool'; tool: 'write'; outcome: 'success' | 'failure' }
+
+export interface OpencodeProbe {
+  url: string
+  capturePath: string
+  sourcePath: string
+  digest: string
+}
+
+interface ProbeHealth {
+  status: 'healthy' | 'unhealthy'
+  subcode?: 'probe_unhealthy'
+  blockCount?: number
+  transformCount?: number
+}
+
+interface FixtureWriteGrade {
+  outcome: 'success' | 'task_failure' | 'infra_failure'
+  subcode: 'none' | 'write_missing' | 'write_mismatch' | 'path_escape'
+}
+
+interface OpencodeHost {
+  url: string
+  stop(): Promise<void>
+}
+
+interface StoppableModelServer {
+  stop(closeActiveConnections?: boolean): void
+}
+
+const activeOpencodeChildren = new Set<ChildProcess>()
+const activeModelServers = new Set<StoppableModelServer>()
+
+function isBoundedProbeEvent(value: unknown): value is BoundedProbeEvent {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const candidate = value as Record<string, unknown>
+  if (candidate.type === 'loaded') {
+    return (
+      Object.keys(candidate).length === 2 &&
+      (candidate.status === 'ok' || candidate.status === 'unhealthy')
+    )
+  }
+  if (candidate.type === 'transform') {
+    return (
+      Object.keys(candidate).length === 4 &&
+      candidate.kind === 'chat' &&
+      (candidate.status === 'healthy' || candidate.status === 'unhealthy') &&
+      typeof candidate.blockCount === 'number' &&
+      Number.isInteger(candidate.blockCount) &&
+      candidate.blockCount >= 0 &&
+      candidate.blockCount <= 8
+    )
+  }
+  return (
+    candidate.type === 'tool' &&
+    Object.keys(candidate).length === 3 &&
+    candidate.tool === 'write' &&
+    (candidate.outcome === 'success' || candidate.outcome === 'failure')
+  )
+}
+
+export function readBoundedProbeEvents(
+  capturePath: string,
+): BoundedProbeEvent[] {
+  if (!fs.existsSync(capturePath)) return []
+  const content = fs.readFileSync(capturePath, 'utf8').trim()
+  if (content === '') return []
+  const events: BoundedProbeEvent[] = []
+  for (const line of content.split('\n')) {
+    try {
+      const parsed = JSON.parse(line) as unknown
+      if (!isBoundedProbeEvent(parsed)) return []
+      events.push(parsed)
+    } catch {
+      return []
+    }
+  }
+  return events
+}
+
+export function createOpencodeProbe(fixture: EvalFixture): OpencodeProbe {
+  const sourcePath = path.join(fixture.probeRoot, 'index.mjs')
+  const packagePath = path.join(fixture.probeRoot, 'package.json')
+  const capturePath = path.join(fixture.probeRoot, 'events.jsonl')
+  fs.writeFileSync(
+    packagePath,
+    JSON.stringify({
+      name: 'systematic-eval-probe',
+      type: 'module',
+      main: './index.mjs',
+    }),
+  )
+  fs.writeFileSync(
+    sourcePath,
+    `import fs from 'node:fs'
+
+const capturePath = ${JSON.stringify(capturePath)}
+const expectedHome = ${JSON.stringify(fixture.homeRoot)}
+const expectedConfig = ${JSON.stringify(fixture.opencodeConfigRoot)}
+const fakeValueMarker = ${JSON.stringify(PROBE_FAKE_VALUE_MARKER)}
+const forbiddenNames = ${JSON.stringify([
+      'GH_TOKEN',
+      'GITHUB_TOKEN',
+      'NPM_TOKEN',
+      'OPENAI_API_KEY',
+      'AWS_SECRET_ACCESS_KEY',
+      'SSH_AUTH_SOCK',
+      'GIT_ASKPASS',
+      'OPENCODE_AUTH_TOKEN',
+    ])}
+
+function append(event) {
+  fs.appendFileSync(capturePath, JSON.stringify(event) + '\\n')
+}
+
+function workflowBlockCount(system) {
+  return system.reduce((count, entry) =>
+    count + (typeof entry === 'string' ? entry.split('<SYSTEMATIC_WORKFLOWS>').length - 1 : 0), 0)
+}
+
+function isChatTransform(input) {
+  return Boolean(input && typeof input === 'object' && typeof input.sessionID === 'string' && 'model' in input)
+}
+
+export default async function systematicEvalProbe() {
+  const forbiddenNamePresent = forbiddenNames.some((name) => Object.hasOwn(process.env, name))
+  const forbiddenValuePresent = Object.values(process.env).includes(fakeValueMarker)
+  const controlledRootsPresent = process.env.HOME === expectedHome && process.env.OPENCODE_CONFIG_DIR === expectedConfig
+  append({ type: 'loaded', status: forbiddenNamePresent || forbiddenValuePresent || !controlledRootsPresent ? 'unhealthy' : 'ok' })
+  return {
+    'experimental.chat.system.transform': async (input, output) => {
+      if (!isChatTransform(input)) return
+      const system = Array.isArray(output?.system) ? output.system : []
+      const blockCount = workflowBlockCount(system)
+      append({ type: 'transform', kind: 'chat', status: Array.isArray(output?.system) ? 'healthy' : 'unhealthy', blockCount })
+    },
+    'tool.execute.after': async (input, output) => {
+      if (input.tool !== 'write') return
+      const failed = Boolean(output && typeof output === 'object' && Object.hasOwn(output, 'error'))
+      append({ type: 'tool', tool: 'write', outcome: failed ? 'failure' : 'success' })
+    },
+  }
+}
+`,
+  )
+  return {
+    url: pathToFileURL(fixture.probeRoot).href,
+    capturePath,
+    sourcePath,
+    digest: PROBE_DIGEST,
+  }
+}
+
+export function gradeBootstrapProbe(
+  events: readonly BoundedProbeEvent[],
+): ProbeHealth {
+  const loaded = events.filter((event) => event.type === 'loaded')
+  const transforms = events.filter((event) => event.type === 'transform')
+  if (
+    loaded.length !== 1 ||
+    loaded[0]?.status !== 'ok' ||
+    transforms.length === 0 ||
+    transforms.some(
+      (event) => event.status !== 'healthy' || event.blockCount !== 1,
+    )
+  ) {
+    return { status: 'unhealthy', subcode: 'probe_unhealthy' }
+  }
+  return {
+    status: 'healthy',
+    blockCount: 1,
+    transformCount: transforms.length,
+  }
+}
+
+function canonicalPath(value: string): string {
+  let current = path.resolve(value)
+  const suffix: string[] = []
+  while (!fs.existsSync(current)) {
+    const parent = path.dirname(current)
+    if (parent === current) return path.resolve(current, ...suffix)
+    suffix.unshift(path.basename(current))
+    current = parent
+  }
+  return path.resolve(fs.realpathSync(current), ...suffix)
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate)
+  return (
+    relative === '' ||
+    (relative !== '..' &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  )
+}
+
+export function gradeFixtureWrite(
+  projectRoot: string,
+  expected: Pick<
+    Extract<EvalCaseManifest, { caseId: 'fixture-local-write' }>,
+    'expectedArtifactId' | 'expectedContentId'
+  >,
+): FixtureWriteGrade {
+  const root = canonicalPath(projectRoot)
+  const target = canonicalPath(
+    path.resolve(projectRoot, expected.expectedArtifactId),
+  )
+  if (!isWithin(root, target)) {
+    return { outcome: 'infra_failure', subcode: 'path_escape' }
+  }
+  if (!fs.existsSync(target)) {
+    return { outcome: 'task_failure', subcode: 'write_missing' }
+  }
+  if (expected.expectedContentId !== EXPECTED_WRITE_CONTENT) {
+    return { outcome: 'task_failure', subcode: 'write_mismatch' }
+  }
+  try {
+    const content = fs.readFileSync(target, 'utf8')
+    return content === EXPECTED_WRITE_CONTENT
+      ? { outcome: 'success', subcode: 'none' }
+      : { outcome: 'task_failure', subcode: 'write_mismatch' }
+  } catch {
+    return { outcome: 'task_failure', subcode: 'write_missing' }
+  }
+}
+
+function sseChunk(value: unknown): string {
+  return `data: ${JSON.stringify(value)}\n\n`
+}
+
+function responseChunks(
+  response: ScriptedResponse,
+  requestId: string,
+  created: number,
+): Record<string, unknown>[] {
+  if (response.toolCalls && response.toolCalls.length > 0) {
+    return [
+      ...response.toolCalls.map((toolCall, index) => ({
+        id: requestId,
+        object: 'chat.completion.chunk',
+        created,
+        model: MODEL_ID,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index,
+                  id: toolCall.id,
+                  type: 'function',
+                  function: {
+                    name: toolCall.name,
+                    arguments: JSON.stringify(toolCall.arguments),
+                  },
+                },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      })),
+      {
+        id: requestId,
+        object: 'chat.completion.chunk',
+        created,
+        model: MODEL_ID,
+        choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }],
+      },
+    ]
+  }
+  const text = response.text ?? ''
+  return [
+    {
+      id: requestId,
+      object: 'chat.completion.chunk',
+      created,
+      model: MODEL_ID,
+      choices: [
+        {
+          index: 0,
+          delta: text ? { role: 'assistant' } : {},
+          finish_reason: null,
+        },
+      ],
+    },
+    ...(text
+      ? [
+          {
+            id: requestId,
+            object: 'chat.completion.chunk',
+            created,
+            model: MODEL_ID,
+            choices: [
+              { index: 0, delta: { content: text }, finish_reason: null },
+            ],
+          },
+        ]
+      : []),
+    {
+      id: requestId,
+      object: 'chat.completion.chunk',
+      created,
+      model: MODEL_ID,
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+    },
+  ]
+}
+
+export function startScriptedModelServer(
+  responses: readonly ScriptedResponse[],
+): ScriptedModelServer {
+  let requestIndex = 0
+  const server = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      if (
+        request.method !== 'POST' ||
+        !request.url.endsWith('/chat/completions')
+      ) {
+        return new Response('not found', { status: 404 })
+      }
+      await request.json()
+      const response = responses[requestIndex] ?? { text: '' }
+      requestIndex += 1
+      const chunks = responseChunks(
+        response,
+        `systematic-eval-${requestIndex}`,
+        Math.floor(Date.now() / 1000),
+      )
+      const stream = new ReadableStream({
+        start(controller) {
+          const encoder = new TextEncoder()
+          for (const chunk of chunks) {
+            controller.enqueue(encoder.encode(sseChunk(chunk)))
+          }
+          controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+          controller.close()
+        },
+      })
+      return new Response(stream, {
+        headers: { 'Content-Type': 'text/event-stream' },
+      })
+    },
+  })
+  activeModelServers.add(server)
+  let stopped = false
+  return {
+    url: `http://localhost:${server.port}/v1`,
+    async stop(): Promise<void> {
+      if (stopped) return
+      stopped = true
+      activeModelServers.delete(server)
+      server.stop(true)
+    },
+  }
+}
+
+function buildProviderConfig(
+  pluginUrls: readonly string[],
+  baseUrl: string,
+): string {
+  return JSON.stringify({
+    formatter: false,
+    lsp: false,
+    plugin: pluginUrls,
+    provider: {
+      [MODEL_PROVIDER_ID]: {
+        name: 'Systematic Eval Local Provider',
+        id: MODEL_PROVIDER_ID,
+        env: [],
+        npm: '@ai-sdk/openai-compatible',
+        models: {
+          [MODEL_ID]: {
+            id: MODEL_ID,
+            name: 'Systematic Eval Local Model',
+            attachment: false,
+            reasoning: false,
+            temperature: false,
+            tool_call: true,
+            release_date: '2026-08-13',
+            limit: { context: 100_000, output: 10_000 },
+            cost: { input: 0, output: 0 },
+            options: {},
+          },
+        },
+        options: { apiKey: 'local-eval-only', baseURL: baseUrl },
+      },
+    },
+  })
+}
+
+function stopChildProcess(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null) return Promise.resolve()
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL')
+      resolve()
+    }, 5_000)
+    child.once('exit', () => {
+      clearTimeout(timeout)
+      resolve()
+    })
+    child.kill('SIGTERM')
+  })
+}
+
+async function startOpencodeHost(
+  fixture: EvalFixture,
+  configContent: string,
+  modelBaseUrl: string,
+  parentEnv: Readonly<Record<string, string | undefined>> | undefined,
+  timeoutMs: number,
+): Promise<OpencodeHost> {
+  const child = spawn(
+    'npx',
+    [
+      '--yes',
+      `opencode-ai@${EXPECTED_OPENCODE_VERSION}`,
+      'serve',
+      '--port',
+      '0',
+      '--print-logs',
+    ],
+    {
+      cwd: fixture.projectRoot,
+      env: buildEvalChildEnv({
+        fixture,
+        configContent,
+        modelBaseUrl,
+        parentEnv,
+      }),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  )
+  activeOpencodeChildren.add(child)
+  child.once('exit', () => activeOpencodeChildren.delete(child))
+  const markerPath = process.env.SYSTEMATIC_EVAL_STARTED_CHILD_MARKER
+  if (markerPath) {
+    try {
+      fs.writeFileSync(markerPath, 'started\n')
+    } catch {
+      // The marker is test-only evidence and must not affect execution.
+    }
+  }
+  const url = await new Promise<string>((resolve, reject) => {
+    let buffer = ''
+    let settled = false
+    const timeout = setTimeout(() => {
+      if (settled) return
+      settled = true
+      void stopChildProcess(child)
+      reject(new Error('opencode-host-timeout'))
+    }, timeoutMs)
+    const onChunk = (chunk: Buffer): void => {
+      if (settled) return
+      buffer = `${buffer}${chunk.toString()}`.slice(-4096)
+      const match = buffer.match(/https?:\/\/(?:localhost|127\.0\.0\.1):\d+/)
+      if (!match) return
+      settled = true
+      clearTimeout(timeout)
+      resolve(match[0])
+    }
+    child.stdout?.on('data', onChunk)
+    child.stderr?.on('data', onChunk)
+    child.once('error', () => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      reject(new Error('opencode-host-unavailable'))
+    })
+    child.once('exit', (code) => {
+      if (settled || code === 0) return
+      settled = true
+      clearTimeout(timeout)
+      reject(new Error('opencode-host-exited'))
+    })
+  })
+  let stopped = false
+  return {
+    url,
+    async stop(): Promise<void> {
+      if (stopped) return
+      stopped = true
+      await stopChildProcess(child)
+    },
+  }
+}
+
+export async function stopActiveEvalResources(): Promise<void> {
+  const children = [...activeOpencodeChildren]
+  await Promise.all(
+    children.map(async (child) => {
+      await stopChildProcess(child)
+      activeOpencodeChildren.delete(child)
+    }),
+  )
+  for (const server of [...activeModelServers]) {
+    try {
+      server.stop(true)
+    } catch {
+      // Cleanup is best effort; the caller owns the bounded force-exit guard.
+    }
+    activeModelServers.delete(server)
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error('opencode-prompt-timeout')),
+      timeoutMs,
+    )
+    promise.then(
+      (value) => {
+        clearTimeout(timeout)
+        resolve(value)
+      },
+      () => {
+        clearTimeout(timeout)
+        reject(new Error('opencode-prompt-failed'))
+      },
+    )
+  })
+}
+
+function executionFailure(
+  subcode: 'opencode_unavailable' | 'probe_unhealthy' | 'unexpected_exit',
+  probeDigest: string,
+): EvalCaseExecution {
+  return {
+    outcome: subcode === 'unexpected_exit' ? 'task_failure' : 'infra_failure',
+    subcode,
+    sanity: 'failed',
+    process: 'failed',
+    probeDigest,
+    artifactRefs: ['probe/events.jsonl'],
+  }
+}
+
+interface ExecuteCaseInput {
+  fixture: EvalFixture
+  caseManifest: EvalCaseManifest
+  pluginEntry: string
+  parentEnv?: Readonly<Record<string, string | undefined>>
+  timeoutMs?: number
+  caseTimeoutMs?: number
+  artifactRefs?: readonly string[]
+}
+
+async function executeCase(
+  input: ExecuteCaseInput,
+): Promise<EvalCaseExecution> {
+  const probe = createOpencodeProbe(input.fixture)
+  const responses: ScriptedResponse[] =
+    input.caseManifest.caseId === 'bootstrap-loading'
+      ? [{ text: 'done' }]
+      : [
+          {
+            toolCalls: [
+              {
+                id: 'fixture-write-call',
+                name: 'write',
+                arguments: {
+                  filePath: 'fixture/output.txt',
+                  content: EXPECTED_WRITE_CONTENT,
+                },
+              },
+            ],
+          },
+          { text: 'done' },
+        ]
+  const model = startScriptedModelServer(responses)
+  let host: OpencodeHost | undefined
+  const hostTimeoutMs = input.timeoutMs ?? 180_000
+  const caseTimeoutMs = input.caseTimeoutMs ?? hostTimeoutMs
+  const caseArtifactRefs =
+    input.caseManifest.caseId === 'bootstrap-loading'
+      ? ['probe/events.jsonl']
+      : ['fixture/output.txt', 'probe/events.jsonl']
+  const artifactRefs = [
+    ...(input.artifactRefs ?? []),
+    ...caseArtifactRefs,
+  ].sort()
+
+  try {
+    const configContent = buildProviderConfig(
+      [pathToFileURL(input.pluginEntry).href, probe.url],
+      model.url,
+    )
+    fs.writeFileSync(input.fixture.opencodeConfigPath, configContent)
+    host = await startOpencodeHost(
+      input.fixture,
+      configContent,
+      model.url,
+      input.parentEnv,
+      hostTimeoutMs,
+    )
+    const client = createOpencodeClient({
+      baseUrl: host.url,
+      directory: input.fixture.projectRoot,
+    })
+    const session = await client.session.create({
+      directory: input.fixture.projectRoot,
+      title: `systematic eval ${input.caseManifest.caseId}`,
+      permission: [{ permission: '*', pattern: '*', action: 'allow' }],
+    })
+    await withTimeout(
+      client.session.prompt({
+        sessionID: session.data.id,
+        directory: input.fixture.projectRoot,
+        model: { providerID: MODEL_PROVIDER_ID, modelID: MODEL_ID },
+        parts: [
+          {
+            type: 'text',
+            text:
+              input.caseManifest.caseId === 'bootstrap-loading'
+                ? 'Complete the deterministic bootstrap probe.'
+                : 'Create the deterministic fixture file using the built-in write tool.',
+          },
+        ],
+      }),
+      caseTimeoutMs,
+    )
+
+    const probeHealth = gradeBootstrapProbe(
+      readBoundedProbeEvents(probe.capturePath),
+    )
+    if (probeHealth.status !== 'healthy') {
+      return executionFailure('probe_unhealthy', probe.digest)
+    }
+    if (input.caseManifest.caseId === 'bootstrap-loading') {
+      return {
+        outcome: 'success',
+        subcode: 'none',
+        sanity: 'passed',
+        process: 'completed',
+        probeDigest: probe.digest,
+        artifactRefs,
+      }
+    }
+    const writeGrade = gradeFixtureWrite(
+      input.fixture.projectRoot,
+      input.caseManifest,
+    )
+    return {
+      outcome: writeGrade.outcome,
+      subcode: writeGrade.subcode,
+      sanity: 'passed',
+      process: 'completed',
+      probeDigest: probe.digest,
+      artifactRefs,
+    }
+  } catch {
+    return executionFailure(
+      host ? 'unexpected_exit' : 'opencode_unavailable',
+      probe.digest,
+    )
+  } finally {
+    try {
+      if (host) await host.stop()
+    } catch {
+      // Cleanup status is owned by the shared runner.
+    }
+    try {
+      await model.stop()
+    } catch {
+      // Cleanup status is owned by the shared runner.
+    }
+  }
+}
+
+export function executeSourceCase(input: {
+  fixture: EvalFixture
+  caseManifest: EvalCaseManifest
+  sourceEntry: string
+  parentEnv?: Readonly<Record<string, string | undefined>>
+  timeoutMs?: number
+  caseTimeoutMs?: number
+}): Promise<EvalCaseExecution> {
+  return executeCase({ ...input, pluginEntry: input.sourceEntry })
+}
+
+export function executeInstalledCase(input: {
+  fixture: EvalFixture
+  caseManifest: EvalCaseManifest
+  installedEntry: string
+  parentEnv?: Readonly<Record<string, string | undefined>>
+  timeoutMs?: number
+  caseTimeoutMs?: number
+}): Promise<EvalCaseExecution> {
+  return executeCase({
+    ...input,
+    pluginEntry: input.installedEntry,
+    artifactRefs: ['artifact/package.tgz', 'package/dist/index.js'],
+  })
+}

--- a/scripts/run-evals.ts
+++ b/scripts/run-evals.ts
@@ -1,0 +1,3653 @@
+import { spawnSync } from 'node:child_process'
+import { createHash, randomUUID } from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { gunzipSync } from 'node:zlib'
+
+const CASE_SCHEMA_VERSION = 1 as const
+const RESULT_SCHEMA_VERSION = 1 as const
+export const RUN_MANIFEST_SCHEMA_VERSION = 1 as const
+const HARNESS = 'opencode' as const
+
+export { CASE_SCHEMA_VERSION, HARNESS, RESULT_SCHEMA_VERSION }
+
+export const CASE_IDS = ['bootstrap-loading', 'fixture-local-write'] as const
+
+export type CaseId = (typeof CASE_IDS)[number]
+
+export const MODES = ['source', 'installed'] as const
+export type EvalMode = (typeof MODES)[number]
+
+export const OUTCOMES = [
+  'success',
+  'infra_failure',
+  'task_failure',
+  'privacy_cleanup_failure',
+] as const
+export type EvalOutcome = (typeof OUTCOMES)[number]
+
+export const OUTCOME_SUBCODES = {
+  success: ['none'],
+  infra_failure: [
+    'identity_drift',
+    'probe_unhealthy',
+    'artifact_resolution',
+    'opencode_unavailable',
+    'path_escape',
+    'primary_checkout_delta',
+    'case_setup',
+  ],
+  task_failure: [
+    'bootstrap_not_observed',
+    'write_missing',
+    'write_mismatch',
+    'unexpected_exit',
+  ],
+  privacy_cleanup_failure: [
+    'redaction_failed',
+    'residue_detected',
+    'quarantine_failed',
+    'atomic_write_failed',
+  ],
+} as const
+
+export type EvalSubcode =
+  (typeof OUTCOME_SUBCODES)[keyof typeof OUTCOME_SUBCODES][number]
+
+export interface BootstrapLoadingCaseManifest {
+  caseSchemaVersion: typeof CASE_SCHEMA_VERSION
+  caseId: 'bootstrap-loading'
+  harness: typeof HARNESS
+  assertionIds: string[]
+}
+
+export interface FixtureLocalWriteCaseManifest {
+  caseSchemaVersion: typeof CASE_SCHEMA_VERSION
+  caseId: 'fixture-local-write'
+  harness: typeof HARNESS
+  assertionIds: string[]
+  expectedArtifactId: string
+  expectedContentId: string
+}
+
+export type EvalCaseManifest =
+  | BootstrapLoadingCaseManifest
+  | FixtureLocalWriteCaseManifest
+
+export interface EvalIdentity {
+  opencodeVersion: string
+  opencodeBuildId: string
+  probeId: string
+  probeDigest: string
+  fixtureContractVersion: number
+  fixtureContractDigest: string
+  caseSchemaVersion: typeof CASE_SCHEMA_VERSION
+  resultSchemaVersion: typeof RESULT_SCHEMA_VERSION
+  artifactId: string
+  artifactDigest: string
+}
+
+export interface EvalEvidence {
+  sanity: 'passed' | 'failed'
+  process: 'completed' | 'failed'
+  assertionIds: string[]
+}
+
+export interface EvalCleanupState {
+  status: 'clean' | 'residue' | 'quarantined'
+  residue: 'none' | 'detected' | 'quarantined'
+}
+
+export interface EvalPrivacyState {
+  status: 'validated' | 'rejected'
+}
+
+export interface SourceProvenance {
+  kind: 'source'
+  checkoutRelativeSource: string
+  commitId: string
+  worktreeId: string
+  canonicalSourceEntryId: string
+  opencodeConfigEntryId: string
+}
+
+export interface InstalledProvenance {
+  kind: 'installed'
+  packageName: string
+  packageVersion: string
+  tarballDigest: string
+  extractedPackageRootId: string
+  canonicalResolvedModuleEntryId: string
+  opencodeConfigEntryId: string
+}
+
+export interface EvalResult {
+  resultSchemaVersion: typeof RESULT_SCHEMA_VERSION
+  caseSchemaVersion: typeof CASE_SCHEMA_VERSION
+  caseId: CaseId
+  harness: typeof HARNESS
+  mode: EvalMode
+  outcome: EvalOutcome
+  subcode?: EvalSubcode
+  runId: string
+  fixtureSeed: string
+  normalizedClock: string
+  assertionIds: string[]
+  identity: EvalIdentity
+  evidence: EvalEvidence
+  cleanup: EvalCleanupState
+  privacy: EvalPrivacyState
+  artifactRefs: string[]
+  provenance: SourceProvenance | InstalledProvenance
+}
+
+export interface EvalCaseExecution {
+  outcome: EvalOutcome
+  subcode: EvalSubcode
+  sanity: 'passed' | 'failed'
+  process: 'completed' | 'failed'
+  probeDigest: string
+  artifactRefs: string[]
+}
+
+export interface EvalFixture {
+  mode: EvalMode
+  runRoot: string
+  caseRoot: string
+  modeRoot: string
+  projectRoot: string
+  homeRoot: string
+  xdgConfigRoot: string
+  xdgDataRoot: string
+  xdgCacheRoot: string
+  xdgStateRoot: string
+  opencodeConfigRoot: string
+  opencodeConfigPath: string
+  probeRoot: string
+  npmCacheRoot: string
+  npmPrefixRoot: string
+  npmUserConfigPath: string
+  artifactRoot: string
+  tarballPath: string
+  stagingRoot: string
+  packageRoot: string
+  provenanceRoot: string
+  tmpRoot: string
+}
+
+interface ActiveEvalFixture {
+  fixture: EvalFixture
+  runId: string
+  hooks?: EvalLifecycleHooks
+  cleanupPromise?: Promise<CleanupResolution>
+}
+
+const activeEvalFixtures = new Map<EvalFixture, ActiveEvalFixture>()
+const completedFixtureCleanups = new WeakMap<EvalFixture, CleanupResolution>()
+let interruptionSignal: NodeJS.Signals | undefined
+let interruptionCleanup: Promise<void> | undefined
+
+function isEvalInterrupted(): boolean {
+  return interruptionSignal !== undefined
+}
+
+export interface CreateEvalFixtureOptions {
+  caseId: CaseId
+  mode: EvalMode
+  runId: string
+  parentDir?: string
+}
+
+export interface ValidatedNpmTarEntry {
+  path: string
+  type: 'file' | 'directory'
+  content: Uint8Array
+}
+
+export interface ValidatedNpmTarball {
+  digest: string
+  entries: readonly ValidatedNpmTarEntry[]
+}
+
+export interface InstalledPluginEntry {
+  packageName: string
+  packageVersion: string
+  moduleEntry: string
+  moduleEntryId: string
+}
+
+export interface InstalledArtifact extends InstalledPluginEntry {
+  tarballPath: string
+  tarballDigest: string
+  packageRoot: string
+  packageRootId: string
+  configEntryId: string
+}
+
+export interface EvalChildEnvOptions {
+  fixture: EvalFixture
+  configContent: string
+  modelBaseUrl: string
+  parentEnv?: Readonly<Record<string, string | undefined>>
+}
+
+export interface PrimaryCheckoutIdentity {
+  status: string
+  sourceDigest: string
+}
+
+export interface ExactOpencodeRuntime {
+  status: 'available' | 'unavailable' | 'mismatch'
+  expectedVersion: string
+  reportedVersion?: string
+}
+
+export interface SourceEvalOptions {
+  caseId: CaseId
+  fixtureSeed: string
+  normalizedClock: string
+  runId?: string
+  parentDir?: string
+  rootDir?: string
+  timeoutMs?: number
+  caseTimeoutMs?: number
+  lifecycleHooks?: EvalLifecycleHooks
+  reusableArtifact?: InstalledArtifact
+}
+
+export interface EvalLifecycleHooks {
+  executeCase?: (input: {
+    mode: EvalMode
+    fixture: EvalFixture
+    caseManifest: EvalCaseManifest
+  }) => Promise<EvalCaseExecution>
+  cleanupFixture?: (fixture: EvalFixture) => void | Promise<void>
+  quarantineResidue?: (
+    fixture: EvalFixture,
+    quarantineRoot: string,
+  ) => void | Promise<void>
+}
+
+export interface EvalSelectionRunnerInput extends SourceEvalOptions {
+  mode: EvalMode
+}
+
+export interface EvalCliOptions {
+  cases: CaseId[]
+  modes: EvalMode[]
+  fixtureSeed: string
+  normalizedClock: string
+  selectionIds: string[]
+}
+
+export interface EvalCliHelp {
+  help: true
+  usage: string
+}
+
+export type EvalCliParseResult = EvalCliHelp | EvalCliOptions
+
+export interface EvalRunResultSummary {
+  selectionId: string
+  resultArtifactId: string
+  outcome: EvalOutcome
+  subcode: EvalSubcode
+}
+
+export interface EvalRunManifest {
+  manifestSchemaVersion: typeof RUN_MANIFEST_SCHEMA_VERSION
+  harness: typeof HARNESS
+  runId: string
+  requestedSelectionIds: string[]
+  completedSelectionIds: string[]
+  partial: boolean
+  results: EvalRunResultSummary[]
+}
+
+export interface PersistEvalRunOptions {
+  manifest: unknown
+  results: readonly unknown[]
+  runsRoot?: string
+  rootDir?: string
+  onRename?: (relativeId: string) => void
+}
+
+export interface EvalSelectionRunnerOptions {
+  selectionIds: readonly string[]
+  fixtureSeed: string
+  normalizedClock: string
+  runId?: string
+  parentDir?: string
+  rootDir?: string
+  runsRoot?: string
+  timeoutMs?: number
+  caseTimeoutMs?: number
+  sourceRunner?: (options: EvalSelectionRunnerInput) => Promise<EvalResult>
+  installedRunner?: (options: EvalSelectionRunnerInput) => Promise<EvalResult>
+  artifactCleanupHooks?: Pick<
+    EvalLifecycleHooks,
+    'cleanupFixture' | 'quarantineResidue'
+  >
+  packInstalledArtifact?: (options: {
+    rootDir: string
+    fixture: EvalFixture
+  }) => InstalledArtifact
+}
+
+export interface EvalRunExecution {
+  runId: string
+  manifest: EvalRunManifest
+  results: EvalResult[]
+  persisted: PersistedEvalRun
+}
+
+export interface EvalCliOptionsOverride {
+  runId?: string
+  parentDir?: string
+  rootDir?: string
+  runsRoot?: string
+  timeoutMs?: number
+  caseTimeoutMs?: number
+  sourceRunner?: (options: EvalSelectionRunnerInput) => Promise<EvalResult>
+  installedRunner?: (options: EvalSelectionRunnerInput) => Promise<EvalResult>
+  packInstalledArtifact?: (options: {
+    rootDir: string
+    fixture: EvalFixture
+  }) => InstalledArtifact
+}
+
+export type EvalCliRunResult =
+  | { kind: 'help'; exitCode: 0; usage: string }
+  | {
+      kind: 'run'
+      exitCode: 0 | 1
+      run: EvalRunExecution
+    }
+  | {
+      kind: 'error'
+      exitCode: 1 | 2
+      code: string
+      usage?: string
+    }
+
+export interface PersistedEvalRun {
+  status: 'written'
+  runId: string
+  manifestArtifactId: 'manifest.json'
+  resultArtifactIds: string[]
+}
+
+type ContractErrorCode =
+  | 'case_invalid_shape'
+  | 'case_unknown_field'
+  | 'case_missing_field'
+  | 'case_unsupported'
+  | 'case_wrong_version'
+  | 'case_invalid_field'
+  | 'privacy_banned_field'
+  | 'privacy_unsafe_value'
+  | 'result_invalid_shape'
+  | 'result_unknown_field'
+  | 'result_missing_field'
+  | 'result_invalid_field'
+  | 'result_invalid_outcome'
+  | 'result_invalid_subcode'
+  | 'result_invalid_provenance'
+  | 'serialized_invalid_encoding'
+  | 'serialized_invalid_json'
+  | 'manifest_invalid_shape'
+  | 'manifest_unknown_field'
+  | 'manifest_missing_field'
+  | 'manifest_invalid_field'
+  | 'manifest_invalid_state'
+  | 'manifest_invalid_summary'
+
+type RecordValue = Record<string, unknown>
+
+const CASE_ASSERTIONS: Record<CaseId, readonly string[]> = {
+  'bootstrap-loading': ['bootstrap-observed'],
+  'fixture-local-write': ['fixture-file-content', 'fixture-file-created'],
+}
+
+const RESULT_REQUIRED_KEYS = [
+  'resultSchemaVersion',
+  'caseSchemaVersion',
+  'caseId',
+  'harness',
+  'mode',
+  'outcome',
+  'runId',
+  'fixtureSeed',
+  'normalizedClock',
+  'assertionIds',
+  'identity',
+  'evidence',
+  'cleanup',
+  'privacy',
+  'artifactRefs',
+  'provenance',
+] as const
+
+const RUN_MANIFEST_REQUIRED_KEYS = [
+  'manifestSchemaVersion',
+  'harness',
+  'runId',
+  'requestedSelectionIds',
+  'completedSelectionIds',
+  'partial',
+  'results',
+] as const
+
+export const BANNED_FIELD_NAMES = new Set([
+  'stdout',
+  'stderr',
+  'transcript',
+  'rawstdout',
+  'rawstderr',
+  'rawtranscript',
+  'env',
+  'environment',
+  'rawenv',
+  'repository',
+  'repositorycontent',
+  'userprose',
+  'userinput',
+  'userprompt',
+  'prompt',
+  'prose',
+  'content',
+  'credentials',
+  'credential',
+  'token',
+  'secret',
+  'password',
+  'privatekey',
+  'socket',
+  'auth',
+  'authorization',
+  'overlay',
+  'configoverlay',
+])
+
+const ABSOLUTE_PATH_PATTERNS = [/^\//, /^\\/, /^[A-Za-z]:[\\/]/, /^file:\/\//i]
+
+const SECRET_PATTERNS = [
+  /\b(?:ghp|gho|github_pat|glpat|npm|sk)[-_A-Za-z0-9]+/i,
+  /\bAKIA[0-9A-Z]{8,}\b/,
+  /\b(?:fake|dummy|test)[-_A-Za-z0-9]*(?:token|auth|key|secret|credential|password|socket)\b/i,
+  /\b(?:token|secret|password|api[-_]?key|private[-_]?key|authorization)\s*[:=]/i,
+  /-----BEGIN [A-Z0-9 ]+ PRIVATE KEY-----/i,
+  /\bssh-(?:rsa|ed25519|ecdsa)\b/i,
+]
+
+function fail(code: ContractErrorCode): never {
+  throw new Error(`eval-contract:${code}`)
+}
+
+function isRecord(value: unknown): value is RecordValue {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function record(value: unknown, code: ContractErrorCode): RecordValue {
+  if (!isRecord(value)) fail(code)
+  return value
+}
+
+function hasOwn(value: RecordValue, key: string): boolean {
+  return Object.hasOwn(value, key)
+}
+
+function assertExactKeys(
+  value: RecordValue,
+  requiredKeys: readonly string[],
+  optionalKeys: readonly string[],
+  unknownCode: ContractErrorCode,
+  missingCode: ContractErrorCode,
+): void {
+  const allowed = new Set([...requiredKeys, ...optionalKeys])
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) fail(unknownCode)
+  }
+  for (const key of requiredKeys) {
+    if (!hasOwn(value, key)) fail(missingCode)
+  }
+}
+
+function normalizedFieldName(value: string): string {
+  return value.replaceAll('_', '').replaceAll('-', '').toLowerCase()
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function serializedFieldNamePattern(value: string): string {
+  return [...value].map(escapeRegExp).join('[_-]*')
+}
+
+const BANNED_SERIALIZED_FIELD_PATTERN = new RegExp(
+  `"(?:${[...BANNED_FIELD_NAMES].map(serializedFieldNamePattern).join('|')})"\\s*:`,
+  'i',
+)
+
+function isAbsolutePath(value: string): boolean {
+  return ABSOLUTE_PATH_PATTERNS.some((pattern) => pattern.test(value))
+}
+
+function hasUnsafeSecret(value: string): boolean {
+  return SECRET_PATTERNS.some((pattern) => pattern.test(value))
+}
+
+function hasControlCharacters(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)
+    if (codePoint !== undefined && (codePoint < 0x20 || codePoint === 0x7f)) {
+      return true
+    }
+  }
+  return false
+}
+
+function assertSafeString(value: string): void {
+  if (
+    value.length === 0 ||
+    value.length > 512 ||
+    hasControlCharacters(value) ||
+    isAbsolutePath(value) ||
+    hasUnsafeSecret(value)
+  ) {
+    fail('privacy_unsafe_value')
+  }
+}
+
+function assertPrivacySafeTree(value: unknown): void {
+  if (typeof value === 'string') {
+    assertSafeString(value)
+    return
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) assertPrivacySafeTree(item)
+    return
+  }
+  if (!isRecord(value)) return
+  for (const [key, nested] of Object.entries(value)) {
+    if (BANNED_FIELD_NAMES.has(normalizedFieldName(key))) {
+      fail('privacy_banned_field')
+    }
+    assertPrivacySafeTree(nested)
+  }
+}
+
+function readString(value: unknown): string {
+  if (typeof value !== 'string') fail('result_invalid_field')
+  assertSafeString(value)
+  return value
+}
+
+function readCaseString(value: unknown): string {
+  if (typeof value !== 'string') fail('case_invalid_field')
+  assertSafeString(value)
+  return value
+}
+
+function readIdentifier(value: unknown): string {
+  const result = readString(value)
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(result)) {
+    fail('privacy_unsafe_value')
+  }
+  return result
+}
+
+function readSafeRelativeId(value: unknown): string {
+  const result = readString(value)
+  if (
+    result.startsWith('.') ||
+    result.includes('\\') ||
+    result.includes(':') ||
+    result
+      .split('/')
+      .some(
+        (segment) => segment === '' || segment === '.' || segment === '..',
+      ) ||
+    !result
+      .split('/')
+      .every((segment) => /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(segment))
+  ) {
+    fail('privacy_unsafe_value')
+  }
+  return result
+}
+
+function readHash(value: unknown): string {
+  const result = readString(value)
+  if (!/^[a-f0-9]{64}$/.test(result)) fail('result_invalid_field')
+  return result
+}
+
+function readCommitId(value: unknown): string {
+  const result = readString(value)
+  if (!/^[a-f0-9]{40}$/.test(result)) fail('result_invalid_field')
+  return result
+}
+
+function readVersion(value: unknown): string {
+  const result = readString(value)
+  if (!/^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$/.test(result)) {
+    fail('result_invalid_field')
+  }
+  return result
+}
+
+function readPackageName(value: unknown): string {
+  const result = readString(value)
+  if (!/^@?[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)?$/.test(result)) {
+    fail('result_invalid_field')
+  }
+  return result
+}
+
+function readClock(value: unknown): string {
+  const result = readString(value)
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(result)) {
+    fail('result_invalid_field')
+  }
+  const parsed = new Date(result)
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString() !== result) {
+    fail('result_invalid_field')
+  }
+  return result
+}
+
+const CLI_USAGE = [
+  'Usage: bun scripts/run-evals.ts [options]',
+  '',
+  'Options:',
+  '  --case <id>       Repeatable: bootstrap-loading | fixture-local-write',
+  '  --mode <mode>     Repeatable: source | installed',
+  '  --seed <seed>     [A-Za-z0-9][A-Za-z0-9._-]{0,127}',
+  '  --clock <UTC>     YYYY-MM-DDTHH:mm:ss.sssZ',
+  '  --help            Show this help',
+  '',
+  'Output: evals/runs/<runId>/; manifest.json is the final completion marker.',
+  'Exit codes: 0 success; 1 completed or partial run with a non-success outcome; 2 invalid arguments.',
+].join('\n')
+
+type CliErrorCode =
+  | 'unknown_argument'
+  | 'missing_value'
+  | 'missing_required'
+  | 'invalid_case'
+  | 'invalid_mode'
+  | 'invalid_seed'
+  | 'invalid_clock'
+  | 'duplicate_singleton'
+  | 'conflicting_argument'
+
+function cliFail(code: CliErrorCode): never {
+  throw new Error(`eval-cli:${code}`)
+}
+
+function isCaseId(value: string): value is CaseId {
+  return CASE_IDS.includes(value as CaseId)
+}
+
+function isEvalMode(value: string): value is EvalMode {
+  return MODES.includes(value as EvalMode)
+}
+
+function readCliSeed(value: unknown): string {
+  if (
+    typeof value !== 'string' ||
+    !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(value) ||
+    hasUnsafeSecret(value) ||
+    isAbsolutePath(value) ||
+    hasControlCharacters(value)
+  ) {
+    cliFail('invalid_seed')
+  }
+  return value
+}
+
+function readCliClock(value: unknown): string {
+  if (
+    typeof value !== 'string' ||
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)
+  ) {
+    cliFail('invalid_clock')
+  }
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString() !== value) {
+    cliFail('invalid_clock')
+  }
+  return value
+}
+
+export function buildEvalSelectionIds(
+  caseIds: readonly CaseId[],
+  modes: readonly EvalMode[],
+): string[] {
+  const cases = [...new Set(caseIds)].sort()
+  const selectedModes = [...new Set(modes)].sort()
+  if (cases.length === 0 || selectedModes.length === 0) {
+    cliFail('missing_required')
+  }
+  if (cases.some((caseId) => !isCaseId(caseId))) cliFail('invalid_case')
+  if (selectedModes.some((mode) => !isEvalMode(mode))) cliFail('invalid_mode')
+  return cases.flatMap((caseId) =>
+    selectedModes.map((mode) => `${caseId}/${mode}`),
+  )
+}
+
+type CliArgument = '--case' | '--mode' | '--seed' | '--clock'
+
+interface CliAccumulator {
+  cases: CaseId[]
+  modes: EvalMode[]
+  fixtureSeed?: string
+  normalizedClock?: string
+}
+
+function isCliArgument(value: string): value is CliArgument {
+  return (
+    value === '--case' ||
+    value === '--mode' ||
+    value === '--seed' ||
+    value === '--clock'
+  )
+}
+
+function readCliArgument(
+  argv: readonly string[],
+  index: number,
+): { argument: CliArgument; value: string; nextIndex: number } {
+  const argument = argv[index]
+  if (argument === undefined || !isCliArgument(argument)) {
+    cliFail('unknown_argument')
+  }
+  const value = argv[index + 1]
+  if (value === undefined || value.startsWith('--')) cliFail('missing_value')
+  return { argument, value, nextIndex: index + 1 }
+}
+
+function applyCliArgument(
+  accumulator: CliAccumulator,
+  argument: CliArgument,
+  value: string,
+): void {
+  switch (argument) {
+    case '--case':
+      if (!isCaseId(value)) cliFail('invalid_case')
+      accumulator.cases.push(value)
+      return
+    case '--mode':
+      if (!isEvalMode(value)) cliFail('invalid_mode')
+      accumulator.modes.push(value)
+      return
+    case '--seed':
+      if (accumulator.fixtureSeed !== undefined) {
+        cliFail('duplicate_singleton')
+      }
+      accumulator.fixtureSeed = readCliSeed(value)
+      return
+    case '--clock':
+      if (accumulator.normalizedClock !== undefined) {
+        cliFail('duplicate_singleton')
+      }
+      accumulator.normalizedClock = readCliClock(value)
+      return
+  }
+}
+
+export function parseEvalCliArgs(argv: readonly string[]): EvalCliParseResult {
+  if (argv.length === 1 && argv[0] === '--help') {
+    return { help: true, usage: CLI_USAGE }
+  }
+
+  const accumulator: CliAccumulator = { cases: [], modes: [] }
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === '--help') cliFail('conflicting_argument')
+    const parsed = readCliArgument(argv, index)
+    applyCliArgument(accumulator, parsed.argument, parsed.value)
+    index = parsed.nextIndex
+  }
+
+  if (
+    accumulator.cases.length === 0 ||
+    accumulator.modes.length === 0 ||
+    accumulator.fixtureSeed === undefined ||
+    accumulator.normalizedClock === undefined
+  ) {
+    cliFail('missing_required')
+  }
+
+  const sortedCases = [...new Set(accumulator.cases)].sort()
+  const sortedModes = [...new Set(accumulator.modes)].sort()
+  return {
+    cases: sortedCases,
+    modes: sortedModes,
+    fixtureSeed: accumulator.fixtureSeed,
+    normalizedClock: accumulator.normalizedClock,
+    selectionIds: buildEvalSelectionIds(sortedCases, sortedModes),
+  }
+}
+
+function readInteger(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
+    fail('result_invalid_field')
+  }
+  return value
+}
+
+function readSortedIdentifiers(
+  value: unknown,
+  expected: readonly string[],
+  code: ContractErrorCode,
+): string[] {
+  if (!Array.isArray(value) || value.length === 0) fail(code)
+  const identifiers: string[] = []
+  for (const item of value) {
+    if (
+      typeof item !== 'string' ||
+      !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(item)
+    ) {
+      fail(code)
+    }
+    assertSafeString(item)
+    if (identifiers.includes(item)) fail(code)
+    identifiers.push(item)
+  }
+  const sorted = [...identifiers].sort()
+  if (
+    sorted.length !== expected.length ||
+    sorted.some((item, index) => item !== expected[index])
+  ) {
+    fail(code)
+  }
+  return sorted
+}
+
+function readSortedArtifactRefs(value: unknown): string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    fail('result_invalid_field')
+  }
+  const refs: string[] = []
+  for (const item of value) {
+    const ref = readSafeRelativeId(item)
+    if (refs.includes(ref)) fail('result_invalid_field')
+    refs.push(ref)
+  }
+  return refs.sort()
+}
+
+function readOutcome(value: unknown): EvalOutcome {
+  if (typeof value !== 'string' || !OUTCOMES.includes(value as EvalOutcome)) {
+    fail('result_invalid_outcome')
+  }
+  return value as EvalOutcome
+}
+
+function readMode(value: unknown): EvalMode {
+  if (typeof value !== 'string' || !MODES.includes(value as EvalMode)) {
+    fail('result_invalid_field')
+  }
+  return value as EvalMode
+}
+
+function readSubcode(value: unknown, outcome: EvalOutcome): EvalSubcode {
+  const allowedSubcodes: readonly string[] = OUTCOME_SUBCODES[outcome]
+  if (typeof value !== 'string' || !allowedSubcodes.includes(value)) {
+    fail('result_invalid_subcode')
+  }
+  return value as EvalSubcode
+}
+
+function normalizeIdentity(value: unknown): EvalIdentity {
+  const input = record(value, 'result_invalid_field')
+  assertExactKeys(
+    input,
+    [
+      'opencodeVersion',
+      'opencodeBuildId',
+      'probeId',
+      'probeDigest',
+      'fixtureContractVersion',
+      'fixtureContractDigest',
+      'caseSchemaVersion',
+      'resultSchemaVersion',
+      'artifactId',
+      'artifactDigest',
+    ],
+    [],
+    'result_unknown_field',
+    'result_missing_field',
+  )
+  const caseSchemaVersion = readInteger(input.caseSchemaVersion)
+  const resultSchemaVersion = readInteger(input.resultSchemaVersion)
+  if (
+    caseSchemaVersion !== CASE_SCHEMA_VERSION ||
+    resultSchemaVersion !== RESULT_SCHEMA_VERSION
+  ) {
+    fail('result_invalid_field')
+  }
+  return {
+    opencodeVersion: readVersion(input.opencodeVersion),
+    opencodeBuildId: readIdentifier(input.opencodeBuildId),
+    probeId: readIdentifier(input.probeId),
+    probeDigest: readHash(input.probeDigest),
+    fixtureContractVersion: readInteger(input.fixtureContractVersion),
+    fixtureContractDigest: readHash(input.fixtureContractDigest),
+    caseSchemaVersion,
+    resultSchemaVersion,
+    artifactId: readIdentifier(input.artifactId),
+    artifactDigest: readHash(input.artifactDigest),
+  }
+}
+
+function normalizeEvidence(
+  value: unknown,
+  assertionIds: readonly string[],
+): EvalEvidence {
+  const input = record(value, 'result_invalid_field')
+  assertExactKeys(
+    input,
+    ['sanity', 'process', 'assertionIds'],
+    [],
+    'result_unknown_field',
+    'result_missing_field',
+  )
+  const sanity = input.sanity
+  const process = input.process
+  if (sanity !== 'passed' && sanity !== 'failed') fail('result_invalid_field')
+  if (process !== 'completed' && process !== 'failed')
+    fail('result_invalid_field')
+  const normalizedAssertionIds = readSortedIdentifiers(
+    input.assertionIds,
+    assertionIds,
+    'result_invalid_field',
+  )
+  return {
+    sanity,
+    process,
+    assertionIds: normalizedAssertionIds,
+  }
+}
+
+function normalizeCleanup(value: unknown): EvalCleanupState {
+  const input = record(value, 'result_invalid_field')
+  assertExactKeys(
+    input,
+    ['status', 'residue'],
+    [],
+    'result_unknown_field',
+    'result_missing_field',
+  )
+  const status = input.status
+  const residue = input.residue
+  if (status !== 'clean' && status !== 'residue' && status !== 'quarantined') {
+    fail('result_invalid_field')
+  }
+  if (
+    residue !== 'none' &&
+    residue !== 'detected' &&
+    residue !== 'quarantined'
+  ) {
+    fail('result_invalid_field')
+  }
+  if (
+    (status === 'clean' && residue !== 'none') ||
+    (status === 'residue' && residue !== 'detected') ||
+    (status === 'quarantined' && residue !== 'quarantined')
+  ) {
+    fail('result_invalid_field')
+  }
+  return { status, residue }
+}
+
+function normalizePrivacy(value: unknown): EvalPrivacyState {
+  const input = record(value, 'result_invalid_field')
+  assertExactKeys(
+    input,
+    ['status'],
+    [],
+    'result_unknown_field',
+    'result_missing_field',
+  )
+  if (input.status !== 'validated' && input.status !== 'rejected') {
+    fail('result_invalid_field')
+  }
+  return { status: input.status }
+}
+
+function normalizeProvenance(
+  value: unknown,
+  mode: EvalMode,
+): SourceProvenance | InstalledProvenance {
+  const input = record(value, 'result_invalid_provenance')
+  const kind = input.kind
+  if (kind === 'source') {
+    if (mode !== 'source') fail('result_invalid_provenance')
+    assertExactKeys(
+      input,
+      [
+        'kind',
+        'checkoutRelativeSource',
+        'commitId',
+        'worktreeId',
+        'canonicalSourceEntryId',
+        'opencodeConfigEntryId',
+      ],
+      [],
+      'result_invalid_provenance',
+      'result_invalid_provenance',
+    )
+    return {
+      kind,
+      checkoutRelativeSource: readSafeRelativeId(input.checkoutRelativeSource),
+      commitId: readCommitId(input.commitId),
+      worktreeId: readIdentifier(input.worktreeId),
+      canonicalSourceEntryId: readIdentifier(input.canonicalSourceEntryId),
+      opencodeConfigEntryId: readIdentifier(input.opencodeConfigEntryId),
+    }
+  }
+  if (kind === 'installed') {
+    if (mode !== 'installed') fail('result_invalid_provenance')
+    assertExactKeys(
+      input,
+      [
+        'kind',
+        'packageName',
+        'packageVersion',
+        'tarballDigest',
+        'extractedPackageRootId',
+        'canonicalResolvedModuleEntryId',
+        'opencodeConfigEntryId',
+      ],
+      [],
+      'result_invalid_provenance',
+      'result_invalid_provenance',
+    )
+    return {
+      kind,
+      packageName: readPackageName(input.packageName),
+      packageVersion: readVersion(input.packageVersion),
+      tarballDigest: readHash(input.tarballDigest),
+      extractedPackageRootId: readIdentifier(input.extractedPackageRootId),
+      canonicalResolvedModuleEntryId: readSafeRelativeId(
+        input.canonicalResolvedModuleEntryId,
+      ),
+      opencodeConfigEntryId: readIdentifier(input.opencodeConfigEntryId),
+    }
+  }
+  fail('result_invalid_provenance')
+}
+
+export function parseCaseManifest(input: unknown): EvalCaseManifest {
+  assertPrivacySafeTree(input)
+  const value = record(input, 'case_invalid_shape')
+  const caseId = value.caseId
+  if (caseId !== 'bootstrap-loading' && caseId !== 'fixture-local-write') {
+    fail('case_unsupported')
+  }
+
+  if (caseId === 'bootstrap-loading') {
+    assertExactKeys(
+      value,
+      ['caseSchemaVersion', 'caseId', 'harness', 'assertionIds'],
+      [],
+      'case_unknown_field',
+      'case_missing_field',
+    )
+    if (value.caseSchemaVersion !== CASE_SCHEMA_VERSION) {
+      fail('case_wrong_version')
+    }
+    if (value.harness !== HARNESS) fail('case_invalid_field')
+    const assertionIds = readSortedIdentifiers(
+      value.assertionIds,
+      CASE_ASSERTIONS[caseId],
+      'case_invalid_field',
+    )
+    return {
+      caseSchemaVersion: CASE_SCHEMA_VERSION,
+      caseId,
+      harness: HARNESS,
+      assertionIds,
+    }
+  }
+
+  assertExactKeys(
+    value,
+    [
+      'caseSchemaVersion',
+      'caseId',
+      'harness',
+      'assertionIds',
+      'expectedArtifactId',
+      'expectedContentId',
+    ],
+    [],
+    'case_unknown_field',
+    'case_missing_field',
+  )
+  if (value.caseSchemaVersion !== CASE_SCHEMA_VERSION) {
+    fail('case_wrong_version')
+  }
+  if (value.harness !== HARNESS) fail('case_invalid_field')
+  const assertionIds = readSortedIdentifiers(
+    value.assertionIds,
+    CASE_ASSERTIONS[caseId],
+    'case_invalid_field',
+  )
+  const expectedArtifactId = readSafeRelativeId(value.expectedArtifactId)
+  const expectedContentId = readCaseString(value.expectedContentId)
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(expectedContentId)) {
+    fail('case_invalid_field')
+  }
+  return {
+    caseSchemaVersion: CASE_SCHEMA_VERSION,
+    caseId,
+    harness: HARNESS,
+    assertionIds,
+    expectedArtifactId,
+    expectedContentId,
+  }
+}
+
+export function normalizeResult(input: unknown): EvalResult {
+  assertPrivacySafeTree(input)
+  const value = record(input, 'result_invalid_shape')
+  assertExactKeys(
+    value,
+    RESULT_REQUIRED_KEYS,
+    ['subcode'],
+    'result_unknown_field',
+    'result_missing_field',
+  )
+
+  if (value.resultSchemaVersion !== RESULT_SCHEMA_VERSION) {
+    fail('result_invalid_field')
+  }
+  if (value.caseSchemaVersion !== CASE_SCHEMA_VERSION) {
+    fail('result_invalid_field')
+  }
+  if (value.harness !== HARNESS) fail('result_invalid_field')
+
+  const caseId = value.caseId
+  if (caseId !== 'bootstrap-loading' && caseId !== 'fixture-local-write') {
+    fail('result_invalid_field')
+  }
+  const mode = readMode(value.mode)
+  const outcome = readOutcome(value.outcome)
+  const subcode = hasOwn(value, 'subcode')
+    ? readSubcode(value.subcode, outcome)
+    : undefined
+  const assertionIds = readSortedIdentifiers(
+    value.assertionIds,
+    CASE_ASSERTIONS[caseId],
+    'result_invalid_field',
+  )
+  const identity = normalizeIdentity(value.identity)
+  if (
+    identity.caseSchemaVersion !== value.caseSchemaVersion ||
+    identity.resultSchemaVersion !== value.resultSchemaVersion
+  ) {
+    fail('result_invalid_field')
+  }
+
+  const normalized: EvalResult = {
+    resultSchemaVersion: RESULT_SCHEMA_VERSION,
+    caseSchemaVersion: CASE_SCHEMA_VERSION,
+    caseId,
+    harness: HARNESS,
+    mode,
+    outcome,
+    runId: readIdentifier(value.runId),
+    fixtureSeed: readIdentifier(value.fixtureSeed),
+    normalizedClock: readClock(value.normalizedClock),
+    assertionIds,
+    identity,
+    evidence: normalizeEvidence(value.evidence, assertionIds),
+    cleanup: normalizeCleanup(value.cleanup),
+    privacy: normalizePrivacy(value.privacy),
+    artifactRefs: readSortedArtifactRefs(value.artifactRefs),
+    provenance: normalizeProvenance(value.provenance, mode),
+  }
+  if (subcode !== undefined) normalized.subcode = subcode
+  return normalized
+}
+
+export function redactResult(input: unknown): EvalResult {
+  return normalizeResult(input)
+}
+
+function readSelectionId(value: unknown, code: ContractErrorCode): string {
+  if (typeof value !== 'string') fail(code)
+  const separator = value.indexOf('/')
+  if (separator <= 0 || separator === value.length - 1) fail(code)
+  const caseId = value.slice(0, separator)
+  const mode = value.slice(separator + 1)
+  if (!isCaseId(caseId) || !isEvalMode(mode)) fail(code)
+  return `${caseId}/${mode}`
+}
+
+function readSortedSelectionIds(
+  value: unknown,
+  allowEmpty: boolean,
+  code: ContractErrorCode,
+): string[] {
+  if (!Array.isArray(value) || (!allowEmpty && value.length === 0)) {
+    fail(code)
+  }
+  const selectionIds: string[] = []
+  for (const item of value) {
+    const selectionId = readSelectionId(item, code)
+    if (selectionIds.includes(selectionId)) fail(code)
+    selectionIds.push(selectionId)
+  }
+  return selectionIds.sort()
+}
+
+function normalizeRunSummary(value: unknown): EvalRunResultSummary {
+  const input = record(value, 'manifest_invalid_summary')
+  assertExactKeys(
+    input,
+    ['selectionId', 'resultArtifactId', 'outcome', 'subcode'],
+    [],
+    'manifest_invalid_summary',
+    'manifest_invalid_summary',
+  )
+  const selectionId = readSelectionId(
+    input.selectionId,
+    'manifest_invalid_summary',
+  )
+  const outcome = readOutcome(input.outcome)
+  return {
+    selectionId,
+    resultArtifactId: readSafeRelativeId(input.resultArtifactId),
+    outcome,
+    subcode: readSubcode(input.subcode, outcome),
+  }
+}
+
+export function normalizeRunManifest(input: unknown): EvalRunManifest {
+  assertPrivacySafeTree(input)
+  const value = record(input, 'manifest_invalid_shape')
+  assertExactKeys(
+    value,
+    RUN_MANIFEST_REQUIRED_KEYS,
+    [],
+    'manifest_unknown_field',
+    'manifest_missing_field',
+  )
+  if (value.manifestSchemaVersion !== RUN_MANIFEST_SCHEMA_VERSION) {
+    fail('manifest_invalid_field')
+  }
+  if (value.harness !== HARNESS) fail('manifest_invalid_field')
+
+  const runId = readIdentifier(value.runId)
+  const requestedSelectionIds = readSortedSelectionIds(
+    value.requestedSelectionIds,
+    false,
+    'manifest_invalid_field',
+  )
+  const completedSelectionIds = readSortedSelectionIds(
+    value.completedSelectionIds,
+    true,
+    'manifest_invalid_field',
+  )
+  if (typeof value.partial !== 'boolean') fail('manifest_invalid_state')
+  const partial = value.partial
+  if (
+    completedSelectionIds.some(
+      (selectionId) => !requestedSelectionIds.includes(selectionId),
+    ) ||
+    partial !== (completedSelectionIds.length !== requestedSelectionIds.length)
+  ) {
+    fail('manifest_invalid_state')
+  }
+
+  if (!Array.isArray(value.results)) fail('manifest_invalid_summary')
+  const results = value.results.map(normalizeRunSummary)
+  const seenArtifactIds = new Set<string>()
+  for (const result of results) {
+    if (
+      !completedSelectionIds.includes(result.selectionId) ||
+      seenArtifactIds.has(result.resultArtifactId)
+    ) {
+      fail('manifest_invalid_summary')
+    }
+    seenArtifactIds.add(result.resultArtifactId)
+  }
+  const resultSelectionIds = results.map((result) => result.selectionId).sort()
+  if (
+    resultSelectionIds.length !== completedSelectionIds.length ||
+    resultSelectionIds.some(
+      (selectionId, index) => selectionId !== completedSelectionIds[index],
+    )
+  ) {
+    fail('manifest_invalid_summary')
+  }
+
+  return {
+    manifestSchemaVersion: RUN_MANIFEST_SCHEMA_VERSION,
+    harness: HARNESS,
+    runId,
+    requestedSelectionIds,
+    completedSelectionIds,
+    partial,
+    results: results.sort((left, right) =>
+      left.selectionId.localeCompare(right.selectionId),
+    ),
+  }
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => canonicalize(item))
+  if (!isRecord(value)) return value
+  const result: RecordValue = {}
+  for (const key of Object.keys(value).sort()) {
+    result[key] = canonicalize(value[key])
+  }
+  return result
+}
+
+function canonicalJson(value: unknown): string {
+  const serialized = JSON.stringify(canonicalize(value))
+  if (typeof serialized !== 'string') fail('serialized_invalid_json')
+  return serialized
+}
+
+function decodeSerializedResult(input: string | Uint8Array): string {
+  if (typeof input === 'string') return input
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(input)
+  } catch {
+    fail('serialized_invalid_encoding')
+  }
+}
+
+export function assertSerializedTextSafe(serialized: string): void {
+  if (
+    BANNED_SERIALIZED_FIELD_PATTERN.test(serialized) ||
+    hasUnsafeSecret(serialized) ||
+    /(?:["':]|^)(?:\/|\\\\|[A-Za-z]:[\\/]|file:\/\/)/i.test(serialized)
+  ) {
+    fail('privacy_unsafe_value')
+  }
+}
+
+export function validateSerializedResult(
+  input: string | Uint8Array,
+): EvalResult {
+  const serialized = decodeSerializedResult(input)
+  if (serialized.startsWith('\uFEFF')) fail('serialized_invalid_json')
+  assertSerializedTextSafe(serialized)
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(serialized) as unknown
+  } catch {
+    fail('serialized_invalid_json')
+  }
+  return normalizeResult(parsed)
+}
+
+export function serializeResult(input: unknown): string {
+  const normalized = redactResult(input)
+  const serialized = canonicalJson(normalized)
+  validateSerializedResult(serialized)
+  return serialized
+}
+
+export function validateSerializedRunManifest(
+  input: string | Uint8Array,
+): EvalRunManifest {
+  const serialized = decodeSerializedResult(input)
+  if (serialized.startsWith('\uFEFF')) fail('serialized_invalid_json')
+  assertSerializedTextSafe(serialized)
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(serialized) as unknown
+  } catch {
+    fail('serialized_invalid_json')
+  }
+  return normalizeRunManifest(parsed)
+}
+
+export function serializeRunManifest(input: unknown): string {
+  const normalized = normalizeRunManifest(input)
+  const serialized = canonicalJson(normalized)
+  validateSerializedRunManifest(serialized)
+  return serialized
+}
+
+export const EXPECTED_OPENCODE_VERSION = '1.18.5' as const
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..')
+const FIXTURE_CONTRACT_VERSION = 1 as const
+const FIXTURE_CONTRACT_DIGEST = createHash('sha256')
+  .update('systematic-eval-fixture-contract-v1')
+  .digest('hex')
+const EXECUTION_PATH =
+  process.env.PATH ?? '/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin'
+const ZERO_DIGEST = '0'.repeat(64)
+
+function sha256Text(value: string): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function sha256File(filePath: string, fallback: string): string {
+  try {
+    return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')
+  } catch {
+    return sha256Text(fallback)
+  }
+}
+
+function ensureSafeFixtureId(value: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(value)) {
+    throw new Error('eval-path:invalid_fixture_id')
+  }
+}
+
+function ensureDirectory(directory: string): void {
+  fs.mkdirSync(directory, { recursive: true })
+}
+
+function canonicalizePath(value: string): string {
+  let current = path.resolve(value)
+  const suffix: string[] = []
+  while (!fs.existsSync(current)) {
+    const parent = path.dirname(current)
+    if (parent === current) return path.resolve(current, ...suffix)
+    suffix.unshift(path.basename(current))
+    current = parent
+  }
+  return path.resolve(fs.realpathSync(current), ...suffix)
+}
+
+function isContained(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate)
+  return (
+    relative === '' ||
+    (relative !== '..' &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  )
+}
+
+export function assertEvalPathContained(
+  root: string,
+  candidate: string,
+): string {
+  const canonicalRoot = canonicalizePath(root)
+  const canonicalCandidate = canonicalizePath(candidate)
+  if (!isContained(canonicalRoot, canonicalCandidate)) {
+    throw new Error('eval-path:path_escape')
+  }
+  return canonicalCandidate
+}
+
+function tryMakePrivateDirectory(directory: string): void {
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 })
+  try {
+    fs.chmodSync(directory, 0o700)
+  } catch {
+    // Some filesystems do not support chmod; creation still remains best effort.
+  }
+}
+
+function persistFail(
+  code: 'invalid_input' | 'run_exists' | 'atomic_write_failed',
+): never {
+  throw new Error(`eval-persist:${code}`)
+}
+
+function selectionIdFor(caseId: CaseId, mode: EvalMode): string {
+  return `${caseId}/${mode}`
+}
+
+interface NormalizedPersistedResult {
+  selectionId: string
+  artifactId: string
+  serialized: string
+}
+
+interface PendingPersistedFile {
+  relativeId: string
+  bytes: Buffer
+  target: string
+  temporary: string
+}
+
+function normalizePersistedResults(
+  manifest: EvalRunManifest,
+  candidates: readonly unknown[],
+): NormalizedPersistedResult[] {
+  const summaryBySelection = new Map(
+    manifest.results.map((summary) => [summary.selectionId, summary]),
+  )
+  const normalizedResults: NormalizedPersistedResult[] = []
+  const seenSelections = new Set<string>()
+  for (const candidate of candidates) {
+    const result = normalizeResult(candidate)
+    const selectionId = selectionIdFor(result.caseId, result.mode)
+    const summary = summaryBySelection.get(selectionId)
+    const subcode = result.subcode ?? 'none'
+    const matchesSummary =
+      summary !== undefined &&
+      !seenSelections.has(selectionId) &&
+      summary.outcome === result.outcome &&
+      summary.subcode === subcode
+    if (result.runId !== manifest.runId || !matchesSummary) {
+      persistFail('invalid_input')
+    }
+    const serialized = serializeResult(result)
+    validateSerializedResult(new TextEncoder().encode(serialized))
+    normalizedResults.push({
+      selectionId,
+      artifactId: summary.resultArtifactId,
+      serialized,
+    })
+    seenSelections.add(selectionId)
+  }
+  if (seenSelections.size !== manifest.completedSelectionIds.length) {
+    persistFail('invalid_input')
+  }
+  return normalizedResults.sort((left, right) =>
+    left.selectionId.localeCompare(right.selectionId),
+  )
+}
+
+function preparePendingPersistedFiles(
+  runRoot: string,
+  files: ReadonlyArray<{ relativeId: string; bytes: Buffer }>,
+): PendingPersistedFile[] {
+  return files.map((file) => {
+    const target = assertEvalPathContained(
+      runRoot,
+      path.join(runRoot, file.relativeId),
+    )
+    if (fs.existsSync(target)) persistFail('run_exists')
+    const temporary = path.join(
+      path.dirname(target),
+      `.${path.basename(target)}.tmp.${randomUUID()}`,
+    )
+    assertEvalPathContained(runRoot, temporary)
+    return { ...file, target, temporary }
+  })
+}
+
+function writePersistedTemps(files: readonly PendingPersistedFile[]): void {
+  for (const file of files) {
+    tryMakePrivateDirectory(path.dirname(file.target))
+    fs.writeFileSync(file.temporary, file.bytes, {
+      flag: 'wx',
+      mode: 0o600,
+    })
+    try {
+      fs.chmodSync(file.temporary, 0o600)
+    } catch {
+      // Some filesystems do not support chmod; creation still remains best effort.
+    }
+  }
+}
+
+function renamePersistedTemps(
+  files: readonly PendingPersistedFile[],
+  createdFinals: string[],
+  onRename?: (relativeId: string) => void,
+): void {
+  for (const file of files) {
+    onRename?.(file.relativeId)
+    fs.renameSync(file.temporary, file.target)
+    createdFinals.push(file.target)
+    try {
+      fs.chmodSync(file.target, 0o600)
+    } catch {
+      // Some filesystems do not support chmod; creation still remains best effort.
+    }
+  }
+}
+
+function writePersistedFiles(
+  runsRoot: string,
+  runRoot: string,
+  files: readonly PendingPersistedFile[],
+  onRename?: (relativeId: string) => void,
+): void {
+  const createdFinals: string[] = []
+  let createdRunRoot = false
+  try {
+    tryMakePrivateDirectory(runsRoot)
+    fs.mkdirSync(runRoot, { mode: 0o700 })
+    createdRunRoot = true
+    try {
+      fs.chmodSync(runRoot, 0o700)
+    } catch {
+      // Some filesystems do not support chmod; creation still remains best effort.
+    }
+    writePersistedTemps(files)
+    renamePersistedTemps(files, createdFinals, onRename)
+  } catch {
+    for (const file of files) fs.rmSync(file.temporary, { force: true })
+    for (const file of createdFinals) fs.rmSync(file, { force: true })
+    if (createdRunRoot) fs.rmSync(runRoot, { recursive: true, force: true })
+    persistFail('atomic_write_failed')
+  }
+}
+
+export function persistEvalRun(
+  options: PersistEvalRunOptions,
+): PersistedEvalRun {
+  const manifest = normalizeRunManifest(options.manifest)
+  const serializedManifest = serializeRunManifest(manifest)
+  validateSerializedRunManifest(new TextEncoder().encode(serializedManifest))
+  if (!Array.isArray(options.results)) persistFail('invalid_input')
+  const normalizedResults = normalizePersistedResults(manifest, options.results)
+  const runsRoot = path.resolve(
+    options.runsRoot ??
+      path.join(options.rootDir ?? REPO_ROOT, 'evals', 'runs'),
+  )
+  const runRoot = path.join(runsRoot, manifest.runId)
+  assertEvalPathContained(runsRoot, runRoot)
+  if (
+    manifest.results.some(
+      (summary) => summary.resultArtifactId === 'manifest.json',
+    )
+  ) {
+    persistFail('invalid_input')
+  }
+  if (fs.existsSync(runRoot)) persistFail('run_exists')
+
+  const pendingFiles = preparePendingPersistedFiles(runRoot, [
+    ...normalizedResults.map((result) => ({
+      relativeId: result.artifactId,
+      bytes: Buffer.from(result.serialized),
+    })),
+    { relativeId: 'manifest.json', bytes: Buffer.from(serializedManifest) },
+  ])
+  writePersistedFiles(runsRoot, runRoot, pendingFiles, options.onRename)
+  return {
+    status: 'written',
+    runId: manifest.runId,
+    manifestArtifactId: 'manifest.json',
+    resultArtifactIds: normalizedResults.map((result) => result.artifactId),
+  }
+}
+
+function fixtureControlledPaths(fixture: EvalFixture): string[] {
+  return [
+    fixture.runRoot,
+    fixture.caseRoot,
+    fixture.modeRoot,
+    fixture.projectRoot,
+    fixture.homeRoot,
+    fixture.xdgConfigRoot,
+    fixture.xdgDataRoot,
+    fixture.xdgCacheRoot,
+    fixture.xdgStateRoot,
+    fixture.opencodeConfigRoot,
+    fixture.opencodeConfigPath,
+    fixture.probeRoot,
+    fixture.npmCacheRoot,
+    fixture.npmPrefixRoot,
+    fixture.npmUserConfigPath,
+    fixture.artifactRoot,
+    fixture.tarballPath,
+    fixture.stagingRoot,
+    fixture.packageRoot,
+    fixture.provenanceRoot,
+    fixture.tmpRoot,
+  ]
+}
+
+function assertFixturePathsContained(fixture: EvalFixture): void {
+  for (const controlledPath of fixtureControlledPaths(fixture)) {
+    assertEvalPathContained(fixture.runRoot, controlledPath)
+  }
+}
+
+export function createEvalFixture(
+  options: CreateEvalFixtureOptions,
+): EvalFixture {
+  ensureSafeFixtureId(options.runId)
+
+  const parentDir = path.resolve(options.parentDir ?? os.tmpdir())
+  ensureDirectory(parentDir)
+  const runRoot = fs.mkdtempSync(
+    path.join(fs.realpathSync(parentDir), 'systematic-eval-'),
+  )
+  const caseRoot = path.join(runRoot, options.caseId)
+  const modeRoot = path.join(caseRoot, options.mode)
+  const fixture: EvalFixture = {
+    mode: options.mode,
+    runRoot,
+    caseRoot,
+    modeRoot,
+    projectRoot: path.join(modeRoot, 'project'),
+    homeRoot: path.join(modeRoot, 'home'),
+    xdgConfigRoot: path.join(modeRoot, 'xdg-config'),
+    xdgDataRoot: path.join(modeRoot, 'xdg-data'),
+    xdgCacheRoot: path.join(modeRoot, 'xdg-cache'),
+    xdgStateRoot: path.join(modeRoot, 'xdg-state'),
+    opencodeConfigRoot: path.join(modeRoot, 'opencode-config'),
+    opencodeConfigPath: path.join(modeRoot, 'opencode-config', 'opencode.json'),
+    probeRoot: path.join(modeRoot, 'probe'),
+    npmCacheRoot: path.join(modeRoot, 'npm-cache'),
+    npmPrefixRoot: path.join(modeRoot, 'npm-prefix'),
+    npmUserConfigPath: path.join(modeRoot, 'npmrc'),
+    artifactRoot: path.join(modeRoot, 'artifact'),
+    tarballPath: path.join(modeRoot, 'artifact', 'package.tgz'),
+    stagingRoot: path.join(modeRoot, 'artifact', 'staging'),
+    packageRoot: path.join(modeRoot, 'package-root'),
+    provenanceRoot: path.join(modeRoot, 'provenance'),
+    tmpRoot: path.join(modeRoot, 'tmp'),
+  }
+
+  for (const directory of [
+    fixture.caseRoot,
+    fixture.modeRoot,
+    fixture.projectRoot,
+    fixture.homeRoot,
+    fixture.xdgConfigRoot,
+    fixture.xdgDataRoot,
+    fixture.xdgCacheRoot,
+    fixture.xdgStateRoot,
+    fixture.opencodeConfigRoot,
+    fixture.probeRoot,
+    fixture.npmCacheRoot,
+    fixture.npmPrefixRoot,
+    fixture.artifactRoot,
+    fixture.stagingRoot,
+    fixture.packageRoot,
+    fixture.provenanceRoot,
+    fixture.tmpRoot,
+  ]) {
+    ensureDirectory(directory)
+  }
+
+  fs.writeFileSync(
+    path.join(fixture.projectRoot, 'package.json'),
+    JSON.stringify({
+      name: 'systematic-eval-fixture',
+      private: true,
+      type: 'module',
+    }),
+  )
+  fs.writeFileSync(fixture.npmUserConfigPath, '# isolated eval npm config\n')
+  assertFixturePathsContained(fixture)
+  return fixture
+}
+
+export function cleanupEvalFixture(fixture: EvalFixture): void {
+  fs.rmSync(fixture.runRoot, { recursive: true, force: true })
+}
+
+interface CleanupResolution {
+  cleanup: EvalCleanupState
+  failureSubcode?: 'residue_detected' | 'quarantine_failed'
+}
+
+function uniqueQuarantineRoot(fixture: EvalFixture, runId: string): string {
+  const parentDir = path.dirname(fixture.runRoot)
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const candidate = path.join(
+      parentDir,
+      `systematic-eval-quarantine-${runId}-${randomUUID().replaceAll('-', '')}`,
+    )
+    assertEvalPathContained(parentDir, candidate)
+    if (!fs.existsSync(candidate)) return candidate
+  }
+  throw new Error('eval-cleanup:quarantine_target_unavailable')
+}
+
+async function cleanupCaseFixture(
+  fixture: EvalFixture,
+  runId: string,
+  hooks: EvalLifecycleHooks | undefined,
+): Promise<CleanupResolution> {
+  let cleanupFailed = false
+  try {
+    if (hooks?.cleanupFixture) {
+      await hooks.cleanupFixture(fixture)
+    } else {
+      cleanupEvalFixture(fixture)
+    }
+  } catch {
+    cleanupFailed = true
+  }
+
+  if (!fs.existsSync(fixture.runRoot)) {
+    return {
+      cleanup: { status: 'clean', residue: 'none' },
+      ...(cleanupFailed ? { failureSubcode: 'residue_detected' as const } : {}),
+    }
+  }
+
+  let quarantineRoot: string
+  try {
+    quarantineRoot = uniqueQuarantineRoot(fixture, runId)
+    if (hooks?.quarantineResidue) {
+      await hooks.quarantineResidue(fixture, quarantineRoot)
+    } else {
+      fs.renameSync(fixture.runRoot, quarantineRoot)
+    }
+  } catch {
+    return {
+      cleanup: { status: 'residue', residue: 'detected' },
+      failureSubcode: 'quarantine_failed',
+    }
+  }
+
+  if (!fs.existsSync(fixture.runRoot) && fs.existsSync(quarantineRoot)) {
+    return {
+      cleanup: { status: 'quarantined', residue: 'quarantined' },
+      failureSubcode: 'residue_detected',
+    }
+  }
+
+  return {
+    cleanup: { status: 'residue', residue: 'detected' },
+    failureSubcode: 'quarantine_failed',
+  }
+}
+
+function registerActiveEvalFixture(
+  fixture: EvalFixture,
+  runId: string,
+  hooks: EvalLifecycleHooks | undefined,
+): void {
+  activeEvalFixtures.set(fixture, { fixture, runId, hooks })
+}
+
+function unregisterActiveEvalFixture(fixture: EvalFixture): void {
+  activeEvalFixtures.delete(fixture)
+}
+
+async function cleanupRegisteredEvalFixture(
+  fixture: EvalFixture,
+  fallbackRunId: string,
+  fallbackHooks: EvalLifecycleHooks | undefined,
+): Promise<CleanupResolution> {
+  const completed = completedFixtureCleanups.get(fixture)
+  if (completed) return completed
+
+  const registration = activeEvalFixtures.get(fixture)
+  if (!registration) {
+    const cleanup = await cleanupCaseFixture(
+      fixture,
+      fallbackRunId,
+      fallbackHooks,
+    )
+    completedFixtureCleanups.set(fixture, cleanup)
+    return cleanup
+  }
+
+  registration.cleanupPromise ??= cleanupCaseFixture(
+    registration.fixture,
+    registration.runId,
+    registration.hooks,
+  )
+  const cleanup = await registration.cleanupPromise
+  completedFixtureCleanups.set(fixture, cleanup)
+  return cleanup
+}
+
+const MAX_NPM_TARBALL_BYTES = 128 * 1024 * 1024
+const MAX_NPM_TAR_ENTRIES = 10_000
+
+function artifactFailure(code: 'artifact_resolution' | 'path_escape'): never {
+  throw new Error(`eval-artifact:${code}`)
+}
+
+function readTarText(
+  header: Buffer,
+  offset: number,
+  length: number,
+  allowEmpty = true,
+): string {
+  const bytes = header.subarray(offset, offset + length)
+  const nulIndex = bytes.indexOf(0)
+  const valueBytes = nulIndex === -1 ? bytes : bytes.subarray(0, nulIndex)
+  let value: string
+  try {
+    value = new TextDecoder('utf-8', { fatal: true }).decode(valueBytes)
+  } catch {
+    artifactFailure('artifact_resolution')
+  }
+  if (!allowEmpty && value.length === 0) artifactFailure('artifact_resolution')
+  for (const character of value) {
+    const code = character.charCodeAt(0)
+    if (code < 0x20 || code === 0x7f) artifactFailure('artifact_resolution')
+  }
+  return value
+}
+
+function readTarOctal(header: Buffer, offset: number, length: number): number {
+  const raw = header
+    .subarray(offset, offset + length)
+    .toString('ascii')
+    .replace(/\0.*$/, '')
+    .trim()
+  if (!/^[0-7]+$/.test(raw)) artifactFailure('artifact_resolution')
+  const value = Number.parseInt(raw, 8)
+  if (!Number.isSafeInteger(value) || value < 0) {
+    artifactFailure('artifact_resolution')
+  }
+  return value
+}
+
+function validateTarPath(value: string, allowRoot: boolean): string {
+  if (
+    value.length === 0 ||
+    value.startsWith('/') ||
+    value.startsWith('\\') ||
+    /^file:/i.test(value) ||
+    /^[A-Za-z]:[\\/]/.test(value) ||
+    value.startsWith('//') ||
+    value.startsWith('\\\\')
+  ) {
+    artifactFailure('path_escape')
+  }
+  const segments = value.split(/[\\/]/)
+  if (
+    segments.some((segment, index) => {
+      if (segment === '' && index !== segments.length - 1) return true
+      return segment === '.' || segment === '..'
+    })
+  ) {
+    artifactFailure('path_escape')
+  }
+  if (segments[0] !== 'package') artifactFailure('path_escape')
+  const relative = segments.slice(1).join('/')
+  if (relative === '' && !allowRoot) artifactFailure('artifact_resolution')
+  return relative.replace(/\/$/, '')
+}
+
+function isZeroTarBlock(block: Buffer): boolean {
+  for (const byte of block) if (byte !== 0) return false
+  return true
+}
+
+function validateTarHeaderChecksum(header: Buffer): void {
+  const stored = readTarOctal(header, 148, 8)
+  let actual = 0
+  for (let index = 0; index < header.length; index += 1) {
+    actual += index >= 148 && index < 156 ? 0x20 : header[index]
+  }
+  if (actual !== stored) artifactFailure('artifact_resolution')
+}
+
+function readNpmTarEntryType(typeFlag: number): 'file' | 'directory' {
+  if (typeFlag === 0 || typeFlag === 0x30) return 'file'
+  if (typeFlag === 0x35) return 'directory'
+  artifactFailure('artifact_resolution')
+}
+
+function parseNpmTarEntry(
+  archive: Buffer,
+  offset: number,
+): { entry: ValidatedNpmTarEntry; nextOffset: number } {
+  const header = archive.subarray(offset, offset + 512)
+  validateTarHeaderChecksum(header)
+  if (header.toString('ascii', 257, 263) !== 'ustar\0') {
+    artifactFailure('artifact_resolution')
+  }
+  const name = readTarText(header, 0, 100, false)
+  const prefix = readTarText(header, 345, 155)
+  const fullName = prefix.length > 0 ? `${prefix}/${name}` : name
+  const type = readNpmTarEntryType(header[156])
+  const relativePath = validateTarPath(fullName, type === 'directory')
+  readTarText(header, 157, 100)
+  const size = readTarOctal(header, 124, 12)
+  const contentOffset = offset + 512
+  if (size > MAX_NPM_TARBALL_BYTES || contentOffset + size > archive.length) {
+    artifactFailure('artifact_resolution')
+  }
+  const nextOffset = contentOffset + Math.ceil(size / 512) * 512
+  if (nextOffset > archive.length) artifactFailure('artifact_resolution')
+  return {
+    entry: {
+      path: relativePath,
+      type,
+      content: Buffer.from(
+        archive.subarray(contentOffset, contentOffset + size),
+      ),
+    },
+    nextOffset,
+  }
+}
+
+function appendNpmTarEntry(
+  archive: Buffer,
+  offset: number,
+  entries: ValidatedNpmTarEntry[],
+  names: Set<string>,
+): number {
+  if (entries.length >= MAX_NPM_TAR_ENTRIES) {
+    artifactFailure('artifact_resolution')
+  }
+  const parsed = parseNpmTarEntry(archive, offset)
+  if (names.has(parsed.entry.path)) artifactFailure('artifact_resolution')
+  names.add(parsed.entry.path)
+  entries.push(parsed.entry)
+  return parsed.nextOffset
+}
+
+function readValidatedNpmTarEntries(archive: Buffer): ValidatedNpmTarEntry[] {
+  const entries: ValidatedNpmTarEntry[] = []
+  const names = new Set<string>()
+  let offset = 0
+  let zeroBlocks = 0
+  while (offset + 512 <= archive.length) {
+    const header = archive.subarray(offset, offset + 512)
+    if (isZeroTarBlock(header)) {
+      zeroBlocks += 1
+      offset += 512
+      if (zeroBlocks >= 2) break
+      continue
+    }
+    if (zeroBlocks > 0) {
+      artifactFailure('artifact_resolution')
+    }
+    offset = appendNpmTarEntry(archive, offset, entries, names)
+  }
+  if (zeroBlocks < 2 || entries.length === 0) {
+    artifactFailure('artifact_resolution')
+  }
+  for (; offset < archive.length; offset += 1) {
+    if (archive[offset] !== 0) artifactFailure('artifact_resolution')
+  }
+  return entries
+}
+
+export function validateNpmTarball(tarballPath: string): ValidatedNpmTarball {
+  let compressed: Buffer
+  try {
+    compressed = fs.readFileSync(tarballPath)
+  } catch {
+    artifactFailure('artifact_resolution')
+  }
+  if (compressed.length > MAX_NPM_TARBALL_BYTES) {
+    artifactFailure('artifact_resolution')
+  }
+
+  let archive: Buffer
+  try {
+    archive = gunzipSync(compressed, {
+      maxOutputLength: MAX_NPM_TARBALL_BYTES,
+    })
+  } catch {
+    artifactFailure('artifact_resolution')
+  }
+  if (archive.length > MAX_NPM_TARBALL_BYTES) {
+    artifactFailure('artifact_resolution')
+  }
+
+  return {
+    digest: createHash('sha256').update(compressed).digest('hex'),
+    entries: readValidatedNpmTarEntries(archive),
+  }
+}
+
+function verifyExtractedPackageTree(
+  packageRoot: string,
+  allowSafeSymlinks = false,
+): void {
+  const canonicalRoot = fs.realpathSync(packageRoot)
+  function walk(directory: string): void {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      verifyExtractedEntry(
+        path.join(directory, entry.name),
+        canonicalRoot,
+        allowSafeSymlinks,
+      )
+    }
+  }
+
+  function verifyExtractedEntry(
+    entryPath: string,
+    root: string,
+    allowSymlink: boolean,
+  ): void {
+    const stat = fs.lstatSync(entryPath)
+    if (stat.isSymbolicLink()) {
+      if (!allowSymlink) artifactFailure('path_escape')
+      if (!isContained(root, fs.realpathSync(entryPath))) {
+        artifactFailure('path_escape')
+      }
+      return
+    }
+    if (!isContained(root, fs.realpathSync(entryPath))) {
+      artifactFailure('path_escape')
+    }
+    if (stat.isDirectory()) {
+      walk(entryPath)
+      return
+    }
+    if (!stat.isFile()) artifactFailure('artifact_resolution')
+  }
+
+  walk(canonicalRoot)
+}
+
+export function extractValidatedNpmTarball(
+  tarballPath: string,
+  destination: string,
+): void {
+  const archive = validateNpmTarball(tarballPath)
+  fs.rmSync(destination, { recursive: true, force: true })
+  fs.mkdirSync(destination, { recursive: true })
+  for (const entry of archive.entries) {
+    if (entry.path === '') continue
+    const target = assertEvalPathContained(
+      destination,
+      path.join(destination, entry.path),
+    )
+    if (entry.type === 'directory') {
+      fs.mkdirSync(target, { recursive: true })
+      continue
+    }
+    fs.mkdirSync(path.dirname(target), { recursive: true })
+    fs.writeFileSync(target, entry.content)
+  }
+  verifyExtractedPackageTree(destination)
+}
+
+function readInstalledPackageJson(packageRoot: string): {
+  packageName: string
+  packageVersion: string
+} {
+  const packageJsonPath = path.join(packageRoot, 'package.json')
+  let value: unknown
+  try {
+    value = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as unknown
+  } catch {
+    artifactFailure('artifact_resolution')
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    artifactFailure('artifact_resolution')
+  }
+  const packageJson = value as Record<string, unknown>
+  const packageName = packageJson.name
+  const packageVersion = packageJson.version
+  if (
+    typeof packageName !== 'string' ||
+    !/^@?[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)?$/.test(packageName) ||
+    typeof packageVersion !== 'string' ||
+    !/^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$/.test(packageVersion)
+  ) {
+    artifactFailure('artifact_resolution')
+  }
+  if (packageJson.main !== './dist/index.js') {
+    artifactFailure('artifact_resolution')
+  }
+  const exportsValue = packageJson.exports
+  if (
+    !exportsValue ||
+    typeof exportsValue !== 'object' ||
+    Array.isArray(exportsValue)
+  ) {
+    artifactFailure('artifact_resolution')
+  }
+  const rootExport = (exportsValue as Record<string, unknown>)['.']
+  if (
+    !rootExport ||
+    typeof rootExport !== 'object' ||
+    Array.isArray(rootExport)
+  ) {
+    artifactFailure('artifact_resolution')
+  }
+  if ((rootExport as Record<string, unknown>).import !== './dist/index.js') {
+    artifactFailure('artifact_resolution')
+  }
+  return { packageName, packageVersion }
+}
+
+function hasExternalNodeModulesFallback(value: string): boolean {
+  if (path.basename(value) === 'node_modules') return true
+  let current = path.dirname(value)
+  while (true) {
+    if (path.basename(current) === 'node_modules') return true
+    try {
+      if (fs.statSync(path.join(current, 'node_modules')).isDirectory()) {
+        return true
+      }
+    } catch {
+      // Missing or inaccessible fallback directories are not usable fallbacks.
+    }
+    const parent = path.dirname(current)
+    if (parent === current) return false
+    current = parent
+  }
+}
+
+export function assertInstalledResolutionPath(
+  packageRoot: string,
+  candidate: string,
+  checkoutRoot = REPO_ROOT,
+): string {
+  const canonicalPackageRoot = canonicalizePath(packageRoot)
+  const canonicalCheckoutRoot = canonicalizePath(checkoutRoot)
+  if (
+    isContained(canonicalCheckoutRoot, canonicalPackageRoot) ||
+    hasExternalNodeModulesFallback(canonicalPackageRoot)
+  ) {
+    artifactFailure('path_escape')
+  }
+  const canonicalCandidate = canonicalizePath(candidate)
+  if (
+    !isContained(canonicalPackageRoot, canonicalCandidate) ||
+    isContained(canonicalCheckoutRoot, canonicalCandidate)
+  ) {
+    artifactFailure('path_escape')
+  }
+  return canonicalCandidate
+}
+
+export function resolveInstalledPluginEntry(
+  packageRoot: string,
+  checkoutRoot = REPO_ROOT,
+): InstalledPluginEntry {
+  const metadata = readInstalledPackageJson(packageRoot)
+  const moduleEntry = assertInstalledResolutionPath(
+    packageRoot,
+    path.join(packageRoot, 'dist/index.js'),
+    checkoutRoot,
+  )
+  try {
+    if (!fs.lstatSync(moduleEntry).isFile()) {
+      artifactFailure('artifact_resolution')
+    }
+  } catch {
+    artifactFailure('artifact_resolution')
+  }
+  return {
+    ...metadata,
+    moduleEntry,
+    moduleEntryId: 'dist/index.js',
+  }
+}
+
+function installPackedArtifact(options: {
+  rootDir: string
+  fixture: EvalFixture
+  sourceTarballPath: string
+  expectedDigest?: string
+}): InstalledArtifact {
+  const { fixture, rootDir } = options
+  const sourceTarballPath = path.resolve(options.sourceTarballPath)
+  const tarballPath = fixture.tarballPath
+  assertFixturePathsContained(fixture)
+  assertEvalPathContained(path.dirname(sourceTarballPath), sourceTarballPath)
+  if (
+    isContained(canonicalizePath(rootDir), canonicalizePath(sourceTarballPath))
+  ) {
+    artifactFailure('path_escape')
+  }
+  assertEvalPathContained(fixture.artifactRoot, tarballPath)
+  if (sourceTarballPath !== tarballPath) {
+    fs.copyFileSync(sourceTarballPath, tarballPath, fs.constants.COPYFILE_EXCL)
+  }
+  if (!fs.existsSync(tarballPath)) artifactFailure('artifact_resolution')
+  const archive = validateNpmTarball(tarballPath)
+  if (
+    options.expectedDigest !== undefined &&
+    archive.digest !== options.expectedDigest
+  ) {
+    artifactFailure('artifact_resolution')
+  }
+
+  const buildEnv = buildEvalChildEnv({
+    fixture,
+    configContent: '{}',
+    modelBaseUrl: 'http://127.0.0.1:1/v1',
+  })
+  extractValidatedNpmTarball(tarballPath, fixture.stagingRoot)
+  fs.rmSync(fixture.packageRoot, { recursive: true, force: true })
+  fs.renameSync(fixture.stagingRoot, fixture.packageRoot)
+  fs.mkdirSync(fixture.stagingRoot, { recursive: true })
+  const install = spawnSync(
+    'npm',
+    [
+      'install',
+      '--ignore-scripts',
+      '--no-package-lock',
+      '--no-audit',
+      '--no-fund',
+      '--omit=dev',
+    ],
+    {
+      cwd: fixture.packageRoot,
+      env: buildEnv,
+      encoding: 'utf8',
+      timeout: 120_000,
+    },
+  )
+  if (install.error || install.status !== 0) {
+    artifactFailure('artifact_resolution')
+  }
+  verifyExtractedPackageTree(fixture.packageRoot, true)
+  const plugin = resolveInstalledPluginEntry(fixture.packageRoot, rootDir)
+  return {
+    ...plugin,
+    tarballPath,
+    tarballDigest: archive.digest,
+    packageRoot: fixture.packageRoot,
+    packageRootId: 'installed-package-root',
+    configEntryId: 'installed-config',
+  }
+}
+
+export function packInstalledArtifact(options: {
+  rootDir: string
+  fixture: EvalFixture
+}): InstalledArtifact {
+  const { fixture, rootDir } = options
+  assertFixturePathsContained(fixture)
+  assertEvalPathContained(rootDir, path.join(rootDir, 'dist/index.js'))
+  const buildEnv = buildEvalChildEnv({
+    fixture,
+    configContent: '{}',
+    modelBaseUrl: 'http://127.0.0.1:1/v1',
+  })
+  const build = spawnSync('bun', ['run', 'build'], {
+    cwd: rootDir,
+    env: buildEnv,
+    encoding: 'utf8',
+    timeout: 120_000,
+  })
+  if (build.error || build.status !== 0) {
+    artifactFailure('artifact_resolution')
+  }
+  const pack = spawnSync(
+    'npm',
+    [
+      'pack',
+      '--ignore-scripts',
+      '--pack-destination',
+      fixture.artifactRoot,
+      '--silent',
+    ],
+    {
+      cwd: rootDir,
+      env: buildEnv,
+      encoding: 'utf8',
+      timeout: 120_000,
+    },
+  )
+  if (pack.error || pack.status !== 0) {
+    artifactFailure('artifact_resolution')
+  }
+  const tarballName = pack.stdout.trim().split(/\r?\n/).at(-1)
+  if (!tarballName || path.basename(tarballName) !== tarballName) {
+    artifactFailure('artifact_resolution')
+  }
+  const packedTarballPath = assertEvalPathContained(
+    fixture.artifactRoot,
+    path.join(fixture.artifactRoot, tarballName),
+  )
+  if (!fs.existsSync(packedTarballPath)) artifactFailure('artifact_resolution')
+  if (packedTarballPath !== fixture.tarballPath) {
+    fs.renameSync(packedTarballPath, fixture.tarballPath)
+  }
+  const archive = validateNpmTarball(fixture.tarballPath)
+  return installPackedArtifact({
+    rootDir,
+    fixture,
+    sourceTarballPath: fixture.tarballPath,
+    expectedDigest: archive.digest,
+  })
+}
+
+export function buildEvalChildEnv(
+  options: EvalChildEnvOptions,
+): Record<string, string> {
+  const parentPath = options.parentEnv?.PATH ?? EXECUTION_PATH
+  return {
+    PATH: parentPath,
+    HOME: options.fixture.homeRoot,
+    LANG: 'C',
+    LC_ALL: 'C',
+    LC_CTYPE: 'C',
+    TZ: 'UTC',
+    TERM: 'dumb',
+    NO_COLOR: '1',
+    TMPDIR: options.fixture.tmpRoot,
+    TMP: options.fixture.tmpRoot,
+    TEMP: options.fixture.tmpRoot,
+    XDG_CONFIG_HOME: options.fixture.xdgConfigRoot,
+    XDG_DATA_HOME: options.fixture.xdgDataRoot,
+    XDG_CACHE_HOME: options.fixture.xdgCacheRoot,
+    XDG_STATE_HOME: options.fixture.xdgStateRoot,
+    OPENCODE_CONFIG_DIR: options.fixture.opencodeConfigRoot,
+    OPENCODE_CONFIG_CONTENT: options.configContent,
+    OPENCODE_DISABLE_AUTOUPDATE: '1',
+    OPENCODE_DISABLE_LSP_DOWNLOAD: '1',
+    OPENCODE_DISABLE_MODELS_FETCH: '1',
+    OPENCODE_DISABLE_PRUNE: '1',
+    NPM_CONFIG_CACHE: options.fixture.npmCacheRoot,
+    npm_config_cache: options.fixture.npmCacheRoot,
+    npm_config_prefix: options.fixture.npmPrefixRoot,
+    NPM_CONFIG_USERCONFIG: options.fixture.npmUserConfigPath,
+    npm_config_update_notifier: 'false',
+    EVAL_MODEL_BASE_URL: options.modelBaseUrl,
+  }
+}
+
+export function capturePrimaryCheckout(
+  rootDir = REPO_ROOT,
+): PrimaryCheckoutIdentity {
+  const status = spawnSync(
+    'git',
+    ['status', '--short', '--untracked-files=all'],
+    { cwd: rootDir, encoding: 'utf8' },
+  )
+  if (status.status !== 0) throw new Error('eval-git:identity_unavailable')
+  const sourcePath = path.join(rootDir, 'src/index.ts')
+  return {
+    status: status.stdout.trim(),
+    sourceDigest: sha256File(sourcePath, 'missing-source-entry'),
+  }
+}
+
+function readGitCommitId(rootDir: string): string {
+  const result = spawnSync('git', ['rev-parse', 'HEAD'], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  })
+  const value = result.status === 0 ? result.stdout.trim() : ''
+  return /^[a-f0-9]{40}$/.test(value)
+    ? value
+    : sha256Text(`commit:${rootDir}`).slice(0, 40)
+}
+
+function readCaseManifest(rootDir: string, caseId: CaseId): EvalCaseManifest {
+  const filePath = path.join(
+    rootDir,
+    'evals',
+    'cases',
+    'opencode',
+    `${caseId}.json`,
+  )
+  return parseCaseManifest(
+    JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown,
+  )
+}
+
+function extractVersion(output: string): string | undefined {
+  const matches = output.match(/\b\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?\b/g)
+  return matches?.at(-1)
+}
+
+export function verifyExactOpencodeRuntime(options: {
+  fixture: EvalFixture
+  parentEnv?: Readonly<Record<string, string | undefined>>
+  timeoutMs?: number
+}): ExactOpencodeRuntime {
+  const env = buildEvalChildEnv({
+    fixture: options.fixture,
+    configContent: '{}',
+    modelBaseUrl: 'http://127.0.0.1:1/v1',
+    parentEnv: options.parentEnv,
+  })
+  const result = spawnSync(
+    'npx',
+    ['--yes', `opencode-ai@${EXPECTED_OPENCODE_VERSION}`, '--version'],
+    {
+      cwd: options.fixture.projectRoot,
+      env,
+      encoding: 'utf8',
+      timeout: options.timeoutMs ?? 300_000,
+    },
+  )
+  if (result.error || result.status !== 0) {
+    return {
+      status: 'unavailable',
+      expectedVersion: EXPECTED_OPENCODE_VERSION,
+    }
+  }
+  const reportedVersion = extractVersion(result.stdout)
+  if (!reportedVersion) {
+    return {
+      status: 'unavailable',
+      expectedVersion: EXPECTED_OPENCODE_VERSION,
+    }
+  }
+  return {
+    status:
+      reportedVersion === EXPECTED_OPENCODE_VERSION ? 'available' : 'mismatch',
+    expectedVersion: EXPECTED_OPENCODE_VERSION,
+    reportedVersion,
+  }
+}
+
+function failedExecution(
+  subcode: EvalSubcode,
+  probeDigest = ZERO_DIGEST,
+): EvalCaseExecution {
+  return {
+    outcome: 'infra_failure',
+    subcode,
+    sanity: 'failed',
+    process: 'failed',
+    probeDigest,
+    artifactRefs: ['probe/events.jsonl'],
+  }
+}
+
+function cleanupFailureExecution(
+  probeDigest: string,
+  subcode: 'residue_detected' | 'quarantine_failed' = 'residue_detected',
+): EvalCaseExecution {
+  return {
+    outcome: 'privacy_cleanup_failure',
+    subcode,
+    sanity: 'failed',
+    process: 'failed',
+    probeDigest,
+    artifactRefs: ['probe/events.jsonl'],
+  }
+}
+
+function classifySetupError(error: unknown): EvalCaseExecution {
+  if (error instanceof Error && error.message === 'eval-path:path_escape') {
+    return failedExecution('path_escape')
+  }
+  return failedExecution('case_setup')
+}
+
+function classifyArtifactError(error: unknown): EvalCaseExecution {
+  if (error instanceof Error && error.message.includes('path_escape')) {
+    return failedExecution('path_escape')
+  }
+  return failedExecution('artifact_resolution')
+}
+
+function createEvalRunId(): string {
+  return `run-${randomUUID().replaceAll('-', '')}`
+}
+
+interface EvalResultBuilderInput {
+  rootDir: string
+  caseManifest: EvalCaseManifest
+  runId: string
+  fixtureSeed: string
+  normalizedClock: string
+  runtime: ExactOpencodeRuntime
+  execution: EvalCaseExecution
+  cleanup: EvalCleanupState
+  artifact?: InstalledArtifact
+}
+
+function buildResultEnvelope(input: {
+  caseManifest: EvalCaseManifest
+  mode: EvalMode
+  runId: string
+  fixtureSeed: string
+  normalizedClock: string
+  runtime: ExactOpencodeRuntime
+  execution: EvalCaseExecution
+  cleanup: EvalCleanupState
+  artifactId: string
+  artifactDigest: string
+  provenance: SourceProvenance | InstalledProvenance
+}): EvalResult {
+  const runtimeVersion =
+    input.runtime.reportedVersion ?? EXPECTED_OPENCODE_VERSION
+  const result: Record<string, unknown> = {
+    resultSchemaVersion: RESULT_SCHEMA_VERSION,
+    caseSchemaVersion: CASE_SCHEMA_VERSION,
+    caseId: input.caseManifest.caseId,
+    harness: HARNESS,
+    mode: input.mode,
+    outcome: input.execution.outcome,
+    subcode: input.execution.subcode,
+    runId: input.runId,
+    fixtureSeed: input.fixtureSeed,
+    normalizedClock: input.normalizedClock,
+    assertionIds: input.caseManifest.assertionIds,
+    identity: {
+      opencodeVersion: runtimeVersion,
+      opencodeBuildId:
+        input.runtime.status === 'available'
+          ? 'opencode-ai-1.18.5'
+          : 'opencode-runtime-unavailable',
+      probeId: 'systematic-eval-probe-v1',
+      probeDigest: input.execution.probeDigest,
+      fixtureContractVersion: FIXTURE_CONTRACT_VERSION,
+      fixtureContractDigest: FIXTURE_CONTRACT_DIGEST,
+      caseSchemaVersion: CASE_SCHEMA_VERSION,
+      resultSchemaVersion: RESULT_SCHEMA_VERSION,
+      artifactId: input.artifactId,
+      artifactDigest: input.artifactDigest,
+    },
+    evidence: {
+      sanity: input.execution.sanity,
+      process: input.execution.process,
+      assertionIds: input.caseManifest.assertionIds,
+    },
+    cleanup: input.cleanup,
+    privacy: { status: 'validated' },
+    artifactRefs: input.execution.artifactRefs,
+    provenance: input.provenance,
+  }
+  return normalizeResult(result)
+}
+
+function buildSourceResult(input: EvalResultBuilderInput): EvalResult {
+  const sourceEntry = path.join(input.rootDir, 'src', 'index.ts')
+  const artifactDigest = sha256File(sourceEntry, 'missing-source-entry')
+  const commitId = readGitCommitId(input.rootDir)
+  const worktreeId = sha256Text(`worktree:${input.rootDir}`).slice(0, 32)
+  return buildResultEnvelope({
+    ...input,
+    mode: 'source',
+    artifactId: 'source-entry',
+    artifactDigest,
+    provenance: {
+      kind: 'source',
+      checkoutRelativeSource: 'src/index.ts',
+      commitId,
+      worktreeId,
+      canonicalSourceEntryId: 'source-entry',
+      opencodeConfigEntryId: 'source-config',
+    },
+  })
+}
+
+function buildInstalledResult(input: EvalResultBuilderInput): EvalResult {
+  const artifact = input.artifact
+  return buildResultEnvelope({
+    ...input,
+    mode: 'installed',
+    artifactId: 'installed-entry',
+    artifactDigest: artifact?.tarballDigest ?? ZERO_DIGEST,
+    provenance: {
+      kind: 'installed',
+      packageName: artifact?.packageName ?? '@fro.bot/systematic',
+      packageVersion: artifact?.packageVersion ?? '0.0.0-semantic-release',
+      tarballDigest: artifact?.tarballDigest ?? ZERO_DIGEST,
+      extractedPackageRootId:
+        artifact?.packageRootId ?? 'installed-package-root',
+      canonicalResolvedModuleEntryId:
+        artifact?.moduleEntryId ?? 'dist/index.js',
+      opencodeConfigEntryId: artifact?.configEntryId ?? 'installed-config',
+    },
+  })
+}
+
+async function executeInstalledArtifactCase(input: {
+  fixture: EvalFixture
+  artifact: InstalledArtifact
+  caseManifest: EvalCaseManifest
+  timeoutMs?: number
+  caseTimeoutMs?: number
+}): Promise<{ runtime: ExactOpencodeRuntime; execution: EvalCaseExecution }> {
+  const runtime = verifyExactOpencodeRuntime({
+    fixture: input.fixture,
+    parentEnv: process.env,
+    timeoutMs: input.timeoutMs,
+  })
+  if (runtime.status !== 'available') {
+    return {
+      runtime,
+      execution: failedExecution(
+        runtime.status === 'mismatch'
+          ? 'identity_drift'
+          : 'opencode_unavailable',
+      ),
+    }
+  }
+  try {
+    const installedModule = (await import(
+      pathToFileURL(input.artifact.moduleEntry).href
+    )) as { default?: unknown }
+    if (typeof installedModule.default !== 'function') {
+      return { runtime, execution: failedExecution('artifact_resolution') }
+    }
+  } catch {
+    return { runtime, execution: failedExecution('artifact_resolution') }
+  }
+  const { executeInstalledCase } = await import('./eval-cases/opencode.ts')
+  return {
+    runtime,
+    execution: await executeInstalledCase({
+      fixture: input.fixture,
+      caseManifest: input.caseManifest,
+      installedEntry: input.artifact.moduleEntry,
+      parentEnv: process.env,
+      timeoutMs: input.timeoutMs,
+      caseTimeoutMs: input.caseTimeoutMs,
+    }),
+  }
+}
+
+async function executeLifecycleCase(
+  hooks: EvalLifecycleHooks,
+  mode: EvalMode,
+  fixture: EvalFixture,
+  caseManifest: EvalCaseManifest,
+): Promise<EvalCaseExecution> {
+  const executeCase = hooks.executeCase
+  if (!executeCase) return failedExecution('case_setup')
+  try {
+    return await executeCase({ mode, fixture, caseManifest })
+  } catch {
+    return failedExecution(
+      mode === 'source' ? 'case_setup' : 'artifact_resolution',
+    )
+  }
+}
+
+interface EvalStageInput {
+  options: SourceEvalOptions
+  fixture: EvalFixture
+  caseManifest: EvalCaseManifest
+  rootDir: string
+}
+
+interface EvalStageResult {
+  runtime: ExactOpencodeRuntime
+  execution: EvalCaseExecution
+  artifact?: InstalledArtifact
+}
+
+type EvalStage = (input: EvalStageInput) => Promise<EvalStageResult>
+
+type EvalResultBuilder = (input: EvalResultBuilderInput) => EvalResult
+
+async function executeSourceStage(options: {
+  options: SourceEvalOptions
+  fixture: EvalFixture
+  caseManifest: EvalCaseManifest
+  rootDir: string
+}): Promise<EvalStageResult> {
+  assertEvalPathContained(
+    options.rootDir,
+    path.join(options.rootDir, 'src', 'index.ts'),
+  )
+  if (options.options.lifecycleHooks?.executeCase) {
+    return {
+      runtime: {
+        status: 'available',
+        expectedVersion: EXPECTED_OPENCODE_VERSION,
+        reportedVersion: EXPECTED_OPENCODE_VERSION,
+      },
+      execution: await executeLifecycleCase(
+        options.options.lifecycleHooks,
+        'source',
+        options.fixture,
+        options.caseManifest,
+      ),
+    }
+  }
+
+  const runtime = verifyExactOpencodeRuntime({
+    fixture: options.fixture,
+    parentEnv: process.env,
+    timeoutMs: options.options.timeoutMs,
+  })
+  if (runtime.status === 'unavailable') {
+    return { runtime, execution: failedExecution('opencode_unavailable') }
+  }
+  if (runtime.status === 'mismatch') {
+    return { runtime, execution: failedExecution('identity_drift') }
+  }
+  const { executeSourceCase } = await import('./eval-cases/opencode.ts')
+  return {
+    runtime,
+    execution: await executeSourceCase({
+      fixture: options.fixture,
+      caseManifest: options.caseManifest,
+      sourceEntry: assertEvalPathContained(
+        options.rootDir,
+        path.join(options.rootDir, 'src', 'index.ts'),
+      ),
+      parentEnv: process.env,
+      timeoutMs: options.options.timeoutMs,
+      caseTimeoutMs: options.options.caseTimeoutMs,
+    }),
+  }
+}
+
+async function executeInstalledStage(options: {
+  options: SourceEvalOptions
+  fixture: EvalFixture
+  artifact: InstalledArtifact
+  caseManifest: EvalCaseManifest
+}): Promise<EvalStageResult> {
+  if (options.options.lifecycleHooks?.executeCase) {
+    return {
+      runtime: {
+        status: 'available',
+        expectedVersion: EXPECTED_OPENCODE_VERSION,
+        reportedVersion: EXPECTED_OPENCODE_VERSION,
+      },
+      execution: await executeLifecycleCase(
+        options.options.lifecycleHooks,
+        'installed',
+        options.fixture,
+        options.caseManifest,
+      ),
+    }
+  }
+  return executeInstalledArtifactCase({
+    fixture: options.fixture,
+    artifact: options.artifact,
+    caseManifest: options.caseManifest,
+    timeoutMs: options.options.timeoutMs,
+    caseTimeoutMs: options.options.caseTimeoutMs,
+  })
+}
+
+async function executeInstalledEvalStage(
+  options: EvalStageInput,
+): Promise<EvalStageResult> {
+  const artifact = options.options.reusableArtifact
+    ? installPackedArtifact({
+        rootDir: options.rootDir,
+        fixture: options.fixture,
+        sourceTarballPath: options.options.reusableArtifact.tarballPath,
+        expectedDigest: options.options.reusableArtifact.tarballDigest,
+      })
+    : packInstalledArtifact({
+        rootDir: options.rootDir,
+        fixture: options.fixture,
+      })
+  const stage = await executeInstalledStage({
+    options: options.options,
+    fixture: options.fixture,
+    artifact,
+    caseManifest: options.caseManifest,
+  })
+  return { ...stage, artifact }
+}
+
+async function runEvalLifecycle(
+  options: SourceEvalOptions,
+  mode: EvalMode,
+  executeStage: EvalStage,
+  buildResult: EvalResultBuilder,
+): Promise<EvalResult> {
+  const rootDir = path.resolve(options.rootDir ?? REPO_ROOT)
+  const runId = options.runId ?? createEvalRunId()
+  const caseManifest = readCaseManifest(rootDir, options.caseId)
+  const before = capturePrimaryCheckout(rootDir)
+  const runtime: ExactOpencodeRuntime = {
+    status: 'unavailable',
+    expectedVersion: EXPECTED_OPENCODE_VERSION,
+  }
+  let execution = failedExecution('case_setup')
+  let cleanup: EvalCleanupState = { status: 'clean', residue: 'none' }
+  let fixture: EvalFixture | undefined
+  let artifact: InstalledArtifact | undefined
+
+  try {
+    fixture = createEvalFixture({
+      caseId: options.caseId,
+      mode,
+      runId,
+      parentDir: options.parentDir,
+    })
+    registerActiveEvalFixture(fixture, runId, options.lifecycleHooks)
+    assertFixturePathsContained(fixture)
+
+    const stage = await executeStage({
+      options,
+      fixture,
+      caseManifest,
+      rootDir,
+    })
+    Object.assign(runtime, stage.runtime)
+    execution = stage.execution
+    artifact = stage.artifact
+  } catch (error) {
+    execution =
+      mode === 'source'
+        ? classifySetupError(error)
+        : classifyArtifactError(error)
+  } finally {
+    if (fixture) {
+      const cleanupResult = await cleanupRegisteredEvalFixture(
+        fixture,
+        runId,
+        options.lifecycleHooks,
+      )
+      cleanup = cleanupResult.cleanup
+      if (cleanupResult.failureSubcode) {
+        execution = cleanupFailureExecution(
+          execution.probeDigest,
+          cleanupResult.failureSubcode,
+        )
+      }
+      unregisterActiveEvalFixture(fixture)
+    }
+
+    try {
+      const after = capturePrimaryCheckout(rootDir)
+      if (
+        execution.outcome !== 'privacy_cleanup_failure' &&
+        (after.status !== before.status ||
+          after.sourceDigest !== before.sourceDigest)
+      ) {
+        execution = failedExecution(
+          'primary_checkout_delta',
+          execution.probeDigest,
+        )
+      }
+    } catch {
+      if (execution.outcome !== 'privacy_cleanup_failure') {
+        execution = failedExecution(
+          'primary_checkout_delta',
+          execution.probeDigest,
+        )
+      }
+    }
+  }
+
+  return buildResult({
+    rootDir,
+    caseManifest,
+    runId,
+    fixtureSeed: options.fixtureSeed,
+    normalizedClock: options.normalizedClock,
+    runtime,
+    execution,
+    cleanup,
+    artifact,
+  })
+}
+
+export async function runSourceEval(
+  options: SourceEvalOptions,
+): Promise<EvalResult> {
+  return runEvalLifecycle(
+    options,
+    'source',
+    executeSourceStage,
+    buildSourceResult,
+  )
+}
+
+export async function runInstalledEval(
+  options: SourceEvalOptions,
+): Promise<EvalResult> {
+  return runEvalLifecycle(
+    options,
+    'installed',
+    executeInstalledEvalStage,
+    buildInstalledResult,
+  )
+}
+
+function parseEvalSelectionId(selectionId: string): {
+  caseId: CaseId
+  mode: EvalMode
+} {
+  const separator = selectionId.indexOf('/')
+  if (separator <= 0 || separator === selectionId.length - 1) {
+    throw new Error('eval-run:invalid_selection')
+  }
+  const caseId = selectionId.slice(0, separator)
+  const mode = selectionId.slice(separator + 1)
+  if (!isCaseId(caseId) || !isEvalMode(mode)) {
+    throw new Error('eval-run:invalid_selection')
+  }
+  return { caseId, mode }
+}
+
+function resultArtifactId(caseId: CaseId, mode: EvalMode): string {
+  return `results/${caseId}/${mode}.json`
+}
+
+function isRunnerWideFailure(result: EvalResult): boolean {
+  return (
+    result.outcome === 'infra_failure' &&
+    [
+      'identity_drift',
+      'path_escape',
+      'primary_checkout_delta',
+      'opencode_unavailable',
+      'probe_unhealthy',
+    ].includes(result.subcode ?? '')
+  )
+}
+
+function isUnresolvedCleanupFailure(result: EvalResult): boolean {
+  return (
+    result.outcome === 'privacy_cleanup_failure' &&
+    (result.subcode === 'quarantine_failed' ||
+      result.cleanup.status === 'residue')
+  )
+}
+
+function buildSelectionFailureResult(options: {
+  caseId: CaseId
+  mode: EvalMode
+  runId: string
+  fixtureSeed: string
+  normalizedClock: string
+  rootDir: string
+  subcode: 'artifact_resolution' | 'path_escape' | 'case_setup'
+}): EvalResult {
+  const caseManifest = readCaseManifest(options.rootDir, options.caseId)
+  const execution = failedExecution(options.subcode)
+  const runtime: ExactOpencodeRuntime = {
+    status: 'unavailable',
+    expectedVersion: EXPECTED_OPENCODE_VERSION,
+  }
+  if (options.mode === 'source') {
+    return buildSourceResult({
+      rootDir: options.rootDir,
+      caseManifest,
+      runId: options.runId,
+      fixtureSeed: options.fixtureSeed,
+      normalizedClock: options.normalizedClock,
+      runtime,
+      execution,
+      cleanup: { status: 'clean', residue: 'none' },
+    })
+  }
+  return buildInstalledResult({
+    caseManifest,
+    runId: options.runId,
+    fixtureSeed: options.fixtureSeed,
+    normalizedClock: options.normalizedClock,
+    runtime,
+    execution,
+    cleanup: { status: 'clean', residue: 'none' },
+  })
+}
+
+interface ParsedEvalSelection {
+  selectionId: string
+  caseId: CaseId
+  mode: EvalMode
+}
+
+interface EvalSelectionState {
+  results: EvalResult[]
+  reusableArtifact?: InstalledArtifact
+  artifactFixture?: EvalFixture
+  artifactCleanup?: CleanupResolution
+  installedBlocked: boolean
+  abortLaterSelections: boolean
+}
+
+type ArtifactPreparation =
+  | {
+      status: 'ready'
+      fixture: EvalFixture
+      artifact: InstalledArtifact
+    }
+  | {
+      status: 'failed'
+      fixture?: EvalFixture
+      result: EvalResult
+      abortLaterSelections: boolean
+    }
+
+function shouldSkipSelection(
+  selection: ParsedEvalSelection,
+  state: EvalSelectionState,
+): boolean {
+  return (
+    state.abortLaterSelections ||
+    (selection.mode === 'installed' && state.installedBlocked)
+  )
+}
+
+function prepareInstalledArtifact(options: {
+  selection: ParsedEvalSelection
+  runId: string
+  rootDir: string
+  parentDir?: string
+  fixtureSeed: string
+  normalizedClock: string
+  packer: (options: {
+    rootDir: string
+    fixture: EvalFixture
+  }) => InstalledArtifact
+}): ArtifactPreparation {
+  let fixture: EvalFixture | undefined
+  try {
+    fixture = createEvalFixture({
+      caseId: options.selection.caseId,
+      mode: 'installed',
+      runId: `${options.runId}-pack`,
+      parentDir: options.parentDir,
+    })
+    return {
+      status: 'ready',
+      fixture,
+      artifact: options.packer({ rootDir: options.rootDir, fixture }),
+    }
+  } catch (error) {
+    const pathEscape =
+      error instanceof Error && error.message.includes('path_escape')
+    return {
+      status: 'failed',
+      fixture,
+      result: buildSelectionFailureResult({
+        caseId: options.selection.caseId,
+        mode: 'installed',
+        runId: options.runId,
+        fixtureSeed: options.fixtureSeed,
+        normalizedClock: options.normalizedClock,
+        rootDir: options.rootDir,
+        subcode: pathEscape ? 'path_escape' : 'artifact_resolution',
+      }),
+      abortLaterSelections: pathEscape,
+    }
+  }
+}
+
+function selectionRunnerOptions(
+  options: EvalSelectionRunnerOptions,
+  selection: ParsedEvalSelection,
+  runId: string,
+  reusableArtifact: InstalledArtifact | undefined,
+): EvalSelectionRunnerInput {
+  return {
+    mode: selection.mode,
+    caseId: selection.caseId,
+    fixtureSeed: options.fixtureSeed,
+    normalizedClock: options.normalizedClock,
+    runId,
+    parentDir: options.parentDir,
+    rootDir: path.resolve(options.rootDir ?? REPO_ROOT),
+    timeoutMs: options.timeoutMs,
+    caseTimeoutMs: options.caseTimeoutMs,
+    ...(selection.mode === 'installed' && reusableArtifact
+      ? { reusableArtifact }
+      : {}),
+  }
+}
+
+async function executeEvalSelection(options: {
+  config: EvalSelectionRunnerOptions
+  selection: ParsedEvalSelection
+  runId: string
+  reusableArtifact?: InstalledArtifact
+}): Promise<EvalResult> {
+  const runnerOptions = selectionRunnerOptions(
+    options.config,
+    options.selection,
+    options.runId,
+    options.reusableArtifact,
+  )
+  const runner =
+    options.selection.mode === 'source'
+      ? (options.config.sourceRunner ?? runSourceEval)
+      : (options.config.installedRunner ?? runInstalledEval)
+  try {
+    return normalizeResult(await runner(runnerOptions))
+  } catch {
+    return buildSelectionFailureResult({
+      caseId: options.selection.caseId,
+      mode: options.selection.mode,
+      runId: options.runId,
+      fixtureSeed: options.config.fixtureSeed,
+      normalizedClock: options.config.normalizedClock,
+      rootDir: path.resolve(options.config.rootDir ?? REPO_ROOT),
+      subcode:
+        options.selection.mode === 'source'
+          ? 'case_setup'
+          : 'artifact_resolution',
+    })
+  }
+}
+
+function updateSelectionState(
+  state: EvalSelectionState,
+  selection: ParsedEvalSelection,
+  result: EvalResult,
+): void {
+  if (
+    selection.mode === 'installed' &&
+    result.subcode === 'artifact_resolution'
+  ) {
+    state.installedBlocked = true
+  }
+  if (isRunnerWideFailure(result) || isUnresolvedCleanupFailure(result)) {
+    state.abortLaterSelections = true
+  }
+}
+
+function convertArtifactDependentResults(
+  results: readonly EvalResult[],
+  cleanup: CleanupResolution,
+): EvalResult[] {
+  if (!cleanup.failureSubcode) return [...results]
+  return results.map((result) => {
+    if (result.mode !== 'installed') return result
+    return normalizeResult({
+      ...result,
+      outcome: 'privacy_cleanup_failure',
+      subcode: cleanup.failureSubcode,
+      evidence: {
+        ...result.evidence,
+        sanity: 'failed',
+        process: 'failed',
+      },
+      cleanup: cleanup.cleanup,
+    })
+  })
+}
+
+async function cleanupSharedArtifact(
+  state: EvalSelectionState,
+  runId: string,
+  hooks: EvalSelectionRunnerOptions['artifactCleanupHooks'],
+): Promise<void> {
+  if (!state.artifactFixture || state.artifactCleanup) return
+  const fixture = state.artifactFixture
+  const cleanup = await cleanupRegisteredEvalFixture(
+    fixture,
+    `${runId}-pack`,
+    hooks,
+  )
+  state.artifactCleanup = cleanup
+  if (cleanup.failureSubcode && state.reusableArtifact) {
+    state.results = convertArtifactDependentResults(state.results, cleanup)
+  }
+  if (
+    cleanup.failureSubcode === 'quarantine_failed' ||
+    cleanup.cleanup.status === 'residue'
+  ) {
+    state.abortLaterSelections = true
+  }
+  unregisterActiveEvalFixture(fixture)
+  state.artifactFixture = undefined
+  state.reusableArtifact = undefined
+}
+
+function buildEvalRunManifest(
+  runId: string,
+  requestedSelectionIds: readonly string[],
+  results: readonly EvalResult[],
+): EvalRunManifest {
+  const completedSelectionIds = results
+    .map((result) => selectionIdFor(result.caseId, result.mode))
+    .sort()
+  return {
+    manifestSchemaVersion: RUN_MANIFEST_SCHEMA_VERSION,
+    harness: HARNESS,
+    runId,
+    requestedSelectionIds: [...requestedSelectionIds],
+    completedSelectionIds,
+    partial: completedSelectionIds.length !== requestedSelectionIds.length,
+    results: results
+      .map((result) => ({
+        selectionId: selectionIdFor(result.caseId, result.mode),
+        resultArtifactId: resultArtifactId(result.caseId, result.mode),
+        outcome: result.outcome,
+        subcode: result.subcode ?? 'none',
+      }))
+      .sort((left, right) => left.selectionId.localeCompare(right.selectionId)),
+  }
+}
+
+function lastInstalledSelectionIndex(
+  selections: readonly ParsedEvalSelection[],
+): number {
+  let lastIndex = -1
+  for (let index = 0; index < selections.length; index += 1) {
+    if (selections[index]?.mode === 'installed') lastIndex = index
+  }
+  return lastIndex
+}
+
+function prepareSelectionArtifact(options: {
+  config: EvalSelectionRunnerOptions
+  selection: ParsedEvalSelection
+  runId: string
+  rootDir: string
+  state: EvalSelectionState
+  packer: (options: {
+    rootDir: string
+    fixture: EvalFixture
+  }) => InstalledArtifact
+}): boolean {
+  if (
+    options.selection.mode !== 'installed' ||
+    options.state.reusableArtifact
+  ) {
+    return true
+  }
+  const preparation = prepareInstalledArtifact({
+    selection: options.selection,
+    runId: options.runId,
+    rootDir: options.rootDir,
+    parentDir: options.config.parentDir,
+    fixtureSeed: options.config.fixtureSeed,
+    normalizedClock: options.config.normalizedClock,
+    packer: options.packer,
+  })
+  options.state.artifactFixture = preparation.fixture
+  if (preparation.fixture) {
+    registerActiveEvalFixture(
+      preparation.fixture,
+      `${options.runId}-pack`,
+      options.config.artifactCleanupHooks,
+    )
+  }
+  if (preparation.status === 'failed') {
+    options.state.results.push(preparation.result)
+    options.state.abortLaterSelections ||= preparation.abortLaterSelections
+    if (!preparation.abortLaterSelections) options.state.installedBlocked = true
+    return false
+  }
+  options.state.reusableArtifact = preparation.artifact
+  return true
+}
+
+async function executeSelectionIteration(options: {
+  config: EvalSelectionRunnerOptions
+  selection: ParsedEvalSelection
+  runId: string
+  rootDir: string
+  state: EvalSelectionState
+  packer: (options: {
+    rootDir: string
+    fixture: EvalFixture
+  }) => InstalledArtifact
+}): Promise<void> {
+  if (shouldSkipSelection(options.selection, options.state)) return
+  if (
+    !prepareSelectionArtifact({
+      config: options.config,
+      selection: options.selection,
+      runId: options.runId,
+      rootDir: options.rootDir,
+      state: options.state,
+      packer: options.packer,
+    })
+  ) {
+    return
+  }
+  const result = await executeEvalSelection({
+    config: options.config,
+    selection: options.selection,
+    runId: options.runId,
+    reusableArtifact: options.state.reusableArtifact,
+  })
+  options.state.results.push(result)
+  updateSelectionState(options.state, options.selection, result)
+}
+
+async function executeSelectionLoop(options: {
+  config: EvalSelectionRunnerOptions
+  selections: readonly ParsedEvalSelection[]
+  runId: string
+  rootDir: string
+  state: EvalSelectionState
+  packer: (options: {
+    rootDir: string
+    fixture: EvalFixture
+  }) => InstalledArtifact
+}): Promise<void> {
+  const { state } = options
+  const lastInstalledIndex = lastInstalledSelectionIndex(options.selections)
+
+  for (let index = 0; index < options.selections.length; index += 1) {
+    const selection = options.selections[index]
+    if (!selection) continue
+    if (isEvalInterrupted()) {
+      state.abortLaterSelections = true
+      break
+    }
+    await executeSelectionIteration({
+      config: options.config,
+      selection,
+      runId: options.runId,
+      rootDir: options.rootDir,
+      state,
+      packer: options.packer,
+    })
+
+    if (index === lastInstalledIndex) {
+      await cleanupSharedArtifact(
+        state,
+        options.runId,
+        options.config.artifactCleanupHooks,
+      )
+    }
+  }
+}
+
+export async function runEvalSelections(
+  options: EvalSelectionRunnerOptions,
+): Promise<EvalRunExecution> {
+  const rootDir = path.resolve(options.rootDir ?? REPO_ROOT)
+  const runId = options.runId ?? createEvalRunId()
+  ensureSafeFixtureId(runId)
+  const requestedSelectionIds = [...new Set(options.selectionIds)].sort()
+  if (requestedSelectionIds.length === 0) {
+    throw new Error('eval-run:invalid_selection')
+  }
+  const selections = requestedSelectionIds.map((selectionId) => ({
+    selectionId,
+    ...parseEvalSelectionId(selectionId),
+  }))
+  const packer = options.packInstalledArtifact ?? packInstalledArtifact
+  const state: EvalSelectionState = {
+    results: [],
+    installedBlocked: false,
+    abortLaterSelections: false,
+  }
+
+  try {
+    await executeSelectionLoop({
+      config: options,
+      selections,
+      runId,
+      rootDir,
+      state,
+      packer,
+    })
+  } finally {
+    if (state.artifactFixture) {
+      await cleanupSharedArtifact(state, runId, options.artifactCleanupHooks)
+    }
+  }
+
+  const manifest = buildEvalRunManifest(
+    runId,
+    requestedSelectionIds,
+    state.results,
+  )
+  const persisted = persistEvalRun({
+    manifest,
+    results: state.results,
+    runsRoot: options.runsRoot,
+    rootDir,
+  })
+  return {
+    runId,
+    manifest: normalizeRunManifest(manifest),
+    results: state.results,
+    persisted,
+  }
+}
+
+function safeCliErrorCode(error: unknown, fallback: string): string {
+  const message = error instanceof Error ? error.message : ''
+  const match = message.match(/^((?:eval-cli|eval-run|eval-persist):[a-z_]+)$/)
+  return match?.[1] ?? fallback
+}
+
+function evalRunExitCode(run: EvalRunExecution): 0 | 1 {
+  return !run.manifest.partial &&
+    run.results.length === run.manifest.requestedSelectionIds.length &&
+    run.results.every((result) => result.outcome === 'success')
+    ? 0
+    : 1
+}
+
+export async function runEvalCli(
+  argv: readonly string[],
+  overrides: EvalCliOptionsOverride = {},
+): Promise<EvalCliRunResult> {
+  let parsed: EvalCliParseResult
+  try {
+    parsed = parseEvalCliArgs(argv)
+  } catch (error) {
+    return {
+      kind: 'error',
+      exitCode: 2,
+      code: safeCliErrorCode(error, 'eval-cli:invalid_arguments'),
+      usage: CLI_USAGE,
+    }
+  }
+  if ('help' in parsed) {
+    return { kind: 'help', exitCode: 0, usage: parsed.usage }
+  }
+
+  try {
+    const run = await runEvalSelections({
+      selectionIds: parsed.selectionIds,
+      fixtureSeed: parsed.fixtureSeed,
+      normalizedClock: parsed.normalizedClock,
+      runId: overrides.runId,
+      parentDir: overrides.parentDir,
+      rootDir: overrides.rootDir,
+      runsRoot: overrides.runsRoot,
+      timeoutMs: overrides.timeoutMs,
+      caseTimeoutMs: overrides.caseTimeoutMs,
+      sourceRunner: overrides.sourceRunner,
+      installedRunner: overrides.installedRunner,
+      packInstalledArtifact: overrides.packInstalledArtifact,
+    })
+    return { kind: 'run', exitCode: evalRunExitCode(run), run }
+  } catch (error) {
+    return {
+      kind: 'error',
+      exitCode: 1,
+      code: safeCliErrorCode(error, 'eval-run:execution_failed'),
+    }
+  }
+}
+
+function printEvalCliResult(result: EvalCliRunResult): void {
+  if (result.kind === 'help') {
+    console.log(result.usage)
+    return
+  }
+  if (result.kind === 'error') {
+    console.error(
+      JSON.stringify({
+        status: 'error',
+        exitCode: result.exitCode,
+        code: result.code,
+        ...(result.usage ? { usage: result.usage } : {}),
+      }),
+    )
+    process.exitCode = result.exitCode
+    return
+  }
+  console.log(
+    JSON.stringify({
+      status: 'written',
+      exitCode: result.exitCode,
+      runId: result.run.runId,
+      manifestArtifactId: `evals/runs/${result.run.runId}/manifest.json`,
+      requestedCount: result.run.manifest.requestedSelectionIds.length,
+      completedCount: result.run.manifest.completedSelectionIds.length,
+      partial: result.run.manifest.partial,
+    }),
+  )
+  process.exitCode = result.exitCode
+}
+
+async function cleanupInterruptedEval(): Promise<void> {
+  try {
+    const resources = await import('./eval-cases/opencode.ts')
+    await resources.stopActiveEvalResources()
+  } catch {
+    // The bounded force-exit timer remains the final cleanup guard.
+  }
+  for (const registration of [...activeEvalFixtures.values()]) {
+    try {
+      await cleanupRegisteredEvalFixture(
+        registration.fixture,
+        registration.runId,
+        registration.hooks,
+      )
+    } catch {
+      // The bounded force-exit timer remains the final cleanup guard.
+    } finally {
+      unregisterActiveEvalFixture(registration.fixture)
+    }
+  }
+}
+
+export function installEvalSignalHandlers(): () => void {
+  const handleSignal = (signal: NodeJS.Signals): void => {
+    if (interruptionSignal) return
+    interruptionSignal = signal
+    process.exitCode = 1
+    const forceExit = setTimeout(() => process.exit(1), 7_500)
+    forceExit.unref()
+    interruptionCleanup = cleanupInterruptedEval().finally(() => {
+      clearTimeout(forceExit)
+    })
+  }
+  const onSigint = (): void => handleSignal('SIGINT')
+  const onSigterm = (): void => handleSignal('SIGTERM')
+  process.on('SIGINT', onSigint)
+  process.on('SIGTERM', onSigterm)
+  return () => {
+    process.off('SIGINT', onSigint)
+    process.off('SIGTERM', onSigterm)
+    interruptionSignal = undefined
+    interruptionCleanup = undefined
+  }
+}
+
+function printInterruptedEvalResult(result: EvalCliRunResult): void {
+  const runId = result.kind === 'run' ? result.run.runId : undefined
+  console.log(
+    JSON.stringify({
+      status: 'interrupted',
+      exitCode: 1,
+      ...(runId
+        ? {
+            runId,
+            manifestArtifactId: `evals/runs/${runId}/manifest.json`,
+          }
+        : {}),
+    }),
+  )
+  process.exitCode = 1
+}
+
+async function main(): Promise<void> {
+  const removeSignalHandlers = installEvalSignalHandlers()
+  try {
+    const result = await runEvalCli(process.argv.slice(2))
+    if (interruptionCleanup) await interruptionCleanup
+    if (interruptionSignal) {
+      printInterruptedEvalResult(result)
+    } else {
+      printEvalCliResult(result)
+    }
+  } finally {
+    removeSignalHandlers()
+  }
+}
+
+if (import.meta.main) {
+  void main().catch(() => {
+    console.error(
+      JSON.stringify({
+        status: 'error',
+        exitCode: 1,
+        code: 'eval-run:execution_failed',
+      }),
+    )
+    process.exitCode = 1
+  })
+}

--- a/scripts/run-evals.ts
+++ b/scripts/run-evals.ts
@@ -474,7 +474,8 @@ export const BANNED_FIELD_NAMES = new Set([
 const ABSOLUTE_PATH_PATTERNS = [/^\//, /^\\/, /^[A-Za-z]:[\\/]/, /^file:\/\//i]
 
 const SECRET_PATTERNS = [
-  /\b(?:ghp|gho|github_pat|glpat|npm|sk)[-_A-Za-z0-9]+/i,
+  /\b(?:ghp|gho|github_pat|glpat|npm)[-_A-Za-z0-9]+/i,
+  /\bsk[-_][A-Za-z0-9_-]{8,}\b/i,
   /\bAKIA[0-9A-Z]{8,}\b/,
   /\b(?:fake|dummy|test)[-_A-Za-z0-9]*(?:token|auth|key|secret|credential|password|socket)\b/i,
   /\b(?:token|secret|password|api[-_]?key|private[-_]?key|authorization)\s*[:=]/i,

--- a/tests/integration/eval-artifact.test.ts
+++ b/tests/integration/eval-artifact.test.ts
@@ -1,0 +1,406 @@
+import { describe, expect, test } from 'bun:test'
+import { createHash } from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { gzipSync } from 'node:zlib'
+
+import {
+  assertInstalledResolutionPath,
+  cleanupEvalFixture,
+  createEvalFixture,
+  type EvalFixture,
+  extractValidatedNpmTarball,
+  packInstalledArtifact,
+  resolveInstalledPluginEntry,
+  validateNpmTarball,
+} from '../../scripts/run-evals.ts'
+
+const ROOT_DIR = path.resolve(import.meta.dirname, '../..')
+
+interface TarEntry {
+  name: string
+  type: 'file' | 'directory' | 'symlink' | 'hardlink' | 'fifo' | 'char'
+  content?: string
+  linkName?: string
+}
+
+function writeOctal(
+  buffer: Buffer,
+  offset: number,
+  length: number,
+  value: number,
+): void {
+  const encoded = `${value.toString(8).padStart(length - 1, '0')}\0`
+  buffer.write(encoded, offset, length, 'ascii')
+}
+
+function tarTypeFlag(type: TarEntry['type']): number {
+  switch (type) {
+    case 'file':
+      return 0x30
+    case 'directory':
+      return 0x35
+    case 'symlink':
+      return 0x32
+    case 'hardlink':
+      return 0x31
+    case 'fifo':
+      return 0x36
+    case 'char':
+      return 0x33
+  }
+}
+
+function tarBlock(entry: TarEntry): Buffer {
+  const block = Buffer.alloc(512)
+  block.write(entry.name, 0, 100, 'utf8')
+  writeOctal(block, 100, 8, entry.type === 'directory' ? 0o755 : 0o644)
+  writeOctal(block, 108, 8, 0)
+  writeOctal(block, 116, 8, 0)
+  const content = Buffer.from(entry.content ?? '', 'utf8')
+  writeOctal(block, 124, 12, content.length)
+  writeOctal(block, 136, 12, 0)
+  block.fill(0x20, 148, 156)
+  block[156] = tarTypeFlag(entry.type)
+  if (entry.linkName) block.write(entry.linkName, 157, 100, 'utf8')
+  block.write('ustar\0', 257, 6, 'ascii')
+  block.write('00', 263, 2, 'ascii')
+  const checksum = block.reduce((sum, byte) => sum + byte, 0)
+  writeOctal(block, 148, 8, checksum)
+  return Buffer.concat([
+    block,
+    content,
+    Buffer.alloc((512 - (content.length % 512)) % 512),
+  ])
+}
+
+function writeTarball(parentDir: string, entries: readonly TarEntry[]): string {
+  const archivePath = path.join(parentDir, 'fixture.tgz')
+  const body = Buffer.concat([...entries.map(tarBlock), Buffer.alloc(1024)])
+  fs.writeFileSync(archivePath, gzipSync(body))
+  return archivePath
+}
+
+function validPackageEntries(): TarEntry[] {
+  return [
+    {
+      name: 'package/package.json',
+      type: 'file',
+      content: JSON.stringify({
+        name: '@fro.bot/systematic',
+        version: '1.2.3',
+        main: './dist/index.js',
+        exports: { '.': { import: './dist/index.js' } },
+      }),
+    },
+    {
+      name: 'package/dist/index.js',
+      type: 'file',
+      content: 'export default () => ({})',
+    },
+  ]
+}
+
+function freshFixture(parentDir: string): EvalFixture {
+  return createEvalFixture({
+    caseId: 'bootstrap-loading',
+    mode: 'installed',
+    runId: 'artifact-test',
+    parentDir,
+  })
+}
+
+describe('installed eval artifact boundary', () => {
+  test('packs once, validates, extracts, and resolves the real package entry under the fixture root', () => {
+    const parentDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'eval-artifact-real-'),
+    )
+    const fixture = freshFixture(parentDir)
+    try {
+      const artifact = packInstalledArtifact({ rootDir: ROOT_DIR, fixture })
+      const archive = validateNpmTarball(artifact.tarballPath)
+      const resolved = resolveInstalledPluginEntry(fixture.packageRoot)
+
+      expect(artifact.packageName).toBe('@fro.bot/systematic')
+      expect(artifact.packageVersion).toMatch(/^\d+\.\d+\.\d+/)
+      expect(artifact.tarballDigest).toMatch(/^[a-f0-9]{64}$/)
+      expect(archive.entries.length).toBeGreaterThan(0)
+      expect(artifact.packageRoot).toBe(fixture.packageRoot)
+      expect(artifact.moduleEntryId).toBe('dist/index.js')
+      expect(resolved.moduleEntryId).toBe('dist/index.js')
+      expect(fs.existsSync(resolved.moduleEntry)).toBe(true)
+      expect(
+        assertInstalledResolutionPath(
+          fixture.packageRoot,
+          resolved.moduleEntry,
+        ),
+      ).toBe(resolved.moduleEntry)
+    } finally {
+      cleanupEvalFixture(fixture)
+      expect(fs.readdirSync(parentDir)).toEqual([])
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  }, 240_000)
+
+  test('rejects malformed and unsafe archive entry categories before extraction', () => {
+    const parentDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'eval-artifact-hostile-'),
+    )
+    const destination = path.join(parentDir, 'extracted')
+    fs.mkdirSync(destination)
+    const cases: Array<{ label: string; entry: TarEntry }> = [
+      {
+        label: 'empty-name',
+        entry: { name: '', type: 'file' },
+      },
+      {
+        label: 'control-character',
+        entry: { name: 'package/\u0001escape', type: 'file' },
+      },
+      { label: 'absolute-posix', entry: { name: '/tmp/escape', type: 'file' } },
+      {
+        label: 'absolute-windows',
+        entry: { name: 'C:\\tmp\\escape', type: 'file' },
+      },
+      {
+        label: 'unc',
+        entry: { name: '\\\\server\\share\\escape', type: 'file' },
+      },
+      {
+        label: 'file-url',
+        entry: { name: 'file:///tmp/escape', type: 'file' },
+      },
+      {
+        label: 'traversal',
+        entry: { name: 'package/../escape', type: 'file' },
+      },
+      {
+        label: 'dot-segment',
+        entry: { name: 'package/./escape', type: 'file' },
+      },
+      {
+        label: 'hardlink',
+        entry: {
+          name: 'package/link',
+          type: 'hardlink',
+          linkName: 'package/dist/index.js',
+        },
+      },
+      {
+        label: 'escaping-symlink',
+        entry: {
+          name: 'package/link',
+          type: 'symlink',
+          linkName: '../../outside',
+        },
+      },
+      {
+        label: 'symlink-chain',
+        entry: {
+          name: 'package/link',
+          type: 'symlink',
+          linkName: 'package/link-target',
+        },
+      },
+      { label: 'special-fifo', entry: { name: 'package/fifo', type: 'fifo' } },
+      {
+        label: 'special-char',
+        entry: { name: 'package/device', type: 'char' },
+      },
+      {
+        label: 'safe-symlink-rejected',
+        entry: {
+          name: 'package/link',
+          type: 'symlink',
+          linkName: 'dist/index.js',
+        },
+      },
+    ]
+
+    try {
+      for (const { label, entry } of cases) {
+        const archivePath = writeTarball(parentDir, [entry])
+        expect(
+          () => extractValidatedNpmTarball(archivePath, destination),
+          label,
+        ).toThrow(/artifact_resolution|path_escape/)
+        expect(fs.readdirSync(destination)).toEqual([])
+      }
+
+      const malformedPath = path.join(parentDir, 'malformed.tgz')
+      fs.writeFileSync(malformedPath, gzipSync(Buffer.from('not-a-tar')))
+      expect(() => validateNpmTarball(malformedPath)).toThrow(
+        /artifact_resolution/,
+      )
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects missing package metadata, main/export, and dist content without source fallback', () => {
+    const parentDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'eval-artifact-missing-'),
+    )
+    const fixture = freshFixture(parentDir)
+    try {
+      const missingPackageJson = writeTarball(parentDir, [
+        {
+          name: 'package/dist/index.js',
+          type: 'file',
+          content: 'export default () => ({})',
+        },
+      ])
+      extractValidatedNpmTarball(missingPackageJson, fixture.packageRoot)
+      expect(() => resolveInstalledPluginEntry(fixture.packageRoot)).toThrow(
+        /artifact_resolution/,
+      )
+
+      const missingMain = writeTarball(parentDir, [
+        {
+          name: 'package/package.json',
+          type: 'file',
+          content: JSON.stringify({
+            name: '@fro.bot/systematic',
+            version: '1.2.3',
+          }),
+        },
+        {
+          name: 'package/dist/index.js',
+          type: 'file',
+          content: 'export default () => ({})',
+        },
+      ])
+      extractValidatedNpmTarball(missingMain, fixture.packageRoot)
+      expect(() => resolveInstalledPluginEntry(fixture.packageRoot)).toThrow(
+        /artifact_resolution/,
+      )
+
+      const missingDist = writeTarball(parentDir, [
+        {
+          name: 'package/package.json',
+          type: 'file',
+          content: JSON.stringify({
+            name: '@fro.bot/systematic',
+            version: '1.2.3',
+            main: './dist/index.js',
+          }),
+        },
+      ])
+      extractValidatedNpmTarball(missingDist, fixture.packageRoot)
+      expect(() => resolveInstalledPluginEntry(fixture.packageRoot)).toThrow(
+        /artifact_resolution/,
+      )
+
+      expect(() =>
+        assertInstalledResolutionPath(
+          fixture.packageRoot,
+          path.join(ROOT_DIR, 'src/index.ts'),
+        ),
+      ).toThrow(/path_escape/)
+    } finally {
+      cleanupEvalFixture(fixture)
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects package roots under ancestor node_modules fallback paths', () => {
+    const parentDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'eval-artifact-ancestor-'),
+    )
+    const packageRoot = path.join(
+      parentDir,
+      'node_modules',
+      '@fro.bot',
+      'systematic',
+    )
+    fs.mkdirSync(path.join(packageRoot, 'dist'), { recursive: true })
+
+    try {
+      expect(() =>
+        assertInstalledResolutionPath(
+          packageRoot,
+          path.join(packageRoot, 'dist/index.js'),
+        ),
+      ).toThrow('eval-artifact:path_escape')
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects external ancestor node_modules fallback while allowing fixture-local dependencies', () => {
+    const parentDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'eval-artifact-external-ancestor-'),
+    )
+    const packageRoot = path.join(parentDir, 'run', 'package')
+    const packageEntry = path.join(packageRoot, 'dist/index.js')
+    fs.mkdirSync(path.dirname(packageEntry), { recursive: true })
+    fs.writeFileSync(packageEntry, 'export default () => ({})')
+    fs.mkdirSync(path.join(packageRoot, 'node_modules', 'declared-dep'), {
+      recursive: true,
+    })
+    fs.mkdirSync(path.join(parentDir, 'node_modules', 'undeclared-dep'), {
+      recursive: true,
+    })
+
+    try {
+      expect(() =>
+        assertInstalledResolutionPath(packageRoot, packageEntry),
+      ).toThrow('eval-artifact:path_escape')
+
+      fs.rmSync(path.join(parentDir, 'node_modules'), {
+        recursive: true,
+        force: true,
+      })
+      expect(assertInstalledResolutionPath(packageRoot, packageEntry)).toBe(
+        fs.realpathSync(packageEntry),
+      )
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('validates a safe internal package archive and keeps extracted paths canonical', () => {
+    const parentDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'eval-artifact-safe-'),
+    )
+    const fixture = freshFixture(parentDir)
+    try {
+      const archivePath = writeTarball(parentDir, validPackageEntries())
+      const digest = createHash('sha256')
+        .update(fs.readFileSync(archivePath))
+        .digest('hex')
+      extractValidatedNpmTarball(archivePath, fixture.packageRoot)
+      const artifact = resolveInstalledPluginEntry(fixture.packageRoot)
+
+      expect(validateNpmTarball(archivePath).digest).toBe(digest)
+      expect(artifact.moduleEntry.startsWith(fixture.packageRoot)).toBe(true)
+      expect(fs.realpathSync(artifact.moduleEntry)).toBe(artifact.moduleEntry)
+    } finally {
+      cleanupEvalFixture(fixture)
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects compressed tar output over the production size cap before validation', () => {
+    const parentDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'eval-artifact-bomb-'),
+    )
+    try {
+      const maxOutputBytes = 128 * 1024 * 1024
+      const oversizedBody = Buffer.alloc(maxOutputBytes + 16 * 1024 * 1024)
+      const archivePath = path.join(parentDir, 'compressed-bomb.tgz')
+      fs.writeFileSync(archivePath, gzipSync(oversizedBody))
+
+      const beforeArrayBuffers = process.memoryUsage().arrayBuffers
+      expect(() => validateNpmTarball(archivePath)).toThrow(
+        /eval-artifact:artifact_resolution/,
+      )
+      const arrayBuffersDelta =
+        process.memoryUsage().arrayBuffers - beforeArrayBuffers
+      expect(arrayBuffersDelta).toBeLessThan(maxOutputBytes + 8 * 1024 * 1024)
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/integration/eval-fixture.test.ts
+++ b/tests/integration/eval-fixture.test.ts
@@ -45,6 +45,20 @@ function controlledPaths(fixture: EvalFixture): string[] {
   ]
 }
 
+const envInspectionScript = `
+  const forbidden = JSON.parse(process.argv[1])
+  const fakeValue = process.argv[2]
+  const names = Object.keys(process.env)
+
+  console.log(
+    JSON.stringify({
+      forbiddenNames: forbidden.filter((key) => names.includes(key)),
+      fakeValue: Object.values(process.env).includes(fakeValue),
+      home: process.env.HOME,
+    }),
+  )
+`
+
 describe('eval fixture isolation', () => {
   test('creates unique roots and keeps every controlled canonical path inside its run root', () => {
     const parentDir = fs.mkdtempSync(
@@ -137,7 +151,8 @@ describe('eval fixture isolation', () => {
         process.execPath,
         [
           '-e',
-          `const forbidden = ${JSON.stringify([
+          envInspectionScript,
+          JSON.stringify([
             'GH_TOKEN',
             'GITHUB_TOKEN',
             'NPM_TOKEN',
@@ -146,7 +161,8 @@ describe('eval fixture isolation', () => {
             'SSH_AUTH_SOCK',
             'GIT_ASKPASS',
             'OPENCODE_AUTH_TOKEN',
-          ])}; const names = Object.keys(process.env); console.log(JSON.stringify({ forbiddenNames: forbidden.filter((key) => names.includes(key)), fakeValue: Object.values(process.env).includes(${JSON.stringify(fakeValue)}), home: process.env.HOME }));`,
+          ]),
+          fakeValue,
         ],
         { cwd: fixture.projectRoot, env: childEnv, encoding: 'utf8' },
       )

--- a/tests/integration/eval-fixture.test.ts
+++ b/tests/integration/eval-fixture.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from 'bun:test'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  createOpencodeProbe,
+  startScriptedModelServer,
+} from '../../scripts/eval-cases/opencode.ts'
+import {
+  assertEvalPathContained,
+  buildEvalChildEnv,
+  capturePrimaryCheckout,
+  cleanupEvalFixture,
+  createEvalFixture,
+  type EvalFixture,
+} from '../../scripts/run-evals.ts'
+
+function fixtureOptions(parentDir: string, runId: string) {
+  return {
+    caseId: 'bootstrap-loading' as const,
+    mode: 'source' as const,
+    runId,
+    parentDir,
+  }
+}
+
+function controlledPaths(fixture: EvalFixture): string[] {
+  return [
+    fixture.runRoot,
+    fixture.caseRoot,
+    fixture.modeRoot,
+    fixture.projectRoot,
+    fixture.homeRoot,
+    fixture.xdgConfigRoot,
+    fixture.xdgDataRoot,
+    fixture.xdgCacheRoot,
+    fixture.xdgStateRoot,
+    fixture.opencodeConfigRoot,
+    fixture.probeRoot,
+    fixture.npmCacheRoot,
+    fixture.packageRoot,
+    fixture.provenanceRoot,
+    fixture.tmpRoot,
+  ]
+}
+
+describe('eval fixture isolation', () => {
+  test('creates unique roots and keeps every controlled canonical path inside its run root', () => {
+    const parentDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'eval-fixture-test-'),
+    )
+    const first = createEvalFixture(fixtureOptions(parentDir, 'fixture-a'))
+    const second = createEvalFixture(fixtureOptions(parentDir, 'fixture-b'))
+
+    try {
+      expect(first.runRoot).not.toBe(second.runRoot)
+      expect(first.caseRoot).not.toBe(second.caseRoot)
+      for (const fixture of [first, second]) {
+        for (const controlledPath of controlledPaths(fixture)) {
+          expect(() =>
+            assertEvalPathContained(fixture.runRoot, controlledPath),
+          ).not.toThrow()
+        }
+      }
+    } finally {
+      cleanupEvalFixture(first)
+      cleanupEvalFixture(second)
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('builds an explicit child env without seeded parent auth or config values', () => {
+    const parentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eval-env-test-'))
+    const fixture = createEvalFixture(fixtureOptions(parentDir, 'env'))
+    const parentHome = path.join(parentDir, 'parent-home')
+    const parentConfig = path.join(parentDir, 'parent-config')
+    fs.mkdirSync(path.join(parentHome, '.ssh'), { recursive: true })
+    fs.mkdirSync(parentConfig, { recursive: true })
+    fs.writeFileSync(path.join(parentHome, '.npmrc'), 'fake npm auth file')
+    fs.writeFileSync(
+      path.join(parentHome, '.ssh', 'agent.sock'),
+      'fake ssh socket placeholder',
+    )
+    fs.writeFileSync(path.join(parentConfig, 'auth.json'), 'fake opencode auth')
+
+    const fakeValue = 'fake-gh-token-value'
+    const parentEnv: Record<string, string> = {
+      PATH: '/usr/bin:/bin',
+      GH_TOKEN: fakeValue,
+      GITHUB_TOKEN: fakeValue,
+      NPM_TOKEN: fakeValue,
+      npm_config_userconfig: path.join(parentHome, '.npmrc'),
+      OPENAI_API_KEY: fakeValue,
+      AWS_SECRET_ACCESS_KEY: fakeValue,
+      SSH_AUTH_SOCK: path.join(parentHome, '.ssh', 'agent.sock'),
+      GIT_ASKPASS: 'fake-git-askpass',
+      OPENCODE_AUTH_TOKEN: fakeValue,
+      HOME: parentHome,
+      XDG_CONFIG_HOME: parentConfig,
+      XDG_DATA_HOME: path.join(parentDir, 'parent-data'),
+      XDG_CACHE_HOME: path.join(parentDir, 'parent-cache'),
+      XDG_STATE_HOME: path.join(parentDir, 'parent-state'),
+    }
+
+    try {
+      const childEnv = buildEvalChildEnv({
+        fixture,
+        configContent: '{}',
+        modelBaseUrl: 'http://127.0.0.1:1/v1',
+        parentEnv,
+      })
+
+      for (const key of [
+        'GH_TOKEN',
+        'GITHUB_TOKEN',
+        'NPM_TOKEN',
+        'npm_config_userconfig',
+        'OPENAI_API_KEY',
+        'AWS_SECRET_ACCESS_KEY',
+        'SSH_AUTH_SOCK',
+        'GIT_ASKPASS',
+        'OPENCODE_AUTH_TOKEN',
+      ]) {
+        expect(childEnv[key]).toBeUndefined()
+      }
+      expect(childEnv.HOME).toBe(fixture.homeRoot)
+      expect(childEnv.XDG_CONFIG_HOME).toBe(fixture.xdgConfigRoot)
+      expect(childEnv.XDG_DATA_HOME).toBe(fixture.xdgDataRoot)
+      expect(childEnv.XDG_CACHE_HOME).toBe(fixture.xdgCacheRoot)
+      expect(childEnv.XDG_STATE_HOME).toBe(fixture.xdgStateRoot)
+      expect(childEnv.NPM_CONFIG_CACHE).toBe(fixture.npmCacheRoot)
+      expect(childEnv.OPENCODE_CONFIG_DIR).toBe(fixture.opencodeConfigRoot)
+      expect(childEnv.EVAL_MODEL_BASE_URL).toBe('http://127.0.0.1:1/v1')
+
+      const inspection = spawnSync(
+        process.execPath,
+        [
+          '-e',
+          `const forbidden = ${JSON.stringify([
+            'GH_TOKEN',
+            'GITHUB_TOKEN',
+            'NPM_TOKEN',
+            'OPENAI_API_KEY',
+            'AWS_SECRET_ACCESS_KEY',
+            'SSH_AUTH_SOCK',
+            'GIT_ASKPASS',
+            'OPENCODE_AUTH_TOKEN',
+          ])}; const names = Object.keys(process.env); console.log(JSON.stringify({ forbiddenNames: forbidden.filter((key) => names.includes(key)), fakeValue: Object.values(process.env).includes(${JSON.stringify(fakeValue)}), home: process.env.HOME }));`,
+        ],
+        { cwd: fixture.projectRoot, env: childEnv, encoding: 'utf8' },
+      )
+      expect(inspection.status).toBe(0)
+      const observed = JSON.parse(inspection.stdout) as {
+        forbiddenNames: string[]
+        fakeValue: boolean
+        home: string
+      }
+      expect(observed).toEqual({
+        forbiddenNames: [],
+        fakeValue: false,
+        home: fixture.homeRoot,
+      })
+    } finally {
+      cleanupEvalFixture(fixture)
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('fails closed on canonical symlink/path escape attempts', () => {
+    const parentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eval-path-test-'))
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eval-outside-'))
+    const fixture = createEvalFixture(fixtureOptions(parentDir, 'path'))
+    const escapeLink = path.join(fixture.runRoot, 'escape-link')
+    fs.symlinkSync(outsideDir, escapeLink, 'dir')
+
+    try {
+      expect(() =>
+        assertEvalPathContained(fixture.runRoot, escapeLink),
+      ).toThrow('eval-path:path_escape')
+      expect(() =>
+        assertEvalPathContained(fixture.runRoot, path.join(escapeLink, 'file')),
+      ).toThrow('eval-path:path_escape')
+    } finally {
+      cleanupEvalFixture(fixture)
+      fs.rmSync(outsideDir, { recursive: true, force: true })
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('always permits explicit cleanup of probe, model, and fixture resources', async () => {
+    const parentDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'eval-cleanup-test-'),
+    )
+    const fixture = createEvalFixture(fixtureOptions(parentDir, 'cleanup'))
+    const probe = createOpencodeProbe(fixture)
+    const model = startScriptedModelServer([])
+
+    expect(fs.existsSync(fixture.runRoot)).toBe(true)
+    expect(fs.existsSync(probe.capturePath)).toBe(false)
+    await model.stop()
+    cleanupEvalFixture(fixture)
+
+    expect(fs.existsSync(fixture.runRoot)).toBe(false)
+    expect(fs.existsSync(probe.capturePath)).toBe(false)
+    fs.rmSync(parentDir, { recursive: true, force: true })
+  })
+
+  test('primary checkout identity is unchanged by fixture setup and cleanup', () => {
+    const before = capturePrimaryCheckout()
+    const parentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eval-git-test-'))
+    const fixture = createEvalFixture(fixtureOptions(parentDir, 'git'))
+
+    try {
+      expect(capturePrimaryCheckout()).toEqual(before)
+    } finally {
+      cleanupEvalFixture(fixture)
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+    expect(capturePrimaryCheckout()).toEqual(before)
+  })
+})

--- a/tests/integration/eval-runner.test.ts
+++ b/tests/integration/eval-runner.test.ts
@@ -1,0 +1,1549 @@
+import { describe, expect, test } from 'bun:test'
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  type BoundedProbeEvent,
+  gradeBootstrapProbe,
+  gradeFixtureWrite,
+} from '../../scripts/eval-cases/opencode.ts'
+import {
+  capturePrimaryCheckout,
+  type EvalFixture,
+  type EvalSelectionRunnerInput,
+  installEvalSignalHandlers,
+  normalizeResult,
+  runEvalCli,
+  runEvalSelections,
+  runInstalledEval,
+  runSourceEval,
+  validateSerializedResult,
+  validateSerializedRunManifest,
+} from '../../scripts/run-evals.ts'
+
+const FIXED_CLOCK = '2026-08-13T00:00:00.000Z'
+const EXPECTED_CLI_HELP = [
+  'Usage: bun scripts/run-evals.ts [options]',
+  '',
+  'Options:',
+  '  --case <id>       Repeatable: bootstrap-loading | fixture-local-write',
+  '  --mode <mode>     Repeatable: source | installed',
+  '  --seed <seed>     [A-Za-z0-9][A-Za-z0-9._-]{0,127}',
+  '  --clock <UTC>     YYYY-MM-DDTHH:mm:ss.sssZ',
+  '  --help            Show this help',
+  '',
+  'Output: evals/runs/<runId>/; manifest.json is the final completion marker.',
+  'Exit codes: 0 success; 1 completed or partial run with a non-success outcome; 2 invalid arguments.',
+].join('\n')
+
+function syntheticExecution(
+  outcome: 'success' | 'task_failure' | 'infra_failure',
+  subcode:
+    | 'none'
+    | 'write_mismatch'
+    | 'unexpected_exit'
+    | 'identity_drift'
+    | 'artifact_resolution',
+): {
+  outcome: 'success' | 'task_failure' | 'infra_failure'
+  subcode:
+    | 'none'
+    | 'write_mismatch'
+    | 'unexpected_exit'
+    | 'identity_drift'
+    | 'artifact_resolution'
+  sanity: 'passed' | 'failed'
+  process: 'completed' | 'failed'
+  probeDigest: string
+  artifactRefs: string[]
+} {
+  return {
+    outcome,
+    subcode,
+    sanity: outcome === 'success' ? 'passed' : 'failed',
+    process: outcome === 'success' ? 'completed' : 'failed',
+    probeDigest: 'a'.repeat(64),
+    artifactRefs: ['probe/events.jsonl'],
+  }
+}
+
+function syntheticResult(options: {
+  caseId: 'bootstrap-loading' | 'fixture-local-write'
+  mode: 'source' | 'installed'
+  runId: string
+  outcome: 'success' | 'task_failure' | 'infra_failure'
+  subcode: 'none' | 'write_mismatch' | 'identity_drift' | 'artifact_resolution'
+}): ReturnType<typeof normalizeResult> {
+  const installed = options.mode === 'installed'
+  const assertionIds =
+    options.caseId === 'bootstrap-loading'
+      ? ['bootstrap-observed']
+      : ['fixture-file-content', 'fixture-file-created']
+  return normalizeResult({
+    resultSchemaVersion: 1,
+    caseSchemaVersion: 1,
+    caseId: options.caseId,
+    harness: 'opencode',
+    mode: options.mode,
+    outcome: options.outcome,
+    subcode: options.subcode,
+    runId: options.runId,
+    fixtureSeed: 'synthetic-seed',
+    normalizedClock: FIXED_CLOCK,
+    assertionIds,
+    identity: {
+      opencodeVersion: '1.18.5',
+      opencodeBuildId: 'opencode-ai-1.18.5',
+      probeId: 'probe-opencode-v1',
+      probeDigest: 'a'.repeat(64),
+      fixtureContractVersion: 1,
+      fixtureContractDigest: 'b'.repeat(64),
+      caseSchemaVersion: 1,
+      resultSchemaVersion: 1,
+      artifactId: installed ? 'installed-entry' : 'source-entry',
+      artifactDigest: 'c'.repeat(64),
+    },
+    evidence: {
+      sanity: options.outcome === 'success' ? 'passed' : 'failed',
+      process: options.outcome === 'success' ? 'completed' : 'failed',
+      assertionIds,
+    },
+    cleanup: { status: 'clean', residue: 'none' },
+    privacy: { status: 'validated' },
+    artifactRefs: ['probe/events.jsonl'],
+    provenance: installed
+      ? {
+          kind: 'installed',
+          packageName: '@fro.bot/systematic',
+          packageVersion: '1.2.3',
+          tarballDigest: 'd'.repeat(64),
+          extractedPackageRootId: 'installed-package-root',
+          canonicalResolvedModuleEntryId: 'dist/index.js',
+          opencodeConfigEntryId: 'installed-config',
+        }
+      : {
+          kind: 'source',
+          checkoutRelativeSource: 'src/index.ts',
+          commitId: 'e'.repeat(40),
+          worktreeId: 'synthetic-worktree',
+          canonicalSourceEntryId: 'source-entry',
+          opencodeConfigEntryId: 'source-config',
+        },
+  })
+}
+
+function runParent(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'systematic-eval-runner-test-'))
+}
+
+function expectRuntimeOutcome(
+  result: ReturnType<typeof normalizeResult>,
+): void {
+  expect(result.outcome).toBe('success')
+  expect(result.identity.opencodeVersion).toBe('1.18.5')
+  expect(result.identity.opencodeBuildId).toBe('opencode-ai-1.18.5')
+}
+
+function boundedInfraResult(): ReturnType<typeof normalizeResult> {
+  return normalizeResult({
+    resultSchemaVersion: 1,
+    caseSchemaVersion: 1,
+    caseId: 'bootstrap-loading',
+    harness: 'opencode',
+    mode: 'source',
+    outcome: 'infra_failure',
+    subcode: 'opencode_unavailable',
+    runId: 'run-infra',
+    fixtureSeed: 'fixture-infra',
+    normalizedClock: FIXED_CLOCK,
+    assertionIds: ['bootstrap-observed'],
+    identity: {
+      opencodeVersion: '1.18.5',
+      opencodeBuildId: 'opencode-ai-1.18.5',
+      probeId: 'probe-opencode-v1',
+      probeDigest: 'a'.repeat(64),
+      fixtureContractVersion: 1,
+      fixtureContractDigest: 'b'.repeat(64),
+      caseSchemaVersion: 1,
+      resultSchemaVersion: 1,
+      artifactId: 'source-entry',
+      artifactDigest: 'c'.repeat(64),
+    },
+    evidence: {
+      sanity: 'failed',
+      process: 'failed',
+      assertionIds: ['bootstrap-observed'],
+    },
+    cleanup: { status: 'clean', residue: 'none' },
+    privacy: { status: 'validated' },
+    artifactRefs: ['probe/events.jsonl'],
+    provenance: {
+      kind: 'source',
+      checkoutRelativeSource: 'src/index.ts',
+      commitId: 'd'.repeat(40),
+      worktreeId: 'worktree-infra',
+      canonicalSourceEntryId: 'source-entry',
+      opencodeConfigEntryId: 'source-config',
+    },
+  })
+}
+
+function withoutOpaqueRunId(
+  result: ReturnType<typeof normalizeResult>,
+): ReturnType<typeof normalizeResult> {
+  return { ...result, runId: 'run-opaque' }
+}
+
+function countEvalServeProcesses(): number {
+  const result = Bun.spawnSync(['ps', '-axo', 'command='])
+  if (result.exitCode !== 0) return 0
+  return result.stdout
+    .toString()
+    .split('\n')
+    .filter(
+      (line) => line.includes('opencode-ai@1.18.5') && line.includes('serve'),
+    ).length
+}
+
+function normalizeRunIdentity<T>(value: T, runIds: readonly string[]): T {
+  if (typeof value === 'string') {
+    return runIds.reduce(
+      (result, runId) => result.replaceAll(runId, 'run-opaque'),
+      value,
+    ) as T
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeRunIdentity(item, runIds)) as T
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [
+        key,
+        normalizeRunIdentity(nested, runIds),
+      ]),
+    ) as T
+  }
+  return value
+}
+
+async function waitForMarker(
+  markerPath: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (fs.existsSync(markerPath)) return
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  throw new Error('started-child marker timeout')
+}
+
+describe('local OpenCode eval runner', () => {
+  test('real-case outcome helpers reject bounded infrastructure results', () => {
+    const result = boundedInfraResult()
+    expect(() => expectRuntimeOutcome(result)).toThrow()
+    expect(() => expectRuntimeOutcome(result)).toThrow()
+  })
+
+  test('gates grading on exact OpenCode runtime identity without silently skipping', async () => {
+    const parentDir = runParent()
+    try {
+      const result = await runSourceEval({
+        caseId: 'bootstrap-loading',
+        fixtureSeed: 'runner-runtime-gate',
+        normalizedClock: FIXED_CLOCK,
+        parentDir,
+      })
+      const normalized = normalizeResult(result)
+
+      if (normalized.outcome === 'infra_failure') {
+        expect(['opencode_unavailable', 'identity_drift']).toContain(
+          normalized.subcode,
+        )
+      } else {
+        expect(normalized.identity.opencodeVersion).toBe('1.18.5')
+      }
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  }, 360_000)
+
+  test('runs bootstrap-loading from bounded probe evidence when exact runtime is available', async () => {
+    const parentDir = runParent()
+    try {
+      const result = normalizeResult(
+        await runSourceEval({
+          caseId: 'bootstrap-loading',
+          fixtureSeed: 'runner-bootstrap',
+          normalizedClock: FIXED_CLOCK,
+          parentDir,
+        }),
+      )
+      expectRuntimeOutcome(result)
+      expect(result.mode).toBe('source')
+      expect(result.fixtureSeed).toBe('runner-bootstrap')
+      expect(result.normalizedClock).toBe(FIXED_CLOCK)
+      expect(result.assertionIds).toEqual(['bootstrap-observed'])
+      expect(result.evidence).toEqual({
+        sanity: 'passed',
+        process: 'completed',
+        assertionIds: ['bootstrap-observed'],
+      })
+      expect(result.cleanup).toEqual({ status: 'clean', residue: 'none' })
+      expect(result.provenance.kind).toBe('source')
+      expect(JSON.stringify(result)).not.toContain('stdout')
+      expect(JSON.stringify(result)).not.toContain('stderr')
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  }, 360_000)
+
+  test('writes and grades fixture-local-write exact content when runtime is available', async () => {
+    const parentDir = runParent()
+    try {
+      const result = normalizeResult(
+        await runSourceEval({
+          caseId: 'fixture-local-write',
+          fixtureSeed: 'runner-local-write',
+          normalizedClock: FIXED_CLOCK,
+          parentDir,
+        }),
+      )
+      expectRuntimeOutcome(result)
+      expect(result.assertionIds).toEqual([
+        'fixture-file-content',
+        'fixture-file-created',
+      ])
+      expect(result.provenance.kind).toBe('source')
+      expect(result.cleanup).toEqual({ status: 'clean', residue: 'none' })
+      expect(JSON.stringify(result)).not.toContain('fixture-local-write-v1')
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  }, 360_000)
+
+  test('classifies missing or unhealthy probe and missing fixture output with bounded results', () => {
+    const missingProbe = gradeBootstrapProbe([])
+    expect(missingProbe).toEqual({
+      status: 'unhealthy',
+      subcode: 'probe_unhealthy',
+    })
+
+    const malformedProbe: BoundedProbeEvent[] = [
+      { type: 'loaded', status: 'ok' },
+      { type: 'transform', kind: 'chat', status: 'unhealthy', blockCount: 0 },
+    ]
+    expect(gradeBootstrapProbe(malformedProbe)).toEqual({
+      status: 'unhealthy',
+      subcode: 'probe_unhealthy',
+    })
+
+    const parentDir = runParent()
+    const projectRoot = path.join(parentDir, 'project')
+    fs.mkdirSync(projectRoot, { recursive: true })
+    try {
+      expect(
+        gradeFixtureWrite(projectRoot, {
+          expectedArtifactId: 'fixture/output.txt',
+          expectedContentId: 'fixture-local-write-v1',
+        }),
+      ).toEqual({ outcome: 'task_failure', subcode: 'write_missing' })
+      fs.mkdirSync(path.join(projectRoot, 'fixture'), { recursive: true })
+      fs.writeFileSync(
+        path.join(projectRoot, 'fixture/output.txt'),
+        'wrong-content',
+      )
+      expect(
+        gradeFixtureWrite(projectRoot, {
+          expectedArtifactId: 'fixture/output.txt',
+          expectedContentId: 'fixture-local-write-v1',
+        }),
+      ).toEqual({ outcome: 'task_failure', subcode: 'write_mismatch' })
+      fs.writeFileSync(
+        path.join(projectRoot, 'fixture/output.txt'),
+        'fixture-local-write-v1',
+      )
+      expect(
+        gradeFixtureWrite(projectRoot, {
+          expectedArtifactId: 'fixture/output.txt',
+          expectedContentId: 'fixture-local-write-v1',
+        }),
+      ).toEqual({ outcome: 'success', subcode: 'none' })
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns bounded failure and removes temporary roots on timeout', async () => {
+    const parentDir = runParent()
+    try {
+      const result = normalizeResult(
+        await runSourceEval({
+          caseId: 'bootstrap-loading',
+          fixtureSeed: 'runner-timeout',
+          normalizedClock: FIXED_CLOCK,
+          parentDir,
+          timeoutMs: 1,
+        }),
+      )
+      expect(result.outcome).toBe('infra_failure')
+      expect(['opencode_unavailable', 'identity_drift']).toContain(
+        result.subcode,
+      )
+      expect(result.cleanup).toEqual({ status: 'clean', residue: 'none' })
+      expect(fs.readdirSync(parentDir)).toEqual([])
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  }, 30_000)
+
+  test('classifies a started-host case timeout as task failure and cleans every root', async () => {
+    const parentDir = runParent()
+    const processCountBefore = countEvalServeProcesses()
+    try {
+      const options = {
+        caseId: 'bootstrap-loading' as const,
+        fixtureSeed: 'runner-started-timeout',
+        normalizedClock: FIXED_CLOCK,
+        parentDir,
+        timeoutMs: 360_000,
+        caseTimeoutMs: 1,
+      }
+      const result = normalizeResult(await runSourceEval(options))
+
+      expect(result.outcome).toBe('task_failure')
+      expect(result.subcode).toBe('unexpected_exit')
+      expect(result.cleanup).toEqual({ status: 'clean', residue: 'none' })
+      expect(fs.readdirSync(parentDir)).toEqual([])
+      expect(countEvalServeProcesses()).toBe(processCountBefore)
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  }, 360_000)
+
+  test('repeated source runs normalize to equal evidence and preserve checkout identity', async () => {
+    const before = capturePrimaryCheckout()
+    const parentDir = runParent()
+    try {
+      const first = normalizeResult(
+        await runSourceEval({
+          caseId: 'bootstrap-loading',
+          fixtureSeed: 'runner-repeat',
+          normalizedClock: FIXED_CLOCK,
+          parentDir,
+        }),
+      )
+      const second = normalizeResult(
+        await runSourceEval({
+          caseId: 'bootstrap-loading',
+          fixtureSeed: 'runner-repeat',
+          normalizedClock: FIXED_CLOCK,
+          parentDir,
+        }),
+      )
+
+      expect(withoutOpaqueRunId(first)).toEqual(withoutOpaqueRunId(second))
+      expect(capturePrimaryCheckout()).toEqual(before)
+      expect(first.artifactRefs).not.toContain(first.runId)
+      expect(second.artifactRefs).not.toContain(second.runId)
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  }, 720_000)
+
+  test('source and installed bootstrap runs succeed with disjoint provenance and matching evidence', async () => {
+    const sourceParent = runParent()
+    const installedParent = runParent()
+    try {
+      const source = normalizeResult(
+        await runSourceEval({
+          caseId: 'bootstrap-loading',
+          fixtureSeed: 'runner-installed-bootstrap',
+          normalizedClock: FIXED_CLOCK,
+          parentDir: sourceParent,
+        }),
+      )
+      const installed = normalizeResult(
+        await runInstalledEval({
+          caseId: 'bootstrap-loading',
+          fixtureSeed: 'runner-installed-bootstrap',
+          normalizedClock: FIXED_CLOCK,
+          parentDir: installedParent,
+        }),
+      )
+
+      expectRuntimeOutcome(source)
+      expectRuntimeOutcome(installed)
+      expect(source.evidence).toEqual(installed.evidence)
+      expect(source.mode).toBe('source')
+      expect(installed.mode).toBe('installed')
+      expect(source.provenance).toMatchObject({
+        kind: 'source',
+        checkoutRelativeSource: 'src/index.ts',
+        canonicalSourceEntryId: 'source-entry',
+        opencodeConfigEntryId: 'source-config',
+      })
+      expect(installed.provenance).toMatchObject({
+        kind: 'installed',
+        packageName: '@fro.bot/systematic',
+        packageVersion: expect.stringMatching(/^\d+\.\d+\.\d+/),
+        tarballDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
+        extractedPackageRootId: 'installed-package-root',
+        canonicalResolvedModuleEntryId: 'dist/index.js',
+        opencodeConfigEntryId: 'installed-config',
+      })
+      expect(installed.identity.artifactId).toBe('installed-entry')
+      expect(JSON.stringify(installed)).not.toContain(sourceParent)
+      expect(JSON.stringify(installed)).not.toContain('src/index.ts')
+    } finally {
+      fs.rmSync(sourceParent, { recursive: true, force: true })
+      fs.rmSync(installedParent, { recursive: true, force: true })
+    }
+  }, 720_000)
+
+  test('installed fixture-local-write grades exact content without source fallback', async () => {
+    const parentDir = runParent()
+    try {
+      const result = normalizeResult(
+        await runInstalledEval({
+          caseId: 'fixture-local-write',
+          fixtureSeed: 'runner-installed-write',
+          normalizedClock: FIXED_CLOCK,
+          parentDir,
+        }),
+      )
+      expectRuntimeOutcome(result)
+      expect(result.mode).toBe('installed')
+      expect(result.assertionIds).toEqual([
+        'fixture-file-content',
+        'fixture-file-created',
+      ])
+      expect(result.provenance.kind).toBe('installed')
+      expect(result.cleanup).toEqual({ status: 'clean', residue: 'none' })
+      expect(JSON.stringify(result)).not.toContain(parentDir)
+      expect(JSON.stringify(result)).not.toContain('src/index.ts')
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  }, 360_000)
+
+  test('cleanup runs after success, task failure, and a started-child interruption', async () => {
+    const parentDir = runParent()
+    const cleanupCalls: string[] = []
+    try {
+      for (const [label, execution] of [
+        ['success', syntheticExecution('success', 'none')],
+        ['task-failure', syntheticExecution('task_failure', 'write_mismatch')],
+        [
+          'started-child-interruption',
+          syntheticExecution('task_failure', 'unexpected_exit'),
+        ],
+      ] as const) {
+        const result = normalizeResult(
+          await runSourceEval({
+            caseId: 'bootstrap-loading',
+            fixtureSeed: `cleanup-${label}`,
+            normalizedClock: FIXED_CLOCK,
+            parentDir,
+            lifecycleHooks: {
+              executeCase: async () => execution,
+              cleanupFixture: (fixture) => {
+                cleanupCalls.push(label)
+                fs.rmSync(fixture.runRoot, { recursive: true, force: true })
+              },
+            },
+          }),
+        )
+
+        expect(result.cleanup).toEqual({ status: 'clean', residue: 'none' })
+        expect(result.outcome).toBe(execution.outcome)
+        expect(result.subcode).toBe(execution.subcode)
+      }
+
+      expect(cleanupCalls).toEqual([
+        'success',
+        'task-failure',
+        'started-child-interruption',
+      ])
+      expect(fs.readdirSync(parentDir)).toEqual([])
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('source lifecycle setup throws return bounded case_setup results and clean the fixture', async () => {
+    const parentDir = runParent()
+    try {
+      const result = normalizeResult(
+        await runSourceEval({
+          caseId: 'bootstrap-loading',
+          fixtureSeed: 'setup-throws',
+          normalizedClock: FIXED_CLOCK,
+          parentDir,
+          lifecycleHooks: {
+            executeCase: async () => {
+              throw new Error('injected source setup failure')
+            },
+          },
+        }),
+      )
+
+      expect(result.outcome).toBe('infra_failure')
+      expect(result.subcode).toBe('case_setup')
+      expect(result.cleanup).toEqual({ status: 'clean', residue: 'none' })
+      expect(fs.readdirSync(parentDir)).toEqual([])
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('cleanup failure overrides success and quarantines residue with unique targets', async () => {
+    const parentDir = runParent()
+    const quarantineTargets: string[] = []
+    try {
+      for (const seed of ['cleanup-residue-one', 'cleanup-residue-two']) {
+        const result = normalizeResult(
+          await runSourceEval({
+            caseId: 'bootstrap-loading',
+            fixtureSeed: seed,
+            normalizedClock: FIXED_CLOCK,
+            parentDir,
+            lifecycleHooks: {
+              executeCase: async () => syntheticExecution('success', 'none'),
+              cleanupFixture: () => undefined,
+              quarantineResidue: (fixture, quarantineRoot) => {
+                quarantineTargets.push(quarantineRoot)
+                fs.renameSync(fixture.runRoot, quarantineRoot)
+              },
+            },
+          }),
+        )
+
+        expect(result.outcome).toBe('privacy_cleanup_failure')
+        expect(result.subcode).toBe('residue_detected')
+        expect(result.cleanup).toEqual({
+          status: 'quarantined',
+          residue: 'quarantined',
+        })
+      }
+
+      expect(quarantineTargets).toHaveLength(2)
+      expect(new Set(quarantineTargets).size).toBe(2)
+      for (const target of quarantineTargets)
+        expect(fs.existsSync(target)).toBe(true)
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('quarantine failure remains bounded and reports unresolved residue', async () => {
+    const parentDir = runParent()
+    try {
+      const result = normalizeResult(
+        await runSourceEval({
+          caseId: 'bootstrap-loading',
+          fixtureSeed: 'cleanup-quarantine-failure',
+          normalizedClock: FIXED_CLOCK,
+          parentDir,
+          lifecycleHooks: {
+            executeCase: async () => syntheticExecution('success', 'none'),
+            cleanupFixture: () => undefined,
+            quarantineResidue: () => {
+              throw new Error('injected quarantine failure')
+            },
+          },
+        }),
+      )
+
+      expect(result.outcome).toBe('privacy_cleanup_failure')
+      expect(result.subcode).toBe('quarantine_failed')
+      expect(result.cleanup).toEqual({ status: 'residue', residue: 'detected' })
+      expect(JSON.stringify(result)).not.toContain(parentDir)
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('cleanup precedence keeps privacy cleanup failure when checkout readback also changes', async () => {
+    const parentDir = runParent()
+    const checkoutRoot = path.join(parentDir, 'checkout')
+    fs.mkdirSync(path.join(checkoutRoot, 'src'), { recursive: true })
+    fs.writeFileSync(
+      path.join(checkoutRoot, 'src/index.ts'),
+      'export default {}',
+    )
+    const manifestPath = path.join(
+      checkoutRoot,
+      'evals/cases/opencode/bootstrap-loading.json',
+    )
+    fs.mkdirSync(path.dirname(manifestPath), { recursive: true })
+    fs.copyFileSync(
+      path.join(
+        path.resolve(import.meta.dirname, '../..'),
+        'evals/cases/opencode/bootstrap-loading.json',
+      ),
+      manifestPath,
+    )
+    const init = Bun.spawnSync(['git', 'init', '-q'], { cwd: checkoutRoot })
+    expect(init.exitCode).toBe(0)
+
+    try {
+      const result = normalizeResult(
+        await runSourceEval({
+          caseId: 'bootstrap-loading',
+          fixtureSeed: 'cleanup-precedence',
+          normalizedClock: FIXED_CLOCK,
+          parentDir,
+          rootDir: checkoutRoot,
+          lifecycleHooks: {
+            executeCase: async () => {
+              fs.writeFileSync(
+                path.join(checkoutRoot, 'checkout-delta.txt'),
+                'delta',
+              )
+              return syntheticExecution('success', 'none')
+            },
+            cleanupFixture: () => undefined,
+            quarantineResidue: (fixture, quarantineRoot) => {
+              fs.renameSync(fixture.runRoot, quarantineRoot)
+            },
+          },
+        }),
+      )
+
+      expect(result.outcome).toBe('privacy_cleanup_failure')
+      expect(result.subcode).toBe('residue_detected')
+      expect(result.cleanup).toEqual({
+        status: 'quarantined',
+        residue: 'quarantined',
+      })
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('continues task failures, aborts runner-wide failures, and packs installed selections once', async () => {
+    const parentDir = runParent()
+    const runsRoot = path.join(parentDir, 'runs')
+    let packCalls = 0
+    const calls: string[] = []
+    try {
+      const run = await runEvalSelections({
+        selectionIds: [
+          'bootstrap-loading/installed',
+          'bootstrap-loading/source',
+          'fixture-local-write/installed',
+          'fixture-local-write/source',
+        ],
+        fixtureSeed: 'orchestration-seed',
+        normalizedClock: FIXED_CLOCK,
+        parentDir,
+        runsRoot,
+        packInstalledArtifact: ({ fixture }) => {
+          packCalls += 1
+          return {
+            packageName: '@fro.bot/systematic',
+            packageVersion: '1.2.3',
+            moduleEntry: path.join(fixture.packageRoot, 'dist/index.js'),
+            moduleEntryId: 'dist/index.js',
+            tarballPath: path.join(fixture.artifactRoot, 'package.tgz'),
+            tarballDigest: 'a'.repeat(64),
+            packageRoot: fixture.packageRoot,
+            packageRootId: 'installed-package-root',
+            configEntryId: 'installed-config',
+          }
+        },
+        sourceRunner: async (options) => {
+          calls.push(`${options.caseId}/${options.mode}`)
+          return syntheticResult({
+            caseId: options.caseId,
+            mode: 'source',
+            runId: options.runId ?? 'run-missing',
+            outcome: 'success',
+            subcode: 'none',
+          })
+        },
+        installedRunner: async (options) => {
+          calls.push(`${options.caseId}/${options.mode}`)
+          return syntheticResult({
+            caseId: options.caseId,
+            mode: 'installed',
+            runId: options.runId ?? 'run-missing',
+            outcome:
+              options.caseId === 'bootstrap-loading'
+                ? 'task_failure'
+                : 'success',
+            subcode:
+              options.caseId === 'bootstrap-loading'
+                ? 'write_mismatch'
+                : 'none',
+          })
+        },
+      })
+
+      expect(packCalls).toBe(1)
+      expect(calls).toEqual([
+        'bootstrap-loading/installed',
+        'bootstrap-loading/source',
+        'fixture-local-write/installed',
+        'fixture-local-write/source',
+      ])
+      expect(run.manifest.partial).toBe(false)
+      expect(run.results).toHaveLength(4)
+      expect(run.results.every((result) => result.runId === run.runId)).toBe(
+        true,
+      )
+
+      const abortedCalls: string[] = []
+      const aborted = await runEvalSelections({
+        selectionIds: [
+          'bootstrap-loading/source',
+          'fixture-local-write/source',
+        ],
+        fixtureSeed: 'orchestration-abort',
+        normalizedClock: FIXED_CLOCK,
+        parentDir,
+        runsRoot: path.join(parentDir, 'aborted-runs'),
+        sourceRunner: async (options) => {
+          abortedCalls.push(options.caseId)
+          return syntheticResult({
+            caseId: options.caseId,
+            mode: 'source',
+            runId: options.runId ?? 'run-missing',
+            outcome: 'infra_failure',
+            subcode: 'identity_drift',
+          })
+        },
+      })
+      expect(abortedCalls).toEqual(['bootstrap-loading'])
+      expect(aborted.manifest.partial).toBe(true)
+      expect(aborted.manifest.completedSelectionIds).toEqual([
+        'bootstrap-loading/source',
+      ])
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('mode-local installed artifact failure still permits independent source selections', async () => {
+    const parentDir = runParent()
+    try {
+      const calls: string[] = []
+      const run = await runEvalSelections({
+        selectionIds: [
+          'bootstrap-loading/installed',
+          'fixture-local-write/installed',
+          'bootstrap-loading/source',
+        ],
+        fixtureSeed: 'orchestration-artifact',
+        normalizedClock: FIXED_CLOCK,
+        parentDir,
+        runsRoot: path.join(parentDir, 'runs'),
+        packInstalledArtifact: () => {
+          throw new Error('eval-artifact:artifact_resolution')
+        },
+        sourceRunner: async (options) => {
+          calls.push(`${options.caseId}/${options.mode}`)
+          return syntheticResult({
+            caseId: options.caseId,
+            mode: 'source',
+            runId: options.runId ?? 'run-missing',
+            outcome: 'success',
+            subcode: 'none',
+          })
+        },
+        installedRunner: async (options) => {
+          calls.push(`${options.caseId}/${options.mode}`)
+          return syntheticResult({
+            caseId: options.caseId,
+            mode: 'installed',
+            runId: options.runId ?? 'run-missing',
+            outcome: 'success',
+            subcode: 'none',
+          })
+        },
+      })
+
+      expect(calls).toEqual(['bootstrap-loading/source'])
+      expect(run.manifest.partial).toBe(true)
+      expect(run.results).toHaveLength(2)
+      expect(
+        run.results.find((result) => result.mode === 'source')?.outcome,
+      ).toBe('success')
+      expect(
+        run.results.find((result) => result.mode === 'installed')?.subcode,
+      ).toBe('artifact_resolution')
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('packing failure after fixture creation persists artifact_resolution and cleans all fixture residue', async () => {
+    const parentDir = runParent()
+    const runsRoot = path.join(parentDir, 'runs')
+    try {
+      const run = await runEvalSelections({
+        selectionIds: [
+          'bootstrap-loading/installed',
+          'bootstrap-loading/source',
+        ],
+        fixtureSeed: 'packing-throws-after-fixture',
+        normalizedClock: FIXED_CLOCK,
+        parentDir,
+        runsRoot,
+        packInstalledArtifact: ({ fixture }) => {
+          fs.writeFileSync(
+            path.join(fixture.artifactRoot, 'packing-started.marker'),
+            'started',
+          )
+          throw new Error('injected packing failure')
+        },
+        sourceRunner: async (input) =>
+          syntheticResult({
+            caseId: input.caseId,
+            mode: 'source',
+            runId: input.runId ?? 'run-missing',
+            outcome: 'success',
+            subcode: 'none',
+          }),
+      })
+
+      expect(run.manifest.partial).toBe(false)
+      expect(
+        run.results.find((result) => result.mode === 'installed'),
+      ).toMatchObject({
+        outcome: 'infra_failure',
+        subcode: 'artifact_resolution',
+      })
+      expect(
+        run.results.find((result) => result.mode === 'source'),
+      ).toMatchObject({ outcome: 'success', subcode: 'none' })
+      expect(
+        validateSerializedRunManifest(
+          fs.readFileSync(path.join(runsRoot, run.runId, 'manifest.json')),
+        ).partial,
+      ).toBe(false)
+      expect(
+        fs
+          .readdirSync(parentDir)
+          .filter((entry) => entry.startsWith('systematic-eval')),
+      ).toEqual([])
+      expect(
+        fs
+          .readdirSync(parentDir)
+          .filter((entry) => entry.startsWith('systematic-eval-quarantine')),
+      ).toEqual([])
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('cleans the shared artifact fixture immediately after the final installed selection', async () => {
+    const parentDir = runParent()
+    const cleanupCalls: string[] = []
+    const options = {
+      selectionIds: [
+        'bootstrap-loading/installed',
+        'bootstrap-loading/source',
+        'fixture-local-write/installed',
+        'fixture-local-write/source',
+      ],
+      fixtureSeed: 'shared-artifact-cleanup',
+      normalizedClock: FIXED_CLOCK,
+      parentDir,
+      runsRoot: path.join(parentDir, 'runs'),
+      packInstalledArtifact: ({ fixture }: { fixture: EvalFixture }) => ({
+        packageName: '@fro.bot/systematic',
+        packageVersion: '1.2.3',
+        moduleEntry: path.join(fixture.packageRoot, 'dist/index.js'),
+        moduleEntryId: 'dist/index.js',
+        tarballPath: path.join(fixture.artifactRoot, 'package.tgz'),
+        tarballDigest: 'a'.repeat(64),
+        packageRoot: fixture.packageRoot,
+        packageRootId: 'installed-package-root',
+        configEntryId: 'installed-config',
+      }),
+      artifactCleanupHooks: {
+        cleanupFixture: (fixture: EvalFixture) => {
+          cleanupCalls.push('cleanup')
+          fs.rmSync(fixture.runRoot, { recursive: true, force: true })
+        },
+      },
+      sourceRunner: async (input: EvalSelectionRunnerInput) => {
+        cleanupCalls.push(`${input.caseId}/${input.mode}`)
+        return syntheticResult({
+          caseId: input.caseId,
+          mode: 'source',
+          runId: input.runId ?? 'run-missing',
+          outcome: 'success',
+          subcode: 'none',
+        })
+      },
+      installedRunner: async (input: EvalSelectionRunnerInput) => {
+        cleanupCalls.push(`${input.caseId}/${input.mode}`)
+        return syntheticResult({
+          caseId: input.caseId,
+          mode: 'installed',
+          runId: input.runId ?? 'run-missing',
+          outcome: 'success',
+          subcode: 'none',
+        })
+      },
+    } as Parameters<typeof runEvalSelections>[0] & {
+      artifactCleanupHooks: {
+        cleanupFixture: (fixture: EvalFixture) => void
+      }
+    }
+
+    try {
+      await runEvalSelections(options)
+      expect(cleanupCalls).toEqual([
+        'bootstrap-loading/installed',
+        'bootstrap-loading/source',
+        'fixture-local-write/installed',
+        'cleanup',
+        'fixture-local-write/source',
+      ])
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('persists shared artifact cleanup failures and converts dependent results', async () => {
+    const parentDir = runParent()
+    const options = {
+      selectionIds: [
+        'bootstrap-loading/installed',
+        'bootstrap-loading/source',
+        'fixture-local-write/installed',
+        'fixture-local-write/source',
+      ],
+      fixtureSeed: 'shared-artifact-quarantine',
+      normalizedClock: FIXED_CLOCK,
+      parentDir,
+      runsRoot: path.join(parentDir, 'runs'),
+      packInstalledArtifact: ({ fixture }: { fixture: EvalFixture }) => ({
+        packageName: '@fro.bot/systematic',
+        packageVersion: '1.2.3',
+        moduleEntry: path.join(fixture.packageRoot, 'dist/index.js'),
+        moduleEntryId: 'dist/index.js',
+        tarballPath: path.join(fixture.artifactRoot, 'package.tgz'),
+        tarballDigest: 'a'.repeat(64),
+        packageRoot: fixture.packageRoot,
+        packageRootId: 'installed-package-root',
+        configEntryId: 'installed-config',
+      }),
+      artifactCleanupHooks: {
+        cleanupFixture: () => undefined,
+        quarantineResidue: (fixture: EvalFixture, quarantineRoot: string) => {
+          fs.renameSync(fixture.runRoot, quarantineRoot)
+        },
+      },
+      sourceRunner: async (input: EvalSelectionRunnerInput) =>
+        syntheticResult({
+          caseId: input.caseId,
+          mode: 'source',
+          runId: input.runId ?? 'run-missing',
+          outcome: 'success',
+          subcode: 'none',
+        }),
+      installedRunner: async (input: EvalSelectionRunnerInput) =>
+        syntheticResult({
+          caseId: input.caseId,
+          mode: 'installed',
+          runId: input.runId ?? 'run-missing',
+          outcome: 'success',
+          subcode: 'none',
+        }),
+    } as Parameters<typeof runEvalSelections>[0] & {
+      artifactCleanupHooks: {
+        cleanupFixture: () => void
+        quarantineResidue: (
+          fixture: EvalFixture,
+          quarantineRoot: string,
+        ) => void
+      }
+    }
+
+    try {
+      const run = await runEvalSelections(options)
+      expect(run.manifest.partial).toBe(false)
+      expect(run.results).toHaveLength(4)
+      expect(
+        run.results
+          .filter((result) => result.mode === 'installed')
+          .map((result) => [result.outcome, result.subcode, result.cleanup]),
+      ).toEqual([
+        [
+          'privacy_cleanup_failure',
+          'residue_detected',
+          { status: 'quarantined', residue: 'quarantined' },
+        ],
+        [
+          'privacy_cleanup_failure',
+          'residue_detected',
+          { status: 'quarantined', residue: 'quarantined' },
+        ],
+      ])
+      expect(
+        run.results.find((result) => result.mode === 'source')?.outcome,
+      ).toBe('success')
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('quarantine failure aborts later selections after persisting dependent privacy failures', async () => {
+    const parentDir = runParent()
+    const calls: string[] = []
+    const options = {
+      selectionIds: [
+        'bootstrap-loading/installed',
+        'bootstrap-loading/source',
+        'fixture-local-write/installed',
+        'fixture-local-write/source',
+      ],
+      fixtureSeed: 'shared-artifact-quarantine-failure',
+      normalizedClock: FIXED_CLOCK,
+      parentDir,
+      runsRoot: path.join(parentDir, 'runs'),
+      packInstalledArtifact: ({ fixture }: { fixture: EvalFixture }) => ({
+        packageName: '@fro.bot/systematic',
+        packageVersion: '1.2.3',
+        moduleEntry: path.join(fixture.packageRoot, 'dist/index.js'),
+        moduleEntryId: 'dist/index.js',
+        tarballPath: path.join(fixture.artifactRoot, 'package.tgz'),
+        tarballDigest: 'a'.repeat(64),
+        packageRoot: fixture.packageRoot,
+        packageRootId: 'installed-package-root',
+        configEntryId: 'installed-config',
+      }),
+      artifactCleanupHooks: {
+        cleanupFixture: () => undefined,
+        quarantineResidue: () => {
+          throw new Error('injected shared quarantine failure')
+        },
+      },
+      sourceRunner: async (input: EvalSelectionRunnerInput) => {
+        calls.push(`${input.caseId}/${input.mode}`)
+        return syntheticResult({
+          caseId: input.caseId,
+          mode: 'source',
+          runId: input.runId ?? 'run-missing',
+          outcome: 'success',
+          subcode: 'none',
+        })
+      },
+      installedRunner: async (input: EvalSelectionRunnerInput) => {
+        calls.push(`${input.caseId}/${input.mode}`)
+        return syntheticResult({
+          caseId: input.caseId,
+          mode: 'installed',
+          runId: input.runId ?? 'run-missing',
+          outcome: 'success',
+          subcode: 'none',
+        })
+      },
+    } as Parameters<typeof runEvalSelections>[0] & {
+      artifactCleanupHooks: {
+        cleanupFixture: () => void
+        quarantineResidue: () => never
+      }
+    }
+
+    try {
+      const run = await runEvalSelections(options)
+      expect(calls).toEqual([
+        'bootstrap-loading/installed',
+        'bootstrap-loading/source',
+        'fixture-local-write/installed',
+      ])
+      expect(run.manifest.partial).toBe(true)
+      expect(run.results).toHaveLength(3)
+      expect(
+        run.results
+          .filter((result) => result.mode === 'installed')
+          .every(
+            (result) =>
+              result.outcome === 'privacy_cleanup_failure' &&
+              result.subcode === 'quarantine_failed',
+          ),
+      ).toBe(true)
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('persists bounded infrastructure results with exit 1 and no path leakage', async () => {
+    const parentDir = runParent()
+    try {
+      const result = await runEvalCli(
+        [
+          '--case',
+          'bootstrap-loading',
+          '--mode',
+          'source',
+          '--seed',
+          'cli-infra-seed',
+          '--clock',
+          FIXED_CLOCK,
+        ],
+        {
+          parentDir,
+          runsRoot: path.join(parentDir, 'runs'),
+          sourceRunner: async (input) => ({
+            ...boundedInfraResult(),
+            runId: input.runId ?? 'run-infra',
+            fixtureSeed: input.fixtureSeed,
+            normalizedClock: input.normalizedClock,
+          }),
+        },
+      )
+
+      expect(result.kind).toBe('run')
+      if (result.kind !== 'run') throw new Error('expected persisted run')
+      expect(result.exitCode).toBe(1)
+      expect(result.run.manifest.partial).toBe(false)
+      const persistedRoot = path.join(parentDir, 'runs', result.run.runId)
+      const manifest = validateSerializedRunManifest(
+        fs.readFileSync(path.join(persistedRoot, 'manifest.json')),
+      )
+      const persistedResult = validateSerializedResult(
+        fs.readFileSync(
+          path.join(persistedRoot, 'results/bootstrap-loading/source.json'),
+        ),
+      )
+      expect(manifest.partial).toBe(false)
+      expect(persistedResult.outcome).toBe('infra_failure')
+      expect(JSON.stringify(result)).not.toContain(parentDir)
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('repeated frozen source and installed selection runs have equal normalized results and manifests', async () => {
+    const firstParent = runParent()
+    const secondParent = runParent()
+    const selectionIds = [
+      'bootstrap-loading/installed',
+      'bootstrap-loading/source',
+      'fixture-local-write/installed',
+      'fixture-local-write/source',
+    ]
+    const buildOptions = (parentDir: string) => ({
+      selectionIds,
+      fixtureSeed: 'frozen-selection-seed',
+      normalizedClock: FIXED_CLOCK,
+      parentDir,
+      runsRoot: path.join(parentDir, 'runs'),
+      packInstalledArtifact: ({ fixture }: { fixture: EvalFixture }) => ({
+        packageName: '@fro.bot/systematic',
+        packageVersion: '1.2.3',
+        moduleEntry: path.join(fixture.packageRoot, 'dist/index.js'),
+        moduleEntryId: 'dist/index.js',
+        tarballPath: path.join(fixture.artifactRoot, 'package.tgz'),
+        tarballDigest: 'a'.repeat(64),
+        packageRoot: fixture.packageRoot,
+        packageRootId: 'installed-package-root',
+        configEntryId: 'installed-config',
+      }),
+      sourceRunner: async (input: EvalSelectionRunnerInput) =>
+        syntheticResult({
+          caseId: input.caseId,
+          mode: 'source',
+          runId: input.runId ?? 'run-missing',
+          outcome: 'success',
+          subcode: 'none',
+        }),
+      installedRunner: async (input: EvalSelectionRunnerInput) =>
+        syntheticResult({
+          caseId: input.caseId,
+          mode: 'installed',
+          runId: input.runId ?? 'run-missing',
+          outcome: 'success',
+          subcode: 'none',
+        }),
+    })
+
+    try {
+      const first = await runEvalSelections(buildOptions(firstParent))
+      const second = await runEvalSelections(buildOptions(secondParent))
+      expect(
+        normalizeRunIdentity(
+          { manifest: first.manifest, results: first.results },
+          [first.runId, second.runId],
+        ),
+      ).toEqual(
+        normalizeRunIdentity(
+          { manifest: second.manifest, results: second.results },
+          [first.runId, second.runId],
+        ),
+      )
+    } finally {
+      fs.rmSync(firstParent, { recursive: true, force: true })
+      fs.rmSync(secondParent, { recursive: true, force: true })
+    }
+  })
+
+  test('CLI returns exact help, argument, and failing-run exit codes', async () => {
+    const help = await runEvalCli(['--help'])
+    expect(help).toEqual({
+      kind: 'help',
+      exitCode: 0,
+      usage: EXPECTED_CLI_HELP,
+    })
+
+    const argumentError = await runEvalCli(['--unknown'])
+    expect(argumentError).toMatchObject({
+      kind: 'error',
+      exitCode: 2,
+      usage: EXPECTED_CLI_HELP,
+    })
+
+    const parentDir = runParent()
+    try {
+      const failed = await runEvalCli(
+        [
+          '--case',
+          'bootstrap-loading',
+          '--mode',
+          'source',
+          '--seed',
+          'cli-failing-seed',
+          '--clock',
+          FIXED_CLOCK,
+        ],
+        {
+          parentDir,
+          runsRoot: path.join(parentDir, 'runs'),
+          sourceRunner: async (options) =>
+            syntheticResult({
+              caseId: options.caseId,
+              mode: 'source',
+              runId: options.runId ?? 'run-missing',
+              outcome: 'task_failure',
+              subcode: 'write_mismatch',
+            }),
+        },
+      )
+
+      expect(failed).toMatchObject({ kind: 'run', exitCode: 1 })
+      expect(JSON.stringify(failed)).not.toContain(parentDir)
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('direct CLI argument errors are one concise JSON object', async () => {
+    const rootDir = path.resolve(import.meta.dirname, '../..')
+    const child = spawn(
+      process.execPath,
+      ['scripts/run-evals.ts', '--unknown'],
+      { cwd: rootDir, stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    const [exitCode] = (await once(child, 'exit')) as [number | null]
+    expect(exitCode).toBe(2)
+    expect(stdout).toBe('')
+    const lines = stderr.trim().split(/\r?\n/)
+    expect(lines).toHaveLength(1)
+    expect(JSON.parse(lines[0] ?? '')).toEqual({
+      status: 'error',
+      exitCode: 2,
+      code: 'eval-cli:unknown_argument',
+      usage: EXPECTED_CLI_HELP,
+    })
+  })
+
+  test('source direct CLI success emits one JSON object and validator-parseable artifacts', async () => {
+    const rootDir = path.resolve(import.meta.dirname, '../..')
+    const child = spawn(
+      process.execPath,
+      [
+        'scripts/run-evals.ts',
+        '--case',
+        'bootstrap-loading',
+        '--mode',
+        'source',
+        '--seed',
+        'direct-cli-success',
+        '--clock',
+        FIXED_CLOCK,
+      ],
+      { cwd: rootDir, stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    const [exitCode] = (await once(child, 'exit')) as [number | null]
+    expect(exitCode).toBe(0)
+    expect(stderr).toBe('')
+    const lines = stdout.trim().split(/\r?\n/)
+    expect(lines).toHaveLength(1)
+    const summary = JSON.parse(lines[0] ?? '') as {
+      status: string
+      exitCode: number
+      runId: string
+      manifestArtifactId: string
+    }
+    expect(summary).toMatchObject({
+      status: 'written',
+      exitCode: 0,
+      manifestArtifactId: `evals/runs/${summary.runId}/manifest.json`,
+    })
+
+    const runRoot = path.join(rootDir, 'evals/runs', summary.runId)
+    try {
+      expect(
+        validateSerializedRunManifest(
+          fs.readFileSync(path.join(runRoot, 'manifest.json')),
+        ).partial,
+      ).toBe(false)
+      expect(
+        validateSerializedResult(
+          fs.readFileSync(
+            path.join(runRoot, 'results/bootstrap-loading/source.json'),
+          ),
+        ).outcome,
+      ).toBe('success')
+    } finally {
+      fs.rmSync(runRoot, { recursive: true, force: true })
+    }
+  }, 360_000)
+
+  test('direct CLI interruption cleans started children and run-owned roots', async () => {
+    const parentDir = runParent()
+    const markerPath = path.join(parentDir, 'started-child.marker')
+    const rootDir = path.resolve(import.meta.dirname, '../..')
+    const beforeServeProcesses = countEvalServeProcesses()
+    const child = spawn(
+      process.execPath,
+      [
+        'scripts/run-evals.ts',
+        '--case',
+        'bootstrap-loading',
+        '--mode',
+        'source',
+        '--seed',
+        'direct-cli-interrupt',
+        '--clock',
+        FIXED_CLOCK,
+      ],
+      {
+        cwd: rootDir,
+        env: {
+          ...process.env,
+          TMPDIR: parentDir,
+          SYSTEMATIC_EVAL_STARTED_CHILD_MARKER: markerPath,
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    )
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    try {
+      await waitForMarker(markerPath, 360_000)
+      child.kill('SIGINT')
+      const [exitCode] = (await once(child, 'exit')) as [number | null]
+      expect(exitCode).not.toBe(0)
+      expect(stderr).toBe('')
+      const lines = stdout.trim().split(/\r?\n/)
+      expect(lines).toHaveLength(1)
+      const summary = JSON.parse(lines[0] ?? '') as {
+        status: string
+        exitCode: number
+        runId?: string
+      }
+      expect(summary.exitCode).toBe(1)
+      expect(summary.status).toBe('interrupted')
+      expect(
+        fs
+          .readdirSync(parentDir)
+          .filter(
+            (entry) =>
+              entry.startsWith('systematic-eval') ||
+              entry.startsWith('systematic-eval-quarantine'),
+          ),
+      ).toEqual([])
+      expect(countEvalServeProcesses()).toBe(beforeServeProcesses)
+      if (summary.runId) {
+        fs.rmSync(path.join(rootDir, 'evals/runs', summary.runId), {
+          recursive: true,
+          force: true,
+        })
+      }
+    } finally {
+      if (child.exitCode === null) child.kill('SIGKILL')
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  }, 360_000)
+
+  test('signal cleanup uses registered hooks and quarantines residue before returning', async () => {
+    const parentDir = runParent()
+    const events: string[] = []
+    const previousExitCode = process.exitCode
+    const removeSignalHandlers = installEvalSignalHandlers()
+    try {
+      const result = normalizeResult(
+        await runSourceEval({
+          caseId: 'bootstrap-loading',
+          fixtureSeed: 'signal-hook-cleanup',
+          normalizedClock: FIXED_CLOCK,
+          parentDir,
+          lifecycleHooks: {
+            executeCase: async () => {
+              process.emit('SIGINT')
+              return syntheticExecution('success', 'none')
+            },
+            cleanupFixture: () => {
+              events.push('cleanup')
+            },
+            quarantineResidue: (fixture, quarantineRoot) => {
+              events.push('quarantine')
+              fs.renameSync(fixture.runRoot, quarantineRoot)
+            },
+          },
+        }),
+      )
+
+      expect(result.outcome).toBe('privacy_cleanup_failure')
+      expect(result.cleanup).toEqual({
+        status: 'quarantined',
+        residue: 'quarantined',
+      })
+      expect(events).toEqual(['cleanup', 'quarantine'])
+      expect(
+        fs
+          .readdirSync(parentDir)
+          .filter((entry) => entry.startsWith('systematic-eval-')),
+      ).toHaveLength(1)
+    } finally {
+      removeSignalHandlers()
+      process.exitCode = previousExitCode ?? 0
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/unit/eval-contract.test.ts
+++ b/tests/unit/eval-contract.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {
+  CASE_IDS,
+  CASE_SCHEMA_VERSION,
+  type EvalMode,
+  normalizeResult,
+  OUTCOMES,
+  parseCaseManifest,
+  RESULT_SCHEMA_VERSION,
+  serializeResult,
+} from '../../scripts/run-evals.ts'
+
+const ROOT_DIR = path.resolve(import.meta.dirname, '../..')
+const MANIFEST_DIR = path.join(ROOT_DIR, 'evals/cases/opencode')
+
+function readManifest(fileName: string): unknown {
+  return JSON.parse(
+    fs.readFileSync(path.join(MANIFEST_DIR, fileName), 'utf8'),
+  ) as unknown
+}
+
+function sourceProvenance(): Record<string, unknown> {
+  return {
+    kind: 'source',
+    checkoutRelativeSource: 'src/index.ts',
+    commitId: 'a'.repeat(40),
+    worktreeId: 'worktree-1',
+    canonicalSourceEntryId: 'source-entry',
+    opencodeConfigEntryId: 'source-config',
+  }
+}
+
+function installedProvenance(): Record<string, unknown> {
+  return {
+    kind: 'installed',
+    packageName: '@fro.bot/systematic',
+    packageVersion: '1.2.3',
+    tarballDigest: 'b'.repeat(64),
+    extractedPackageRootId: 'package-root-1',
+    canonicalResolvedModuleEntryId: 'dist/index.js',
+    opencodeConfigEntryId: 'installed-config',
+  }
+}
+
+function validResult(mode: EvalMode = 'source'): Record<string, unknown> {
+  const fixtureAssertions = ['fixture-file-content', 'fixture-file-created']
+  return {
+    resultSchemaVersion: RESULT_SCHEMA_VERSION,
+    caseSchemaVersion: CASE_SCHEMA_VERSION,
+    caseId: 'fixture-local-write',
+    harness: 'opencode',
+    mode,
+    outcome: 'success',
+    subcode: 'none',
+    runId: 'run-001',
+    fixtureSeed: 'fixture-seed-001',
+    normalizedClock: '2026-08-13T00:00:00.000Z',
+    assertionIds: fixtureAssertions,
+    identity: {
+      opencodeVersion: '1.18.16',
+      opencodeBuildId: 'build-001',
+      probeId: 'probe-opencode-v1',
+      probeDigest: 'c'.repeat(64),
+      fixtureContractVersion: 1,
+      fixtureContractDigest: 'd'.repeat(64),
+      caseSchemaVersion: CASE_SCHEMA_VERSION,
+      resultSchemaVersion: RESULT_SCHEMA_VERSION,
+      artifactId: mode === 'source' ? 'source-entry' : 'installed-entry',
+      artifactDigest: 'e'.repeat(64),
+    },
+    evidence: {
+      sanity: 'passed',
+      process: 'completed',
+      assertionIds: fixtureAssertions,
+    },
+    cleanup: {
+      status: 'clean',
+      residue: 'none',
+    },
+    privacy: {
+      status: 'validated',
+    },
+    artifactRefs: ['artifacts/result.json', 'probe/health.json'],
+    provenance: mode === 'source' ? sourceProvenance() : installedProvenance(),
+  }
+}
+
+describe('local OpenCode eval contracts', () => {
+  test('exposes exactly two cases, four outcomes, and the supported schema versions', () => {
+    expect(CASE_IDS).toEqual(['bootstrap-loading', 'fixture-local-write'])
+    expect(OUTCOMES).toEqual([
+      'success',
+      'infra_failure',
+      'task_failure',
+      'privacy_cleanup_failure',
+    ])
+    expect(CASE_SCHEMA_VERSION).toBe(1)
+    expect(RESULT_SCHEMA_VERSION).toBe(1)
+  })
+
+  test('accepts both declarative case manifests', () => {
+    const bootstrap = parseCaseManifest(readManifest('bootstrap-loading.json'))
+    const fixture = parseCaseManifest(readManifest('fixture-local-write.json'))
+
+    expect(bootstrap).toEqual({
+      caseSchemaVersion: 1,
+      caseId: 'bootstrap-loading',
+      harness: 'opencode',
+      assertionIds: ['bootstrap-observed'],
+    })
+    expect(fixture).toEqual({
+      caseSchemaVersion: 1,
+      caseId: 'fixture-local-write',
+      harness: 'opencode',
+      assertionIds: ['fixture-file-content', 'fixture-file-created'],
+      expectedArtifactId: 'fixture/output.txt',
+      expectedContentId: 'fixture-local-write-v1',
+    })
+  })
+
+  test('rejects unknown, missing, unsupported, and wrong-version manifest fields', () => {
+    const valid = readManifest('bootstrap-loading.json') as Record<
+      string,
+      unknown
+    >
+
+    expect(() =>
+      parseCaseManifest({ ...valid, prompt: 'not executable prose' }),
+    ).toThrow()
+
+    const missing = { ...valid }
+    delete missing.assertionIds
+    expect(() => parseCaseManifest(missing)).toThrow()
+
+    expect(() =>
+      parseCaseManifest({ ...valid, caseId: 'third-case' }),
+    ).toThrow()
+    expect(() =>
+      parseCaseManifest({ ...valid, caseSchemaVersion: 2 }),
+    ).toThrow()
+    expect(() =>
+      parseCaseManifest({ ...valid, harness: 'other-harness' }),
+    ).toThrow()
+  })
+
+  test('accepts every primary outcome only with its bounded subcodes', () => {
+    const cases = [
+      ['success', 'none'],
+      ['infra_failure', 'identity_drift'],
+      ['task_failure', 'write_mismatch'],
+      ['privacy_cleanup_failure', 'redaction_failed'],
+    ] as const
+
+    for (const [outcome, subcode] of cases) {
+      const result = normalizeResult({
+        ...validResult(),
+        outcome,
+        subcode,
+      })
+      expect(result.outcome).toBe(outcome)
+      expect(result.subcode).toBe(subcode)
+    }
+  })
+
+  test('rejects fifth outcomes and invalid outcome/subcode pairings', () => {
+    for (const [outcome, subcode] of [
+      ['success', 'identity_drift'],
+      ['infra_failure', 'write_mismatch'],
+      ['task_failure', 'redaction_failed'],
+      ['privacy_cleanup_failure', 'bootstrap_not_observed'],
+      ['not_an_outcome', 'none'],
+    ]) {
+      expect(() =>
+        normalizeResult({ ...validResult(), outcome, subcode }),
+      ).toThrow()
+    }
+  })
+
+  test('keeps source and installed provenance disjoint and complete', () => {
+    expect(normalizeResult(validResult('source')).provenance).toMatchObject({
+      kind: 'source',
+    })
+    expect(normalizeResult(validResult('installed')).provenance).toMatchObject({
+      kind: 'installed',
+    })
+
+    expect(() =>
+      normalizeResult({
+        ...validResult('source'),
+        provenance: installedProvenance(),
+      }),
+    ).toThrow()
+    expect(() =>
+      normalizeResult({
+        ...validResult('installed'),
+        provenance: sourceProvenance(),
+      }),
+    ).toThrow()
+
+    const incomplete = sourceProvenance()
+    delete incomplete.canonicalSourceEntryId
+    expect(() =>
+      normalizeResult({ ...validResult('source'), provenance: incomplete }),
+    ).toThrow()
+  })
+
+  test('canonicalizes keys and collections deterministically', () => {
+    const first = validResult()
+    const second = validResult()
+    second.assertionIds = ['fixture-file-created', 'fixture-file-content']
+    second.evidence = {
+      assertionIds: ['fixture-file-created', 'fixture-file-content'],
+      process: 'completed',
+      sanity: 'passed',
+    }
+    second.artifactRefs = ['probe/health.json', 'artifacts/result.json']
+
+    expect(serializeResult(first)).toBe(serializeResult(second))
+    expect(JSON.parse(serializeResult(first))).toEqual(normalizeResult(first))
+  })
+})

--- a/tests/unit/eval-redaction.test.ts
+++ b/tests/unit/eval-redaction.test.ts
@@ -531,6 +531,21 @@ describe('local OpenCode eval redaction and serialization', () => {
     }
   })
 
+  test('treats skill-loading as safe while still rejecting realistic sk token shapes', () => {
+    expect(() =>
+      assertSerializedTextSafe(JSON.stringify({ note: 'skill-loading' })),
+    ).not.toThrow()
+
+    for (const seededValue of [
+      'sk-fake-provider-key-123',
+      'sk_fake_provider_key_123',
+    ]) {
+      expect(() =>
+        assertSerializedTextSafe(JSON.stringify({ note: seededValue })),
+      ).toThrow()
+    }
+  })
+
   test('rejects banned raw fields anywhere in nested candidates', () => {
     for (const field of [
       ...BANNED_FIELD_NAMES,

--- a/tests/unit/eval-redaction.test.ts
+++ b/tests/unit/eval-redaction.test.ts
@@ -1,0 +1,626 @@
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import {
+  assertSerializedTextSafe,
+  BANNED_FIELD_NAMES,
+  normalizeResult,
+  normalizeRunManifest,
+  parseEvalCliArgs,
+  persistEvalRun,
+  serializeResult,
+  serializeRunManifest,
+  validateSerializedResult,
+} from '../../scripts/run-evals.ts'
+
+const ROOT_DIR = path.resolve(import.meta.dirname, '../..')
+const FIXED_CLOCK = '2026-08-13T00:00:00.000Z'
+
+function rejectionMessage(action: () => unknown): string {
+  try {
+    action()
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error)
+  }
+  throw new Error('expected rejection')
+}
+
+function validResult(): Record<string, unknown> {
+  return {
+    resultSchemaVersion: 1,
+    caseSchemaVersion: 1,
+    caseId: 'bootstrap-loading',
+    harness: 'opencode',
+    mode: 'source',
+    outcome: 'success',
+    subcode: 'none',
+    runId: 'run-002',
+    fixtureSeed: 'fixture-seed-002',
+    normalizedClock: '2026-08-13T00:00:00.000Z',
+    assertionIds: ['bootstrap-observed'],
+    identity: {
+      opencodeVersion: '1.18.16',
+      opencodeBuildId: 'build-002',
+      probeId: 'probe-opencode-v1',
+      probeDigest: 'a'.repeat(64),
+      fixtureContractVersion: 1,
+      fixtureContractDigest: 'b'.repeat(64),
+      caseSchemaVersion: 1,
+      resultSchemaVersion: 1,
+      artifactId: 'source-entry',
+      artifactDigest: 'c'.repeat(64),
+    },
+    evidence: {
+      sanity: 'passed',
+      process: 'completed',
+      assertionIds: ['bootstrap-observed'],
+    },
+    cleanup: { status: 'clean', residue: 'none' },
+    privacy: { status: 'validated' },
+    artifactRefs: ['artifacts/result.json'],
+    provenance: {
+      kind: 'source',
+      checkoutRelativeSource: 'src/index.ts',
+      commitId: 'd'.repeat(40),
+      worktreeId: 'worktree-2',
+      canonicalSourceEntryId: 'source-entry',
+      opencodeConfigEntryId: 'source-config',
+    },
+  }
+}
+
+function validRunManifest(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    manifestSchemaVersion: 1,
+    harness: 'opencode',
+    runId: 'run-002',
+    requestedSelectionIds: ['bootstrap-loading/source'],
+    completedSelectionIds: ['bootstrap-loading/source'],
+    partial: false,
+    results: [
+      {
+        selectionId: 'bootstrap-loading/source',
+        resultArtifactId: 'results/bootstrap-loading/source.json',
+        outcome: 'success',
+        subcode: 'none',
+      },
+    ],
+    ...overrides,
+  }
+}
+
+function tempRunParent(): string {
+  return fs.mkdtempSync(path.join(ROOT_DIR, '.tmp-eval-redaction-'))
+}
+
+describe('local OpenCode eval redaction and serialization', () => {
+  test('parses closed CLI selections and builds sorted deduplicated Cartesian IDs', () => {
+    expect(
+      parseEvalCliArgs([
+        '--mode',
+        'source',
+        '--case',
+        'fixture-local-write',
+        '--case',
+        'bootstrap-loading',
+        '--case',
+        'bootstrap-loading',
+        '--mode',
+        'installed',
+        '--mode',
+        'source',
+        '--seed',
+        'fixture-seed-001',
+        '--clock',
+        FIXED_CLOCK,
+      ]),
+    ).toEqual({
+      cases: ['bootstrap-loading', 'fixture-local-write'],
+      modes: ['installed', 'source'],
+      fixtureSeed: 'fixture-seed-001',
+      normalizedClock: FIXED_CLOCK,
+      selectionIds: [
+        'bootstrap-loading/installed',
+        'bootstrap-loading/source',
+        'fixture-local-write/installed',
+        'fixture-local-write/source',
+      ],
+    })
+  })
+
+  test('rejects unknown, missing, duplicate singleton, and conflicting CLI arguments', () => {
+    const validArgs = [
+      '--case',
+      'bootstrap-loading',
+      '--mode',
+      'source',
+      '--seed',
+      'fixture-seed-001',
+      '--clock',
+      FIXED_CLOCK,
+    ]
+
+    for (const args of [
+      ['--unknown', ...validArgs],
+      ['--case', 'all', ...validArgs.slice(2)],
+      ['--case', ...validArgs.slice(2)],
+      ['--mode', ...validArgs.slice(2)],
+      [...validArgs, '--seed', 'another-seed'],
+      [...validArgs, '--clock', FIXED_CLOCK],
+      ['--help', ...validArgs],
+    ]) {
+      expect(() => parseEvalCliArgs(args)).toThrow()
+    }
+
+    expect(() =>
+      parseEvalCliArgs([
+        '--case',
+        'bootstrap-loading',
+        '--mode',
+        'source',
+        '--seed',
+        'ghp_fake_github_token_123',
+        '--clock',
+        FIXED_CLOCK,
+      ]),
+    ).toThrow()
+  })
+
+  test('normalizes the closed run manifest and rejects unknown fields or states', () => {
+    const reversed = validRunManifest({
+      requestedSelectionIds: [
+        'fixture-local-write/source',
+        'bootstrap-loading/source',
+      ],
+      completedSelectionIds: [
+        'fixture-local-write/source',
+        'bootstrap-loading/source',
+      ],
+      results: [
+        {
+          selectionId: 'fixture-local-write/source',
+          resultArtifactId: 'results/fixture-local-write/source.json',
+          outcome: 'infra_failure',
+          subcode: 'opencode_unavailable',
+        },
+        {
+          selectionId: 'bootstrap-loading/source',
+          resultArtifactId: 'results/bootstrap-loading/source.json',
+          outcome: 'success',
+          subcode: 'none',
+        },
+      ],
+    })
+
+    expect(normalizeRunManifest(reversed)).toEqual({
+      manifestSchemaVersion: 1,
+      harness: 'opencode',
+      runId: 'run-002',
+      requestedSelectionIds: [
+        'bootstrap-loading/source',
+        'fixture-local-write/source',
+      ],
+      completedSelectionIds: [
+        'bootstrap-loading/source',
+        'fixture-local-write/source',
+      ],
+      partial: false,
+      results: [
+        {
+          selectionId: 'bootstrap-loading/source',
+          resultArtifactId: 'results/bootstrap-loading/source.json',
+          outcome: 'success',
+          subcode: 'none',
+        },
+        {
+          selectionId: 'fixture-local-write/source',
+          resultArtifactId: 'results/fixture-local-write/source.json',
+          outcome: 'infra_failure',
+          subcode: 'opencode_unavailable',
+        },
+      ],
+    })
+    expect(serializeRunManifest(reversed)).toBe(
+      serializeRunManifest(normalizeRunManifest(reversed)),
+    )
+
+    for (const invalid of [
+      { ...validRunManifest(), extra: true },
+      { ...validRunManifest(), partial: true },
+      { ...validRunManifest(), completedSelectionIds: [] },
+      {
+        ...validRunManifest(),
+        results: [
+          {
+            selectionId: 'bootstrap-loading/source',
+            resultArtifactId: '../escape.json',
+            outcome: 'success',
+            subcode: 'none',
+          },
+        ],
+      },
+      {
+        ...validRunManifest(),
+        results: [
+          {
+            selectionId: 'bootstrap-loading/source',
+            resultArtifactId: 'results/bootstrap-loading/source.json',
+            outcome: 'success',
+            subcode: 'identity_drift',
+          },
+        ],
+      },
+    ]) {
+      expect(() => normalizeRunManifest(invalid)).toThrow()
+    }
+  })
+
+  test('atomically persists only fully validated result and manifest bytes', () => {
+    const parent = tempRunParent()
+    try {
+      const runsRoot = path.join(parent, 'evals', 'runs')
+      const persisted = persistEvalRun({
+        runsRoot,
+        manifest: validRunManifest(),
+        results: [validResult()],
+      })
+
+      expect(persisted).toEqual({
+        status: 'written',
+        runId: 'run-002',
+        manifestArtifactId: 'manifest.json',
+        resultArtifactIds: ['results/bootstrap-loading/source.json'],
+      })
+      const runRoot = path.join(runsRoot, 'run-002')
+      expect(fs.readFileSync(path.join(runRoot, 'manifest.json'), 'utf8')).toBe(
+        serializeRunManifest(validRunManifest()),
+      )
+      expect(
+        fs.readFileSync(
+          path.join(runRoot, 'results/bootstrap-loading/source.json'),
+          'utf8',
+        ),
+      ).toBe(serializeResult(validResult()))
+      expect(fs.statSync(runRoot).mode & 0o777).toBe(0o700)
+      expect(
+        fs.statSync(path.join(runRoot, 'manifest.json')).mode & 0o777,
+      ).toBe(0o600)
+      expect(
+        fs
+          .readdirSync(runRoot, { recursive: true })
+          .some((entry) => String(entry).includes('.tmp.')),
+      ).toBe(false)
+    } finally {
+      fs.rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  test('renames every result before the manifest commit marker', () => {
+    const parent = tempRunParent()
+    const renameOrder: string[] = []
+    try {
+      persistEvalRun({
+        runsRoot: path.join(parent, 'evals', 'runs'),
+        manifest: validRunManifest(),
+        results: [validResult()],
+        onRename: (relativeId) => renameOrder.push(relativeId),
+      })
+
+      expect(renameOrder).toEqual([
+        'results/bootstrap-loading/source.json',
+        'manifest.json',
+      ])
+    } finally {
+      fs.rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  test('removes all finals and temps when the manifest commit rename fails', () => {
+    const parent = tempRunParent()
+    const runsRoot = path.join(parent, 'evals', 'runs')
+    try {
+      expect(() =>
+        persistEvalRun({
+          runsRoot,
+          manifest: validRunManifest(),
+          results: [validResult()],
+          onRename: (relativeId) => {
+            if (relativeId === 'manifest.json') {
+              throw new Error('injected manifest rename failure')
+            }
+          },
+        }),
+      ).toThrow('eval-persist:atomic_write_failed')
+
+      expect(fs.existsSync(path.join(runsRoot, 'run-002'))).toBe(false)
+      expect(fs.existsSync(runsRoot)).toBe(true)
+      expect(
+        fs
+          .readdirSync(runsRoot, { recursive: true })
+          .some((entry) => String(entry).includes('.tmp.')),
+      ).toBe(false)
+    } finally {
+      fs.rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects unsafe values before creating final or temporary artifacts', () => {
+    const unsafeInputs = [
+      {
+        manifest: validRunManifest({ runId: 'ghp_fake_github_token_123' }),
+        results: [validResult()],
+      },
+      {
+        manifest: validRunManifest({
+          results: [
+            {
+              selectionId: 'bootstrap-loading/source',
+              resultArtifactId: '/tmp/private-result.json',
+              outcome: 'success',
+              subcode: 'none',
+            },
+          ],
+        }),
+        results: [validResult()],
+      },
+      {
+        manifest: validRunManifest(),
+        results: [
+          {
+            ...validResult(),
+            evidence: {
+              sanity: 'passed',
+              process: 'completed',
+              assertionIds: ['bootstrap-observed'],
+              stdout: 'raw output must not persist',
+            },
+          },
+        ],
+      },
+      {
+        manifest: { ...validRunManifest(), unknownState: 'future' },
+        results: [validResult()],
+      },
+    ]
+
+    for (const [index, input] of unsafeInputs.entries()) {
+      const parent = tempRunParent()
+      try {
+        const runsRoot = path.join(parent, `evals-${index}`, 'runs')
+        expect(() => persistEvalRun({ runsRoot, ...input })).toThrow()
+        expect(fs.existsSync(runsRoot)).toBe(false)
+      } finally {
+        fs.rmSync(parent, { recursive: true, force: true })
+      }
+    }
+  })
+
+  test('rejects traversal and keeps repeated persistence bytes deterministic', () => {
+    const parent = tempRunParent()
+    try {
+      const firstRoot = path.join(parent, 'first', 'runs')
+      const secondRoot = path.join(parent, 'second', 'runs')
+      const firstManifest = validRunManifest({ runId: 'run-first' })
+      const secondManifest = validRunManifest({ runId: 'run-second' })
+      const firstResult = { ...validResult(), runId: 'run-first' }
+      const secondResult = { ...validResult(), runId: 'run-second' }
+
+      persistEvalRun({
+        runsRoot: firstRoot,
+        manifest: firstManifest,
+        results: [firstResult],
+      })
+      persistEvalRun({
+        runsRoot: secondRoot,
+        manifest: secondManifest,
+        results: [secondResult],
+      })
+
+      const normalizeRunId = (value: string): string =>
+        value
+          .replaceAll('run-first', 'run-opaque')
+          .replaceAll('run-second', 'run-opaque')
+      expect(
+        normalizeRunId(
+          fs.readFileSync(
+            path.join(firstRoot, 'run-first', 'manifest.json'),
+            'utf8',
+          ),
+        ),
+      ).toBe(
+        normalizeRunId(
+          fs.readFileSync(
+            path.join(secondRoot, 'run-second', 'manifest.json'),
+            'utf8',
+          ),
+        ),
+      )
+      expect(
+        normalizeRunId(
+          fs.readFileSync(
+            path.join(
+              firstRoot,
+              'run-first',
+              'results/bootstrap-loading/source.json',
+            ),
+            'utf8',
+          ),
+        ),
+      ).toBe(
+        normalizeRunId(
+          fs.readFileSync(
+            path.join(
+              secondRoot,
+              'run-second',
+              'results/bootstrap-loading/source.json',
+            ),
+            'utf8',
+          ),
+        ),
+      )
+
+      expect(() =>
+        persistEvalRun({
+          runsRoot: path.join(parent, 'traversal', 'runs'),
+          manifest: validRunManifest({
+            results: [
+              {
+                selectionId: 'bootstrap-loading/source',
+                resultArtifactId: 'results/../../escape.json',
+                outcome: 'success',
+                subcode: 'none',
+              },
+            ],
+          }),
+          results: [validResult()],
+        }),
+      ).toThrow()
+    } finally {
+      fs.rmSync(parent, { recursive: true, force: true })
+    }
+  })
+
+  test('accepts safe relative artifact IDs and rejects POSIX/Windows paths', () => {
+    expect(
+      normalizeResult({
+        ...validResult(),
+        artifactRefs: ['artifacts/result.json', 'fixture/output.txt'],
+      }).artifactRefs,
+    ).toEqual(['artifacts/result.json', 'fixture/output.txt'])
+
+    for (const unsafePath of [
+      '/tmp/private-result.json',
+      'C:\\Users\\marcus\\private-result.json',
+      'C:/Users/marcus/private-result.json',
+      '\\\\server\\share\\private-result.json',
+      '//server/share/private-result.json',
+      '../private-result.json',
+    ]) {
+      expect(() =>
+        normalizeResult({ ...validResult(), artifactRefs: [unsafePath] }),
+      ).toThrow()
+    }
+  })
+
+  test('rejects seeded fake credential, auth, key, token, and socket values without echoing them', () => {
+    const seededValues = [
+      'ghp_fake_github_token_123',
+      'npm_fake_npm_token_123',
+      'sk-fake-provider-key-123',
+      'AKIAFAKECLOUDKEY123456',
+      'fake-azure-client-secret',
+      'fake-google-cloud-token',
+      '-----BEGIN OPENSSH PRIVATE KEY-----',
+      '/tmp/fake-ssh-agent.sock',
+      'fake-git-password-123',
+      'fake-opencode-auth-token',
+    ]
+
+    for (const seededValue of seededValues) {
+      const message = rejectionMessage(() =>
+        normalizeResult({
+          ...validResult(),
+          runId: seededValue,
+        }),
+      )
+      expect(message).not.toContain(seededValue)
+    }
+  })
+
+  test('rejects banned raw fields anywhere in nested candidates', () => {
+    for (const field of [
+      ...BANNED_FIELD_NAMES,
+      'stdout',
+      'stderr',
+      'transcript',
+      'env',
+      'repositoryContent',
+      'userProse',
+      'configOverlay',
+    ]) {
+      const candidate = {
+        ...validResult(),
+        evidence: {
+          sanity: 'passed',
+          process: 'completed',
+          assertionIds: ['bootstrap-observed'],
+          nested: { [field]: 'sensitive value must not persist' },
+        },
+      }
+      expect(() => serializeResult(candidate)).toThrow()
+    }
+  })
+
+  test('uses the same banned field vocabulary for object and serialized validation', () => {
+    for (const field of BANNED_FIELD_NAMES) {
+      const candidate = {
+        ...validResult(),
+        evidence: {
+          sanity: 'passed',
+          process: 'completed',
+          assertionIds: ['bootstrap-observed'],
+          nested: { [field]: 'bounded sensitive value' },
+        },
+      }
+
+      expect(() => normalizeResult(candidate)).toThrow()
+      expect(() =>
+        assertSerializedTextSafe(JSON.stringify({ [field]: 'bounded value' })),
+      ).toThrow()
+      expect(() =>
+        validateSerializedResult(JSON.stringify(candidate)),
+      ).toThrow()
+    }
+  })
+
+  test('validates the entire serialized result on strings and bytes', () => {
+    const serialized = serializeResult(validResult())
+    expect(validateSerializedResult(serialized)).toEqual(
+      normalizeResult(validResult()),
+    )
+    expect(
+      validateSerializedResult(new TextEncoder().encode(serialized)),
+    ).toEqual(normalizeResult(validResult()))
+
+    const unsafeSerialized = serialized.replace(
+      'artifacts/result.json',
+      '/tmp/private-result.json',
+    )
+    expect(() => validateSerializedResult(unsafeSerialized)).toThrow()
+
+    const rejectedValue = 'ghp_fake_serialized_token_456'
+    const serializedWithSecret = serialized.replace('run-002', rejectedValue)
+    const secretMessage = rejectionMessage(() =>
+      validateSerializedResult(serializedWithSecret),
+    )
+    expect(secretMessage).not.toContain(rejectedValue)
+
+    const malformedMessage = rejectionMessage(() =>
+      validateSerializedResult('{"artifactRefs":["/tmp/private-result.json"]'),
+    )
+    expect(malformedMessage).not.toContain('/tmp/private-result.json')
+  })
+
+  test('does not write or execute a runner when imported', async () => {
+    const scriptsDir = path.join(ROOT_DIR, 'scripts')
+    const runsDir = path.join(ROOT_DIR, 'evals/runs')
+    const before = fs.readdirSync(scriptsDir).sort()
+    const runsBefore = fs.existsSync(runsDir)
+      ? fs.readdirSync(runsDir, { recursive: true }).map(String).sort()
+      : undefined
+    await import(
+      `${pathToFileURL(path.join(scriptsDir, 'run-evals.ts')).href}?side-effect-check`
+    )
+    const after = fs.readdirSync(scriptsDir).sort()
+    const runsAfter = fs.existsSync(runsDir)
+      ? fs.readdirSync(runsDir, { recursive: true }).map(String).sort()
+      : undefined
+
+    expect(after).toEqual(before)
+    expect(runsAfter).toEqual(runsBefore)
+  })
+})


### PR DESCRIPTION
## Summary
This PR adds a local OpenCode eval runner foundation and the first two-case execution set so evaluation can be run deterministically against local runs and verified outcomes.

## Highlights
- Adds deterministic local OpenCode eval support for exactly two cases: `bootstrap-loading` and `fixture-local-write`.
- Adds both execution modes for those cases: `source` and `installed` (packed-installed), with distinct provenance per mode.
- Uses fixture-scoped local isolation (explicitly not OS sandboxing), with denied-by-default child environment inheritance and explicit allowlisting for test execution.
- Hardens runtime boundaries so execution source/provenance is constrained and validated.
- Enforces fail-closed behavior for archive and dependency-resolution handling, privacy redaction, residue/quarantine cleanup, signal-based lifecycle cleanup, and atomic manifest persistence.
- Writes output only to local run artifacts under `evals/runs/<runId>/` with no telemetry and no upload.

## Verification
- Unit: 1,886 / 1,886
- Strict eval runner: 28 / 28
- Focused artifact/fixture/privacy suites: green
- `typecheck`, `build`, `content-integrity`, `registry`, and schema/diff checks: green
- Harness-routed full integration run: 125 passed, 1 skipped; one unrelated pre-existing PID-identity assertion is failing due to harness spawning the wrapped OpenCode child process.

## Notes
No demo section is included by request.
