### PR TITLE
docs(solutions): capture verification blind spots from the model-defaults wedge

### DIFF
--- a/docs/solutions/best-practices/comments-and-commit-messages-are-claims-not-evidence-2026-08-16.md
+++ b/docs/solutions/best-practices/comments-and-commit-messages-are-claims-not-evidence-2026-08-16.md
@@ -1,0 +1,102 @@
+---
+title: Comments and commit messages are claims, not evidence of final state
+module: src/lib/config-handler.ts + src/lib/source-model-defaults.ts
+date: 2026-08-16
+problem_type: best_practice
+component: development_workflow
+severity: low
+tags:
+  - dead-code
+  - dependency-surface
+  - commit-sequencing
+  - pr-narrative
+  - final-state-verification
+applies_when:
+  - A field, parameter, or module is annotated as retained for compatibility
+  - A multi-commit change deletes something an earlier commit in the same change modified
+  - Writing a PR description or release note from commit messages
+---
+
+# Comments and commit messages are claims, not evidence of final state
+
+## Context
+
+Prose written next to code makes assertions about that code. Those assertions are unverified, they are never invalidated automatically, and they survive the conditions that made them true. Two variants of this showed up in one change.
+
+**A comment claimed a consumer that did not exist.** Removing a config hook's model-availability discovery left a dependency field behind:
+
+```ts
+export interface ConfigHandlerDeps {
+  /** Retained for dependency-surface compatibility; config emission does not use it. */
+  client?: OpencodeClientLike
+}
+```
+
+The comment is accurate about the present and misleading about the future. It says nothing reads the field, then keeps it anyway. A search across `src/`, `scripts/`, and `tests/` found zero reads and exactly one write — a pass-through in `src/index.ts` that existed only to populate it. Both were deleted.
+
+**A commit message claimed work that HEAD does not contain.** One commit replaced a closed seven-literal `ProviderID` union with structural validation, hardening input handling in `src/lib/source-model-defaults.ts`. The next commit deleted that file. Both commits were correct in isolation, and the sequencing was deliberate so each stayed independently revertable. But the net diff for that file is:
+
+```
+src/lib/source-model-defaults.ts | 430 ---------------------------------------
+1 file changed, 430 deletions(-)
+```
+
+The hardening does not exist at HEAD. Its commit message describes it in the present tense, and a PR description assembled from commit messages would have credited a security improvement that shipped nothing.
+
+## Guidance
+
+**For retained-for-compatibility annotations:** treat the comment as a hypothesis and test it. A field no code reads is dead regardless of what the comment says about why it is there. Compatibility is a property of consumers, so if you cannot name one, there is nothing to be compatible with.
+
+```bash
+# Name the consumer or delete the field
+rg 'deps\.client|\.client\b' src/ scripts/ tests/
+```
+
+**For multi-commit changes:** verify the net diff before writing the narrative. Commit messages describe intent at a point in history; the PR ships a final tree.
+
+```bash
+# What actually changed, versus what the commits say changed
+git diff --stat <base>..HEAD -- <path>
+git log --oneline <base>..HEAD
+```
+
+When a commit's work is fully removed by a later commit in the same change, that is fine and often correct — but say so, or say nothing about it. Do not describe it as shipped.
+
+## Why This Matters
+
+Both failures are invisible to every automated gate. Types, tests, and linters have no opinion about whether a comment is true, and none of them read commit messages at all. The only detection mechanism is a reader who checks, and readers extend trust to prose precisely because checking is expensive.
+
+The cost compounds. A retained field teaches the next reader that something depends on it, so they preserve it too. An overstated commit message flows into a squash body, then into release notes, and becomes the public record of what a version contains.
+
+## When to Apply
+
+- Any time you write "retained for", "kept for compatibility", or "reserved for future use" — name the consumer or the future, or delete the thing
+- Before opening a PR whose commits modify and then delete the same file
+- When assembling release notes or a PR description from commit history rather than from the diff
+
+## Examples
+
+**The audit that settles a retained field.** One command, three trees, zero reads found:
+
+| Check | Result |
+|---|---|
+| `rg 'deps\.client' src/` | no matches |
+| Constructions of `ConfigHandlerDeps` | one, in `src/index.ts` |
+| Reads in that construction | none — it only wrote the field |
+
+Verdict: delete the field and the pass-through.
+
+**The net-diff check that catches an overstated narrative.** A file with insertions and deletions across the range still nets to a pure removal:
+
+```bash
+$ git diff --stat 09703a1..HEAD -- src/lib/source-model-defaults.ts
+ src/lib/source-model-defaults.ts | 430 ---------------------------------------
+```
+
+No insertions. Whatever the intermediate commits said they added is not there.
+
+## Related
+
+- [`docs/solutions/workflow-issues/pr-title-selects-release-type-under-squash-merge-2026-08-16.md`](../workflow-issues/pr-title-selects-release-type-under-squash-merge-2026-08-16.md) — the downstream consequence: commit and PR text become the public release record
+- [`docs/solutions/workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md`](../workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md) — verify the artifact, not the process that claims to produce it
+- PR #790 — where both variants surfaced

