### PR TITLE
docs(solutions): capture squash-release and version-pin learnings

### DIFF
--- a/docs/plans/2026-08-13-003-feat-local-opencode-eval-foundation-plan.md
+++ b/docs/plans/2026-08-13-003-feat-local-opencode-eval-foundation-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: Establish a local OpenCode eval foundation'
 type: feat
-status: active
+status: completed
 date: 2026-08-13
 origin: docs/plans/2026-08-13-001-refactor-bitter-lesson-harness-plan.md
 ---

--- a/docs/plans/2026-08-14-001-refactor-bootstrap-catalog-deletion-plan.md
+++ b/docs/plans/2026-08-14-001-refactor-bootstrap-catalog-deletion-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'refactor: Delete the duplicated bootstrap skill catalog'
 type: refactor
-status: active
+status: completed
 date: 2026-08-14
 origin: docs/plans/2026-08-13-001-refactor-bitter-lesson-harness-plan.md
 ---

--- a/docs/solutions/developer-experience/gh-api-heredoc-backtick-escape-2026-05-17.md
+++ b/docs/solutions/developer-experience/gh-api-heredoc-backtick-escape-2026-05-17.md
@@ -2,6 +2,7 @@
 title: gh api PR/issue body with heredoc escapes backticks visibly
 module: scripts (PR/issue authoring)
 date: 2026-05-17
+last_updated: 2026-08-16
 problem_type: developer_experience
 component: tooling
 severity: low
@@ -15,6 +16,7 @@ applies_when:
   - Authoring PR or issue body content via `gh api -X POST ... -f body=...` with a shell heredoc
   - Using `gh pr create --body "$(cat <<EOF ... EOF)"` patterns
   - Migrating existing PR-creation scripts and seeing escaped backticks render on GitHub
+  - Passing any multi-line message body through a shell, including `git commit -m`
 ---
 
 # gh api PR/issue body with heredoc escapes backticks visibly
@@ -139,6 +141,41 @@ EOF
 
 Unquoted heredoc DOES interpolate, so the escapes are necessary here to preserve backticks as literals. Equivalent output, but more fragile — any future contributor who adds `$VAR` or `$(cmd)` content has to keep track of two different escape rules in the same heredoc.
 
