### PR TITLE
feat(evals): add prompt composition evidence and host catalog coverage gate

### DIFF
--- a/docs/plans/2026-08-14-001-refactor-bootstrap-catalog-deletion-plan.md
+++ b/docs/plans/2026-08-14-001-refactor-bootstrap-catalog-deletion-plan.md
@@ -1,0 +1,333 @@
+---
+title: 'refactor: Delete the duplicated bootstrap skill catalog'
+type: refactor
+status: active
+date: 2026-08-14
+origin: docs/plans/2026-08-13-001-refactor-bitter-lesson-harness-plan.md
+---
+
+# refactor: Delete the duplicated bootstrap skill catalog
+
+## Overview
+
+Systematic injects a verbose `<available_skills>` catalog into the bootstrap system prompt. Measurement shows it is 11,911 characters — 65.6% of the entire 18,145-character bootstrap payload — and that every skill name and description it carries is already present in the running context twice over: once in OpenCode's own host-rendered skill catalog, and once in the `systematic_skill` tool description.
+
+This plan removes that third copy. It is the first behavior-changing slice of initiative I2 in the parent program (see origin: `docs/plans/2026-08-13-001-refactor-bitter-lesson-harness-plan.md`), and it is deliberately narrow: measure first, assert host coverage at the pinned runtime, then delete the catalog and the code that becomes dead with it.
+
+## Problem Frame
+
+The parent program frames I2 as "move large catalogs out of global context, then delete the superseded payload." Research reduced that to a sharper and smaller problem: the catalog is not a mechanism that needs replacing. Its replacement already runs in production.
+
+`registerSkillsPaths()` in `src/lib/config-handler.ts` unconditionally registers the bundled skills directory into OpenCode's native `skills.paths`. The host therefore discovers every bundled Systematic skill and renders its own catalog into the session. Independently, `buildSkillToolDescription()` in `src/lib/skill-resolver.ts` embeds a compact catalog of the same skills in the `systematic_skill` tool description.
+
+The result is three catalogs describing the same 23 skills, and ours is the worst of them:
+
+| Property | Host native catalog | `systematic_skill` description | Bootstrap catalog (this plan's target) |
+|---|---|---|---|
+| Freshness | Live; emits a supersede notice when the set changes | Rebuilt per plugin load | Static snapshot taken once at plugin init |
+| Permission awareness | Filters skills denied to the active agent | None | None |
+| Skill names + descriptions | Yes | Yes | Yes |
+| Absolute machine paths | Host-owned | No | Yes |
+| Owner | OpenCode | Systematic | Systematic |
+
+Ours is the stale, permission-blind copy, and it is the only one that writes absolute machine paths into the prompt. The repository already treats those paths as a defect on another surface: `tests/unit/build-claude-code-plugin.test.ts` asserts the Claude Code bundle contains no `<location>` tag, under the rationale that absolute machine paths must not leak into shipped artifacts.
+
+## Requirements Trace
+
+- R1. The bootstrap system prompt no longer contains a Systematic-rendered `<available_skills>` catalog.
+- R2. Every non-disabled bundled skill remains discoverable to the model on OpenCode after deletion, evidenced by observation of the running host rather than by assumption.
+- R3. Every non-disabled bundled skill remains discoverable on Pi after deletion, where no host-rendered catalog exists.
+- R4. Deletion is gated: the eval suite must observe host coverage at the pinned runtime before the catalog is removed, and must fail closed when that observation is inconclusive.
+- R5. Absolute machine paths are no longer emitted into the OpenCode or Pi system prompt.
+- R6. Code that becomes unreachable as a result of the deletion is removed in the same change, not left as unused exports.
+- R7. Bootstrap injection semantics — marker handling, idempotency across duplicate plugin registration, and preservation of foreign prompt content — are unchanged.
+- R8. Claude Code output is byte-unchanged.
+- R9. Disabled-skill and model-invocation filtering behavior is preserved wherever a catalog is still rendered.
+- R10. Host catalog coverage is re-verified whenever the pinned OpenCode runtime changes, not measured once.
+- R11. The behavior when `systematic_skill` is unavailable or denied is stated explicitly for each harness, and is not left to inference.
+
+Advances parent requirements R5-R8, R15, R22-R24, R31-R32, R34, and R36.
+
+## What This Plan Does and Does Not Prove
+
+Stated plainly, because three independent review lanes converged on it.
+
+**Proves:** the deleted content is duplicated elsewhere in the same context; the host catalog covers every non-disabled bundled skill at the pinned runtime; bootstrap composition, idempotency, and marker handling are unchanged; no code path still depends on the deleted surface.
+
+**Does not prove:** that model behavior is unchanged. Identical content at a different prompt position, with different framing and one fewer repetition, can shift model behavior. This plan argues equivalence from content and coverage; it does not measure routing.
+
+That gap is accepted deliberately, not overlooked. Measuring it needs a credentialed live-model eval tier, which contradicts the fixture-scoped, credential-free isolation contract approved for the eval foundation and would need its own plan and privacy review.
+
+The claim this plan makes is therefore **content deduplication with coverage evidence** — not "proven behavior-neutral" and not "improves routing." Anyone citing this work later should carry that distinction forward.
+
+**Revisit trigger:** if skill-selection quality is suspected to regress after this ships, the first response is to build the behavioral eval tier, not to restore the catalog by reflex. Restoring it without measurement would re-add the duplication without resolving the question.
+
+## Scope Boundaries
+
+- The `systematic_skill` tool and its compact catalog are not modified. Whether that tool itself duplicates the host's native `skill` tool is a separate question.
+- `renderCatalogCompact()` stays. It is the tool description's live dependency.
+- No change to agent catalogs, persona taxonomy, or `buildAgentCatalog()`.
+- No new eval harness tier, no credentialed model access, and no network egress beyond the already-pinned runtime fetch. I1's fixture-scoped, credential-free isolation contract is unchanged.
+- No change to config precedence, trust boundaries, or `SECURITY_OVERLAY_FIELDS`.
+
+### Deferred to Separate Tasks
+
+- Evaluating whether `systematic_skill` should be retired in favor of the host's native `skill` tool: needs its own plan, and depends on Pi and Claude Code parity that this plan does not establish.
+- Live-model routing evaluation: would require a credentialed eval tier that contradicts I1's approved isolation contract. If a future initiative wants it, it earns its own plan and its own privacy review.
+- The lazy `cachedDescription` / `cachedParameterHint` staleness in `src/lib/skill-tool.ts` when config changes mid-session: pre-existing, unrelated to this deletion.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/lib/bootstrap.ts` — `getBootstrapContent()` assembles the payload and holds the single production call to `renderCatalogVerbose()`. `applyBootstrapContent()` owns marker stripping and idempotent re-injection.
+- `src/lib/skill-catalog.ts` — `renderCatalogVerbose()` (deletion target), `renderCatalogCompact()` (retained), `buildCatalogEntries()` (retained; owns disabled and model-invocation filtering).
+- `src/lib/skill-tool.ts` — `formatSkillsXml()` is already dead: it has no production caller and is referenced only by its own tests.
+- `src/lib/config-handler.ts` — `registerSkillsPaths()` is the reason host coverage exists at all. It is the load-bearing fact behind this plan.
+- `src/lib/skill-resolver.ts` — `buildSkillToolDescription()`, the surviving catalog surface.
+- `scripts/eval-cases/opencode.ts` — probe and graders. The probe records plugin-load health, transform health, and `<SYSTEMATIC_WORKFLOWS>` block count; it does not inspect prompt contents.
+- `scripts/run-evals.ts` — case manifest parsing, fixed `CASE_IDS`, four-outcome taxonomy.
+- `tests/integration/fixtures/receipt-workflow-host.ts` — `assertWorkflowSystem()` requires `<available_skills>` and specific skill names in `system[0]`. This is a hard dependency, not a snapshot, and blocks deletion until updated.
+
+### Institutional Learnings
+
+- `docs/plans/2026-07-21-002-test-receipt-workflow-capabilities-plan.md` — probe health is separate from behavior; a probe that cannot distinguish outcomes must not report a green one. Directly shapes R4's fail-closed gate.
+- `docs/solutions/best-practices/subagent-stop-prose-behavioral-null-result-2026-05-20.md` — a null result may mean the probe was incapable, not that the behavior is safe.
+- `docs/solutions/integration-issues/opencode-plugin-hook-silent-defect-swallow-2026-05-19.md` — absence of output is not proof of execution; the probe must confirm the path ran.
+- `docs/solutions/security-issues/redos-after-plugin-trust-boundary-inversion-2026-05-11.md` — bootstrap marker handling is a security boundary. This plan removes a section from generated content and must not touch the strip-and-replace logic.
+- `docs/solutions/integration-issues/opencode-plugin-factory-duplicate-registration-2026-05-04.md` — injection must stay idempotent across multiple registrations.
+- `docs/solutions/logic-errors/pi-chained-bootstrap-composition-2026-07-14.md` — Pi composition must preserve foreign, non-Systematic prompt content.
+- `docs/plans/2026-04-17-002-refactor-truth-reset-plan.md` — delete stale infrastructure only after the replacement is independently verified.
+
+### External References
+
+- `.slim/clonedeps/repos/anomalyco__opencode/` at v1.17.6 — `packages/opencode/src/skill/index.ts` (`fmt`, `available`) and `packages/core/src/skill/guidance.ts` show the host's catalog rendering and permission filtering. Read-only reference. The clone is *not* the pinned eval runtime, which is why host coverage is asserted at runtime rather than inferred from this source.
+
+## Key Technical Decisions
+
+- **Assert host coverage rather than assume it.** The clone is pinned at v1.17.6 while evals pin 1.18.5, and catalog rendering is host-version-dependent. Coverage becomes a measured precondition of deletion.
+- **Delete for OpenCode and Pi together, with no harness branch.** Adding a harness conditional would introduce exactly the kind of special-casing the parent program exists to remove, and would need deleting later. Pi keeps full coverage through the `systematic_skill` description, which carries all names and descriptions.
+- **Measurement lands before deletion, as separate units.** The instrument must be trustworthy before it is used as a gate.
+- **Delete dead code in the same change.** Leaving `renderCatalogVerbose()` and `formatSkillsXml()` as unused exports preserves the illusion of a supported surface.
+- **Drop `<location>` rather than relocate it.** No production code reads it back, the repository already classifies absolute paths in generated artifacts as a defect, and their presence invites models to read `SKILL.md` directly — bypassing the permission gate and metadata hooks in `createSkillTool()`.
+- **No credentialed eval tier.** The honest claim is duplicate removal, not model-routing improvement, so the evidence needed is coverage and composition — both mechanically observable. The cost of this choice is stated above rather than buried.
+- **Host coverage is a standing gate, not a one-time proof.** The Unit 2 case stays in the corpus permanently and must be re-run whenever the pinned runtime version changes. A version bump without a passing coverage run is treated as an unverified host, because catalog rendering is host-owned and can change under us.
+- **State the unavailable-tool behavior per harness rather than generalizing.** OpenCode and Pi have materially different fallbacks, and the weaker one must not hide behind the stronger.
+
+## Deletion Standard for Later Slices
+
+This is the program's first live deletion, so it sets precedent. The standard it establishes:
+
+- Deletion is justified by **demonstrated redundancy plus observed coverage of the replacement**, never by size or duplication alone.
+- The replacement path must be identified, already running, and asserted by a test that fails when the replacement stops covering it.
+- Where evidence stops short of proving behavioral equivalence, the plan says so in its own text — as this one does above.
+- "Smaller" is not a success criterion. It is a side effect. A slice that reduces payload while weakening a capability has failed, whatever the character count says.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Does query-based discovery need building? No. It is already live in all three harnesses.
+- Do the bootstrap catalog and the tool description actually carry the same content? Yes — measured: all 23 names and all 23 descriptions appear in both.
+- Does anything consume the `<location>` URLs? No production code does. The only references are test assertions, and one of them exists to forbid the tag.
+- Are custom `bootstrap.file` users affected? No. That path returns file contents verbatim and never renders a catalog.
+- Does deletion break Claude Code? No. `buildOutputStyleContent()` already omits the catalog.
+
+### Deferred to Implementation
+
+- Whether the pinned 1.18.5 host renders a catalog covering every non-disabled bundled skill. This is Unit 2's measurement and the plan's stop condition — if coverage does not hold, deletion does not proceed.
+- The exact probe event fields needed to capture prompt composition without recording prompt text that would violate I1's persistence privacy rules.
+- Whether `tests/integration/fixtures/receipt-workflow-host.ts` should assert the host catalog instead of the Systematic one, or drop the catalog assertion entirely and keep only the workflow-block invariants.
+
+## Implementation Units
+
+- [x] **Unit 1: Give the eval probe the ability to observe prompt composition**
+
+**Goal:** Extend the probe and result schema so a case can state, as evidence, which catalogs are present in the injected system prompt and how large the bootstrap payload is.
+
+**Requirements:** R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `scripts/eval-cases/opencode.ts`
+- Modify: `scripts/run-evals.ts`
+- Test: `tests/integration/eval-runner.test.ts`
+- Test: `tests/unit/eval-contract.test.ts`
+
+**Approach:**
+- Record bounded, structured facts only — catalog presence flags, entry counts, skill-name sets, and payload sizes. Do not persist raw prompt text; it would collide with the fail-closed privacy validation shipped in I1.
+- Keep the four-outcome taxonomy. An observation the probe could not make is `infra_failure`, never `success`.
+- Distinguish three states explicitly: catalog observed, catalog observed absent, and observation impossible. Collapsing the third into either of the first two is the false-green this unit exists to prevent.
+
+**Execution note:** Test-first. The probe is the instrument every later gate depends on, so its failure modes need pinning before its success path.
+
+**Patterns to follow:** existing probe event recording and `gradeBootstrapProbe()` in `scripts/eval-cases/opencode.ts`; bounded fact shapes in `scripts/run-evals.ts`.
+
+**Test scenarios:**
+- Happy path: a run with the current bootstrap reports the Systematic catalog present with 23 entries and a payload size in the expected range.
+- Happy path: recorded facts round-trip through result serialization unchanged.
+- Edge case: zero discoverable skills reports catalog-absent rather than observation-impossible.
+- Error path: a probe that never observes a chat transform yields `infra_failure`, not a passing catalog-absent result.
+- Error path: attempting to persist raw prompt text trips the existing privacy validator.
+- Integration: recorded facts survive the write-then-rename persistence ordering with the manifest written last.
+
+**Verification:**
+- A run against unmodified `main` reports the Systematic catalog as present, proving the instrument detects what it is about to be used to delete.
+- No new absolute paths or prompt text appear in persisted artifacts.
+
+- [x] **Unit 2: Assert host catalog coverage at the pinned runtime**
+
+**Goal:** Establish, by observation, that OpenCode's native catalog covers every non-disabled bundled skill at the pinned runtime — the precondition for deletion.
+
+**Requirements:** R2, R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `evals/cases/opencode/host-skill-coverage.json`
+- Modify: `scripts/eval-cases/opencode.ts`
+- Modify: `scripts/run-evals.ts`
+- Test: `tests/integration/eval-runner.test.ts`
+- Test: `tests/unit/eval-contract.test.ts`
+
+**Approach:**
+- Register a new case ID and its manifest assertions alongside the existing two.
+- Grade coverage as a set relationship: every non-disabled bundled skill name must appear in the host-rendered catalog. Report the missing set on failure rather than a bare boolean.
+- Treat partial coverage as failure. A catalog listing most skills is not a replacement for one listing all of them.
+- If the host renders no catalog at the pinned version, the case fails and the plan stops at this unit. That outcome is a legitimate result, not a defect to work around.
+- `CASE_IDS` in `scripts/run-evals.ts` is a fixed tuple and `tests/unit/eval-contract.test.ts` asserts its exact contents. Both must be updated when the new case is registered, or the contract test fails before the new case ever runs.
+- Keep the case in the corpus after deletion ships. It is the standing regression gate for R10, not scaffolding to remove.
+
+**Execution note:** Test-first.
+
+**Patterns to follow:** case-manifest validation in `scripts/run-evals.ts`; deterministic grading in `gradeBootstrapProbe()`.
+
+**Test scenarios:**
+- Happy path: at the pinned runtime, the host catalog covers all non-disabled bundled skills and the case reports `success`.
+- Edge case: a skill excluded via `disabled_skills` is absent from both catalogs and does not count as a coverage gap.
+- Edge case: a skill marked `disableModelInvocation` is handled per existing filter semantics without failing coverage.
+- Error path: a simulated missing skill in the host catalog produces failure naming the missing entry.
+- Error path: a host that renders no catalog yields a failing, clearly-labelled outcome rather than a vacuous pass.
+- Integration: the case runs in both source and packed-installed modes with consistent results.
+- Integration: the `CASE_IDS` contract test passes with the new case registered.
+
+**Verification:**
+- Coverage is reported from observed host output at the pinned runtime, with the missing set empty.
+- The case fails loudly when coverage is incomplete.
+- The case remains registered and runnable after Unit 3, so a later runtime bump re-exercises it.
+
+- [ ] **Unit 3: Delete the bootstrap catalog and the code it kept alive**
+
+**Goal:** Remove the catalog from generated bootstrap content and delete the code paths that become unreachable.
+
+**Requirements:** R1, R5, R6, R7, R9
+
+**Dependencies:** Unit 2 passing
+
+**Files:**
+- Modify: `src/lib/bootstrap.ts`
+- Modify: `src/lib/skill-catalog.ts`
+- Modify: `src/lib/skill-tool.ts`
+- Modify: `tests/unit/bootstrap.test.ts`
+- Modify: `tests/unit/skill-catalog.test.ts`
+- Modify: `tests/unit/skill-tool.test.ts`
+- Modify: `tests/integration/fixtures/receipt-workflow-host.ts`
+- Test: `tests/unit/config-handler.test.ts`
+
+**Approach:**
+- Remove the `renderCatalogVerbose()` call and its section assembly from `getBootstrapContent()`, leaving the surrounding sections and their separators intact.
+- Delete `renderCatalogVerbose()` from `src/lib/skill-catalog.ts` and `formatSkillsXml()` from `src/lib/skill-tool.ts`, along with imports and tests that exist solely to exercise them.
+- Do not touch `applyBootstrapContent()`, marker handling, or idempotency logic. The payload shrinks; the injection contract does not move.
+- Update `assertWorkflowSystem()` in the receipt fixture. It currently requires `<available_skills>` and named skills in `system[0]`; the workflow-block invariants it also enforces must survive unchanged.
+- Refresh the byte-pinned bootstrap snapshots and the I2a non-interference characterization tests. Those tests were written to prove I2a changed nothing, so their update here is the intended signal that this change is the one altering bootstrap bytes.
+
+**Execution note:** Characterization-first. Re-run the pinned bootstrap tests before editing so the pre-deletion baseline is explicit, then update the snapshots as a deliberate act rather than a mechanical regeneration.
+
+**Patterns to follow:** existing section assembly in `getBootstrapContent()`; snapshot conventions in `tests/unit/bootstrap.test.ts`.
+
+**Test scenarios:**
+- Happy path: generated bootstrap contains no `<available_skills>` block and no `<location>` tag.
+- Happy path: `using-systematic` body, skill usage template, and harness profile block remain present, ordered, and correctly separated.
+- Happy path: measured bootstrap size drops by approximately 11,900 characters.
+- Edge case: zero discoverable skills produces well-formed bootstrap with no empty-section artifacts.
+- Edge case: all skills disabled behaves identically to zero skills.
+- Edge case: a custom `bootstrap.file` override still returns file contents verbatim.
+- Error path: `renderCatalogCompact()` and the `systematic_skill` description still list all 23 skills, proving the retained surface was not collaterally damaged.
+- Integration: repeated `applyBootstrapContent()` calls remain idempotent and leave exactly one workflow block.
+- Integration: duplicate plugin registration still produces a single workflow block.
+- Integration: the receipt-workflow host fixture passes with its workflow-block invariants intact.
+
+**Verification:**
+- Unit 1's probe now reports the Systematic catalog absent while Unit 2's host coverage still reports complete.
+- Claude Code bundle output is byte-unchanged.
+- No unused exports remain from the deleted surface.
+
+- [ ] **Unit 4: Confirm Pi coverage and record the cross-harness posture**
+
+**Goal:** Verify Pi retains full skill discoverability without a host-rendered catalog, state the unavailable-tool contract per harness, and document the resulting architecture.
+
+**Requirements:** R3, R8, R10, R11
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Test: `tests/unit/pi.test.ts`
+- Test: `tests/unit/build-claude-code-plugin.test.ts`
+- Modify: `ARCHITECTURE.md`
+
+**Approach:**
+- Pi has no host-rendered catalog, so its coverage rests entirely on the `systematic_skill` tool description. Assert that directly rather than inferring it from the OpenCode result. `registerSkillsPaths()` is called only from the OpenCode config handler; Pi has no equivalent, so the OpenCode fallback argument does not transfer and must not be reused for Pi.
+- State the unavailable-tool contract explicitly per harness, since the fallbacks differ in strength:
+  - **OpenCode** — bundled skills are registered into native `skills.paths`, so the host's own `skill` tool continues to discover and load them even if `systematic_skill` is denied. Degraded, not lost.
+  - **Pi** — discovery depends solely on the `systematic_skill` tool description. If that tool is absent or denied, Pi has no remaining discovery surface. This is a real reduction in resilience relative to today, where the bootstrap catalog at least named the skills, and it is accepted knowingly rather than papered over.
+  - **Claude Code** — already on the no-catalog path via its native Skill tool; unaffected.
+- Record in `ARCHITECTURE.md` where skill discovery comes from per harness, the unavailable-tool contract above, and that bootstrap deliberately does not carry a catalog.
+- Record the host-upgrade revalidation rule (R10) alongside it, so a future runtime bump has a written obligation attached rather than relying on someone remembering this plan.
+
+**Test scenarios:**
+- Happy path: Pi's `systematic_skill` description lists every non-disabled bundled skill by name and description.
+- Happy path: Pi bootstrap composition still preserves foreign, non-Systematic prompt content.
+- Happy path: Claude Code output style remains byte-identical and still contains no `<available_skills>` or `<location>`.
+- Edge case: disabled skills are absent from Pi's tool description.
+- Edge case: with `systematic_skill` unavailable on OpenCode, bundled skills remain registered in `skills.paths` and reachable through the host's native skill tool.
+
+**Verification:**
+- Each harness has a named, tested discovery path, and none of them is the deleted bootstrap catalog.
+- The unavailable-tool contract is written down per harness, including the case where Pi has no fallback.
+
+## System-Wide Impact
+
+- **Interaction graph:** `getBootstrapContent()` feeds the OpenCode chat transform hook and Pi's prompt composition. Both lose the catalog section simultaneously; neither loses discoverability.
+- **Error propagation:** Eval observation failures must surface as `infra_failure` and block promotion. A case that cannot observe must not report success.
+- **State lifecycle risks:** Bootstrap is snapshotted once per plugin init and the tool description caches lazily. This plan changes payload content only, so it neither introduces nor resolves that staleness.
+- **API surface parity:** `renderCatalogCompact()` and `buildCatalogEntries()` remain the shared catalog surface for every harness after `renderCatalogVerbose()` is gone.
+- **Integration coverage:** The receipt-workflow fixture is the one integration surface with a hard dependency on the catalog; unit tests alone will not catch its breakage.
+- **Unchanged invariants:** marker stripping and idempotent re-injection in `applyBootstrapContent()`; config precedence and trust boundaries; `systematic_skill` resolution, permission prompt, and metadata; content-integrity gates; Claude Code bundle bytes.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Host catalog coverage differs at 1.18.5 from the v1.17.6 reference clone | Unit 2 measures coverage at the pinned runtime and stops the plan if it does not hold |
+| Host changes catalog rendering on a later upgrade, silently breaking coverage after this ships | R10: the Unit 2 case stays in the corpus as a standing gate and must pass on any pinned-runtime bump; ARCHITECTURE.md records the obligation |
+| Model behavior degrades despite identical content, and coverage evals stay green | Accepted and disclosed in "What This Plan Does and Does Not Prove", with a named revisit trigger; not claimed as proven-neutral |
+| Pi loses discovery entirely if `systematic_skill` is denied or absent | Documented as an explicit per-harness contract in Unit 4 rather than left implicit; Pi's weaker position is stated, not averaged away |
+| Deletion looks green because the eval harness cannot see prompt contents | Unit 1 lands the observation capability first and proves it detects the catalog before it is used to confirm absence |
+| Pi silently loses discoverability, having no host catalog | Unit 4 asserts Pi coverage directly rather than generalizing from OpenCode |
+| Snapshot churn hides an unintended bootstrap change | Characterization-first execution in Unit 3; assertions on retained sections, not just on the removed one |
+| Receipt-workflow fixture breaks mid-plan | Identified in advance as a hard dependency and updated within Unit 3 |
+| A user denies the `systematic_skill` permission | Host-registered `skills.paths` keeps skills reachable through the native `skill` tool; Unit 2 evidences that path |
+
+## Documentation / Operational Notes
+
+- `ARCHITECTURE.md` gains a short statement of per-harness skill discovery, the unavailable-tool contract, the deliberate absence of a bootstrap catalog, and the host-upgrade revalidation obligation.
+- No migration, config change, or user action is required.
+- Operationally, the visible change is a smaller prompt. That is the side effect, not the goal — the goal is one authoritative, permission-aware catalog instead of three, one of which was stale and leaked absolute machine paths.
+
+## Sources & References
+
+- **Origin document:** [docs/plans/2026-08-13-001-refactor-bitter-lesson-harness-plan.md](docs/plans/2026-08-13-001-refactor-bitter-lesson-harness-plan.md), initiative I2
+- Sibling plans: `docs/plans/2026-08-13-002-feat-read-only-capability-diagnostic-plan.md`, `docs/plans/2026-08-13-003-feat-local-opencode-eval-foundation-plan.md`
+- Related code: `src/lib/bootstrap.ts`, `src/lib/skill-catalog.ts`, `src/lib/config-handler.ts`, `src/lib/skill-resolver.ts`, `scripts/eval-cases/opencode.ts`
+- Host reference: `.slim/clonedeps/repos/anomalyco__opencode/` at v1.17.6 (read-only)

--- a/evals/cases/opencode/host-skill-coverage.json
+++ b/evals/cases/opencode/host-skill-coverage.json
@@ -1,0 +1,31 @@
+{
+  "caseSchemaVersion": 1,
+  "caseId": "host-skill-coverage",
+  "harness": "opencode",
+  "assertionIds": ["host-catalog-covered"],
+  "expectedSkillNames": [
+    "agent-browser",
+    "agent-native-architecture",
+    "ce:brainstorm",
+    "ce:compound",
+    "ce:ideate",
+    "ce:plan",
+    "ce:review",
+    "ce:work",
+    "deepen-plan",
+    "document-review",
+    "frontend-design",
+    "git-clean-gone-branches",
+    "git-commit",
+    "git-commit-push-pr",
+    "git-worktree",
+    "onboarding",
+    "orchestrating-subagents",
+    "reproduce-bug",
+    "resolve-pr-feedback",
+    "test-browser",
+    "test-driven-development",
+    "using-systematic",
+    "writing-skills"
+  ]
+}

--- a/scripts/eval-cases/opencode.ts
+++ b/scripts/eval-cases/opencode.ts
@@ -482,6 +482,8 @@ function observePromptComposition(system) {
   }
 }
 
+export { observePromptComposition }
+
 function isChatTransform(input) {
   return Boolean(input && typeof input === 'object' && typeof input.sessionID === 'string' && 'model' in input)
 }

--- a/scripts/eval-cases/opencode.ts
+++ b/scripts/eval-cases/opencode.ts
@@ -11,6 +11,8 @@ import {
   type EvalCaseManifest,
   type EvalFixture,
   EXPECTED_OPENCODE_VERSION,
+  type HostCatalogCoverageObservation,
+  type PromptCompositionObservation,
 } from '../run-evals.ts'
 
 const MODEL_PROVIDER_ID = 'systematic-eval-local-provider'
@@ -18,8 +20,18 @@ const MODEL_ID = 'systematic-eval-local-model'
 const EXPECTED_WRITE_CONTENT = 'fixture-local-write-v1'
 const PROBE_FAKE_VALUE_MARKER = 'eval-parent-fake-value'
 const PROBE_DIGEST = createHash('sha256')
-  .update('systematic-eval-probe-v1')
+  .update('systematic-eval-probe-v3')
   .digest('hex')
+
+const BOOTSTRAP_MARKER_OPEN = '<SYSTEMATIC_WORKFLOWS>'
+const BOOTSTRAP_MARKER_CLOSE = '</SYSTEMATIC_WORKFLOWS>'
+const CATALOG_MARKER_OPEN = '<available_skills>'
+const CATALOG_MARKER_CLOSE = '</available_skills>'
+const OPENCODE_HOST_TIMEOUT = 'opencode-host-timeout'
+const OPENCODE_PROMPT_TIMEOUT = 'opencode-prompt-timeout'
+const SAFE_SKILL_NAME = /^[A-Za-z0-9][A-Za-z0-9._:+-]{0,127}$/
+const MAX_BOOTSTRAP_PAYLOAD_SIZE = 100_000
+const MAX_CATALOG_ENTRIES = 128
 
 export interface ScriptedToolCall {
   id: string
@@ -44,6 +56,7 @@ export type BoundedProbeEvent =
       kind: 'chat'
       status: 'healthy' | 'unhealthy'
       blockCount: number
+      promptComposition?: PromptCompositionObservation
     }
   | { type: 'tool'; tool: 'write'; outcome: 'success' | 'failure' }
 
@@ -59,6 +72,7 @@ interface ProbeHealth {
   subcode?: 'probe_unhealthy'
   blockCount?: number
   transformCount?: number
+  promptComposition: PromptCompositionObservation
 }
 
 interface FixtureWriteGrade {
@@ -78,6 +92,201 @@ interface StoppableModelServer {
 const activeOpencodeChildren = new Set<ChildProcess>()
 const activeModelServers = new Set<StoppableModelServer>()
 
+function impossiblePromptComposition(): PromptCompositionObservation {
+  return {
+    bootstrapPayloadSize: 0,
+    systematicCatalog: {
+      state: 'impossible',
+      entryCount: 0,
+      skillNames: [],
+    },
+    hostCatalog: {
+      state: 'impossible',
+      entryCount: 0,
+      skillNames: [],
+    },
+  }
+}
+
+function findCompleteBlocks(
+  text: string,
+  open: string,
+  close: string,
+): Array<{ start: number; end: number }> {
+  const blocks: Array<{ start: number; end: number }> = []
+  let cursor = 0
+  while (cursor < text.length) {
+    const start = text.indexOf(open, cursor)
+    if (start === -1) break
+    const closeStart = text.indexOf(close, start + open.length)
+    if (closeStart === -1) break
+    blocks.push({ start, end: closeStart + close.length })
+    cursor = closeStart + close.length
+  }
+  return blocks
+}
+
+function findWorkflowBlocks(text: string): {
+  valid: boolean
+  blocks: Array<{ start: number; end: number }>
+} {
+  const blocks: Array<{ start: number; end: number }> = []
+  let openStart = -1
+  let openCount = 0
+  let closeCount = 0
+  let cursor = 0
+
+  while (cursor < text.length) {
+    const openStartCandidate = text.indexOf(BOOTSTRAP_MARKER_OPEN, cursor)
+    const closeStartCandidate = text.indexOf(BOOTSTRAP_MARKER_CLOSE, cursor)
+    if (openStartCandidate === -1 && closeStartCandidate === -1) break
+
+    if (
+      closeStartCandidate === -1 ||
+      (openStartCandidate !== -1 && openStartCandidate < closeStartCandidate)
+    ) {
+      openCount += 1
+      if (openStart !== -1) return { valid: false, blocks: [] }
+      openStart = openStartCandidate
+      cursor = openStartCandidate + BOOTSTRAP_MARKER_OPEN.length
+      continue
+    }
+
+    closeCount += 1
+    if (openStart === -1) return { valid: false, blocks: [] }
+    blocks.push({
+      start: openStart,
+      end: closeStartCandidate + BOOTSTRAP_MARKER_CLOSE.length,
+    })
+    openStart = -1
+    cursor = closeStartCandidate + BOOTSTRAP_MARKER_CLOSE.length
+  }
+
+  if (openStart !== -1 || openCount !== closeCount) {
+    return { valid: false, blocks: [] }
+  }
+  return { valid: true, blocks }
+}
+
+export function observePromptComposition(
+  system: readonly unknown[],
+): PromptCompositionObservation {
+  if (!system.every((entry) => typeof entry === 'string')) {
+    return impossiblePromptComposition()
+  }
+
+  const text = system.join('\n\n')
+  const workflowStructure = findWorkflowBlocks(text)
+  if (!workflowStructure.valid) return impossiblePromptComposition()
+  const workflowBlocks = workflowStructure.blocks
+  const catalogBlocks = findCompleteBlocks(
+    text,
+    CATALOG_MARKER_OPEN,
+    CATALOG_MARKER_CLOSE,
+  )
+  const systematicBlocks = catalogBlocks.filter((block) =>
+    workflowBlocks.some(
+      (workflow) => block.start >= workflow.start && block.end <= workflow.end,
+    ),
+  )
+  const systematicBlockTexts = new Set(
+    systematicBlocks.map((block) => text.slice(block.start, block.end)),
+  )
+  const hostBlocks = catalogBlocks.filter(
+    (block) =>
+      !workflowBlocks.some(
+        (workflow) =>
+          block.start >= workflow.start && block.end <= workflow.end,
+      ) && !systematicBlockTexts.has(text.slice(block.start, block.end)),
+  )
+  const summarize = (
+    blocks: readonly { start: number; end: number }[],
+  ): PromptCompositionObservation['systematicCatalog'] => {
+    const names = new Set<string>()
+    let entryCount = 0
+    for (const block of blocks) {
+      const catalogText = text.slice(block.start, block.end)
+      for (const skillBlock of catalogText.matchAll(
+        /<skill>([\s\S]*?)<\/skill>/g,
+      )) {
+        const name = skillBlock[1]
+          ?.match(/<name>\s*([^<]+?)\s*<\/name>/)?.[1]
+          ?.trim()
+        if (!name || !SAFE_SKILL_NAME.test(name)) continue
+        entryCount += 1
+        names.add(name)
+      }
+    }
+    return {
+      state: blocks.length > 0 ? 'present' : 'absent',
+      entryCount,
+      skillNames: [...names].sort(),
+    }
+  }
+
+  return {
+    bootstrapPayloadSize: workflowBlocks.reduce(
+      (size, block) => size + (block.end - block.start),
+      0,
+    ),
+    systematicCatalog: summarize(systematicBlocks),
+    hostCatalog: summarize(hostBlocks),
+  }
+}
+
+function isBoundedCatalogObservation(
+  value: unknown,
+): value is PromptCompositionObservation['systematicCatalog'] {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const candidate = value as Record<string, unknown>
+  if (
+    Object.keys(candidate).length !== 3 ||
+    (candidate.state !== 'present' &&
+      candidate.state !== 'absent' &&
+      candidate.state !== 'impossible') ||
+    typeof candidate.entryCount !== 'number' ||
+    !Number.isInteger(candidate.entryCount) ||
+    candidate.entryCount < 0 ||
+    candidate.entryCount > MAX_CATALOG_ENTRIES ||
+    !Array.isArray(candidate.skillNames) ||
+    candidate.skillNames.length > MAX_CATALOG_ENTRIES
+  ) {
+    return false
+  }
+  const names = candidate.skillNames
+  if (
+    names.some(
+      (name) =>
+        typeof name !== 'string' ||
+        !SAFE_SKILL_NAME.test(name) ||
+        name.length > 128,
+    )
+  ) {
+    return false
+  }
+  if (new Set(names).size !== names.length) return false
+  if (candidate.state !== 'present') {
+    return candidate.entryCount === 0 && names.length === 0
+  }
+  return names.length <= candidate.entryCount
+}
+
+function isBoundedPromptComposition(
+  value: unknown,
+): value is PromptCompositionObservation {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const candidate = value as Record<string, unknown>
+  return (
+    Object.keys(candidate).length === 3 &&
+    typeof candidate.bootstrapPayloadSize === 'number' &&
+    Number.isInteger(candidate.bootstrapPayloadSize) &&
+    candidate.bootstrapPayloadSize >= 0 &&
+    candidate.bootstrapPayloadSize <= MAX_BOOTSTRAP_PAYLOAD_SIZE &&
+    isBoundedCatalogObservation(candidate.systematicCatalog) &&
+    isBoundedCatalogObservation(candidate.hostCatalog)
+  )
+}
+
 function isBoundedProbeEvent(value: unknown): value is BoundedProbeEvent {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false
   const candidate = value as Record<string, unknown>
@@ -88,14 +297,19 @@ function isBoundedProbeEvent(value: unknown): value is BoundedProbeEvent {
     )
   }
   if (candidate.type === 'transform') {
+    const hasPromptComposition = candidate.promptComposition !== undefined
     return (
-      Object.keys(candidate).length === 4 &&
+      Object.keys(candidate).length === (hasPromptComposition ? 5 : 4) &&
       candidate.kind === 'chat' &&
       (candidate.status === 'healthy' || candidate.status === 'unhealthy') &&
       typeof candidate.blockCount === 'number' &&
       Number.isInteger(candidate.blockCount) &&
       candidate.blockCount >= 0 &&
-      candidate.blockCount <= 8
+      candidate.blockCount <= 8 &&
+      (candidate.status !== 'healthy' ||
+        isBoundedPromptComposition(candidate.promptComposition)) &&
+      (candidate.promptComposition === undefined ||
+        isBoundedPromptComposition(candidate.promptComposition))
     )
   }
   return (
@@ -165,6 +379,109 @@ function workflowBlockCount(system) {
     count + (typeof entry === 'string' ? entry.split('<SYSTEMATIC_WORKFLOWS>').length - 1 : 0), 0)
 }
 
+const bootstrapMarkerOpen = '<SYSTEMATIC_WORKFLOWS>'
+const bootstrapMarkerClose = '</SYSTEMATIC_WORKFLOWS>'
+const catalogMarkerOpen = '<available_skills>'
+const catalogMarkerClose = '</available_skills>'
+const safeSkillName = /^[A-Za-z0-9][A-Za-z0-9._:+-]{0,127}$/
+
+function impossiblePromptComposition() {
+  return {
+    bootstrapPayloadSize: 0,
+    systematicCatalog: { state: 'impossible', entryCount: 0, skillNames: [] },
+    hostCatalog: { state: 'impossible', entryCount: 0, skillNames: [] },
+  }
+}
+
+function findCompleteBlocks(text, open, close) {
+  const blocks = []
+  let cursor = 0
+  while (cursor < text.length) {
+    const start = text.indexOf(open, cursor)
+    if (start === -1) break
+    const closeStart = text.indexOf(close, start + open.length)
+    if (closeStart === -1) break
+    blocks.push({ start, end: closeStart + close.length })
+    cursor = closeStart + close.length
+  }
+  return blocks
+}
+
+function findWorkflowBlocks(text) {
+  const blocks = []
+  let openStart = -1
+  let openCount = 0
+  let closeCount = 0
+  let cursor = 0
+  while (cursor < text.length) {
+    const openStartCandidate = text.indexOf(bootstrapMarkerOpen, cursor)
+    const closeStartCandidate = text.indexOf(bootstrapMarkerClose, cursor)
+    if (openStartCandidate === -1 && closeStartCandidate === -1) break
+    if (
+      closeStartCandidate === -1 ||
+      (openStartCandidate !== -1 && openStartCandidate < closeStartCandidate)
+    ) {
+      openCount += 1
+      if (openStart !== -1) return { valid: false, blocks: [] }
+      openStart = openStartCandidate
+      cursor = openStartCandidate + bootstrapMarkerOpen.length
+      continue
+    }
+    closeCount += 1
+    if (openStart === -1) return { valid: false, blocks: [] }
+    blocks.push({
+      start: openStart,
+      end: closeStartCandidate + bootstrapMarkerClose.length,
+    })
+    openStart = -1
+    cursor = closeStartCandidate + bootstrapMarkerClose.length
+  }
+  if (openStart !== -1 || openCount !== closeCount) {
+    return { valid: false, blocks: [] }
+  }
+  return { valid: true, blocks }
+}
+
+function summarizeCatalog(text, blocks) {
+  const names = new Set()
+  let entryCount = 0
+  for (const block of blocks) {
+    const catalogText = text.slice(block.start, block.end)
+    for (const skillBlock of catalogText.matchAll(/<skill>([\\s\\S]*?)<\\/skill>/g)) {
+      const name = skillBlock[1]?.match(/<name>\\s*([^<]+?)\\s*<\\/name>/)?.[1]?.trim()
+      if (!name || !safeSkillName.test(name)) continue
+      entryCount += 1
+      names.add(name)
+    }
+  }
+  return {
+    state: blocks.length > 0 ? 'present' : 'absent',
+    entryCount,
+    skillNames: [...names].sort(),
+  }
+}
+
+function observePromptComposition(system) {
+  if (!system.every((entry) => typeof entry === 'string')) {
+    return impossiblePromptComposition()
+  }
+  const text = system.join('\\n\\n')
+  const workflowStructure = findWorkflowBlocks(text)
+  if (!workflowStructure.valid) return impossiblePromptComposition()
+  const workflowBlocks = workflowStructure.blocks
+  const catalogBlocks = findCompleteBlocks(text, catalogMarkerOpen, catalogMarkerClose)
+  const systematicBlocks = catalogBlocks.filter((block) => workflowBlocks.some((workflow) => block.start >= workflow.start && block.end <= workflow.end))
+  const systematicBlockTexts = new Set(systematicBlocks.map((block) => text.slice(block.start, block.end)))
+  const hostBlocks = catalogBlocks.filter((block) =>
+    !workflowBlocks.some((workflow) => block.start >= workflow.start && block.end <= workflow.end) &&
+    !systematicBlockTexts.has(text.slice(block.start, block.end)))
+  return {
+    bootstrapPayloadSize: workflowBlocks.reduce((size, block) => size + block.end - block.start, 0),
+    systematicCatalog: summarizeCatalog(text, systematicBlocks),
+    hostCatalog: summarizeCatalog(text, hostBlocks),
+  }
+}
+
 function isChatTransform(input) {
   return Boolean(input && typeof input === 'object' && typeof input.sessionID === 'string' && 'model' in input)
 }
@@ -177,9 +494,13 @@ export default async function systematicEvalProbe() {
   return {
     'experimental.chat.system.transform': async (input, output) => {
       if (!isChatTransform(input)) return
-      const system = Array.isArray(output?.system) ? output.system : []
+      const systemVisible = Array.isArray(output?.system)
+      const system = systemVisible ? output.system : []
       const blockCount = workflowBlockCount(system)
-      append({ type: 'transform', kind: 'chat', status: Array.isArray(output?.system) ? 'healthy' : 'unhealthy', blockCount })
+      const promptComposition = systemVisible
+        ? observePromptComposition(system)
+        : impossiblePromptComposition()
+      append({ type: 'transform', kind: 'chat', status: systemVisible ? 'healthy' : 'unhealthy', blockCount, promptComposition })
     },
     'tool.execute.after': async (input, output) => {
       if (input.tool !== 'write') return
@@ -203,20 +524,116 @@ export function gradeBootstrapProbe(
 ): ProbeHealth {
   const loaded = events.filter((event) => event.type === 'loaded')
   const transforms = events.filter((event) => event.type === 'transform')
+  const promptComposition =
+    transforms.at(-1)?.promptComposition ?? impossiblePromptComposition()
   if (
     loaded.length !== 1 ||
     loaded[0]?.status !== 'ok' ||
     transforms.length === 0 ||
     transforms.some(
-      (event) => event.status !== 'healthy' || event.blockCount !== 1,
+      (event) =>
+        event.status !== 'healthy' ||
+        event.blockCount !== 1 ||
+        event.promptComposition === undefined ||
+        event.promptComposition.systematicCatalog.state === 'impossible' ||
+        event.promptComposition.hostCatalog.state === 'impossible',
     )
   ) {
-    return { status: 'unhealthy', subcode: 'probe_unhealthy' }
+    return {
+      status: 'unhealthy',
+      subcode: 'probe_unhealthy',
+      promptComposition,
+    }
   }
   return {
     status: 'healthy',
     blockCount: 1,
     transformCount: transforms.length,
+    promptComposition,
+  }
+}
+
+export interface HostSkillCoverageGrade {
+  outcome: 'success' | 'infra_failure' | 'task_failure'
+  subcode:
+    | 'none'
+    | 'probe_unhealthy'
+    | 'host_catalog_absent'
+    | 'host_catalog_incomplete'
+  promptComposition: PromptCompositionObservation
+  hostCatalogCoverage: HostCatalogCoverageObservation
+}
+
+export function gradeHostSkillCoverage(
+  events: readonly BoundedProbeEvent[],
+  expectedSkillNames: readonly string[],
+): HostSkillCoverageGrade {
+  const expected = [...expectedSkillNames].sort()
+  const transforms = events.filter((event) => event.type === 'transform')
+  const promptComposition =
+    transforms.at(-1)?.promptComposition ?? impossiblePromptComposition()
+  const impossibleCoverage: HostCatalogCoverageObservation = {
+    state: 'impossible',
+    expectedSkillNames: expected,
+    observedSkillNames: [],
+    missingSkillNames: [],
+  }
+  const loaded = events.filter((event) => event.type === 'loaded')
+  const probeHealthy =
+    loaded.length === 1 &&
+    loaded[0]?.status === 'ok' &&
+    transforms.length > 0 &&
+    transforms.every(
+      (event) =>
+        event.status === 'healthy' &&
+        event.blockCount === 1 &&
+        event.promptComposition !== undefined &&
+        event.promptComposition.systematicCatalog.state !== 'impossible' &&
+        event.promptComposition.hostCatalog.state !== 'impossible',
+    )
+
+  if (!probeHealthy || promptComposition.hostCatalog.state === 'impossible') {
+    return {
+      outcome: 'infra_failure',
+      subcode: 'probe_unhealthy',
+      promptComposition,
+      hostCatalogCoverage: impossibleCoverage,
+    }
+  }
+
+  const observed = promptComposition.hostCatalog.skillNames
+  const missing = expected.filter((name) => !observed.includes(name))
+  const hostCatalogCoverage: HostCatalogCoverageObservation = {
+    state: promptComposition.hostCatalog.state,
+    expectedSkillNames: expected,
+    observedSkillNames: observed,
+    missingSkillNames: missing,
+  }
+
+  if (promptComposition.hostCatalog.state === 'absent') {
+    return {
+      outcome: 'task_failure',
+      subcode: 'host_catalog_absent',
+      promptComposition,
+      hostCatalogCoverage: {
+        ...hostCatalogCoverage,
+        missingSkillNames: expected,
+      },
+    }
+  }
+  if (missing.length > 0) {
+    return {
+      outcome: 'task_failure',
+      subcode: 'host_catalog_incomplete',
+      promptComposition,
+      hostCatalogCoverage,
+    }
+  }
+  return {
+    outcome: 'success',
+    subcode: 'none',
+    promptComposition,
+    hostCatalogCoverage,
   }
 }
 
@@ -498,7 +915,7 @@ async function startOpencodeHost(
       if (settled) return
       settled = true
       void stopChildProcess(child)
-      reject(new Error('opencode-host-timeout'))
+      reject(new Error(OPENCODE_HOST_TIMEOUT))
     }, timeoutMs)
     const onChunk = (chunk: Buffer): void => {
       if (settled) return
@@ -556,7 +973,7 @@ export async function stopActiveEvalResources(): Promise<void> {
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timeout = setTimeout(
-      () => reject(new Error('opencode-prompt-timeout')),
+      () => reject(new Error(OPENCODE_PROMPT_TIMEOUT)),
       timeoutMs,
     )
     promise.then(
@@ -572,9 +989,10 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   })
 }
 
-function executionFailure(
+export function executionFailure(
   subcode: 'opencode_unavailable' | 'probe_unhealthy' | 'unexpected_exit',
   probeDigest: string,
+  promptComposition = impossiblePromptComposition(),
 ): EvalCaseExecution {
   return {
     outcome: subcode === 'unexpected_exit' ? 'task_failure' : 'infra_failure',
@@ -583,7 +1001,44 @@ function executionFailure(
     process: 'failed',
     probeDigest,
     artifactRefs: ['probe/events.jsonl'],
+    promptComposition,
   }
+}
+
+function isKnownTimeoutError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message === OPENCODE_HOST_TIMEOUT ||
+      error.message === OPENCODE_PROMPT_TIMEOUT)
+  )
+}
+
+export function classifyExecutionFailure(
+  hostStarted: boolean,
+  error: unknown,
+  events: readonly BoundedProbeEvent[],
+  probeDigest: string,
+): EvalCaseExecution {
+  const probeHealth = gradeBootstrapProbe(events)
+  if (hostStarted && isKnownTimeoutError(error)) {
+    return executionFailure(
+      'unexpected_exit',
+      probeDigest,
+      probeHealth.promptComposition,
+    )
+  }
+  if (hostStarted && probeHealth.status !== 'healthy') {
+    return executionFailure(
+      'probe_unhealthy',
+      probeDigest,
+      probeHealth.promptComposition,
+    )
+  }
+  return executionFailure(
+    hostStarted ? 'unexpected_exit' : 'opencode_unavailable',
+    probeDigest,
+    probeHealth.promptComposition,
+  )
 }
 
 interface ExecuteCaseInput {
@@ -596,36 +1051,101 @@ interface ExecuteCaseInput {
   artifactRefs?: readonly string[]
 }
 
+function isPromptOnlyCase(caseId: EvalCaseManifest['caseId']): boolean {
+  return caseId === 'bootstrap-loading' || caseId === 'host-skill-coverage'
+}
+
+function buildScriptedResponses(
+  caseId: EvalCaseManifest['caseId'],
+): ScriptedResponse[] {
+  if (isPromptOnlyCase(caseId)) return [{ text: 'done' }]
+  return [
+    {
+      toolCalls: [
+        {
+          id: 'fixture-write-call',
+          name: 'write',
+          arguments: {
+            filePath: 'fixture/output.txt',
+            content: EXPECTED_WRITE_CONTENT,
+          },
+        },
+      ],
+    },
+    { text: 'done' },
+  ]
+}
+
+function gradeObservedCase(
+  input: ExecuteCaseInput,
+  events: readonly BoundedProbeEvent[],
+  probeDigest: string,
+  artifactRefs: string[],
+): EvalCaseExecution {
+  if (input.caseManifest.caseId === 'host-skill-coverage') {
+    const coverageGrade = gradeHostSkillCoverage(
+      events,
+      input.caseManifest.expectedSkillNames,
+    )
+    const failed = coverageGrade.outcome === 'infra_failure'
+    return {
+      outcome: coverageGrade.outcome,
+      subcode: coverageGrade.subcode,
+      sanity: failed ? 'failed' : 'passed',
+      process: failed ? 'failed' : 'completed',
+      probeDigest,
+      artifactRefs,
+      promptComposition: coverageGrade.promptComposition,
+      hostCatalogCoverage: coverageGrade.hostCatalogCoverage,
+    }
+  }
+
+  const probeHealth = gradeBootstrapProbe(events)
+  if (probeHealth.status !== 'healthy') {
+    return executionFailure(
+      'probe_unhealthy',
+      probeDigest,
+      probeHealth.promptComposition,
+    )
+  }
+  if (input.caseManifest.caseId === 'bootstrap-loading') {
+    return {
+      outcome: 'success',
+      subcode: 'none',
+      sanity: 'passed',
+      process: 'completed',
+      probeDigest,
+      artifactRefs,
+      promptComposition: probeHealth.promptComposition,
+    }
+  }
+  const writeGrade = gradeFixtureWrite(
+    input.fixture.projectRoot,
+    input.caseManifest,
+  )
+  return {
+    outcome: writeGrade.outcome,
+    subcode: writeGrade.subcode,
+    sanity: 'passed',
+    process: 'completed',
+    probeDigest,
+    artifactRefs,
+    promptComposition: probeHealth.promptComposition,
+  }
+}
+
 async function executeCase(
   input: ExecuteCaseInput,
 ): Promise<EvalCaseExecution> {
   const probe = createOpencodeProbe(input.fixture)
-  const responses: ScriptedResponse[] =
-    input.caseManifest.caseId === 'bootstrap-loading'
-      ? [{ text: 'done' }]
-      : [
-          {
-            toolCalls: [
-              {
-                id: 'fixture-write-call',
-                name: 'write',
-                arguments: {
-                  filePath: 'fixture/output.txt',
-                  content: EXPECTED_WRITE_CONTENT,
-                },
-              },
-            ],
-          },
-          { text: 'done' },
-        ]
+  const responses = buildScriptedResponses(input.caseManifest.caseId)
   const model = startScriptedModelServer(responses)
   let host: OpencodeHost | undefined
   const hostTimeoutMs = input.timeoutMs ?? 180_000
   const caseTimeoutMs = input.caseTimeoutMs ?? hostTimeoutMs
-  const caseArtifactRefs =
-    input.caseManifest.caseId === 'bootstrap-loading'
-      ? ['probe/events.jsonl']
-      : ['fixture/output.txt', 'probe/events.jsonl']
+  const caseArtifactRefs = isPromptOnlyCase(input.caseManifest.caseId)
+    ? ['probe/events.jsonl']
+    : ['fixture/output.txt', 'probe/events.jsonl']
   const artifactRefs = [
     ...(input.artifactRefs ?? []),
     ...caseArtifactRefs,
@@ -671,37 +1191,17 @@ async function executeCase(
       caseTimeoutMs,
     )
 
-    const probeHealth = gradeBootstrapProbe(
+    return gradeObservedCase(
+      input,
       readBoundedProbeEvents(probe.capturePath),
-    )
-    if (probeHealth.status !== 'healthy') {
-      return executionFailure('probe_unhealthy', probe.digest)
-    }
-    if (input.caseManifest.caseId === 'bootstrap-loading') {
-      return {
-        outcome: 'success',
-        subcode: 'none',
-        sanity: 'passed',
-        process: 'completed',
-        probeDigest: probe.digest,
-        artifactRefs,
-      }
-    }
-    const writeGrade = gradeFixtureWrite(
-      input.fixture.projectRoot,
-      input.caseManifest,
-    )
-    return {
-      outcome: writeGrade.outcome,
-      subcode: writeGrade.subcode,
-      sanity: 'passed',
-      process: 'completed',
-      probeDigest: probe.digest,
+      probe.digest,
       artifactRefs,
-    }
-  } catch {
-    return executionFailure(
-      host ? 'unexpected_exit' : 'opencode_unavailable',
+    )
+  } catch (error) {
+    return classifyExecutionFailure(
+      host !== undefined,
+      error,
+      readBoundedProbeEvents(probe.capturePath),
       probe.digest,
     )
   } finally {

--- a/scripts/run-evals.ts
+++ b/scripts/run-evals.ts
@@ -2852,7 +2852,7 @@ function buildResultEnvelope(input: {
         input.runtime.status === 'available'
           ? 'opencode-ai-1.18.5'
           : 'opencode-runtime-unavailable',
-      probeId: 'systematic-eval-probe-v2',
+      probeId: 'systematic-eval-probe-v3',
       probeDigest: input.execution.probeDigest,
       fixtureContractVersion: FIXTURE_CONTRACT_VERSION,
       fixtureContractDigest: FIXTURE_CONTRACT_DIGEST,

--- a/scripts/run-evals.ts
+++ b/scripts/run-evals.ts
@@ -13,7 +13,11 @@ const HARNESS = 'opencode' as const
 
 export { CASE_SCHEMA_VERSION, HARNESS, RESULT_SCHEMA_VERSION }
 
-export const CASE_IDS = ['bootstrap-loading', 'fixture-local-write'] as const
+export const CASE_IDS = [
+  'bootstrap-loading',
+  'fixture-local-write',
+  'host-skill-coverage',
+] as const
 
 export type CaseId = (typeof CASE_IDS)[number]
 
@@ -41,6 +45,8 @@ export const OUTCOME_SUBCODES = {
   ],
   task_failure: [
     'bootstrap_not_observed',
+    'host_catalog_absent',
+    'host_catalog_incomplete',
     'write_missing',
     'write_mismatch',
     'unexpected_exit',
@@ -72,9 +78,19 @@ export interface FixtureLocalWriteCaseManifest {
   expectedContentId: string
 }
 
+export interface HostSkillCoverageCaseManifest {
+  caseSchemaVersion: typeof CASE_SCHEMA_VERSION
+  caseId: 'host-skill-coverage'
+  harness: typeof HARNESS
+  assertionIds: string[]
+  /** Raw SKILL.md names; OpenCode's catalog does not add Systematic's prefix. */
+  expectedSkillNames: string[]
+}
+
 export type EvalCaseManifest =
   | BootstrapLoadingCaseManifest
   | FixtureLocalWriteCaseManifest
+  | HostSkillCoverageCaseManifest
 
 export interface EvalIdentity {
   opencodeVersion: string
@@ -93,6 +109,29 @@ export interface EvalEvidence {
   sanity: 'passed' | 'failed'
   process: 'completed' | 'failed'
   assertionIds: string[]
+  promptComposition?: PromptCompositionObservation
+  hostCatalogCoverage?: HostCatalogCoverageObservation
+}
+
+export type PromptCatalogState = 'present' | 'absent' | 'impossible'
+
+export interface PromptCatalogObservation {
+  state: PromptCatalogState
+  entryCount: number
+  skillNames: string[]
+}
+
+export interface PromptCompositionObservation {
+  bootstrapPayloadSize: number
+  systematicCatalog: PromptCatalogObservation
+  hostCatalog: PromptCatalogObservation
+}
+
+export interface HostCatalogCoverageObservation {
+  state: PromptCatalogState
+  expectedSkillNames: string[]
+  observedSkillNames: string[]
+  missingSkillNames: string[]
 }
 
 export interface EvalCleanupState {
@@ -150,6 +189,8 @@ export interface EvalCaseExecution {
   process: 'completed' | 'failed'
   probeDigest: string
   artifactRefs: string[]
+  promptComposition?: PromptCompositionObservation
+  hostCatalogCoverage?: HostCatalogCoverageObservation
 }
 
 export interface EvalFixture {
@@ -409,6 +450,7 @@ type RecordValue = Record<string, unknown>
 const CASE_ASSERTIONS: Record<CaseId, readonly string[]> = {
   'bootstrap-loading': ['bootstrap-observed'],
   'fixture-local-write': ['fixture-file-content', 'fixture-file-created'],
+  'host-skill-coverage': ['host-catalog-covered'],
 }
 
 const RESULT_REQUIRED_KEYS = [
@@ -665,7 +707,7 @@ const CLI_USAGE = [
   'Usage: bun scripts/run-evals.ts [options]',
   '',
   'Options:',
-  '  --case <id>       Repeatable: bootstrap-loading | fixture-local-write',
+  '  --case <id>       Repeatable: bootstrap-loading | fixture-local-write | host-skill-coverage',
   '  --mode <mode>     Repeatable: source | installed',
   '  --seed <seed>     [A-Za-z0-9][A-Za-z0-9._-]{0,127}',
   '  --clock <UTC>     YYYY-MM-DDTHH:mm:ss.sssZ',
@@ -841,6 +883,150 @@ function readInteger(value: unknown): number {
   return value
 }
 
+const MAX_PROMPT_COMPOSITION_SIZE = 100_000
+const MAX_PROMPT_CATALOG_ENTRIES = 128
+const SAFE_PROMPT_SKILL_NAME = /^[A-Za-z0-9][A-Za-z0-9._:+-]{0,127}$/
+
+function readNonNegativeInteger(value: unknown, maximum: number): number {
+  if (
+    typeof value !== 'number' ||
+    !Number.isInteger(value) ||
+    value < 0 ||
+    value > maximum
+  ) {
+    fail('result_invalid_field')
+  }
+  return value
+}
+
+function readPromptSkillNames(value: unknown): string[] {
+  if (!Array.isArray(value) || value.length > MAX_PROMPT_CATALOG_ENTRIES) {
+    fail('result_invalid_field')
+  }
+  const names: string[] = []
+  for (const item of value) {
+    if (typeof item !== 'string' || !SAFE_PROMPT_SKILL_NAME.test(item)) {
+      fail('result_invalid_field')
+    }
+    assertSafeString(item)
+    if (names.includes(item)) fail('result_invalid_field')
+    names.push(item)
+  }
+  return names.sort()
+}
+
+function normalizePromptCatalogObservation(
+  value: unknown,
+): PromptCatalogObservation {
+  const input = record(value, 'result_invalid_field')
+  assertExactKeys(
+    input,
+    ['state', 'entryCount', 'skillNames'],
+    [],
+    'result_unknown_field',
+    'result_missing_field',
+  )
+  const state = input.state
+  if (state !== 'present' && state !== 'absent' && state !== 'impossible') {
+    fail('result_invalid_field')
+  }
+  const entryCount = readNonNegativeInteger(
+    input.entryCount,
+    MAX_PROMPT_CATALOG_ENTRIES,
+  )
+  const skillNames = readPromptSkillNames(input.skillNames)
+  if (state !== 'present' && (entryCount !== 0 || skillNames.length !== 0)) {
+    fail('result_invalid_field')
+  }
+  if (skillNames.length > entryCount) fail('result_invalid_field')
+  return { state, entryCount, skillNames }
+}
+
+function normalizePromptComposition(
+  value: unknown,
+): PromptCompositionObservation {
+  const input = record(value, 'result_invalid_field')
+  assertExactKeys(
+    input,
+    ['bootstrapPayloadSize', 'systematicCatalog', 'hostCatalog'],
+    [],
+    'result_unknown_field',
+    'result_missing_field',
+  )
+  const bootstrapPayloadSize = readNonNegativeInteger(
+    input.bootstrapPayloadSize,
+    MAX_PROMPT_COMPOSITION_SIZE,
+  )
+  const systematicCatalog = normalizePromptCatalogObservation(
+    input.systematicCatalog,
+  )
+  const hostCatalog = normalizePromptCatalogObservation(input.hostCatalog)
+  return {
+    bootstrapPayloadSize,
+    systematicCatalog,
+    hostCatalog,
+  }
+}
+
+function sameStringList(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  )
+}
+
+function normalizeHostCatalogCoverage(
+  value: unknown,
+): HostCatalogCoverageObservation {
+  const input = record(value, 'result_invalid_field')
+  assertExactKeys(
+    input,
+    ['state', 'expectedSkillNames', 'observedSkillNames', 'missingSkillNames'],
+    [],
+    'result_unknown_field',
+    'result_missing_field',
+  )
+  const state = input.state
+  if (state !== 'present' && state !== 'absent' && state !== 'impossible') {
+    fail('result_invalid_field')
+  }
+  const expectedSkillNames = readPromptSkillNames(input.expectedSkillNames)
+  const observedSkillNames = readPromptSkillNames(input.observedSkillNames)
+  const missingSkillNames = readPromptSkillNames(input.missingSkillNames)
+  if (expectedSkillNames.length === 0) fail('result_invalid_field')
+
+  if (state === 'impossible') {
+    if (observedSkillNames.length !== 0 || missingSkillNames.length !== 0) {
+      fail('result_invalid_field')
+    }
+    return {
+      state,
+      expectedSkillNames,
+      observedSkillNames,
+      missingSkillNames,
+    }
+  }
+
+  const expectedMissingSkillNames = expectedSkillNames.filter(
+    (name) => !observedSkillNames.includes(name),
+  )
+  if (!sameStringList(missingSkillNames, expectedMissingSkillNames)) {
+    fail('result_invalid_field')
+  }
+  if (state === 'absent' && observedSkillNames.length !== 0) {
+    fail('result_invalid_field')
+  }
+  return {
+    state,
+    expectedSkillNames,
+    observedSkillNames,
+    missingSkillNames,
+  }
+}
+
 function readSortedIdentifiers(
   value: unknown,
   expected: readonly string[],
@@ -954,7 +1140,7 @@ function normalizeEvidence(
   assertExactKeys(
     input,
     ['sanity', 'process', 'assertionIds'],
-    [],
+    ['promptComposition', 'hostCatalogCoverage'],
     'result_unknown_field',
     'result_missing_field',
   )
@@ -968,11 +1154,22 @@ function normalizeEvidence(
     assertionIds,
     'result_invalid_field',
   )
-  return {
+  const normalized: EvalEvidence = {
     sanity,
     process,
     assertionIds: normalizedAssertionIds,
   }
+  if (hasOwn(input, 'promptComposition')) {
+    normalized.promptComposition = normalizePromptComposition(
+      input.promptComposition,
+    )
+  }
+  if (hasOwn(input, 'hostCatalogCoverage')) {
+    normalized.hostCatalogCoverage = normalizeHostCatalogCoverage(
+      input.hostCatalogCoverage,
+    )
+  }
+  return normalized
 }
 
 function normalizeCleanup(value: unknown): EvalCleanupState {
@@ -1084,11 +1281,47 @@ function normalizeProvenance(
   fail('result_invalid_provenance')
 }
 
+function parseHostSkillCoverageCaseManifest(
+  value: RecordValue,
+): HostSkillCoverageCaseManifest {
+  assertExactKeys(
+    value,
+    [
+      'caseSchemaVersion',
+      'caseId',
+      'harness',
+      'assertionIds',
+      'expectedSkillNames',
+    ],
+    [],
+    'case_unknown_field',
+    'case_missing_field',
+  )
+  if (value.caseSchemaVersion !== CASE_SCHEMA_VERSION) {
+    fail('case_wrong_version')
+  }
+  if (value.harness !== HARNESS) fail('case_invalid_field')
+  const assertionIds = readSortedIdentifiers(
+    value.assertionIds,
+    CASE_ASSERTIONS['host-skill-coverage'],
+    'case_invalid_field',
+  )
+  const expectedSkillNames = readPromptSkillNames(value.expectedSkillNames)
+  if (expectedSkillNames.length === 0) fail('case_invalid_field')
+  return {
+    caseSchemaVersion: CASE_SCHEMA_VERSION,
+    caseId: 'host-skill-coverage',
+    harness: HARNESS,
+    assertionIds,
+    expectedSkillNames,
+  }
+}
+
 export function parseCaseManifest(input: unknown): EvalCaseManifest {
   assertPrivacySafeTree(input)
   const value = record(input, 'case_invalid_shape')
   const caseId = value.caseId
-  if (caseId !== 'bootstrap-loading' && caseId !== 'fixture-local-write') {
+  if (typeof caseId !== 'string' || !isCaseId(caseId)) {
     fail('case_unsupported')
   }
 
@@ -1115,6 +1348,10 @@ export function parseCaseManifest(input: unknown): EvalCaseManifest {
       harness: HARNESS,
       assertionIds,
     }
+  }
+
+  if (caseId === 'host-skill-coverage') {
+    return parseHostSkillCoverageCaseManifest(value)
   }
 
   assertExactKeys(
@@ -1175,7 +1412,7 @@ export function normalizeResult(input: unknown): EvalResult {
   if (value.harness !== HARNESS) fail('result_invalid_field')
 
   const caseId = value.caseId
-  if (caseId !== 'bootstrap-loading' && caseId !== 'fixture-local-write') {
+  if (typeof caseId !== 'string' || !isCaseId(caseId)) {
     fail('result_invalid_field')
   }
   const mode = readMode(value.mode)
@@ -2615,7 +2852,7 @@ function buildResultEnvelope(input: {
         input.runtime.status === 'available'
           ? 'opencode-ai-1.18.5'
           : 'opencode-runtime-unavailable',
-      probeId: 'systematic-eval-probe-v1',
+      probeId: 'systematic-eval-probe-v2',
       probeDigest: input.execution.probeDigest,
       fixtureContractVersion: FIXTURE_CONTRACT_VERSION,
       fixtureContractDigest: FIXTURE_CONTRACT_DIGEST,
@@ -2628,6 +2865,12 @@ function buildResultEnvelope(input: {
       sanity: input.execution.sanity,
       process: input.execution.process,
       assertionIds: input.caseManifest.assertionIds,
+      ...(input.execution.promptComposition
+        ? { promptComposition: input.execution.promptComposition }
+        : {}),
+      ...(input.execution.hostCatalogCoverage
+        ? { hostCatalogCoverage: input.execution.hostCatalogCoverage }
+        : {}),
     },
     cleanup: input.cleanup,
     privacy: { status: 'validated' },

--- a/tests/integration/eval-runner.test.ts
+++ b/tests/integration/eval-runner.test.ts
@@ -4,8 +4,10 @@ import { once } from 'node:events'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import {
   type BoundedProbeEvent,
+  createOpencodeProbe,
   gradeBootstrapProbe,
   gradeFixtureWrite,
   gradeHostSkillCoverage,
@@ -13,6 +15,8 @@ import {
 } from '../../scripts/eval-cases/opencode.ts'
 import {
   capturePrimaryCheckout,
+  cleanupEvalFixture,
+  createEvalFixture,
   type EvalFixture,
   type EvalSelectionRunnerInput,
   installEvalSignalHandlers,
@@ -835,6 +839,67 @@ describe('local OpenCode eval runner', () => {
         skillNames: [],
       },
     })
+  })
+
+  test('keeps the generated probe observation implementation behaviorally identical', async () => {
+    const catalog = (name: string) =>
+      `<available_skills>\n<skill><name>${name}</name></skill>\n</available_skills>`
+    const systematicCatalog = catalog('systematic:alpha')
+    const hostCatalog = catalog('host:alpha')
+    const validSystem = [
+      `<SYSTEMATIC_WORKFLOWS>\n${systematicCatalog}\n</SYSTEMATIC_WORKFLOWS>`,
+    ]
+    const corpus: readonly (readonly unknown[])[] = [
+      validSystem,
+      [`<SYSTEMATIC_WORKFLOWS>\n${systematicCatalog}`],
+      [`${systematicCatalog}\n</SYSTEMATIC_WORKFLOWS>`],
+      [
+        `<SYSTEMATIC_WORKFLOWS><SYSTEMATIC_WORKFLOWS>${systematicCatalog}</SYSTEMATIC_WORKFLOWS></SYSTEMATIC_WORKFLOWS>`,
+      ],
+      [
+        `<SYSTEMATIC_WORKFLOWS>${systematicCatalog}</SYSTEMATIC_WORKFLOWS>\n${systematicCatalog}`,
+      ],
+      [
+        `${hostCatalog}\n<SYSTEMATIC_WORKFLOWS>\n${systematicCatalog}\n</SYSTEMATIC_WORKFLOWS>`,
+      ],
+      [validSystem[0], { role: 'system', content: 'not a string entry' }],
+    ]
+    const parentDir = runParent()
+    const fixture = createEvalFixture({
+      caseId: 'bootstrap-loading',
+      mode: 'source',
+      runId: 'probe-differential',
+      parentDir,
+    })
+
+    try {
+      const probe = createOpencodeProbe(fixture)
+      const generatedProbe = (await import(
+        `${pathToFileURL(probe.sourcePath).href}?differential`
+      )) as {
+        observePromptComposition?: (system: readonly unknown[]) => unknown
+      }
+      expect(typeof generatedProbe.observePromptComposition).toBe('function')
+      if (typeof generatedProbe.observePromptComposition !== 'function') return
+
+      const typedObservations = corpus.map((system) =>
+        observePromptComposition(system),
+      )
+      const generatedObservations = corpus.map((system) =>
+        generatedProbe.observePromptComposition?.(system),
+      )
+
+      expect(generatedObservations).toEqual(typedObservations)
+      expect(typedObservations[0]).toMatchObject({
+        systematicCatalog: { state: 'present' },
+      })
+      expect(generatedObservations[0]).toMatchObject({
+        systematicCatalog: { state: 'present' },
+      })
+    } finally {
+      cleanupEvalFixture(fixture)
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
   })
 
   test('persists prompt composition facts before the final manifest rename', () => {

--- a/tests/integration/eval-runner.test.ts
+++ b/tests/integration/eval-runner.test.ts
@@ -8,6 +8,8 @@ import {
   type BoundedProbeEvent,
   gradeBootstrapProbe,
   gradeFixtureWrite,
+  gradeHostSkillCoverage,
+  observePromptComposition,
 } from '../../scripts/eval-cases/opencode.ts'
 import {
   capturePrimaryCheckout,
@@ -15,6 +17,7 @@ import {
   type EvalSelectionRunnerInput,
   installEvalSignalHandlers,
   normalizeResult,
+  persistEvalRun,
   runEvalCli,
   runEvalSelections,
   runInstalledEval,
@@ -22,13 +25,15 @@ import {
   validateSerializedResult,
   validateSerializedRunManifest,
 } from '../../scripts/run-evals.ts'
+import { buildCatalogEntries } from '../../src/lib/skill-catalog.js'
 
 const FIXED_CLOCK = '2026-08-13T00:00:00.000Z'
+const ROOT_DIR = path.resolve(import.meta.dirname, '../..')
 const EXPECTED_CLI_HELP = [
   'Usage: bun scripts/run-evals.ts [options]',
   '',
   'Options:',
-  '  --case <id>       Repeatable: bootstrap-loading | fixture-local-write',
+  '  --case <id>       Repeatable: bootstrap-loading | fixture-local-write | host-skill-coverage',
   '  --mode <mode>     Repeatable: source | installed',
   '  --seed <seed>     [A-Za-z0-9][A-Za-z0-9._-]{0,127}',
   '  --clock <UTC>     YYYY-MM-DDTHH:mm:ss.sssZ',
@@ -286,7 +291,51 @@ describe('local OpenCode eval runner', () => {
       expect(result.fixtureSeed).toBe('runner-bootstrap')
       expect(result.normalizedClock).toBe(FIXED_CLOCK)
       expect(result.assertionIds).toEqual(['bootstrap-observed'])
-      expect(result.evidence).toEqual({
+      expect(result.evidence.sanity).toBe('passed')
+      expect(result.evidence.process).toBe('completed')
+      expect(result.evidence.assertionIds).toEqual(['bootstrap-observed'])
+      expect(result.evidence.promptComposition).toBeDefined()
+      expect(result.evidence.promptComposition).toMatchObject({
+        systematicCatalog: {
+          state: 'present',
+          entryCount: 23,
+          skillNames: [
+            'ce:brainstorm',
+            'ce:compound',
+            'ce:ideate',
+            'ce:plan',
+            'ce:review',
+            'ce:work',
+            'systematic:agent-browser',
+            'systematic:agent-native-architecture',
+            'systematic:deepen-plan',
+            'systematic:document-review',
+            'systematic:frontend-design',
+            'systematic:git-clean-gone-branches',
+            'systematic:git-commit',
+            'systematic:git-commit-push-pr',
+            'systematic:git-worktree',
+            'systematic:onboarding',
+            'systematic:orchestrating-subagents',
+            'systematic:reproduce-bug',
+            'systematic:resolve-pr-feedback',
+            'systematic:test-browser',
+            'systematic:test-driven-development',
+            'systematic:using-systematic',
+            'systematic:writing-skills',
+          ],
+        },
+        hostCatalog: {
+          state: 'present',
+        },
+      })
+      expect(
+        result.evidence.promptComposition?.bootstrapPayloadSize,
+      ).toBeGreaterThan(19_000)
+      expect(
+        result.evidence.promptComposition?.bootstrapPayloadSize,
+      ).toBeLessThan(21_000)
+      expect(result.evidence).toMatchObject({
         sanity: 'passed',
         process: 'completed',
         assertionIds: ['bootstrap-observed'],
@@ -329,6 +378,19 @@ describe('local OpenCode eval runner', () => {
     expect(missingProbe).toEqual({
       status: 'unhealthy',
       subcode: 'probe_unhealthy',
+      promptComposition: {
+        bootstrapPayloadSize: 0,
+        systematicCatalog: {
+          state: 'impossible',
+          entryCount: 0,
+          skillNames: [],
+        },
+        hostCatalog: {
+          state: 'impossible',
+          entryCount: 0,
+          skillNames: [],
+        },
+      },
     })
 
     const malformedProbe: BoundedProbeEvent[] = [
@@ -338,6 +400,19 @@ describe('local OpenCode eval runner', () => {
     expect(gradeBootstrapProbe(malformedProbe)).toEqual({
       status: 'unhealthy',
       subcode: 'probe_unhealthy',
+      promptComposition: {
+        bootstrapPayloadSize: 0,
+        systematicCatalog: {
+          state: 'impossible',
+          entryCount: 0,
+          skillNames: [],
+        },
+        hostCatalog: {
+          state: 'impossible',
+          entryCount: 0,
+          skillNames: [],
+        },
+      },
     })
 
     const parentDir = runParent()
@@ -371,6 +446,474 @@ describe('local OpenCode eval runner', () => {
           expectedContentId: 'fixture-local-write-v1',
         }),
       ).toEqual({ outcome: 'success', subcode: 'none' })
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('grades host catalog coverage as a set and fails closed for absent or impossible observations', async () => {
+    const opencodeModule = (await import(
+      '../../scripts/eval-cases/opencode.ts'
+    )) as unknown as Record<string, unknown>
+    expect(typeof opencodeModule.gradeHostSkillCoverage).toBe('function')
+    if (typeof opencodeModule.gradeHostSkillCoverage !== 'function') return
+
+    const gradeHostSkillCoverage = opencodeModule.gradeHostSkillCoverage as (
+      events: readonly BoundedProbeEvent[],
+      expectedSkillNames: readonly string[],
+    ) => unknown
+    const expectedSkillNames = ['agent-browser', 'ce:brainstorm']
+    const presentPromptComposition = {
+      bootstrapPayloadSize: 100,
+      systematicCatalog: {
+        state: 'present' as const,
+        entryCount: 1,
+        skillNames: ['systematic:agent-browser'],
+      },
+      hostCatalog: {
+        state: 'present' as const,
+        entryCount: 3,
+        skillNames: ['agent-browser', 'ce:brainstorm', 'extra-skill'],
+      },
+    }
+    const presentEvents: BoundedProbeEvent[] = [
+      { type: 'loaded', status: 'ok' },
+      {
+        type: 'transform',
+        kind: 'chat',
+        status: 'healthy',
+        blockCount: 1,
+        promptComposition: presentPromptComposition,
+      },
+    ]
+
+    expect(gradeHostSkillCoverage(presentEvents, expectedSkillNames)).toEqual({
+      outcome: 'success',
+      subcode: 'none',
+      promptComposition: presentPromptComposition,
+      hostCatalogCoverage: {
+        state: 'present',
+        expectedSkillNames,
+        observedSkillNames: ['agent-browser', 'ce:brainstorm', 'extra-skill'],
+        missingSkillNames: [],
+      },
+    })
+
+    const partialPromptComposition = {
+      ...presentPromptComposition,
+      hostCatalog: {
+        state: 'present' as const,
+        entryCount: 1,
+        skillNames: ['agent-browser'],
+      },
+    }
+    expect(
+      gradeHostSkillCoverage(
+        [
+          presentEvents[0] as BoundedProbeEvent,
+          {
+            ...presentEvents[1],
+            promptComposition: partialPromptComposition,
+          } as BoundedProbeEvent,
+        ],
+        expectedSkillNames,
+      ),
+    ).toEqual({
+      outcome: 'task_failure',
+      subcode: 'host_catalog_incomplete',
+      promptComposition: partialPromptComposition,
+      hostCatalogCoverage: {
+        state: 'present',
+        expectedSkillNames,
+        observedSkillNames: ['agent-browser'],
+        missingSkillNames: ['ce:brainstorm'],
+      },
+    })
+
+    const absentPromptComposition = {
+      ...presentPromptComposition,
+      hostCatalog: {
+        state: 'absent' as const,
+        entryCount: 0,
+        skillNames: [],
+      },
+    }
+    expect(
+      gradeHostSkillCoverage(
+        [
+          presentEvents[0] as BoundedProbeEvent,
+          {
+            ...presentEvents[1],
+            promptComposition: absentPromptComposition,
+          } as BoundedProbeEvent,
+        ],
+        expectedSkillNames,
+      ),
+    ).toEqual({
+      outcome: 'task_failure',
+      subcode: 'host_catalog_absent',
+      promptComposition: absentPromptComposition,
+      hostCatalogCoverage: {
+        state: 'absent',
+        expectedSkillNames,
+        observedSkillNames: [],
+        missingSkillNames: expectedSkillNames,
+      },
+    })
+
+    expect(gradeHostSkillCoverage([], expectedSkillNames)).toEqual({
+      outcome: 'infra_failure',
+      subcode: 'probe_unhealthy',
+      promptComposition: {
+        bootstrapPayloadSize: 0,
+        systematicCatalog: {
+          state: 'impossible',
+          entryCount: 0,
+          skillNames: [],
+        },
+        hostCatalog: {
+          state: 'impossible',
+          entryCount: 0,
+          skillNames: [],
+        },
+      },
+      hostCatalogCoverage: {
+        state: 'impossible',
+        expectedSkillNames,
+        observedSkillNames: [],
+        missingSkillNames: [],
+      },
+    })
+
+    const laterCompletePromptComposition = presentPromptComposition
+    expect(
+      gradeHostSkillCoverage(
+        [
+          presentEvents[0],
+          {
+            type: 'transform',
+            kind: 'chat',
+            status: 'healthy',
+            blockCount: 1,
+            promptComposition: {
+              bootstrapPayloadSize: 0,
+              systematicCatalog: {
+                state: 'impossible',
+                entryCount: 0,
+                skillNames: [],
+              },
+              hostCatalog: {
+                state: 'impossible',
+                entryCount: 0,
+                skillNames: [],
+              },
+            },
+          },
+          {
+            type: 'transform',
+            kind: 'chat',
+            status: 'healthy',
+            blockCount: 1,
+            promptComposition: laterCompletePromptComposition,
+          },
+        ],
+        expectedSkillNames,
+      ),
+    ).toMatchObject({
+      outcome: 'infra_failure',
+      subcode: 'probe_unhealthy',
+    })
+  })
+
+  test('classifies an undiagnosed host-started prompt failure without a transform as infrastructure failure', async () => {
+    const opencodeModule = (await import(
+      '../../scripts/eval-cases/opencode.ts'
+    )) as unknown as Record<string, unknown>
+    expect(typeof opencodeModule.classifyExecutionFailure).toBe('function')
+    if (typeof opencodeModule.classifyExecutionFailure !== 'function') return
+
+    const classifyExecutionFailure =
+      opencodeModule.classifyExecutionFailure as (
+        hostStarted: boolean,
+        error: unknown,
+        events: readonly BoundedProbeEvent[],
+        probeDigest: string,
+      ) => { outcome: string; subcode?: string }
+    expect(
+      classifyExecutionFailure(
+        true,
+        new Error('opencode-prompt-failed'),
+        [],
+        'a'.repeat(64),
+      ),
+    ).toMatchObject({
+      outcome: 'infra_failure',
+      subcode: 'probe_unhealthy',
+    })
+  })
+
+  test('classifies a diagnosed host-started prompt timeout as task failure', async () => {
+    const opencodeModule = (await import(
+      '../../scripts/eval-cases/opencode.ts'
+    )) as unknown as Record<string, unknown>
+    expect(typeof opencodeModule.classifyExecutionFailure).toBe('function')
+    if (typeof opencodeModule.classifyExecutionFailure !== 'function') return
+
+    const classifyExecutionFailure =
+      opencodeModule.classifyExecutionFailure as (
+        hostStarted: boolean,
+        error: unknown,
+        events: readonly BoundedProbeEvent[],
+        probeDigest: string,
+      ) => { outcome: string; subcode?: string }
+    expect(
+      classifyExecutionFailure(
+        true,
+        new Error('opencode-prompt-timeout'),
+        [],
+        'a'.repeat(64),
+      ),
+    ).toMatchObject({
+      outcome: 'task_failure',
+      subcode: 'unexpected_exit',
+    })
+  })
+
+  test('scopes Systematic and host catalogs independently around the workflow block', () => {
+    const observation = observePromptComposition([
+      [
+        '<available_skills>',
+        '  <skill><name>host:alpha</name></skill>',
+        '</available_skills>',
+        '<SYSTEMATIC_WORKFLOWS>',
+        'bootstrap body',
+        '<available_skills>',
+        '  <skill><name>systematic:alpha</name></skill>',
+        '  <skill><name>systematic:beta</name></skill>',
+        '</available_skills>',
+        '</SYSTEMATIC_WORKFLOWS>',
+      ].join('\n'),
+    ])
+
+    expect(observation).toEqual({
+      bootstrapPayloadSize: expect.any(Number),
+      systematicCatalog: {
+        state: 'present',
+        entryCount: 2,
+        skillNames: ['systematic:alpha', 'systematic:beta'],
+      },
+      hostCatalog: {
+        state: 'present',
+        entryCount: 1,
+        skillNames: ['host:alpha'],
+      },
+    })
+    expect(observation.bootstrapPayloadSize).toBeGreaterThan(0)
+  })
+
+  test('fails closed when workflow markers are unmatched or nested', () => {
+    const catalog =
+      '<available_skills>\n<skill><name>systematic:agent-browser</name></skill>\n</available_skills>'
+    const impossible = {
+      bootstrapPayloadSize: 0,
+      systematicCatalog: {
+        state: 'impossible' as const,
+        entryCount: 0,
+        skillNames: [],
+      },
+      hostCatalog: {
+        state: 'impossible' as const,
+        entryCount: 0,
+        skillNames: [],
+      },
+    }
+
+    expect(
+      observePromptComposition([`<SYSTEMATIC_WORKFLOWS>\n${catalog}`]),
+    ).toEqual(impossible)
+    expect(
+      observePromptComposition([`${catalog}\n</SYSTEMATIC_WORKFLOWS>`]),
+    ).toEqual(impossible)
+    expect(
+      observePromptComposition([
+        `<SYSTEMATIC_WORKFLOWS><SYSTEMATIC_WORKFLOWS>${catalog}</SYSTEMATIC_WORKFLOWS></SYSTEMATIC_WORKFLOWS>`,
+      ]),
+    ).toEqual(impossible)
+  })
+
+  test('does not count a catalog duplicated outside the workflow as host coverage', () => {
+    const catalog =
+      '<available_skills>\n<skill><name>systematic:agent-browser</name></skill>\n</available_skills>'
+    const observation = observePromptComposition([
+      `<SYSTEMATIC_WORKFLOWS>${catalog}</SYSTEMATIC_WORKFLOWS>\n${catalog}`,
+    ])
+
+    expect(observation.systematicCatalog).toEqual({
+      state: 'present',
+      entryCount: 1,
+      skillNames: ['systematic:agent-browser'],
+    })
+    expect(observation.hostCatalog).toEqual({
+      state: 'absent',
+      entryCount: 0,
+      skillNames: [],
+    })
+    expect(
+      gradeHostSkillCoverage(
+        [
+          { type: 'loaded', status: 'ok' },
+          {
+            type: 'transform',
+            kind: 'chat',
+            status: 'healthy',
+            blockCount: 1,
+            promptComposition: observation,
+          },
+        ],
+        ['systematic:agent-browser'],
+      ),
+    ).toMatchObject({
+      outcome: 'task_failure',
+      subcode: 'host_catalog_absent',
+    })
+  })
+
+  test('disabled_skills exclusions are removed from the expected coverage set', () => {
+    const disabledSkill = 'agent-browser'
+    const filteredEntries = buildCatalogEntries({
+      bundledSkillsDir: path.join(ROOT_DIR, 'skills'),
+      disabledSkills: [disabledSkill],
+    })
+    const expectedSkillNames = filteredEntries.map((entry) => entry.name)
+    const promptComposition = {
+      bootstrapPayloadSize: 100,
+      systematicCatalog: {
+        state: 'present' as const,
+        entryCount: expectedSkillNames.length,
+        skillNames: filteredEntries.map((entry) => entry.prefixedName),
+      },
+      hostCatalog: {
+        state: 'present' as const,
+        entryCount: expectedSkillNames.length,
+        skillNames: expectedSkillNames,
+      },
+    }
+
+    expect(expectedSkillNames).not.toContain(disabledSkill)
+    expect(
+      gradeHostSkillCoverage(
+        [
+          { type: 'loaded', status: 'ok' },
+          {
+            type: 'transform',
+            kind: 'chat',
+            status: 'healthy',
+            blockCount: 1,
+            promptComposition,
+          },
+        ],
+        expectedSkillNames,
+      ),
+    ).toMatchObject({ outcome: 'success', subcode: 'none' })
+  })
+
+  test('reports an observed empty prompt catalog as absent rather than impossible', () => {
+    expect(
+      observePromptComposition([
+        '<SYSTEMATIC_WORKFLOWS>\nbootstrap body\n</SYSTEMATIC_WORKFLOWS>',
+      ]),
+    ).toEqual({
+      bootstrapPayloadSize: expect.any(Number),
+      systematicCatalog: {
+        state: 'absent',
+        entryCount: 0,
+        skillNames: [],
+      },
+      hostCatalog: {
+        state: 'absent',
+        entryCount: 0,
+        skillNames: [],
+      },
+    })
+  })
+
+  test('persists prompt composition facts before the final manifest rename', () => {
+    const parentDir = runParent()
+    const runsRoot = path.join(parentDir, 'runs')
+    const promptComposition = {
+      bootstrapPayloadSize: 18_145,
+      systematicCatalog: {
+        state: 'present' as const,
+        entryCount: 23,
+        skillNames: ['systematic:alpha', 'systematic:beta'],
+      },
+      hostCatalog: {
+        state: 'absent' as const,
+        entryCount: 0,
+        skillNames: [],
+      },
+    }
+    const result = normalizeResult({
+      ...syntheticResult({
+        caseId: 'bootstrap-loading',
+        mode: 'source',
+        runId: 'run-prompt-facts',
+        outcome: 'success',
+        subcode: 'none',
+      }),
+      evidence: {
+        sanity: 'passed',
+        process: 'completed',
+        assertionIds: ['bootstrap-observed'],
+        promptComposition,
+      },
+    })
+
+    try {
+      const renameOrder: string[] = []
+      persistEvalRun({
+        runsRoot,
+        manifest: {
+          manifestSchemaVersion: 1,
+          harness: 'opencode',
+          runId: 'run-prompt-facts',
+          requestedSelectionIds: ['bootstrap-loading/source'],
+          completedSelectionIds: ['bootstrap-loading/source'],
+          partial: false,
+          results: [
+            {
+              selectionId: 'bootstrap-loading/source',
+              resultArtifactId: 'results/bootstrap-loading/source.json',
+              outcome: 'success',
+              subcode: 'none',
+            },
+          ],
+        },
+        results: [result],
+        onRename: (relativeId) => renameOrder.push(relativeId),
+      })
+
+      expect(renameOrder).toEqual([
+        'results/bootstrap-loading/source.json',
+        'manifest.json',
+      ])
+      expect(
+        validateSerializedResult(
+          fs.readFileSync(
+            path.join(
+              runsRoot,
+              'run-prompt-facts/results/bootstrap-loading/source.json',
+            ),
+          ),
+        ).evidence.promptComposition,
+      ).toEqual(promptComposition)
+      expect(
+        validateSerializedRunManifest(
+          fs.readFileSync(
+            path.join(runsRoot, 'run-prompt-facts/manifest.json'),
+          ),
+        ).results,
+      ).toHaveLength(1)
     } finally {
       fs.rmSync(parentDir, { recursive: true, force: true })
     }
@@ -453,7 +996,7 @@ describe('local OpenCode eval runner', () => {
     }
   }, 720_000)
 
-  test('source and installed bootstrap runs succeed with disjoint provenance and matching evidence', async () => {
+  test('source and installed bootstrap runs succeed with disjoint provenance and matching catalog evidence', async () => {
     const sourceParent = runParent()
     const installedParent = runParent()
     try {
@@ -476,7 +1019,28 @@ describe('local OpenCode eval runner', () => {
 
       expectRuntimeOutcome(source)
       expectRuntimeOutcome(installed)
-      expect(source.evidence).toEqual(installed.evidence)
+      expect(source.evidence).toMatchObject({
+        sanity: 'passed',
+        process: 'completed',
+        assertionIds: ['bootstrap-observed'],
+      })
+      expect(installed.evidence).toMatchObject({
+        sanity: 'passed',
+        process: 'completed',
+        assertionIds: ['bootstrap-observed'],
+      })
+      expect(source.evidence.promptComposition?.systematicCatalog).toEqual(
+        installed.evidence.promptComposition?.systematicCatalog,
+      )
+      expect(source.evidence.promptComposition?.hostCatalog).toEqual(
+        installed.evidence.promptComposition?.hostCatalog,
+      )
+      expect(
+        source.evidence.promptComposition?.bootstrapPayloadSize,
+      ).toBeGreaterThan(0)
+      expect(
+        installed.evidence.promptComposition?.bootstrapPayloadSize,
+      ).toBeGreaterThan(0)
       expect(source.mode).toBe('source')
       expect(installed.mode).toBe('installed')
       expect(source.provenance).toMatchObject({
@@ -497,6 +1061,71 @@ describe('local OpenCode eval runner', () => {
       expect(installed.identity.artifactId).toBe('installed-entry')
       expect(JSON.stringify(installed)).not.toContain(sourceParent)
       expect(JSON.stringify(installed)).not.toContain('src/index.ts')
+    } finally {
+      fs.rmSync(sourceParent, { recursive: true, force: true })
+      fs.rmSync(installedParent, { recursive: true, force: true })
+    }
+  }, 720_000)
+
+  test('host-skill-coverage passes in source and installed modes with complete observed coverage', async () => {
+    const sourceParent = runParent()
+    const installedParent = runParent()
+    try {
+      const source = normalizeResult(
+        await runSourceEval({
+          caseId: 'host-skill-coverage',
+          fixtureSeed: 'runner-host-skill-coverage',
+          normalizedClock: FIXED_CLOCK,
+          parentDir: sourceParent,
+        }),
+      )
+      const installed = normalizeResult(
+        await runInstalledEval({
+          caseId: 'host-skill-coverage',
+          fixtureSeed: 'runner-host-skill-coverage',
+          normalizedClock: FIXED_CLOCK,
+          parentDir: installedParent,
+        }),
+      )
+
+      expectRuntimeOutcome(source)
+      expectRuntimeOutcome(installed)
+      expect(source.assertionIds).toEqual(['host-catalog-covered'])
+      expect(installed.assertionIds).toEqual(['host-catalog-covered'])
+      const sourceCoverage = source.evidence.hostCatalogCoverage
+      const installedCoverage = installed.evidence.hostCatalogCoverage
+      if (!sourceCoverage || !installedCoverage) {
+        throw new Error('host catalog coverage evidence missing')
+      }
+      expect(sourceCoverage).toMatchObject({
+        state: 'present',
+        missingSkillNames: [],
+      })
+      expect(installedCoverage).toMatchObject({
+        state: 'present',
+        missingSkillNames: [],
+      })
+      expect(sourceCoverage.expectedSkillNames.length).toBeGreaterThan(0)
+      expect(installedCoverage.expectedSkillNames.length).toBeGreaterThan(0)
+      expect(
+        sourceCoverage.expectedSkillNames.every((name) =>
+          sourceCoverage.observedSkillNames.includes(name),
+        ),
+      ).toBe(true)
+      expect(
+        installedCoverage.expectedSkillNames.every((name) =>
+          installedCoverage.observedSkillNames.includes(name),
+        ),
+      ).toBe(true)
+      expect(sourceCoverage).toEqual(installedCoverage)
+      expect(source.evidence.promptComposition?.hostCatalog.state).toBe(
+        'present',
+      )
+      expect(installed.evidence.promptComposition?.hostCatalog.state).toBe(
+        'present',
+      )
+      expect(JSON.stringify(source)).not.toContain('<available_skills>')
+      expect(JSON.stringify(installed)).not.toContain('<available_skills>')
     } finally {
       fs.rmSync(sourceParent, { recursive: true, force: true })
       fs.rmSync(installedParent, { recursive: true, force: true })

--- a/tests/unit/eval-contract.test.ts
+++ b/tests/unit/eval-contract.test.ts
@@ -12,6 +12,7 @@ import {
   RESULT_SCHEMA_VERSION,
   serializeResult,
 } from '../../scripts/run-evals.ts'
+import { buildCatalogEntries } from '../../src/lib/skill-catalog.js'
 
 const ROOT_DIR = path.resolve(import.meta.dirname, '../..')
 const MANIFEST_DIR = path.join(ROOT_DIR, 'evals/cases/opencode')
@@ -89,8 +90,12 @@ function validResult(mode: EvalMode = 'source'): Record<string, unknown> {
 }
 
 describe('local OpenCode eval contracts', () => {
-  test('exposes exactly two cases, four outcomes, and the supported schema versions', () => {
-    expect(CASE_IDS).toEqual(['bootstrap-loading', 'fixture-local-write'])
+  test('exposes exactly three cases, four outcomes, and the supported schema versions', () => {
+    expect(CASE_IDS).toEqual([
+      'bootstrap-loading',
+      'fixture-local-write',
+      'host-skill-coverage',
+    ])
     expect(OUTCOMES).toEqual([
       'success',
       'infra_failure',
@@ -101,9 +106,30 @@ describe('local OpenCode eval contracts', () => {
     expect(RESULT_SCHEMA_VERSION).toBe(1)
   })
 
-  test('accepts both declarative case manifests', () => {
+  test('accepts the host-skill-coverage case manifest with raw bundled skill names', () => {
+    expect(
+      parseCaseManifest({
+        caseSchemaVersion: 1,
+        caseId: 'host-skill-coverage',
+        harness: 'opencode',
+        assertionIds: ['host-catalog-covered'],
+        expectedSkillNames: ['agent-browser', 'ce:brainstorm'],
+      }),
+    ).toEqual({
+      caseSchemaVersion: 1,
+      caseId: 'host-skill-coverage',
+      harness: 'opencode',
+      assertionIds: ['host-catalog-covered'],
+      expectedSkillNames: ['agent-browser', 'ce:brainstorm'],
+    })
+  })
+
+  test('accepts all declarative case manifests', () => {
     const bootstrap = parseCaseManifest(readManifest('bootstrap-loading.json'))
     const fixture = parseCaseManifest(readManifest('fixture-local-write.json'))
+    const hostCoverage = parseCaseManifest(
+      readManifest('host-skill-coverage.json'),
+    )
 
     expect(bootstrap).toEqual({
       caseSchemaVersion: 1,
@@ -119,6 +145,46 @@ describe('local OpenCode eval contracts', () => {
       expectedArtifactId: 'fixture/output.txt',
       expectedContentId: 'fixture-local-write-v1',
     })
+    expect(hostCoverage).toMatchObject({
+      caseSchemaVersion: 1,
+      caseId: 'host-skill-coverage',
+      harness: 'opencode',
+      assertionIds: ['host-catalog-covered'],
+    })
+  })
+
+  test('keeps host coverage manifest names exactly in sync with the live bundled catalog', () => {
+    const hostCoverage = parseCaseManifest(
+      readManifest('host-skill-coverage.json'),
+    )
+    if (hostCoverage.caseId !== 'host-skill-coverage') {
+      throw new Error('expected host-skill-coverage manifest')
+    }
+
+    const bundledSkillNames = buildCatalogEntries({
+      bundledSkillsDir: path.join(ROOT_DIR, 'skills'),
+      disabledSkills: [],
+    }).map((entry) => entry.name)
+    const manifestSkillNames = hostCoverage.expectedSkillNames
+    const missingFromManifest = bundledSkillNames.filter(
+      (name) => !manifestSkillNames.includes(name),
+    )
+    const staleManifestNames = manifestSkillNames.filter(
+      (name) => !bundledSkillNames.includes(name),
+    )
+
+    if (missingFromManifest.length > 0 || staleManifestNames.length > 0) {
+      throw new Error(
+        [
+          'host-skill-coverage manifest drift detected.',
+          `Add bundled skills missing from the manifest: ${missingFromManifest.join(', ') || 'none'}.`,
+          `Remove manifest skills absent from the bundled catalog: ${staleManifestNames.join(', ') || 'none'}.`,
+        ].join(' '),
+      )
+    }
+
+    expect(missingFromManifest).toEqual([])
+    expect(staleManifestNames).toEqual([])
   })
 
   test('rejects unknown, missing, unsupported, and wrong-version manifest fields', () => {
@@ -220,5 +286,140 @@ describe('local OpenCode eval contracts', () => {
 
     expect(serializeResult(first)).toBe(serializeResult(second))
     expect(JSON.parse(serializeResult(first))).toEqual(normalizeResult(first))
+  })
+
+  test('round-trips bounded prompt composition observations without prompt text', () => {
+    const promptComposition = {
+      bootstrapPayloadSize: 18_145,
+      systematicCatalog: {
+        state: 'present',
+        entryCount: 23,
+        skillNames: ['systematic:alpha', 'systematic:beta'],
+      },
+      hostCatalog: {
+        state: 'absent',
+        entryCount: 0,
+        skillNames: [],
+      },
+    }
+    const candidate = {
+      ...validResult(),
+      evidence: {
+        sanity: 'passed',
+        process: 'completed',
+        assertionIds: ['fixture-file-content', 'fixture-file-created'],
+        promptComposition,
+      },
+    }
+
+    expect(normalizeResult(candidate).evidence.promptComposition).toEqual(
+      promptComposition,
+    )
+    expect(
+      JSON.parse(serializeResult(candidate)).evidence.promptComposition,
+    ).toEqual(promptComposition)
+  })
+
+  test('keeps present, absent, and impossible prompt observations distinct', () => {
+    const states = ['present', 'absent', 'impossible'] as const
+
+    for (const state of states) {
+      const promptComposition = {
+        bootstrapPayloadSize: state === 'impossible' ? 0 : 128,
+        systematicCatalog: {
+          state,
+          entryCount: state === 'present' ? 1 : 0,
+          skillNames: state === 'present' ? ['systematic:alpha'] : [],
+        },
+        hostCatalog: {
+          state: 'absent' as const,
+          entryCount: 0,
+          skillNames: [],
+        },
+      }
+
+      expect(
+        normalizeResult({
+          ...validResult(),
+          evidence: {
+            sanity: 'passed',
+            process: 'completed',
+            assertionIds: ['fixture-file-content', 'fixture-file-created'],
+            promptComposition,
+          },
+        }).evidence.promptComposition?.systematicCatalog.state,
+      ).toBe(state)
+    }
+  })
+
+  test('rejects raw prompt fields before result serialization', () => {
+    expect(() =>
+      serializeResult({
+        ...validResult(),
+        evidence: {
+          sanity: 'passed',
+          process: 'completed',
+          assertionIds: ['fixture-file-content', 'fixture-file-created'],
+          prompt: 'raw system prompt text',
+        },
+      }),
+    ).toThrow()
+  })
+
+  test('round-trips host catalog coverage evidence and rejects an incorrect missing set', () => {
+    const hostCatalogCoverage = {
+      state: 'present',
+      expectedSkillNames: ['agent-browser', 'ce:brainstorm'],
+      observedSkillNames: ['agent-browser', 'ce:brainstorm', 'extra-skill'],
+      missingSkillNames: [],
+    }
+    const candidate = {
+      ...validResult(),
+      evidence: {
+        sanity: 'passed',
+        process: 'completed',
+        assertionIds: ['fixture-file-content', 'fixture-file-created'],
+        hostCatalogCoverage,
+      },
+    }
+
+    expect(normalizeResult(candidate).evidence.hostCatalogCoverage).toEqual(
+      hostCatalogCoverage,
+    )
+    expect(
+      JSON.parse(serializeResult(candidate)).evidence.hostCatalogCoverage,
+    ).toEqual(hostCatalogCoverage)
+    expect(() =>
+      normalizeResult({
+        ...candidate,
+        evidence: {
+          ...candidate.evidence,
+          hostCatalogCoverage: {
+            ...hostCatalogCoverage,
+            missingSkillNames: ['agent-browser'],
+          },
+        },
+      }),
+    ).toThrow()
+
+    const impossibleCoverage = {
+      state: 'impossible',
+      expectedSkillNames: ['agent-browser', 'ce:brainstorm'],
+      observedSkillNames: [],
+      missingSkillNames: [],
+    }
+    expect(
+      normalizeResult({
+        ...validResult(),
+        outcome: 'infra_failure',
+        subcode: 'probe_unhealthy',
+        evidence: {
+          sanity: 'failed',
+          process: 'failed',
+          assertionIds: ['fixture-file-content', 'fixture-file-created'],
+          hostCatalogCoverage: impossibleCoverage,
+        },
+      }).evidence.hostCatalogCoverage,
+    ).toEqual(impossibleCoverage)
   })
 })


### PR DESCRIPTION
This adds evaluation tooling only. Nothing under `src/` is changed and no runtime behavior is affected.

Systematic currently injects its own `<available_skills>` catalog into the OpenCode bootstrap system prompt, even though OpenCode already renders permission-aware discovery through `skills.paths` and the `systematic_skill` tool description already carries the same skill names and descriptions. This change is the evidence layer that lets us remove that duplicate catalog in a later step instead of treating duplication as enough justification.

The eval probe now records bounded prompt-composition evidence and tracks three states for each catalog:
- present,
- observed absent,
- and observation impossible.

`impossible` is intentionally distinct from absent; if we cannot observe a catalog, that is an infrastructure-failure condition rather than a green pass.

Systematic catalog evidence and host catalog evidence are partitioned by workflow-block markers with fail-closed handling on malformed or unmatched markers, so a Systematic-rendered catalog can never be miscounted as host coverage.

A permanent `host-skill-coverage` eval case is added. It grades exact set inclusion of raw bundled skill names from the host catalog at the pinned runtime. Extra host entries are allowed; missing bundled entries fail and are reported explicitly.

A drift guard test now derives expected names from the live bundled catalog, so the manifest cannot silently go stale when bundled skills are added, removed, or their invocation permissions change.

Execution-failure classification now distinguishes a diagnosed task timeout from an undiagnosed failure with no observable transform.

The pinned runtime currently reports host coverage with an empty missing set, and this case is now permanent in the corpus to act as a standing regression gate when the pinned runtime changes.

Verification (already completed in this sequence): unit suite 1893/1893, typecheck, build, lint at the established baseline, and post-merge git diff cleanliness checks passed.

Origin: `docs/plans/2026-08-14-001-refactor-bootstrap-catalog-deletion-plan.md`