--- a/docs/solutions/best-practices/deletion-gates-must-observe-every-field-the-deleted-code-wrote-2026-08-16.md
+++ b/docs/solutions/best-practices/deletion-gates-must-observe-every-field-the-deleted-code-wrote-2026-08-16.md
@@ -1,0 +1,97 @@
+---
+title: A deletion gate must observe every field the deleted code could write
+module: evals/cases/opencode/model-inheritance.json + src/lib/config-handler.ts
+date: 2026-08-16
+problem_type: best_practice
+component: testing_framework
+severity: medium
+tags:
+  - evals
+  - regression-gate
+  - deletion-verification
+  - assertion-coverage
+  - adversarial-review
+applies_when:
+  - Building a test whose purpose is to prove deleted behavior stays deleted
+  - The deleted mechanism wrote more than one field
+  - A gate's headline assertion names one symptom of a broader capability
+---
+
+# A deletion gate must observe every field the deleted code could write
+
+## Context
+
+Retiring a mechanism is only half the work. The other half is a gate that fails if someone reintroduces it. That gate is easy to write and easy to write narrowly, because you naturally reach for the field that motivated the deletion.
+
+Systematic removed a table that pinned each bundled agent category to a provider/model pair. A new eval case was built for exactly one purpose, stated in its own commit message: fail if source-owned defaulting returns. It observed whether an agent's emitted config carried a `model` key and what value it held, across all 37 bundled agents and all five categories.
+
+The retired table also set variants:
+
+```ts
+{ provider: 'openai',    models: [{ model: 'gpt-5.5', variant: 'high' }] }
+{ provider: 'anthropic', models: [{ model: 'claude-opus-4-7', variant: 'max' }] }
+```
+
+And `variant` was still a live emitted field — `applyOverlayObjectWithVariantClearing` in `src/lib/config-handler.ts` continued to manage it. So a regression that reintroduced source-owned *variant* pinning without touching `model` would have passed the gate clean. The gate watched half of what the deleted code wrote.
+
+An adversarial reviewer found it. The confirmation was one command:
+
+```bash
+grep -c variant scripts/eval-cases/opencode.ts   # 0
+```
+
+## Guidance
+
+Before writing the gate, enumerate every field the deleted mechanism could write. Assert on all of them, not on the one that motivated the deletion.
+
+For an absence gate, require absence of the whole set:
+
+```ts
+// Narrow: catches the headline case only
+expect(agent.model).toBeUndefined()
+
+// Complete: catches any field the retired mechanism controlled
+expect(agent.model).toBeUndefined()
+expect(agent.variant).toBeUndefined()
+```
+
+Two sources make the enumeration cheap and non-speculative:
+
+1. **The deleted code itself.** Read what it assigned, from git if it is already gone. `git show <commit-before-deletion>:<path>` gives you the exact write set.
+2. **What still consumes those fields.** If a field survives the deletion with live handling elsewhere, it is reachable, and reachable means a regression can target it.
+
+## Why This Matters
+
+A gate's value is entirely in what it would catch. A gate that catches the obvious reintroduction and misses the adjacent one is worse than no gate, because the commit message, the PR, and the next reader all treat it as proof. This one was described as "fails if a source-owned default reappears" — true for `model`, false for `variant`, and nothing in the artifact disclosed the difference.
+
+The failure mode is not carelessness. It is that the field which motivated the deletion crowds out the fields that merely came along with it.
+
+## When to Apply
+
+- Any test written to prove a deletion stays deleted
+- Any assertion phrased as an absence, where the thing being absent had more than one observable
+- Retiring a config layer, a defaulting mechanism, an injection point, or a middleware that set multiple keys
+
+## Examples
+
+**Enumerating from the deleted source.** The write set is recoverable even after deletion:
+
+```bash
+# The last commit before the file was removed
+git show 8d61cf4:src/lib/source-model-defaults.ts | grep -E "model:|variant:"
+```
+
+**Checking for survivors that make a field reachable:**
+
+```bash
+# variant still handled in the config hook → still a regression target
+rg 'variant' src/lib/config-handler.ts
+```
+
+**The resulting assertion shape.** Inheritance scenarios require both absent; overlay scenarios assert the expected value, so the gate distinguishes "user asked for this variant" from "something pinned it."
+
+## Related
+
+- [`docs/solutions/best-practices/provider-availability-source-defaults-2026-05-12.md`](provider-availability-source-defaults-2026-05-12.md) — the mechanism this gate guards, now retired
+- [`docs/solutions/workflow-issues/version-pinned-evidence-must-be-reproven-2026-08-16.md`](../workflow-issues/version-pinned-evidence-must-be-reproven-2026-08-16.md) — the other half of trusting a gate: its evidence expires when the pinned runtime moves
+- PR #790 — where the gap was found and closed