+### Same trap, different command: `git commit -m`
+
+The backtick rule is not a `gh` rule — it is a shell rule, and it bites hardest where there is no rendering step to make the damage obvious. In a double-quoted `git commit -m "..."`, backticks are command substitution. They are evaluated and their contents vanish. Git records whatever is left, silently and with exit code 0.
+
+```bash
+# Wrong: inside double quotes, every backtick-wrapped identifier is
+# executed as a command and its output (nothing) is substituted in.
+git commit -m "`origin/main` bumped `@opencode-ai/sdk` to 1.18.18."
+```
+
+The recorded body becomes:
+
+```text
+ bumped  to 1.18.18.
+```
+
+No error, no warning — just broken prose in permanent history. This repo squash-merges with `squash_merge_commit_message: COMMIT_MESSAGES`, so a mangled branch commit body is concatenated into the public squash commit and flows onward into release notes.
+
+```bash
+# Right: write the message to a file, commit with -F.
+MSG_FILE=$(mktemp -t commit-msg-XXXXXX.txt)
+cat > "$MSG_FILE" <<'EOF'
+build(evals): move host pin to OpenCode 1.18.18
+
+`origin/main` bumped `@opencode-ai/plugin` and `@opencode-ai/sdk` to 1.18.18,
+which trips the host-pin drift guard this branch introduced.
+EOF
+
+git commit -F "$MSG_FILE"
+git log -1 --format=%B    # verify the backticks and blank lines survived
+rm -f "$MSG_FILE"
+```
+
+Recovery is disproportionately expensive relative to the mistake. Fixing an already-pushed mangled body means rewriting history — rebuild the branch on its base, re-commit with `-F`, prove the resulting tree is byte-identical to the original, then `git push --force-with-lease` and wait out a full CI re-run. Writing the message to a file the first time costs one extra line.
+
 ### Verification after PR creation
 
 ```bash
@@ -151,4 +188,6 @@ gh api -X PATCH repos/owner/repo/pulls/N -F body=@FILE
 ## Related
 
 - `docs/solutions/developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md` — sibling lesson from the same release; both about `gh` CLI body content for PRs and releases
+- [`docs/solutions/workflow-issues/pr-title-selects-release-type-under-squash-merge-2026-08-16.md`](../workflow-issues/pr-title-selects-release-type-under-squash-merge-2026-08-16.md) — the other half of squash-merge message hygiene: the header decides whether a release happens at all
 - PR #401 — where the trap was caught mid-flight
+- PR #786 / commit `932be10` — where the same trap hit `git commit -m` and cost a history rewrite

--- a/docs/solutions/developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md
+++ b/docs/solutions/developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md
@@ -2,7 +2,7 @@
 title: semantic-release release-notes-generator ignores commit bodies; patch with gh release edit
 module: .releaserc.yaml + release-pipeline
 date: 2026-05-17
-last_updated: 2026-05-23
+last_updated: 2026-08-16
 problem_type: developer_experience
 component: tooling
 severity: medium
@@ -28,6 +28,8 @@ applies_when:
 Systematic's release pipeline uses `@semantic-release/release-notes-generator` with the `conventionalcommits` preset. The plugin reads the conventional-commits in the release range, groups commit SUBJECT lines under section headers configured in `presetConfig.types[]` (`Features`, `Bug Fixes`, `Build System`, etc.), and writes the result to the GitHub release body via `@semantic-release/github`.
 
 The common mistaken assumption — held by this author across multiple session arcs before being empirically falsified — is that the BODY of each conventional-commit also flows into the release notes. It does not. Only the subject line plus PR/commit links is included.
+
+The subject line carries a second, separate responsibility: `@semantic-release/commit-analyzer` reads it to decide whether a release happens at all, and at what level. A type that appears in `presetConfig.types` gets a changelog section but does not necessarily trigger a release — see the companion doc linked below.
 
 This matters when a release ships an audience-facing narrative — a deprecation announcement, a migration guide, a breaking-change explanation. Authoring that narrative inside the squash-commit body looks right (the body IS in git history, and it survives the squash), but the GitHub release notes show only:
 
@@ -143,6 +145,7 @@ fi
 ## Related
 
 - `docs/solutions/developer-experience/gh-api-heredoc-backtick-escape-2026-05-17.md` — sibling lesson from the same release; both involve `gh` CLI body content
+- [`docs/solutions/workflow-issues/pr-title-selects-release-type-under-squash-merge-2026-08-16.md`](../workflow-issues/pr-title-selects-release-type-under-squash-merge-2026-08-16.md) — the subject line's other job: selecting the release type, and which types publish nothing
 - `.releaserc.yaml` — the source of truth for the plugin chain and section mapping
 - PR #401 / v2.19.0 — where this lesson was empirically verified
 - `.agents/skills/release-notes-narrative/SKILL.md` — formalized procedure for the post-publish patch recommended above

--- a/docs/solutions/workflow-issues/pr-title-selects-release-type-under-squash-merge-2026-08-16.md
+++ b/docs/solutions/workflow-issues/pr-title-selects-release-type-under-squash-merge-2026-08-16.md
@@ -1,0 +1,137 @@
+---
+title: PR title selects the release type in a squash-only repo
+module: .releaserc.yaml + release-pipeline
+date: 2026-08-16
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+tags:
+  - semantic-release
+  - conventional-commits
+  - squash-merge
+  - release-pipeline
+  - pr-workflow
+applies_when:
+  - Opening or retitling a PR whose change is user-visible but whose conventional type may not publish
+  - Deciding the conventional type for a removal, cleanup, or internal-sounding change
+  - Verifying what a merge will actually publish before clicking merge
+---
+
+# PR title selects the release type in a squash-only repo
+
+## Context
+
+This repository allows squash merges only:
+
+```bash
+gh api repos/marcusrbrown/systematic \
+  --jq '{squash:.allow_squash_merge, merge:.allow_merge_commit, rebase:.allow_rebase_merge,
+         title:.squash_merge_commit_title, msg:.squash_merge_commit_message}'
+# {"squash":true,"merge":false,"rebase":false,
+#  "title":"COMMIT_OR_PR_TITLE","msg":"COMMIT_MESSAGES"}
+```
+
+`squash_merge_commit_title: COMMIT_OR_PR_TITLE` means the PR title becomes the squash commit's subject line whenever a branch has more than one commit. That subject is the only thing `@semantic-release/commit-analyzer` reads to decide the release type.
+
+`.releaserc.yaml` uses `preset: conventionalcommits` and adds exactly these rules:
+
+```yaml
+analyzeCommits:
+  releaseRules:
+    - {type: build, release: patch}
+    - {type: build, scope: dev, release: false}
+    - {type: docs, release: patch, scope: readme}
+    - {type: docs, release: patch, scope: readme.md}
+    - {type: docs, release: patch, scope: skill}
+    - {type: docs, release: patch, scope: skills}
+    - {type: docs, release: patch, scope: agents}
+    - {type: docs, release: patch, scope: commands}
+```
+
+Everything else falls through to the preset defaults, which publish on `feat` (minor), `fix` (patch), and `perf` (patch) — and on nothing else. `refactor`, `test`, `chore`, `style`, and `ci` all appear in `presetConfig.types` and therefore show up as changelog *sections*, which makes them look like releasing types. They are not. A `refactor:` PR merges to `main`, produces a commit, produces no version, and publishes no package.
+
+## Guidance
+
+**Before merging, ask what the change does for the user, then pick the conventional type that publishes it. Appearing in `presetConfig.types` does not mean a type triggers a release.**
+
+Releasing types in this repo:
+
+| Type | Result |
+|---|---|
+| `feat` | minor |
+| `fix` | patch |
+| `perf` | patch |
+| `build` (unscoped) | patch |
+| `docs` with scope `readme`/`skill`/`skills`/`agents`/`commands` | patch |
+| `refactor`, `test`, `chore`, `style`, `ci`, `build(dev)` | **no release** |
+
+A removal is not automatically a `refactor`. If deleting code changes what users observe at runtime — smaller payload, less latency, fewer bytes on the wire, less data leaked — `perf` or `fix` is the honest type and it ships. Reserve `refactor` for changes with no observable difference.
+
+Two checks worth running while the PR is open:
+
+```bash
+# What header will the squash produce?
+gh pr view <N> --json title --jq .title
+
+# Which rules are actually configured?
+grep -A20 'releaseRules' .releaserc.yaml
+```
+
+Retitling is a one-line fix while the PR is open and costs nothing:
+
+```bash
+gh pr edit <N> --title "perf(bootstrap): remove redundant bootstrap skill catalog"
+```
+
+## Why This Matters
+
+PR #786 removed Systematic's duplicated `<available_skills>` bootstrap catalog. It cut the generated bootstrap payload from 18,145 to 6,232 characters — a 65.6% reduction on every prompt of every session — and removed 23 absolute machine paths from prompt output. Both effects are user-visible.
+
+It was titled `refactor(bootstrap): remove redundant bootstrap skill catalog`. Merged under that title it would have landed on `main`, published nothing, and sat unreleased until some unrelated later commit happened to trigger a version bump — at which point the improvement would ship inside another change's release notes, uncredited and undiscoverable. It was retitled to `perf(bootstrap):` before merge and shipped as a patch.
+
+The failure mode is quiet in both directions. Nothing errors. CI is green. The merge succeeds. The only symptom is a release that never happens, which is invisible unless someone is specifically watching for it.
+
+## When to Apply
+
+- Any PR whose diff is mostly deletions but whose effect is user-visible
+- Any PR titled `refactor`, `test`, `chore`, `style`, or `ci` that you expect to ship
+- Any PR where the branch has multiple commits, since that is when the PR title — not a commit subject — becomes the release-deciding header
+- When adding a new conventional type to `presetConfig.types`, confirm whether it also needs a `releaseRules` entry; the two lists serve different purposes
+
+## Examples
+
+### Wrong: internal-sounding type for a user-visible change
+
+```text
+refactor(bootstrap): remove redundant bootstrap skill catalog
+```
+
+Merges cleanly. Publishes nothing. The 65.6% payload reduction reaches no user until an unrelated commit drags it out.
+
+### Right: the type that matches the observable effect
+
+```text
+perf(bootstrap): remove redundant bootstrap skill catalog
+```
+
+Merges cleanly and publishes a patch release carrying the change on its own terms.
+
+### Squash body is prefilled from branch commits
+
+`squash_merge_commit_message: COMMIT_MESSAGES` concatenates every branch commit message into the squash body. A branch commit subject that disagrees with the retitled header will appear inside the release notes:
+
+```text
+perf(bootstrap): remove redundant bootstrap skill catalog (#786)
+
+refactor(bootstrap): remove redundant bootstrap skill catalog   <- stale branch subject
+...
+```
+
+Either reword the branch commit before merging, or edit the squash body in the merge dialog. The header still drives the release type; the stale line is a cosmetic leak into a public artifact.
+
+## Related
+
+- [`docs/solutions/developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md`](../developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md) — the adjacent trap: the release *type* comes from the subject, and the release *notes* ignore the body entirely
+- [`docs/solutions/best-practices/release-notes-narrative-procedure-2026-05-23.md`](../best-practices/release-notes-narrative-procedure-2026-05-23.md) — what to do after a release publishes
+- `.releaserc.yaml` — source of truth for `releaseRules` and `presetConfig.types`
+- PR #786 / commit `a875314` — where the near-miss was caught

--- a/docs/solutions/workflow-issues/version-pinned-evidence-must-be-reproven-2026-08-16.md
+++ b/docs/solutions/workflow-issues/version-pinned-evidence-must-be-reproven-2026-08-16.md
@@ -1,0 +1,125 @@
+---
+title: Version-pinned evidence must be re-proven when the pinned runtime moves
+module: scripts/run-evals.ts + eval host pin
+date: 2026-08-16
+problem_type: workflow_issue
+component: testing_framework
+severity: medium
+tags:
+  - evals
+  - version-pinning
+  - drift-guard
+  - opencode-host
+  - test-evidence
+applies_when:
+  - A test asserts an external runtime version pin
+  - Recorded evidence depends on that runtime's own behavior rather than on this repo's code
+  - A dependency bump lands on main while a PR carrying version-dependent evidence is open
+---
+
+# Version-pinned evidence must be re-proven when the pinned runtime moves
+
+## Context
+
+Some claims in this repository are only true relative to a specific external runtime version. The clearest case is host skill discovery: Systematic can delete its own bootstrap skill catalog *because* OpenCode renders an equivalent catalog itself. That is not a property of Systematic's code — it is a property of the OpenCode build being run against. Change the build, and the evidence is no longer evidence.
+
+`tests/unit/eval-contract.test.ts` guards the pins:
+
+```ts
+// EXPECTED_OPENCODE_VERSION  (scripts/run-evals.ts)
+// EXACT_OPENCODE_VERSION     (tests/integration/fixtures/receipt-workflow-host.ts)
+// must both equal the @opencode-ai/sdk devDependency, and
+// @opencode-ai/sdk must equal @opencode-ai/plugin.
+```
+
+Its failure message is deliberately more than a diff report:
+
+> `OpenCode host pin drift: <name> is <pin>, but package.json devDependencies @opencode-ai/sdk and @opencode-ai/plugin are <version>. Change <name> to <version>, then re-run the host-coverage eval before relying on bootstrap catalog deletion evidence.`
+
+## Guidance
+
+**Treat the version pin and the evidence gathered at that version as a single unit. When the pin moves, the evidence is invalidated until it is collected again at the new version. Bumping the constant to make the guard pass, without re-running the suite, converts a real gate into a rubber stamp.**
+
+The sequence when a pinned runtime moves:
+
+1. Bump every pin in lockstep — `EXPECTED_OPENCODE_VERSION`, `EXACT_OPENCODE_VERSION`, and the `@opencode-ai/sdk` / `@opencode-ai/plugin` devDependencies must all agree.
+2. Re-run the version-dependent suite against the real host:
+
+   ```bash
+   bun test tests/integration/eval-runner.test.ts \
+            tests/integration/eval-artifact.test.ts \
+            tests/integration/eval-fixture.test.ts
+   ```
+
+3. Record the result at the new version. Only a fresh pass supports the claim.
+
+That suite takes roughly 15 minutes. The agent harness kills foreground shell commands at about 7 minutes, so run it as a tracked background process and watch for completion rather than blocking a foreground call.
+
+When writing a new pin guard, put the required follow-up action in the assertion message. A guard that says "these two numbers disagree" invites the minimal edit that silences it. A guard that says "change the pin, *then re-run X before relying on Y*" tells the next reader that the number was never the point.
+
+## Why This Matters
+
+This fired for real, mid-PR. PR #786 introduced the drift guard and collected its host-coverage evidence at OpenCode 1.18.17. While it was open, `main` merged #787, bumping `@opencode-ai/plugin` and `@opencode-ai/sdk` to 1.18.18. Updating the branch immediately failed the branch's own guard.
+
+The cheap response — bump two constants, push, merge — would have shipped a deletion justified entirely by a measurement taken against a build no longer in use. Nothing would have failed. The suite would have been green. The claim would simply have been unproven.
+
+Instead both pins moved to 1.18.18 and the real-host suite was re-run there: 51 pass, 0 fail, 328 assertions, 878 seconds. The host still covered every bundled skill at the new version, so the deletion stayed justified — this time with evidence that matched the runtime.
+
+The guard is worth having precisely because it is inconvenient at exactly the right moment. It converts a silent staleness problem into a loud failing test.
+
+## When to Apply
+
+- A constant in the repo names an external runtime, SDK, CLI, or host version
+- A test or documented claim depends on how that external thing behaves, not on how this repo's code behaves
+- A dependency bump lands while a PR carrying such evidence is open
+- Renovate opens a version-bump PR touching a pinned runtime — the bump and the re-proof belong in the same PR
+
+## Examples
+
+### Wrong: satisfy the guard, keep the old result
+
+```diff
+-export const EXPECTED_OPENCODE_VERSION = '1.18.17' as const
++export const EXPECTED_OPENCODE_VERSION = '1.18.18' as const
+```
+
+Tests pass. The host-coverage claim still rests on a 1.18.17 observation. The guard has been converted into a formality.
+
+### Right: move the pin and re-collect the evidence
+
+```diff
+-export const EXPECTED_OPENCODE_VERSION = '1.18.17' as const
++export const EXPECTED_OPENCODE_VERSION = '1.18.18' as const
+```
+
+```diff
+-export const EXACT_OPENCODE_VERSION = '1.18.17'
++export const EXACT_OPENCODE_VERSION = '1.18.18'
+```
+
+```bash
+bun test tests/integration/eval-runner.test.ts \
+         tests/integration/eval-artifact.test.ts \
+         tests/integration/eval-fixture.test.ts
+# 51 pass, 0 fail, 328 expect() calls
+```
+
+### Write the follow-up into the guard itself
+
+```ts
+throw new Error(
+  `OpenCode host pin drift: ${name} is ${pin}, but package.json devDependencies ` +
+  `@opencode-ai/sdk and @opencode-ai/plugin are ${sdkVersion}. Change ${name} to ` +
+  `${sdkVersion}, then re-run the host-coverage eval before relying on bootstrap ` +
+  `catalog deletion evidence.`,
+)
+```
+
+The instruction is the load-bearing part. The comparison only detects drift; the message is what prevents the drift from being papered over.
+
+## Related
+
+- [`docs/solutions/best-practices/pi-real-runtime-integration-harness-2026-07-16.md`](../best-practices/pi-real-runtime-integration-harness-2026-07-16.md) — real-runtime verification over mocked approximations
+- [`docs/solutions/best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md`](../best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md) — contract tests across harnesses
+- `ARCHITECTURE.md` — records the `host-skill-coverage` eval case as a standing gate to re-run on every pinned-runtime change
+- PR #786 / #787 — where the guard fired and the evidence was re-collected


### PR DESCRIPTION
Shipping the bootstrap catalog deletion turned up two failure modes that are quiet enough to reach `main` without anyone noticing, so both are now written down.

**The PR title decides whether a change publishes.** This repo is squash-only with `squash_merge_commit_title: COMMIT_OR_PR_TITLE`, so the PR title becomes the commit header that `@semantic-release/commit-analyzer` reads. The types in `presetConfig.types` are changelog sections, not releasing types — `refactor`, `test`, `chore`, `style`, and `ci` all render a section and publish nothing. PR #786 cut the injected bootstrap payload by 65.6% and removed 23 absolute machine paths from every prompt, and was titled `refactor(bootstrap):`. Merged as-is it would have landed on `main` and shipped nothing until an unrelated commit happened to trigger a version. Nothing errors in that scenario; the only symptom is a release that never happens.

**Evidence pinned to an external runtime expires when the pin moves.** The host-pin drift guard added in #786 fired for real when `main` merged the OpenCode 1.18.18 bump. Bumping the two constants would have made the suite green while leaving the catalog-deletion claim resting on a 1.18.17 observation. The pins moved and the real-host eval suite was re-run at 1.18.18 instead — 51 pass, 0 fail. The doc argues the guard's assertion message is the load-bearing part: a guard that only reports a mismatch invites the minimal edit that silences it.

The existing `gh` heredoc doc picks up a third case rather than a separate doc, because the root cause is identical. Backticks inside a double-quoted `git commit -m` are command substitution, so the identifiers are evaluated and discarded with no error and exit code 0. That happened here, and because squash bodies are prefilled from branch commits, the damage was headed for public release notes. Recovering from it cost a history rewrite; writing the message to a file and using `git commit -F` costs one line.

Also marks the bootstrap catalog deletion and local OpenCode eval foundation plans completed now that both have shipped.

`docs` without a releasing scope publishes nothing, which is the intended outcome for a docs-only change.