--- a/docs/solutions/test-failures/duplicated-cli-help-fixture-is-a-hidden-registration-point-2026-08-16.md
+++ b/docs/solutions/test-failures/duplicated-cli-help-fixture-is-a-hidden-registration-point-2026-08-16.md
@@ -1,0 +1,87 @@
+---
+title: A duplicated literal is a registration point nobody documented
+module: scripts/run-evals.ts + tests/integration/eval-runner.test.ts
+date: 2026-08-16
+problem_type: test_failure
+component: testing_framework
+severity: medium
+tags:
+  - evals
+  - fixture-drift
+  - registration-points
+  - integration-tests
+  - duplicated-literal
+symptoms:
+  - Unit suite passes 1798/0 while the integration suite fails two tests
+  - '`direct CLI argument errors are one concise JSON object` fails with a one-line diff'
+  - The `--help` assertion fails on text that looks correct in the source
+root_cause: missing_workflow_step
+resolution_type: test_fix
+---
+
+# A duplicated literal is a registration point nobody documented
+
+## Problem
+
+Registering a new case in the eval runner has four documented touch points in `scripts/run-evals.ts`: `CASE_IDS`, `CASE_ASSERTIONS`, `CLI_USAGE`, and `parseCaseManifest`. All four were updated. The unit suite passed 1798/0. The integration suite then failed two tests.
+
+There was a fifth touch point, and nothing named it: `tests/integration/eval-runner.test.ts` holds a hand-maintained verbatim copy of the runner's help text as `EXPECTED_CLI_HELP` and asserts stderr equals it exactly.
+
+## Symptoms
+
+```
+(fail) local OpenCode eval runner > direct CLI argument errors are one concise JSON object
+  Expected  - 1
+  Received  + 1
+  at tests/integration/eval-runner.test.ts:2065:40
+```
+
+The unit suite stayed green throughout. Only the integration suite, which spawns the runner as a subprocess and compares real stderr, saw the mismatch.
+
+## What Didn't Work
+
+Following the documented registration list. It was complete and correct, and it was not sufficient. The four points live in the source module; the fifth lives in a test file, holds a copy of one of them, and is reachable only by reading the test.
+
+Trusting the unit suite as a proxy for "the change is wired up." Unit tests import the runner's constants, so they agree with the source by construction. The duplicate can only disagree with something that observes the runner from outside.
+
+## Solution
+
+Update the copy. The change is one line — adding the new case id to the `--case <id>` line — and the useful part is the check that proves the two agree:
+
+```bash
+diff <(sed -n '38,49p' tests/integration/eval-runner.test.ts) \
+     <(sed -n '754,765p' scripts/run-evals.ts)
+```
+
+Empty output means they match.
+
+## Why This Works
+
+The test asserts an exact string equality against a literal it owns. There is no import, no generation step, and no shared constant between the two, so nothing detects divergence until the assertion runs. Restoring equality restores the contract the test was written to enforce.
+
+## Prevention
+
+The obvious fix is to import `CLI_USAGE` into the test. Resist it, or at least price it honestly: the test would then assert the runner matches itself, which passes unconditionally and proves nothing. The duplication is what gives the assertion its value — it is an independent statement of what the CLI should print.
+
+The real options, in order of preference:
+
+| Option | Cost | What it buys |
+|---|---|---|
+| Keep the duplicate, add an explicit drift check | One CI step or unit test running the `diff` above | Independent assertion preserved, divergence caught immediately |
+| Generate the fixture from the source at build time | Build wiring | No drift, but the assertion weakens toward tautology |
+| Import the constant | Free | Nothing. The test stops testing the text |
+
+When a duplicate must exist for independence, the duplication itself deserves a named guard. Otherwise the second copy is a registration point that only failure will teach you about.
+
+More generally: when a change has a documented list of touch points, the list describes the module, not the repository. Grep the full tree for a distinctive fragment of whatever you edited before believing the list is complete.
+
+```bash
+# Before trusting a registration list, look for copies of what you just changed
+rg --fixed-strings 'Repeatable: bootstrap-loading' -- . 
+```
+
+## Related
+
+- [`docs/solutions/workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md`](../workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md) — same family: a mechanical gate passed while the real artifact differed
+- [`docs/solutions/test-failures/unit-suite-rewrites-repo-file-trap-2026-07-17.md`](unit-suite-rewrites-repo-file-trap-2026-07-17.md) — another case where the unit suite's view diverged from reality
+- PR #790 — where this surfaced


### PR DESCRIPTION
Three failure modes surfaced while retiring source-owned model defaults in #790. All three passed every automated gate at the moment they mattered, which is what makes them worth writing down.

**A duplicated literal is a registration point nobody documented.** Adding an eval case has four documented touch points in `scripts/run-evals.ts`. All four were updated and the unit suite passed 1798/0. The integration suite then failed, because `tests/integration/eval-runner.test.ts` keeps a hand-maintained verbatim copy of the runner's help text and asserts exact equality against it. Nothing links the two. The obvious fix — importing the constant — would make the test assert the runner matches itself, so the doc argues for keeping the duplicate behind an explicit drift check instead of collapsing it.

**A deletion gate must observe every field the deleted code could write.** The regression gate added in #790 was built to fail if source-owned defaulting returns, and it observed `model` but not `variant`. The retired table set both, and `variant` was still a live emitted field, so variant-only reintroduction would have passed clean. The rule: enumerate the deleted code's full write set from git before writing the gate, rather than asserting on whichever field motivated the deletion.

**Comments and commit messages are claims, not evidence of final state.** A dependency field annotated "retained for dependency-surface compatibility" had no reader anywhere in the tree. Separately, a commit describing input-validation hardening was fully erased by the next commit deleting that file, so its message describes work absent from HEAD. Neither is visible to types, tests, or linters, and the second flows into squash bodies and release notes when a description is assembled from commit history.

That last one is not hypothetical. The squash body on #790 carries the erased-hardening line into the permanent commit record, which is how the pattern earned a document.

## Testing

Documentation only. Content-integrity clean at 64 solution docs, every cross-reference resolves, no absolute paths. `docs(solutions)` publishes nothing.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this adds three Markdown files under `docs/solutions/` with no runtime impact.
