### PR TITLE
fix(ce-review): enforce the review artifact contract

### DIFF
--- a/agents/review/architecture-strategist.md
+++ b/agents/review/architecture-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: architecture-strategist
-description: "Analyzes code changes from an architectural perspective for pattern compliance and design integrity. Use when reviewing PRs, adding services, or evaluating structural refactors."
+description: "Analyzes code changes from an architectural perspective for pattern compliance and design integrity. Use when reviewing PRs, adding services, or evaluating structural refactors. Dispatched by deepen-plan and ce-plan's deepening workflow, not by ce:review."
 tools: Read, Grep, Glob, Bash
 mode: subagent
 temperature: 0.1

--- a/agents/review/code-simplicity-reviewer.md
+++ b/agents/review/code-simplicity-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: code-simplicity-reviewer
-description: "Final review pass to ensure code is as simple and minimal as possible. Use after implementation is complete to identify YAGNI violations and simplification opportunities."
+description: "Final review pass to ensure code is as simple and minimal as possible. Use after implementation is complete to identify YAGNI violations and simplification opportunities. Dispatched by ce-compound for code-heavy issues, not by ce:review."
 tools: Read, Grep, Glob, Bash
 mode: subagent
 temperature: 0.1

--- a/agents/review/pattern-recognition-specialist.md
+++ b/agents/review/pattern-recognition-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: pattern-recognition-specialist
-description: "Analyzes code for design patterns, anti-patterns, naming conventions, and duplication. Use when checking codebase consistency or verifying new code follows established patterns."
+description: "Analyzes code for design patterns, anti-patterns, naming conventions, and duplication. Use when checking codebase consistency or verifying new code follows established patterns. Dispatched by deepen-plan, ce-plan's deepening workflow, and ce-compound, not by ce:review."
 tools: Read, Grep, Glob, Bash
 mode: subagent
 temperature: 0.6

--- a/docs/plans/2026-08-13-001-refactor-bitter-lesson-harness-plan.md
+++ b/docs/plans/2026-08-13-001-refactor-bitter-lesson-harness-plan.md
@@ -466,7 +466,8 @@ An initiative cannot enter implementation while two other behavior-changing surf
   - Retire or radically narrow: `src/lib/source-model-defaults.ts`.
   - Modify: `src/lib/model-availability.ts`, `src/lib/config-handler.ts`, `src/lib/agent-overlays.ts`, `src/lib/config-schema.ts`.
   - Modify: generated configuration docs and OMO/standalone registry profiles.
-  - Test: model inheritance, explicit user overrides, unavailable capability handling, and eval-backed optional escalation.
+  - Modify: bundled skill dispatch references (`skills/*/SKILL.md`, persona catalogs) so every named agent resolves to a registered dispatch key.
+  - Test: model inheritance, explicit user overrides, unavailable capability handling, eval-backed optional escalation, and workflow dispatch resolution.
 - **Approach:**
   - Default every bundled agent/capability to the invoking model.
   - Preserve explicit user configuration as the only unconditional model override.
@@ -474,13 +475,15 @@ An initiative cannot enter implementation while two other behavior-changing surf
   - Do not implement automatic escalation in this migration. Capability incompatibility may explain why the active model cannot perform a task, but changing models remains explicit user policy.
   - Remove provider frequency lore and hardcoded provider unions from runtime policy; validate identifiers structurally rather than against a closed commercial catalog.
   - Remove fallback-to-first-provider behavior as the first deletion slice; unknown availability inherits rather than guesses.
+  - Bind every workflow-dispatched agent to a resolvable dispatch key. Config-owned model policy only takes effect if the identifier a skill names is the identifier the harness can dispatch, and today it usually is not. Three failure modes, all silent: 99 references across bundled skills use the qualified `systematic:<category>:<name>` form while the OpenCode config hook registers bare names (`src/lib/config-handler.ts:217`); `ce:compound` Phase 1 names roles in prose ("Context Analyzer", "Solution Extractor", "Related Docs Finder") with no agent binding at all; and `ce:review`/`ce:ideate` instruct a `model:` parameter that OpenCode's `task` tool does not accept. Each one ends the same way — the orchestrator substitutes or falls back, the substitute runs the session default, and per-agent and per-category assignments in `systematic.jsonc` never apply. Exactly one skill dispatches correctly today (`skills/ce-work/SKILL.md:148`). See issue #784, which covers the qualified-name and `model:`-parameter modes; the unbound-prose mode is newly identified. The identity mechanism is I6's `stable IDs and reversible aliases` work — this wedge only requires that named agents resolve, not that the namespace be unified.
 - **Test scenarios:**
   - New provider/model: becomes usable without a Systematic release.
   - Active-model improvement: stronger invoking model receives full workflow freedom rather than being downgraded by category defaults.
   - User override: remains authoritative and trust-protected.
   - Unknown availability: inherits safely instead of guessing a model.
   - Scorecard drift: stale eval data is visible and cannot silently route.
-- **Child-plan entry gate:** inventory each current default's consumer and fallback behavior, select one deletion wedge, and define config precedence and rollback without introducing scorecard-driven routing.
+  - Workflow dispatch: every agent a bundled skill names resolves to a registered dispatch key, and the model that runs is the one the user's config assigns to that agent — not the session default reached by substitution or fallback.
+- **Child-plan entry gate:** inventory each current default's consumer and fallback behavior, select one deletion wedge, and define config precedence and rollback without introducing scorecard-driven routing. For the dispatch-binding wedge, additionally inventory every dispatch reference in bundled skills and classify each as resolvable, qualified-unresolvable, or unbound prose.
 - **Verification:** each promoted wedge removes a source-owned market assumption without reducing task success or overriding explicit user policy. Final zero-literal cleanup is a later deletion decision.
 
 ### I6. Unify generated projection facts without flattening native behavior

--- a/docs/plans/2026-08-16-002-refactor-review-artifact-contract-plan.md
+++ b/docs/plans/2026-08-16-002-refactor-review-artifact-contract-plan.md
@@ -120,7 +120,7 @@ It also shows the limit worth learning from: that plan's enforcement was an AJV 
 
 ## Implementation Units
 
-- [ ] **Unit 1: Correct the ownership record for three shared personas**
+- [x] **Unit 1: Correct the ownership record for three shared personas**
 
 **Goal:** Make it discoverable that `architecture-strategist`, `pattern-recognition-specialist`, and `code-simplicity-reviewer` are dispatched by `ce-compound` and plan-deepening, not `ce:review`.
 
@@ -158,7 +158,7 @@ It also shows the limit worth learning from: that plan's enforcement was an AJV 
 - Reading any of the three agent files reveals which workflow dispatches it.
 - No identifier in any of the five namespaces changed.
 
-- [ ] **Unit 2: Tighten the findings schema and add its regression test**
+- [x] **Unit 2: Tighten the findings schema and add its regression test**
 
 **Goal:** Make the schema express the contract Unit 3 will enforce, and guard it with the executable test `ce:review` never had.
 
@@ -199,7 +199,7 @@ It also shows the limit worth learning from: that plan's enforcement was an AJV 
 - The real schema compiles and representative objects validate.
 - Every schema-expressible bound in R4 is expressed in the schema; the rest is named as Unit 3 validation logic rather than assumed.
 
-- [ ] **Unit 3: Move artifact persistence to the parent orchestrator**
+- [x] **Unit 3: Move artifact persistence to the parent orchestrator**
 
 **Goal:** Make non-conforming artifacts impossible to persist, on every harness, by removing sub-agent disk access from the design entirely.
 
@@ -248,7 +248,7 @@ Concretely:
 - No non-conforming artifact reaches disk.
 - Enforcement is uniform across OpenCode, Pi, and Claude Code, because it no longer depends on a plugin runtime.
 
-- [ ] **Unit 4: Require synthesis artifacts with provenance and disposition**
+- [x] **Unit 4: Require synthesis artifacts with provenance and disposition**
 
 **Goal:** Every run records what was dispatched, who contributed to each merged finding, and what happened to every input finding.
 

--- a/docs/plans/2026-08-16-002-refactor-review-artifact-contract-plan.md
+++ b/docs/plans/2026-08-16-002-refactor-review-artifact-contract-plan.md
@@ -1,0 +1,359 @@
+---
+title: 'refactor: Enforce the review artifact contract'
+type: refactor
+status: active
+date: 2026-08-16
+origin: docs/plans/2026-08-13-001-refactor-bitter-lesson-harness-plan.md
+---
+
+# refactor: Enforce the review artifact contract
+
+## Overview
+
+`ce:review` has run 24 times on this repository since May 2026, writing per-persona artifacts to `.context/systematic/ce-review/<run-id>/` each time. Three independent analyses of that corpus tried to answer whether any review personas duplicate each other enough to merge. None could. Not because the personas are demonstrably distinct, but because the artifacts do not record what would settle it.
+
+This plan moves artifact emission from agent prose into plugin code that validates and rejects, then requires the recording that makes review measurable. It also corrects one categorization error the investigation surfaced.
+
+It merges, renames, moves, and deletes no persona.
+
+## Relationship to I4
+
+**This plan does not satisfy I4's entry gate and does not claim to.**
+
+I4 asks to collapse one redundant persona cluster, and its gate requires paired deletion of that cluster into temporary aliases. This plan collapses nothing and deletes no persona. Reviewers correctly rejected an earlier framing that presented a deleted instruction block as satisfying that gate; deleting a write path is not deleting a persona cluster, and calling it one was scope evasion.
+
+The honest relationship is a dependency, not a substitution. I4's gate also demands seeded defects and a coordination baseline. Three analyses established that the recorded data cannot produce either — 11 of 19 runs have any synthesis artifact, 5 preserve reviewer credit. I4 stays open and blocked, and this is prerequisite work it depends on.
+
+Whether I4 is ever worth doing is a separate question this plan takes no position on. The measurement it enables may well show the collapse is not worth the compatibility cost, which is a legitimate outcome.
+
+## Problem Frame
+
+Two findings and one dead end came out of investigating I4's entry gate.
+
+**The named cluster is not what the initiative assumed.** I4 points at personas differing only by prose framing. The three closest candidates — `architecture-strategist`, `pattern-recognition-specialist`, `code-simplicity-reviewer` — were dispatched by `ce:review` zero times in 24 runs. They appear in neither `skills/ce-review/SKILL.md`'s selection tables nor `skills/ce-review/references/persona-catalog.md`. They were never selectable. Their real consumers are `skills/ce-compound/SKILL.md`, `skills/deepen-plan/SKILL.md`, and `skills/ce-plan/references/deepening-workflow.md`.
+
+**The redundancy question is unanswerable from what was recorded.** A semantic analysis found 59 cross-persona duplicate pairs across 27 defects; an independent validation against review-time merge decisions could not ratify it. Coverage is why: 11 of 19 qualifying runs have any synthesis artifact, and only 5 record which reviewers contributed to a merged finding. One run recorded 22 raw findings and 8 named outcomes, with no disposition for the other 14. The single claim strong enough to act on — that `api-contract` finds nothing another persona also finds — rests on 2 of its 6 findings having ground truth, and one of those two was a shared false positive both personas got wrong.
+
+That last detail is the crux. A duplicate is not a defect. Artifacts recording agreement without recording whether the agreed finding survived validation cannot distinguish convergence on truth from convergence on error.
+
+**The dead end:** the recording cannot be fixed by asking more nicely. Today the skill instructs sub-agents in Markdown to write JSON to a path. Nothing checks what lands. Tightening the instructions produces better-behaved artifacts on average and no guarantee, which is how the current gaps arose — the contract was already documented.
+
+## Requirements Trace
+
+- R1. Ownership of shared personas is discoverable from the persona itself, not inferred from its directory.
+- R2. Artifact writes are validated at the write boundary; non-conforming artifacts are rejected rather than persisted.
+- R3. Every run emits a synthesis artifact recording which personas were dispatched, which contributed to each merged finding, and what disposition every input finding received.
+- R4. Findings carry non-empty, bounded reasoning and evidence, with repo-relative paths, a defined overflow policy, and no environment values.
+- R5. No persona is renamed, moved between categories, merged, or deleted.
+- R6. Every artifact records which harness produced it, so analysis can distinguish runs by the guarantees that applied.
+
+## Scope Boundaries
+
+- No persona collapse. The evidence that would justify one does not exist; this plan is what makes collecting it possible.
+- No identifier changes. Personas reach five namespaces — OpenCode's filename stem, Pi's runtime frontmatter `name`, Pi export's `systematic-<name>.md`, Claude Code's flattened name, and the registry's `agent-<stem>` — with no alias layer spanning them. `src/lib/removed-names.ts` accepts-and-drops stale config values; it maps nothing. R5 exists because violating it turns a documentation fix into a cross-harness migration.
+- No change to persona selection. Adding the three misfiled personas to `ce:review`'s roster would raise dispatch cost with no evidence any review needed them.
+- No retroactive repair of the 24 existing run directories. They are historical records, and analyses citing them must say they predate this contract.
+- No new review personas.
+- No change to `document-review`, which received its equivalent contract fix in PR #679.
+
+### Deferred to Separate Tasks
+
+- Re-running the overlap measurement once decision-grade runs accumulate. This is the question the plan unblocks. The threshold is not a fixed run count — it is enough runs for the per-pair co-occurrence denominators to stop being single-digit, which the prior analysis named as its own largest weakness.
+- Deciding what to do about `api-contract`, the most-contained persona under an unratified measurement.
+- Reconciling the two confidence scales: PR #679 moved `document-review` to integer anchors `0 | 25 | 50 | 75 | 100`, while `ce:review` still uses continuous `0.0-1.0` with a `0.60` gate. The contracts have diverged. Deliberate or drift is a separate question, and converging them exceeds a recording fix. Recorded here so it is a known divergence rather than an unnoticed one.
+- **The `tools:` frontmatter divergence.** `src/lib/agents.ts:30` types `tools` as `Record<string, boolean>`, so the string form every bundled agent uses (`tools: Read, Grep, Glob, Bash`) fails `isToolsMap()` and is discarded — OpenCode applies no restriction. Pi parses the same string as a least-privilege allowlist. One declaration, opposite meanings. This plan routes around it rather than fixing it, but it is a live cross-harness defect deserving its own issue.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `skills/ce-review/SKILL.md` — the artifact contract lives here inline, unlike `document-review` which extracts its synthesis pipeline to a reference. Stage 4 defines what sub-agents write and where, Stage 5 defines merge and dedup and the cross-reviewer agreement boost, Stage 5b the validation pass, Stage 6 report assembly and the run artifact.
+- `skills/ce-review/references/findings-schema.json` — the schema personas are given, with a merge-tier vs detail-tier split; `why_it_matters` and `evidence[]` live on the detail tier.
+- `skills/ce-review/references/subagent-template.md` — the prompt each persona receives, including the artifact write path.
+- `skills/ce-review/references/persona-catalog.md` — the roster the skill treats as authoritative.
+- `src/lib/agent-resolver.ts:151-199` — `OPENCODE_TO_PI_TOOL` and `resolveToolAllowlist`. Pi maps persona `tools:` declarations against a fixed built-in table and throws on anything unrecognized. This is why a custom sub-agent-callable tool cannot exist on Pi, and why review personas declaring `Read, Grep, Glob, Bash` have no write capability there.
+- `src/lib/agents.ts:30,80` — OpenCode types `tools` as `Record<string, boolean>`, so the string form every bundled agent uses fails `isToolsMap()` and is discarded. The same declaration that restricts Pi restricts nothing on OpenCode.
+- `skills/ce-review/SKILL.md:384-395` — the parent already generates the run id and creates the artifact directory, so it is the natural place for persistence.
+- `tests/unit/document-review-findings-schema.test.ts` — compiles `document-review`'s real schema with AJV and validates representative findings. There is no `ce:review` equivalent; `skills/ce-review/references/findings-schema.json` has never been executably validated, which is why its drift went unnoticed. AJV 8.20.0 is a direct dependency.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/qualified-persona-ids-are-canonical-validated-references-2026-07-17.md` — `systematic:<category>:<name>` references are validated against physical files. Do not weaken them to bare names.
+- `docs/solutions/workflow-issues/reconciliation-sync-reference-integrity-20260417.md` — high severity: content updates that miss referenced agent files ship dangling dispatch targets.
+- `docs/solutions/best-practices/content-integrity-has-no-warning-channel-2026-06-06.md` — the gate is binary and fails closed. A check either fails the build or does not exist.
+- `docs/solutions/best-practices/deletion-gates-must-observe-every-field-the-deleted-code-wrote-2026-08-16.md` — a gate observing a subset of what it guards proves less than it claims. Applies directly to schema enforcement here.
+
+### Prior Art In This Repository
+
+[`docs/plans/2026-07-21-001-fix-document-review-findings-contract-plan.md`](2026-07-21-001-fix-document-review-findings-contract-plan.md) (shipped as PR #679 → v3.2.4) fixed the equivalent producer/consumer contract failure for `document-review`. It settles two questions:
+
+- **Producer and consumer ship as one release slice.** No mergeable state may carry a mixed contract, because a reviewer dispatched under the old contract returning to a new consumer is the failure being fixed.
+- **Behavioral verification means dispatching real personas** and validating their returned JSON, not asserting on prose.
+
+It also shows the limit worth learning from: that plan's enforcement was an AJV regression test over the schema document, which proves the schema is valid and not that emitted artifacts conform. `ce:review` has the same gap plus no test at all. This plan closes both, and the write-boundary tool is the part PR #679 did not have.
+
+## Key Technical Decisions
+
+- **Enforce at a boundary, not in prose.** Instructions in a Markdown skill are advisory by construction — the current contract is already documented and the gaps exist anyway. The AJV test is a regression guard on the schema, not the enforcement.
+- **Enforce by deleting the write path, not by guarding it.** A validating tool must be reachable and mandatory; on Pi it is not reachable, and on OpenCode it cannot be made mandatory. Moving persistence to the parent removes the bypass by construction and works identically on all three harnesses, including Claude Code, because it needs no plugin runtime. This is smaller than the tool design it replaces — two Markdown files instead of a TypeScript module and two registration sites.
+- **Bound what evidence may contain.** `evidence[]` holds verbatim excerpts from the reviewed diff, and requiring it means every review persists source text — including from private repositories — to local disk. The model-inheritance eval one week earlier was required to persist structural facts only, with that restriction asserted in a contract test. Review artifacts genuinely need excerpts where that eval did not, so the answer is bounds rather than prohibition: capped length, capped count, repo-relative paths, no environment values.
+- **Fix recording rather than acting on thin evidence.** Acting on `api-contract` at n=2 verified findings would repeat the error that produced the unfalsifiable 1.000 uniqueness result — trusting a measurement whose instrument could not detect what it looked for.
+- **Correct ownership in documentation, not by moving files.** The three personas are correctly implemented and actively used; only their location misleads. Moving them changes their category, which changes overlay keys and reaches all five namespaces.
+- **Distinguish submission from agreement credit.** `20260522` credits `correctness` and `kieran-typescript` on a merged `testing` finding while both recorded zero findings. Under the current contract those are indistinguishable, and any overlap measurement reading it over-counts.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Are the three personas dead code? No. `ce:review` never dispatches them; `ce-compound`, `deepen-plan`, and `ce-plan`'s deepening workflow do.
+- Is the redundancy real? Unproven. The strongest confirmed instance is one six-persona cluster in one run; corpus-wide rates are unratifiable.
+- Can `src/lib/removed-names.ts` carry persona aliases? No.
+- Does removing an agent break existing user config? Yes, loudly — `validateExactAgentOverlays` throws on an unknown `agents.<name>` key. Reinforces R5.
+- Can a validating tool cover all three harnesses? No, and the question is moot. Pi's fixed tool table rejects custom tools at catalog-build time, OpenCode cannot make a tool mandatory, and Claude Code ships static Markdown. Parent-side persistence sidesteps all three.
+- Is `.context/` committed? No — gitignored at `.gitignore:49`, no tracked files. Artifacts are ephemeral local output, invisible to CI unless a job generates them.
+
+### Deferred to Implementation
+
+- Whether a rejected artifact fails the review run or degrades it with the rejection recorded. Failing is stricter; degrading preserves partial results and keeps one malformed persona from destroying a whole review. The choice affects Unit 4's disposition semantics and should be settled in Unit 3.
+- Whether returning the detail tier inline measurably degrades parent context on a full multi-persona run. Unit 3's execution note names the fallback if it does.
+- Whether tightening the schema reveals that the documented contract already disagrees with what Stage 5 consumes. If so, that is the same producer/consumer mismatch class PR #679 fixed and Unit 2 grows.
+
+## Implementation Units
+
+- [ ] **Unit 1: Correct the ownership record for three shared personas**
+
+**Goal:** Make it discoverable that `architecture-strategist`, `pattern-recognition-specialist`, and `code-simplicity-reviewer` are dispatched by `ce-compound` and plan-deepening, not `ce:review`.
+
+**Requirements:** R1, R5
+
+**Dependencies:** None. Independent of Units 2-4 and separately revertable.
+
+**Files:**
+- Modify: `agents/review/architecture-strategist.md`
+- Modify: `agents/review/pattern-recognition-specialist.md`
+- Modify: `agents/review/code-simplicity-reviewer.md`
+- Modify: `skills/ce-review/references/persona-catalog.md`
+- Regenerate: `registry/registry.jsonc` — generated output that embeds agent `description` verbatim (`registry/registry.jsonc:43`), so any frontmatter description edit drifts it. Run `bun scripts/generate-registry.ts`.
+- Regenerate: `tests/fixtures/pi-subagents-personas/systematic-{architecture-strategist,code-simplicity-reviewer,pattern-recognition-specialist}.md` and `systematic-personas-manifest.json` — all three personas are in `CURATED_PERSONAS` (`src/lib/pi-subagents-personas.ts:102,112,137`), so the committed Pi-export fixtures embed their descriptions and a source-side drift gate in `tests/unit/generate-pi-subagents-personas.test.ts` fails otherwise. Run `bun scripts/generate-pi-subagents-personas.ts`.
+
+**Blast-radius note:** editing one bundled agent's `description` touches three generated surfaces. The plan's original four-file list was wrong twice over; both gaps were caught by drift gates rather than by planning, which is the gates working as intended.
+
+**Approach:**
+- State each persona's consuming workflow in its own description so the fact travels with the agent to every harness rather than living only in a catalog.
+- Record in the persona catalog that `agents/review/` is a shared pool rather than `ce:review`'s roster. Frame this as establishing directory semantics that were never defined, not as correcting a misfiling — no document ever claimed the directory implied ownership, and the ambiguity is the actual defect.
+- Preserve every identifier exactly. No file moves, no frontmatter `name` changes, no category changes.
+
+**Patterns to follow:**
+- Existing `agents/review/` frontmatter conventions — description phrasing that names the triggering condition.
+- Qualified `systematic:review:<name>` reference form.
+
+**Test scenarios:**
+- Happy path: `bun run scripts/content-integrity.ts` reports clean with no phantom references.
+- Edge case: the three agents still appear in emitted OpenCode config under unchanged keys.
+- Edge case: after regenerating, the `registry/registry.jsonc` diff contains only `description` lines — no component `name`, `files`, or dependency entries change. That is the proof no identifier moved. `registry:drift` alone proves only that generated output is fresh, which is a different property.
+- Edge case: `bun scripts/generate-pi-subagents-personas.ts --check` passes, and the regenerated fixture diff changes only description text and the manifest's content hashes — no generated filename changes, which would signal an identifier moved in the Pi export namespace.
+- Integration: `bun test tests/unit` passes with unchanged agent-discovery counts.
+
+**Verification:**
+- Reading any of the three agent files reveals which workflow dispatches it.
+- No identifier in any of the five namespaces changed.
+
+- [ ] **Unit 2: Tighten the findings schema and add its regression test**
+
+**Goal:** Make the schema express the contract Unit 3 will enforce, and guard it with the executable test `ce:review` never had.
+
+**Requirements:** R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `skills/ce-review/references/findings-schema.json`
+- Modify: `skills/ce-review/references/subagent-template.md`
+- Create/Test: `tests/unit/ce-review-findings-schema.test.ts`
+
+**Approach:**
+- Require non-empty `why_it_matters` and `evidence[]` on detail-tier findings.
+- Bound evidence: cap entry count and per-entry length in the schema, and require repo-relative paths. Define an explicit overflow policy — a finding whose evidence exceeds the cap splits into multiple entries or records a bounded excerpt plus an overflow marker. Never silently truncate: truncation preserves the appearance of complete evidence while corrupting the trail the measurement depends on.
+- Absolute-path rejection is schema-expressible; "no environment values" is not, since JSON Schema cannot infer a string's origin. Implement that as detection logic in Unit 3's validation step and describe it there, not as a schema constraint the schema cannot enforce.
+- Bounds limit size and shape, not sensitivity. A compliant `evidence[]` entry can still contain a secret quoted from the diff. The plan accepts verbatim excerpts as necessary for review to function and does not claim they are scrubbed.
+- Require `file` and `line` on findings naming a location, including from personas currently reporting in prose.
+- Add fields for the provenance and disposition Units 3 and 4 record, so the schema is ready before the tool enforces it.
+- Compile the real schema with AJV and validate representative objects, mirroring `tests/unit/document-review-findings-schema.test.ts`. Validate data, not schema descriptions or guidance prose.
+- Keep canonical values owned by the JSON Schema. No TypeScript findings model, no second contract representation.
+
+**Execution note:** Test-first for the executable contract, per PR #679 — add failing AJV cases before tightening the schema. Characterization-first for deciding what to tighten: the 24 existing runs show real drift, and enforcement should be shaped by what artifacts contain rather than what the schema already claims.
+
+**Patterns to follow:**
+- `tests/unit/document-review-findings-schema.test.ts` — compile the real schema, use representative object fixtures, assert nothing about Markdown or file contents.
+
+**Test scenarios:**
+- Happy path: a well-formed finding with populated bounded reasoning and evidence validates.
+- Edge case: empty `why_it_matters` is rejected.
+- Edge case: empty `evidence[]` is rejected.
+- Edge case: evidence exceeding the length or count cap is rejected.
+- Edge case: an absolute path in `file` is rejected; the repo-relative equivalent validates.
+- Edge case: a finding naming a location without `line` is rejected.
+- Error path: validation failure names the offending field.
+
+**Verification:**
+- The real schema compiles and representative objects validate.
+- Every schema-expressible bound in R4 is expressed in the schema; the rest is named as Unit 3 validation logic rather than assumed.
+
+- [ ] **Unit 3: Move artifact persistence to the parent orchestrator**
+
+**Goal:** Make non-conforming artifacts impossible to persist, on every harness, by removing sub-agent disk access from the design entirely.
+
+**Requirements:** R2, R4
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `skills/ce-review/SKILL.md` (Stage 4 dispatch and return contract)
+- Modify: `skills/ce-review/references/subagent-template.md` (output contract)
+
+**Approach:**
+
+Sub-agents stop writing files. They return the detail tier alongside the merge tier, and the parent validates and writes once. This is the plan's narrowing slice: an entire write path is deleted rather than guarded.
+
+The design follows from what the current one cannot do:
+
+- **A sub-agent-callable validating tool cannot work.** On Pi, `resolveToolAllowlist` (`src/lib/agent-resolver.ts:174-199`) maps persona `tools:` declarations against a fixed built-in table and throws `UnknownDeclaredToolError` on anything unrecognized, so a custom tool fails at catalog-build time. On OpenCode, a registered tool cannot be made mandatory — nothing prevents a sub-agent from writing directly instead.
+- **Sub-agent writes are already broken on Pi.** All 18 review personas declare `tools: Read, Grep, Glob, Bash`. Pi parses that into `['read', 'grep', 'find', 'bash']` — no write capability — while the subagent template instructs them to write an artifact and calls it "the ONE write operation you are permitted to make." Pi review runs have never been able to produce artifacts.
+- **The parent already has what it needs.** It generates the run id, creates the directory (`skills/ce-review/SKILL.md:390`), and receives every persona's return. Moving persistence there requires no new tool, no registration, and no harness-specific code.
+
+Concretely:
+- Delete the artifact-write instruction and file path from the subagent template's output contract. Sub-agents return one JSON payload containing both tiers.
+- Have the parent validate each return against the Unit 2 schema before writing, rejecting non-conforming payloads with a message naming the persona and field, and never echoing the offending value.
+- Record the harness that produced the run in the synthesis artifact, so later analysis can tell which guarantees applied.
+- Keep `mode:report-only` exempt — no run id, no directory, no write.
+
+**Execution note:** Returning the detail tier increases parent context per persona, which the current split was designed to avoid. Verify against a real multi-persona run that this does not degrade synthesis; if it does, the fallback is parent-side writes driven by a second targeted request per persona rather than restoring sub-agent disk access.
+
+**Patterns to follow:**
+- Stage 4's existing dispatch and compact-return contract, extended rather than replaced.
+- `mode:report-only`'s no-write contract, which already proves the parent can run the pipeline without any artifact write.
+
+**Test scenarios:**
+- Happy path: a conforming return is validated and persisted by the parent.
+- Edge case: a return with empty `evidence[]` is rejected and nothing is written for that persona.
+- Edge case: a return with an absolute path in `file` is rejected and nothing is written.
+- Edge case: evidence exceeding bounds triggers the Unit 2 overflow policy rather than silent truncation.
+- Edge case: a malformed payload that is not valid JSON is rejected without partial write.
+- Edge case: a rejected persona is recorded in the synthesis artifact as a dispatch outcome, not silently dropped.
+- Error path: rejection names the persona and failing field and omits the offending value.
+- Error path: `mode:report-only` writes nothing.
+
+**Verification:**
+- No sub-agent writes to `.context/` on any harness.
+- No non-conforming artifact reaches disk.
+- Enforcement is uniform across OpenCode, Pi, and Claude Code, because it no longer depends on a plugin runtime.
+
+- [ ] **Unit 4: Require synthesis artifacts with provenance and disposition**
+
+**Goal:** Every run records what was dispatched, who contributed to each merged finding, and what happened to every input finding.
+
+**Requirements:** R3, R6
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `skills/ce-review/SKILL.md` (Stages 5, 5b, 6)
+- Modify: `skills/ce-review/references/review-output-template.md`
+
+**Approach:**
+- Make the synthesis artifact unconditional. A zero-finding run is a data point; its absence is ambiguous between "clean" and "never ran." Keep `mode:report-only` exempt — its no-write contract is deliberate and other workflows depend on it.
+- Record dispatch outcome per persona: returned with findings, returned empty, returned malformed, or never returned. `20260714`'s summary records `malformed_returns` incidentally; make it contractual.
+- Record contributing personas on every merged finding, distinguishing independent submission from agreement credit. Preserve the dedup fingerprint that produced each merge so a later analysis can tell a fingerprint match from a judgment call.
+- Reconcile inputs against outputs: every finding is surviving, merged, suppressed, filtered, or rejected, with a reason. Record rejection reasons as stated rather than bucketed — validation observed at least six distinct causes, and the difference between "premise disproven" and "team declined on scope" is the difference between a wrong persona and a correct one.
+- Record runs that end abnormally. Every count in this plan's evidence came from runs that successfully wrote artifacts; crashed and interrupted runs are missing by construction, and any future rate computed without them repeats that bias.
+- Record the harness that produced the run (R6), since sub-agent write capability and tool semantics differ across the three.
+
+**Patterns to follow:**
+- `.context/systematic/ce-review/20260729-060016-e24c854b/merged-findings.json` — the most complete existing artifact and the closest target shape.
+- `.context/systematic/ce-review/20260528-233035-5e3b4743/run-summary.md` — records a rejection with its actual reasoning rather than a category.
+- Stage 5's cross-reviewer agreement rule, which already computes the submission-vs-agreement distinction internally and discards it.
+
+**Test scenarios:**
+- Happy path: a run producing findings writes a synthesis artifact listing dispatched personas and surviving findings.
+- Happy path: two personas independently submitting the same finding produce one merged entry crediting both as submitters.
+- Edge case: a persona credited only via the agreement boost is recorded as agreement, not submission.
+- Edge case: a persona submitting zero findings never appears as a submitter.
+- Edge case: a run where every persona returns empty still writes an artifact recording that.
+- Edge case: input finding count reconciles exactly against recorded dispositions.
+- Edge case: a finding suppressed below the 0.60 gate records its confidence; a P0 retained at 0.50+ records as surviving.
+- Error path: `mode:report-only` writes nothing, unchanged.
+
+**Verification:**
+- Per-persona submission counts are derivable from the synthesis artifact alone.
+- Agreement credit can never be mistaken for an independent finding.
+- Input findings reconcile exactly against recorded dispositions.
+
+## Release Slicing
+
+Units 2, 3, and 4 change the producer contract, the write path, and the consumer together. They ship as **one release slice** — no mergeable state may carry a mixed contract, because a persona dispatched under the old contract returning to a new consumer is precisely the failure being fixed. A temporary failing state during local work is expected.
+
+Unit 1 is documentation-only, shares no file with the others, and may ship separately or alongside.
+
+## Behavioral Verification
+
+Schema tests prove the contract is expressible; the tool proves conforming writes are enforceable. Neither proves personas produce useful output or that synthesis consumes it. After Units 2-4 converge:
+
+- Dispatch a real multi-persona `ce:review` against a diff that elicits findings from several personas, including at least one defect two would both surface.
+- Confirm the synthesis artifact exists, records dispatch outcome per persona, credits submitters distinctly from agreement, and reconciles every input finding to a disposition.
+- Deliberately emit one non-conforming artifact and confirm the tool rejects it without writing.
+- Confirm `mode:report-only` still writes nothing.
+- Confirm Pi registration works, and that Claude Code's documented limitation matches its actual behavior.
+- Run existing unit and integration suites as regression checks. Add no assertions about Markdown, file contents, or generated text.
+
+## System-Wide Impact
+
+- **Interaction graph:** `ce:review` is invoked directly and by `ce:work`'s shipping workflow; contract changes affect both. `ce-compound`, `deepen-plan`, and `ce-plan` dispatch the Unit 1 personas but consume no review artifacts.
+- **Error propagation:** Unit 3 introduces a rejection path where none existed. It must name the persona and field, or it converts a silent data gap into an opaque failure.
+- **State lifecycle risks:** Artifacts accumulate under `.context/systematic/ce-review/`, gitignored at `.gitignore:49` with no tracked files — ephemeral local output, never committed, invisible to CI unless a job generates them. The duplicate-timestamp directory pair from July 6 suggests run-id collision is possible and worth handling in Unit 4.
+- **API surface parity:** New tool registration on two harnesses. `src/index.ts` must continue to export only `default`.
+- **Cost:** Every review gains parent-side validation and larger sub-agent returns. That is real overhead in the hot path of a workflow users run often, accepted because the alternative is continuing to record data that cannot answer questions asked of it. If the measurement question is abandoned, this overhead should be revisited rather than kept by inertia.
+- **Who benefits:** This is maintainer-first instrumentation. The direct beneficiary is whoever analyzes review behavior, which today means this repository's maintainers. The user-facing effects are indirect and worth stating plainly rather than inflating: Pi users gain artifacts that currently cannot be written at all, and all users gain a synthesis record explaining why a finding did not reach their report. The larger payoff is downstream and speculative — a review workflow whose personas can be justified by evidence rather than retained by default.
+- **Unchanged invariants:** Persona identifiers across all five namespaces, agent frontmatter contracts, the model-free bundled-markdown rule, config precedence and trust boundaries, and `mode:report-only`'s no-write guarantee.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Rejection breaks reviews mid-run | Unit 3's deferred question decides fail-vs-degrade before implementation. Characterization against the 24 existing runs shapes what is rejected, so the bar matches real output rather than an aspirational schema. |
+| Producer and consumer ship out of step | Units 2-4 land as one release slice, per PR #679. |
+| Claude Code silently lacks enforcement | Stated in the skill where a Claude Code reader will see it, and recorded as deferred work rather than implied parity. |
+| Evidence bounds are too tight and personas lose the ability to justify findings | Bounds are schema-expressed and adjustable; behavioral verification uses a real multi-persona run to check that findings remain justifiable under them. |
+| The unblocked question is never revisited | Recorded in Deferred with a concrete signal — co-occurrence denominators leaving single digits — rather than a run count that would be arbitrary. |
+| Scope creeps into persona collapse | R5 forbids identifier changes, and Scope Boundaries names the five-namespace consequence. |
+
+## Terminology
+
+One canonical term per outcome, to keep implementation and test names aligned:
+
+| Term | Meaning |
+|---|---|
+| **Dispatch outcome** | What a persona returned: findings, empty, malformed, or never returned |
+| **Disposition** | What happened to an input finding: surviving, merged, suppressed, filtered, or rejected |
+| **Suppressed** | Dropped by the confidence gate |
+| **Filtered** | Dropped by the Stage 5b validation pass |
+| **Rejected** | Refused at the write boundary for contract violation |
+
+"Disposition" is the umbrella term; suppressed, filtered, and rejected are its subcases.
+
+## Documentation / Operational Notes
+
+- The three personas in Unit 1 keep their names, categories, files, and dispatch behavior. Only documented ownership changes.
+- Conventional type at merge: this touches `skills/`, `agents/`, and `src/`, and adds a user-visible tool. `refactor` publishes nothing in this repository (see `docs/solutions/workflow-issues/pr-title-selects-release-type-under-squash-merge-2026-08-16.md`); a releasing type is required for the tool to reach users.
+- Existing run directories are untouched, and analyses citing them must state that they predate this contract.
+- Artifacts have no retention policy today and 24 runs have accumulated since May. This plan does not add one, and that is a deliberate deferral rather than an oversight: verbatim excerpts from private repositories accumulating indefinitely on local disk is a data-minimization gap worth its own decision.
+- Unit 1 is documentation-only and should ship independently by default, ahead of the contract slice.
+
+## Sources & References
+
+- **Origin document:** [`docs/plans/2026-08-13-001-refactor-bitter-lesson-harness-plan.md`](2026-08-13-001-refactor-bitter-lesson-harness-plan.md) — Phase 1 "Measure and expose"; initiative I4 stays blocked on this work
+- Direct precedent: [`docs/plans/2026-07-21-001-fix-document-review-findings-contract-plan.md`](2026-07-21-001-fix-document-review-findings-contract-plan.md) — the same contract fix for `document-review`, shipped as PR #679 → v3.2.4
+- Prior wedge: [`docs/plans/2026-08-16-001-refactor-retire-source-model-defaults-plan.md`](2026-08-16-001-refactor-retire-source-model-defaults-plan.md) — merged as PR #790
+- Evidence corpus: `.context/systematic/ce-review/` — 24 runs, 2026-05-10 through 2026-08-16
+- Contract surface: `skills/ce-review/SKILL.md` (Stages 4-6) and `skills/ce-review/references/`
+- Tool-registration precedent: `src/lib/skill-tool.ts`, `src/index.ts`, `src/pi.ts`
+- Executable-contract seam to mirror: `tests/unit/document-review-findings-schema.test.ts`

--- a/docs/solutions/best-practices/a-perfect-measurement-means-a-broken-instrument-2026-08-16.md
+++ b/docs/solutions/best-practices/a-perfect-measurement-means-a-broken-instrument-2026-08-16.md
@@ -1,0 +1,103 @@
+---
+title: A perfect measurement is evidence about the instrument, not the system
+date: 2026-08-16
+category: best-practices
+module: measurement
+problem_type: best_practice
+component: testing_framework
+severity: high
+applies_when:
+  - "A metric reports zero collisions, zero duplicates, or perfect separation over a large sample"
+  - "Similarity or identity is inferred from normalized strings, hashes, or buckets"
+  - "The phenomenon measured is semantic, behavioral, or human-generated"
+  - "A result would justify removing a safeguard or declaring a system already clean"
+tags:
+  - measurement
+  - evidence
+  - ground-truth
+  - instrument-validation
+  - analysis
+---
+
+# A perfect measurement is evidence about the instrument, not the system
+
+## Context
+
+The question was whether any code-review personas overlapped enough to merge. An analysis across 238 recorded findings from 24 runs returned a unique-contribution fraction of exactly **1.000** for all eleven personas. Zero cross-persona duplicates. A flawless result.
+
+The fingerprint was:
+
+```text
+normalize(file) + line_bucket(line, ±3) + normalize(title)
+```
+
+Two reviewers describing the same defect in different words produce different titles, so they produce different fingerprints. The instrument could not detect the thing it was built to measure, and reported the resulting absence as a finding.
+
+A semantic re-analysis found 59 same-issue pairs across 27 distinct defects — roughly 15% finding-level redundancy where the first pass had reported none.
+
+That was not the end. An independent validation against review-time merge artifacts found the semantic numbers unratifiable: only 11 of 19 qualifying runs had a synthesis artifact at all, and only 5 recorded which reviewers contributed to a merged finding. It also caught a specific inflation — one run credited two personas on a merged finding when both had submitted zero findings of their own. Agreement credit and independent submission were indistinguishable in the record.
+
+Three passes, three answers: *no overlap*, *15% overlap*, *unanswerable*. Only the third was true, and it was a statement about the data rather than about the personas.
+
+## Guidance
+
+**Treat a perfect result over a large sample as a defect report against the instrument.** Real systems with 238 human-authored artifacts do not produce exactly 1.000. When they appear to, the first hypothesis is that the measurement is blind, not that the system is immaculate.
+
+**Ask what the instrument structurally cannot see, before reading its output.** This is answerable from the measurement function alone and costs nothing:
+
+| Instrument | Can detect | Cannot detect |
+|---|---|---|
+| Normalized string match | Identical phrasing | The same defect described differently |
+| Line bucket ±3 | Nearby locations | The same defect reported at its cause and its symptom |
+| Exact ID match | Recorded identity | Anything the recorder failed to record |
+
+**Validate against independent ground truth before acting.** Ground truth must come from a different source than the measurement. Re-running the same analysis more carefully is not validation; it lets the instrument grade its own output. When validating an earlier analysis, use a fresh session or a different method entirely.
+
+**Accept "unanswerable" as a real result.** It is more useful than a confident wrong number, and it identifies what to fix. Here the answer was a data-collection gap — missing synthesis artifacts, missing reviewer credit — so no further analysis of that corpus could have helped. Recognizing that stopped a planned 500–800-run seeded-defect study that would have measured the wrong thing at significant cost.
+
+## Why This Matters
+
+The failure mode is not a wrong number, it is a *clean* number. A noisy or implausible result invites scrutiny. A perfect one invites action, and it arrives looking like good news.
+
+The stakes scale with what the measurement authorizes. This one was being used to decide whether to delete review personas. Acting on the first pass would have concluded all eleven were uniquely valuable; acting on the second would have merged personas on evidence that could not be ratified. Both are worse than knowing the corpus could not answer the question.
+
+## When to Apply
+
+- A metric returns exactly 0 or exactly 1.0 across a large sample.
+- Identity or similarity is approximated by string, hash, or bucket comparison.
+- The measured phenomenon involves human or model-generated language.
+- Ground truth is partial, missing, or produced by the same pipeline as the measurement.
+- The result would justify a deletion, a merge, or removing a safeguard.
+
+## Examples
+
+**Overclaiming:**
+
+```text
+All 238 findings were unique. No personas overlap.
+```
+
+**Defensible:**
+
+```text
+Lexical fingerprinting found no file/bucket/title collisions across 238 findings.
+That instrument cannot detect paraphrase, so it does not measure semantic overlap.
+Semantic re-analysis found 59 same-issue pairs, but only 11 of 19 runs have a
+synthesis artifact and 5 record reviewer credit, so persona-level overlap is
+unratifiable against ground truth.
+```
+
+**Guarding against agreement inflation.** Where a merge process credits reviewers for concurring, keep the two facts apart in the record:
+
+```text
+submitters:        personas that independently reported this finding
+agreement_credit:  personas credited by the agreement rule without reporting it
+```
+
+Collapsing them makes every subsequent overlap measurement over-count, and the error is invisible in the artifact.
+
+## Related
+
+- [`docs/solutions/workflow-issues/version-pinned-evidence-must-be-reproven-2026-08-16.md`](../workflow-issues/version-pinned-evidence-must-be-reproven-2026-08-16.md) — evidence valid under one pinned runtime is not evidence under another.
+- [`docs/solutions/best-practices/comments-and-commit-messages-are-claims-not-evidence-2026-08-16.md`](comments-and-commit-messages-are-claims-not-evidence-2026-08-16.md) — a written claim is not evidence about the code.
+- [`docs/solutions/best-practices/deletion-gates-must-observe-every-field-the-deleted-code-wrote-2026-08-16.md`](deletion-gates-must-observe-every-field-the-deleted-code-wrote-2026-08-16.md) — a gate blind to a field cannot prove that field is safe to delete.

--- a/docs/solutions/best-practices/schemas-need-adversarial-probes-not-just-compilation-2026-08-16.md
+++ b/docs/solutions/best-practices/schemas-need-adversarial-probes-not-just-compilation-2026-08-16.md
@@ -1,0 +1,135 @@
+---
+title: Compiling the real schema proves it parses, not that it rejects
+date: 2026-08-16
+category: best-practices
+module: contract-validation
+problem_type: best_practice
+component: testing_framework
+severity: high
+applies_when:
+  - "A schema is treated as the write boundary for untrusted or agent-generated data"
+  - "A contract claims bounds on size, path shape, or collection length"
+  - "Required fields and enums are tested but unknown-field behavior is not"
+  - "A document asserts a guarantee the schema is supposed to enforce"
+root_cause: missing_validation
+tags:
+  - json-schema
+  - ajv
+  - contract-testing
+  - adversarial-testing
+  - validation
+  - agent-output
+---
+
+# Compiling the real schema proves it parses, not that it rejects
+
+## Context
+
+A findings schema was written as the enforcement point for untrusted sub-agent output. It had required fields, enums, confidence ranges, a repo-relative path pattern, and explicit bounds on evidence entries. It was covered by a test that compiled the shipped file with AJV and validated representative objects. Every gate passed.
+
+A single adversarial probe showed the enforcement was mostly imaginary:
+
+```js
+import Ajv from 'ajv'
+import fs from 'node:fs'
+
+const schema = JSON.parse(fs.readFileSync('path/to/schema.json', 'utf8'))
+const validate = new Ajv({ strict: false }).compile(schema)
+
+console.log('valid:', validate({
+  reviewer: 'probe',
+  findings: [{
+    title: 't', severity: 'P2', file: 'src/a.ts', line: 1,
+    why_it_matters: 'X'.repeat(50000),
+    confidence: 0.9,
+    evidence: ['/Users/someone/secret/absolute/path.ts'],
+    autofix_class: 'manual', owner: 'human',
+    requires_verification: false, pre_existing: false,
+    EXTRA_INJECTED_FIELD: 'survives',
+  }],
+  residual_risks: Array(10000).fill('r'),
+  testing_gaps: [],
+  ROGUE_TOP_LEVEL: 'survives',
+}))
+```
+
+Output: `valid: true`, no errors. Four distinct violations accepted at once.
+
+The causes were all omissions rather than mistakes. No `additionalProperties: false` on the payload or finding objects, so injected fields passed through. `maxLength` on three strings out of many, so a 50,000-character field was in bounds. No `maxItems` anywhere, so a 10,000-entry array was fine. The repo-relative path pattern applied to `file` alone, so an absolute path travelled inside `evidence[]` untouched.
+
+## Guidance
+
+**Probe the schema with input that should fail.** Compiling the real schema and validating a good fixture proves the schema parses and accepts valid data. It cannot detect a constraint that was never written. Only a payload designed to violate the contract can.
+
+Write the probe from the *claims*, not from the schema. Read what the surrounding documentation promises — bounded evidence, repo-relative paths, no unknown fields — and construct one payload violating each. If the schema accepts it, the claim is false no matter how strict the schema looks.
+
+**Assert which constraint rejected, not merely that validation failed.** A test asserting `valid === false` passes for the wrong reason as easily as the right one.
+
+```ts
+expect(validate(payloadWithUnknownField())).toBe(false)
+expect(validate.errors?.some((e) => e.keyword === 'additionalProperties')).toBe(true)
+```
+
+This caught a real error while fixing the schema above: an early probe rejected its own baseline case because it referenced the wrong schema definition. A bare `toBe(false)` would have reported success.
+
+**Pin the accepting boundary too.** Bounds derived from observed maxima have no headroom by construction. If the cap is 5 entries and 500 characters, assert that exactly 5 and exactly 500 are accepted, not only that 6 and 501 are rejected.
+
+**Separate the shapes that have different authority.** If a producer must not set a field and a consumer must, one schema cannot express both. Split it:
+
+```text
+subAgentReturn  — forbids harness, dispatch_outcome, disposition
+parentRecord    — requires harness and dispatch_outcome
+```
+
+Sharing one permissive schema across both directions means a producer can forge provenance and a persisted record can omit it, with neither caught.
+
+## Why This Matters
+
+A schema that looks strict is worse than an obviously absent one, because it stops people looking. The surrounding documentation asserted "artifact writes are validated at the write boundary; non-conforming artifacts are rejected," and that sentence was false while every test was green.
+
+The failure is asymmetric. Missing constraints never announce themselves — they cause acceptance, and acceptance is indistinguishable from correctness until something malformed reaches disk.
+
+## When to Apply
+
+- The schema is a trust boundary for output from an agent, plugin, or external service.
+- Prose anywhere claims the schema enforces something. Every such claim is a probe case.
+- A contract is being tightened. The change is only real if a previously accepted payload is now rejected.
+- Bounds are derived from a corpus. Observed maxima leave no headroom, so both sides need pinning.
+
+## Examples
+
+**Insufficient:**
+
+```ts
+const validate = new Ajv({ strict: false }).compile(realSchema)
+expect(validate(validFixture())).toBe(true)
+expect(validate(missingRequiredField())).toBe(false)
+```
+
+Proves the schema parses and that `required` works. Says nothing about bounds, unknown fields, or path shape.
+
+**Sufficient:**
+
+```ts
+// Accepting boundaries — pinned so a later edit cannot silently tighten them
+expect(validate(withEvidenceCount(5))).toBe(true)
+expect(validate(withEvidenceLength(500))).toBe(true)
+
+// Each claimed constraint, asserted by the keyword that enforces it
+for (const [payload, keyword] of [
+  [withUnknownTopLevelField(), 'additionalProperties'],
+  [withUnknownFindingField(), 'additionalProperties'],
+  [withOversizedString(), 'maxLength'],
+  [withEvidenceCount(6), 'maxItems'],
+  [withAbsolutePathInEvidence(), 'pattern'],
+] as const) {
+  expect(validate(payload)).toBe(false)
+  expect(validate.errors?.some((e) => e.keyword === keyword)).toBe(true)
+}
+```
+
+## Related
+
+- [`docs/solutions/best-practices/behavior-first-ajv-contract-verification-2026-07-21.md`](behavior-first-ajv-contract-verification-2026-07-21.md) — compile the real schema and test emitted objects at the producer/consumer boundary. This doc is the next step: necessary, but insufficient on its own.
+- [`docs/solutions/best-practices/comments-and-commit-messages-are-claims-not-evidence-2026-08-16.md`](comments-and-commit-messages-are-claims-not-evidence-2026-08-16.md) — the same shape one layer up: a written assertion that the code contradicts.
+- [`docs/solutions/best-practices/deletion-gates-must-observe-every-field-the-deleted-code-wrote-2026-08-16.md`](deletion-gates-must-observe-every-field-the-deleted-code-wrote-2026-08-16.md) — a gate that observes fewer fields than the contract covers.

--- a/docs/solutions/integration-issues/availability-guards-must-check-executability-2026-08-16.md
+++ b/docs/solutions/integration-issues/availability-guards-must-check-executability-2026-08-16.md
@@ -1,0 +1,104 @@
+---
+title: Availability guards must check executability, not PATH presence
+date: 2026-08-16
+category: integration-issues
+module: integration-test-harness
+problem_type: integration_issue
+component: testing_framework
+severity: high
+symptoms:
+  - "`which opencode` succeeds while `opencode --version` fails"
+  - "Real-host integration tests execute instead of skipping"
+  - "`bun test` hangs with no error explaining why"
+root_cause: missing_validation
+resolution_type: test_fix
+related_components:
+  - mise
+  - opencode
+tags:
+  - integration-tests
+  - skip-guard
+  - shims
+  - mise
+  - availability-check
+---
+
+# Availability guards must check executability, not PATH presence
+
+## Problem
+
+The OpenCode integration-test guard checks only that the command exists on `PATH`. A version manager can place a shim there that fails on every invocation, so the guard passes and the tests run against a runtime that cannot start.
+
+## Symptoms
+
+```console
+$ which opencode
+/Users/<user>/.local/share/mise/shims/opencode
+
+$ opencode --version
+mise ERROR No version is set for shim: opencode
+```
+
+The guard sees success from the first command and never runs the second:
+
+```ts
+export const OPENCODE_AVAILABLE = (() => {
+  const result = Bun.spawnSync(['which', 'opencode'])
+  return result.exitCode === 0
+})()
+```
+
+`tests/integration/fixtures/receipt-workflow-host.ts:7-10`
+
+Result: `bun test` starts the real-host receipt and eval-runner suites, which wait on a host that will never come up. There is no failure message — the run simply stops making progress, and the whole suite becomes unusable locally.
+
+## What Didn't Work
+
+**Reading the hang as a test bug.** The natural first assumption is that a recently changed test introduced the stall. It had not; the environment had.
+
+**Assuming a skip guard implies a skip.** The guard's existence made "these tests skip when OpenCode is absent" feel guaranteed. The guard was real, its check was just too shallow to fire.
+
+**Grouping suites by name.** `eval-runner.test.ts` reads like a unit-adjacent suite but spawns hosts the same way the receipt suites do. Splitting "host-independent" tests by intuition still included it, and the run hung again.
+
+## Solution
+
+Probe the executable rather than the path:
+
+```ts
+export const OPENCODE_AVAILABLE = (() => {
+  const result = Bun.spawnSync(['opencode', '--version'])
+  return result.exitCode === 0
+})()
+```
+
+Retaining the failure reason makes the skip self-explanatory:
+
+```ts
+export const OPENCODE_AVAILABILITY = (() => {
+  const result = Bun.spawnSync(['opencode', '--version'])
+  return {
+    available: result.exitCode === 0,
+    detail: result.stderr.toString().trim(),
+  }
+})()
+```
+
+Gate on `available`, and put `detail` in the skip message so the next person sees `No version is set for shim: opencode` instead of an unexplained skip.
+
+## Why This Works
+
+`which` answers "does a file exist at this name." It says nothing about whether the file runs. A shim is a file that exists precisely so it can decide later whether it works.
+
+`--version` exercises path lookup, shim resolution, runtime selection, and process startup, while staying cheap and side-effect-free. Do not use a real workload such as `opencode run` as the probe — that reintroduces the hang the guard exists to prevent.
+
+## Prevention
+
+- Guard optional real-host suites on a successful trivial invocation, never on `which` or `command -v` alone.
+- Include captured stderr in the skip message. A silent skip and a silent hang look identical from the outside.
+- Suspect the environment when a suite hangs without output, especially after installing or switching a version manager. Verify with `<tool> --version` before investigating test code.
+- Do not classify suites as host-independent by filename. Check what they actually spawn.
+
+## Related
+
+- [`docs/solutions/best-practices/pi-real-runtime-integration-harness-2026-07-16.md`](../best-practices/pi-real-runtime-integration-harness-2026-07-16.md) — skip-guard discipline for optional runtimes, and when a missing dependency should hard-fail instead.
+- [`docs/solutions/integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md`](isolated-opencode-subprocess-fixtures-2026-05-14.md) — isolating real-host subprocess fixtures.

--- a/docs/solutions/integration-issues/cross-harness-tools-frontmatter-divergence-2026-08-16.md
+++ b/docs/solutions/integration-issues/cross-harness-tools-frontmatter-divergence-2026-08-16.md
@@ -1,0 +1,89 @@
+---
+title: The same tools frontmatter is permissive on OpenCode and restrictive on Pi
+date: 2026-08-16
+category: integration-issues
+module: agent-resolution
+problem_type: integration_issue
+component: tooling
+severity: high
+symptoms:
+  - "Bundled agents declaring `tools:` receive no tool restriction on OpenCode"
+  - "The same agents cannot write files on Pi"
+  - "A skill instruction to write an artifact is unsatisfiable on one harness but succeeds on the other"
+root_cause: wrong_api
+resolution_type: workflow_improvement
+related_components:
+  - opencode
+  - pi
+tags:
+  - cross-harness
+  - tool-permissions
+  - agent-frontmatter
+  - agent-resolver
+  - least-privilege
+---
+
+# The same tools frontmatter is permissive on OpenCode and restrictive on Pi
+
+## Problem
+
+Bundled agents declare tools as a comma-separated string:
+
+```yaml
+tools: Read, Grep, Glob, Bash
+```
+
+OpenCode and Pi parse that identical line into opposite outcomes. OpenCode discards it and applies no restriction. Pi reads it as a least-privilege allowlist. One declaration, two contradictory meanings, no error on either side.
+
+## Symptoms
+
+- `src/lib/agents.ts:30` types `tools` as `Record<string, boolean>`.
+- `isToolsMap()` rejects any non-object value, so the string form fails the guard and `src/lib/agents.ts:80` assigns `undefined`. An undefined `tools` means no restriction.
+- `src/lib/agent-resolver.ts:151-158` maps `Read`, `Grep`, `Glob`, and `Bash` to Pi's `read`, `grep`, `find`, and `bash`.
+- `resolveToolAllowlist` fails closed on anything unrecognized (`src/lib/agent-resolver.ts:174-199`).
+
+Every persona under `agents/review/` declares the string form. All of them are unrestricted on OpenCode and write-incapable on Pi.
+
+## What Didn't Work
+
+Two designs died on this before the cause was understood.
+
+**Trusting the declaration as written.** The frontmatter reads like a least-privilege grant, so it was assumed to be enforced everywhere. On OpenCode it enforces nothing, and nothing surfaces that.
+
+**Adding a validating tool for sub-agents to call.** The `ce:review` workflow needed non-conforming artifacts rejected at the write boundary, and a registered plugin tool looked like the answer. It cannot work on either harness:
+
+- On Pi, `resolveToolAllowlist` throws `UnknownDeclaredToolError` at catalog-build time for any tool outside the fixed built-in table. A custom tool never becomes callable.
+- On OpenCode, a registered tool can be *offered* but not *required*. Nothing prevents a sub-agent from writing directly instead.
+
+The workflow had also been instructing personas to write their own artifacts, calling it "the ONE write operation you are permitted to make." On Pi that instruction was unsatisfiable from the start — those runs could never produce artifacts at all.
+
+## Solution
+
+Delete the sub-agent write path rather than guarding it. Sub-agents return structured data inline; the parent orchestrator validates and persists.
+
+```text
+Sub-agent:  inspect → return JSON inline → never touch disk
+Parent:     validate → annotate provenance → persist
+```
+
+This needs no tool registration, so it behaves identically on OpenCode, Pi, and Claude Code — including Claude Code, which has no plugin runtime at all.
+
+## Why This Works
+
+The bypass is removed by construction instead of being policed. A sub-agent with no write instruction and no write path cannot produce a non-conforming artifact, regardless of what its `tools:` declaration means on the current harness.
+
+It also sidesteps the divergence rather than depending on it. Any design that relies on `tools:` meaning the same thing across harnesses is building on a contradiction.
+
+## Prevention
+
+- Do not treat `tools:` frontmatter as an enforced grant on OpenCode. Verify the parsed value is a boolean map before assuming any restriction applies.
+- When a workflow requires a capability, confirm every target harness can actually provide it. Check `OPENCODE_TO_PI_TOOL` in `src/lib/agent-resolver.ts` before assuming a tool is reachable on Pi.
+- Prefer designs where the orchestrator holds the capability. The parent has one well-understood permission set; sub-agents have as many as there are harnesses.
+- Treat "this instruction is unsatisfiable on one harness" as a contract bug, not a runtime edge case. It produces silence, not errors.
+
+## Related
+
+- [`docs/solutions/best-practices/destructive-to-nondestructive-converter-Systematic-20260209.md`](../best-practices/destructive-to-nondestructive-converter-Systematic-20260209.md) — earlier evidence of `tools:` being silently dropped, in the converter path rather than the resolver.
+- [`docs/solutions/best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md`](../best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md) — why shared-core tests do not prove adapter parity.
+- [`docs/solutions/workflow-issues/subagent-skill-permission-scoping-2026-05-20.md`](../workflow-issues/subagent-skill-permission-scoping-2026-05-20.md) — related but distinct: per-agent *skill* permissions, not `tools:` parsing.
+- Issue #784 — persona agents dispatched as generic sub-agents, losing per-agent model tiering.

--- a/docs/solutions/workflow-issues/registry-drift-on-skill-description-change-2026-05-20.md
+++ b/docs/solutions/workflow-issues/registry-drift-on-skill-description-change-2026-05-20.md
@@ -1,6 +1,7 @@
 ---
-title: Registry drift when SKILL.md description changes
+title: Generated-artifact drift when a skill or agent description changes
 date: 2026-05-20
+last_updated: 2026-08-16
 category: workflow-issues
 module: registry
 problem_type: workflow_issue
@@ -8,21 +9,26 @@ component: tooling
 severity: medium
 applies_when:
   - Editing a SKILL.md description field
-  - Running the build without also running registry generation
-  - CI fails on "Registry drift check" after an otherwise clean build
+  - Editing an agent frontmatter description field
+  - Running the build without also running registry or Pi fixture generation
+  - CI fails on a drift check after an otherwise clean build
 tags:
   - registry
   - drift
   - skill-description
+  - agent-description
   - generate-registry
+  - pi-subagents
   - ci-gate
 ---
 
-# Registry drift when SKILL.md description changes
+# Generated-artifact drift when a skill or agent description changes
 
 ## Context
 
-`scripts/generate-registry.ts` reads each skill's frontmatter `description` into `registry/registry.jsonc`. The CI "Registry drift check" step (`bun scripts/generate-registry.ts --check`) compares the generated output against the committed file and fails if they differ. `bun run build` does not include registry generation, so a SKILL.md description change that passes `build` + `typecheck` + `lint` + `test` locally will fail CI.
+`scripts/generate-registry.ts` reads each skill's frontmatter `description` into `registry/registry.jsonc`. The CI "Registry drift check" step (`bun scripts/generate-registry.ts --check`) compares the generated output against the committed file and fails if they differ. `bun run build` does not include registry generation, so a description change that passes `build` + `typecheck` + `lint` + `test` locally will fail CI.
+
+**Agent descriptions reach a second generated surface.** Personas listed in `CURATED_PERSONAS` (`src/lib/pi-subagents-personas.ts`) are also exported as committed Pi fixtures under `tests/fixtures/pi-subagents-personas/`, which embed the description verbatim. That surface has its own source-side drift gate, run as `bun scripts/generate-pi-subagents-personas.ts --check`. It is not covered by `registry:drift` and has no npm script alias, so it is the easier of the two to miss — editing one agent description turned a four-file change into eight.
 
 ## Guidance
 
@@ -38,7 +44,23 @@ Then commit the updated `registry/registry.jsonc` alongside the skill change. Th
 bun run build && bun run typecheck && bun run lint && bun test tests/unit && bun scripts/generate-registry.ts --check
 ```
 
-When delegating skill edits to subagents, include `bun scripts/generate-registry.ts` in the verification checklist explicitly — the standard `build` + `typecheck` + `lint` + `test` gate does not cover it.
+For an **agent** description change, regenerate and check both surfaces:
+
+```bash
+bun scripts/generate-registry.ts
+bun scripts/generate-pi-subagents-personas.ts
+
+bun run registry:drift
+bun scripts/generate-pi-subagents-personas.ts --check
+```
+
+When delegating skill or agent edits to subagents, include the generator commands in the verification checklist explicitly — the standard `build` + `typecheck` + `lint` + `test` gate does not cover either surface.
+
+### A passing drift check is not proof that nothing else moved
+
+`registry:drift` proves the committed output is **fresh** relative to source. It does not prove that no identifier changed — a rename regenerates cleanly and passes just the same. For a description-only edit, inspect the regenerated diff and confirm the stronger invariant: only `description` values changed, no component `name`, `files`, or dependency entries changed, and no Pi fixture filename changed.
+
+A changed fixture filename signals an identity or sanitization change rather than ordinary description drift. That distinction matters because bundled agents reach five separate identifier namespaces with no shared alias layer, so an accidental rename is a cross-harness migration rather than a metadata edit.
 
 ## Why This Matters
 

--- a/registry/registry.jsonc
+++ b/registry/registry.jsonc
@@ -40,7 +40,7 @@
     {
       "name": "agent-architecture-strategist",
       "type": "agent",
-      "description": "Analyzes code changes from an architectural perspective for pattern compliance and design integrity. Use when reviewing PRs, adding services, or evaluating structural refactors.",
+      "description": "Analyzes code changes from an architectural perspective for pattern compliance and design integrity. Use when reviewing PRs, adding services, or evaluating structural refactors. Dispatched by deepen-plan and ce-plan's deepening workflow, not by ce:review.",
       "files": ["agents/review/architecture-strategist.md"]
     },
     {
@@ -70,7 +70,7 @@
     {
       "name": "agent-code-simplicity-reviewer",
       "type": "agent",
-      "description": "Final review pass to ensure code is as simple and minimal as possible. Use after implementation is complete to identify YAGNI violations and simplification opportunities.",
+      "description": "Final review pass to ensure code is as simple and minimal as possible. Use after implementation is complete to identify YAGNI violations and simplification opportunities. Dispatched by ce-compound for code-heavy issues, not by ce:review.",
       "files": ["agents/review/code-simplicity-reviewer.md"]
     },
     {
@@ -182,7 +182,7 @@
     {
       "name": "agent-pattern-recognition-specialist",
       "type": "agent",
-      "description": "Analyzes code for design patterns, anti-patterns, naming conventions, and duplication. Use when checking codebase consistency or verifying new code follows established patterns.",
+      "description": "Analyzes code for design patterns, anti-patterns, naming conventions, and duplication. Use when checking codebase consistency or verifying new code follows established patterns. Dispatched by deepen-plan, ce-plan's deepening workflow, and ce-compound, not by ce:review.",
       "files": ["agents/review/pattern-recognition-specialist.md"]
     },
     {

--- a/skills/ce-review/SKILL.md
+++ b/skills/ce-review/SKILL.md
@@ -64,7 +64,7 @@ All tokens are optional. Each one present means one less thing to infer. When ab
 - **Skip all user questions.** Never use the platform question tool (`question` in OpenCode, `request_user_input` in Codex, `ask_user` in Gemini; in Pi, use the blocking-question extension if available, otherwise present numbered options in chat and wait) or other interactive prompts. Infer intent conservatively if the diff metadata is thin.
 - **Require a determinable diff scope.** If headless mode cannot determine a diff scope (no branch, PR, or `base:` ref determinable without user interaction), emit `Review failed (headless mode). Reason: no diff scope detected. Re-invoke with a branch name, PR number, or base:<ref>.` and stop without dispatching agents.
 - **Apply only `safe_auto -> review-fixer` findings in a single pass.** No bounded re-review rounds. Leave `gated_auto`, `manual`, `human`, and `release` work unresolved and return them in the structured output.
-- **Return all non-auto findings as structured text output.** Use the headless output envelope format (see Stage 6 below) preserving severity, autofix_class, owner, requires_verification, confidence, pre_existing, and suggested_fix per finding. Enrich with detail-tier fields (why_it_matters, evidence[]) from the per-agent artifact files on disk (see Detail enrichment in Stage 6).
+- **Return all non-auto findings as structured text output.** Use the headless output envelope format (see Stage 6 below) preserving severity, autofix_class, owner, requires_verification, confidence, pre_existing, and suggested_fix per finding. Enrich with detail-tier fields (why_it_matters, evidence[]) from the validated inline persona returns (see Detail enrichment in Stage 6).
 - **Write a run artifact** under `.context/systematic/ce-review/<run-id>/` summarizing findings, applied fixes, and advisory outputs. Include the artifact path in the structured output.
 - **Do not create todo files.** The caller receives structured findings and routes downstream work itself.
 - **Do not switch the shared checkout.** If the caller passes an explicit PR or branch target, `mode:headless` must run in an isolated checkout/worktree or stop instead of running `gh pr checkout` / `git checkout`. When stopping, emit `Review failed (headless mode). Reason: cannot switch shared checkout. Re-invoke with base:<ref> to review the current checkout, or run from an isolated worktree.`
@@ -383,16 +383,18 @@ The orchestrator (this skill) stays on the default model because it handles inte
 
 #### Run ID
 
-Generate a unique run identifier before dispatching any agents. This ID scopes all agent artifact files and the post-review run artifact to the same directory.
+Generate a unique run identifier before dispatching any agents. This ID scopes the parent-owned per-agent records and the post-review run artifact to the same directory.
 
 ```bash
 RUN_ID=$(date +%Y%m%d-%H%M%S)-$(head -c4 /dev/urandom | od -An -tx1 | tr -d ' ')
 mkdir -p ".context/systematic/ce-review/$RUN_ID"
 ```
 
-Pass `{run_id}` to every persona sub-agent so they can write their full analysis to `.context/systematic/ce-review/{run_id}/{reviewer_name}.json`.
+Keep `{run_id}` in the parent orchestrator. Do not pass it, an artifact path, or any write instruction to persona sub-agents. The parent writes a per-agent record only after the returned payload passes validation.
 
-**Report-only mode:** Skip run-id generation and directory creation. Do not pass `{run_id}` to agents. Agents return compact JSON only with no file write, consistent with report-only's no-write contract.
+Capture the actual invoking harness once in the parent (`opencode`, `pi`, or `claude-code`). Do not infer it from persona metadata or declared tools. Add this parent-owned value to each persisted record and to the synthesis artifact so R6 remains explicit. `mode:report-only` still records nothing because it has no run artifact.
+
+**Report-only mode:** Skip run-id generation and directory creation. Agents return the same full JSON payload, with no file write, consistent with report-only's no-write contract.
 
 #### Spawning
 
@@ -405,14 +407,14 @@ Spawn each selected persona reviewer as a parallel sub-agent using the subagent 
 3. The JSON output contract from the findings schema included below
 4. PR metadata: title, body, and URL when reviewing a PR (empty string otherwise). Passed in a `<pr-context>` block so reviewers can verify code against stated intent
 5. Review context: intent summary, file list, diff
-6. Run ID and reviewer name for the artifact file path
+6. Reviewer name for the returned `reviewer` field
 7. **For `project-standards` only:** the standards file path list from Stage 3b, wrapped in a `<standards-paths>` block appended to the review context
 
-Persona sub-agents are **read-only** with respect to the project: they review and return structured JSON. They do not edit project files or propose refactors. The one permitted write is saving their full analysis to the `.context/` artifact path specified in the output contract.
+Persona sub-agents are **read-only** with respect to the project: they review and return structured JSON. They do not edit project files, write artifacts, or propose refactors. The parent orchestrator owns all persistence.
 
 Read-only here means **non-mutating**, not "no shell access." Reviewer sub-agents may use non-mutating inspection commands when needed to gather evidence or verify scope, including read-oriented `git` / `gh` usage such as `git diff`, `git show`, `git blame`, `git log`, and `gh pr view`. They must not edit project files, change branches, commit, push, create PRs, or otherwise mutate the checkout or repository state.
 
-Each persona sub-agent writes full JSON (all schema fields) to `.context/systematic/ce-review/{run_id}/{reviewer_name}.json` and returns compact JSON with merge-tier fields only:
+Each persona sub-agent returns one full JSON payload (all schema fields) to the parent:
 
 ```json
 {
@@ -428,6 +430,10 @@ Each persona sub-agent writes full JSON (all schema fields) to `.context/systema
       "owner": "downstream-resolver",
       "requires_verification": true,
       "pre_existing": false,
+      "why_it_matters": "An unowned lookup can expose another account's orders.",
+      "evidence": [
+        "orders_controller.rb:42 uses params[:id] without an ownership guard."
+      ],
       "suggested_fix": "Add current_user.owns?(account) guard before lookup"
     }
   ],
@@ -436,7 +442,9 @@ Each persona sub-agent writes full JSON (all schema fields) to `.context/systema
 }
 ```
 
-Detail-tier fields (`why_it_matters`, `evidence`) are in the artifact file only. `suggested_fix` is optional in both tiers -- included in compact returns when present so the orchestrator has fix context for auto-apply decisions. If the file write fails, the compact return still provides everything the merge needs.
+`why_it_matters` and `evidence` are returned inline with the merge-tier fields. `suggested_fix` remains optional. The parent validates the complete payload before writing any per-agent record; a malformed or rejected return is never partially persisted.
+
+Returning the detail tier inline increases parent context per persona. The previous compact/detail split kept synthesis context lean, so this is an intentional cost of deleting the sub-agent write path. Verify it against a real multi-persona run. If it materially degrades synthesis, use a second targeted request per persona and keep the write parent-side; never restore sub-agent disk access.
 
 **CE always-on agents** (agent-native-reviewer, learnings-researcher) are dispatched as standard Agent calls in parallel with the persona agents. Give them the same review context bundle the personas receive: entry mode, any PR metadata gathered in Stage 1, intent summary, review base branch name when known, `BASE:` marker, file list, diff, and `UNTRACKED:` scope notes. Do not invoke them with a generic "review this" prompt. Their output is unstructured and synthesized separately in Stage 6.
 
@@ -444,22 +452,22 @@ Detail-tier fields (`why_it_matters`, `evidence`) are in the artifact file only.
 
 ### Stage 5: Merge findings
 
-Convert multiple reviewer compact JSON returns into one deduplicated, confidence-gated finding set. The compact returns contain merge-tier fields (title, severity, file, line, confidence, autofix_class, owner, requires_verification, pre_existing) plus the optional suggested_fix. Detail-tier fields (why_it_matters, evidence) are on disk in the per-agent artifact files and are not loaded at this stage.
+Convert multiple reviewer JSON returns into one deduplicated, confidence-gated finding set. Each persona return already contains both tiers. The parent must retain the validated payload in memory for merge and synthesis, then persist only the same validated data.
 
-1. **Validate.** Check each compact return for required top-level and per-finding fields, plus value constraints. Drop malformed returns or findings. Record the drop count.
-   - **Top-level required:** reviewer (string), findings (array), residual_risks (array), testing_gaps (array). Drop the entire return if any are missing or wrong type.
-   - **Per-finding required:** title, severity, file, line, confidence, autofix_class, owner, requires_verification, pre_existing
-   - **Value constraints:**
-     - severity: P0 | P1 | P2 | P3
-     - autofix_class: safe_auto | gated_auto | manual | advisory
-     - owner: review-fixer | downstream-resolver | human | release
-     - confidence: numeric, 0.0-1.0
-     - line: positive integer
-     - pre_existing, requires_verification: boolean
-   - Do not validate against the full schema here -- the full schema (including why_it_matters and evidence) applies to the artifact files on disk, not the compact returns.
-2. **Confidence gate.** Suppress findings below 0.60 confidence. Exception: P0 findings at 0.50+ confidence survive the gate -- critical-but-uncertain issues must not be silently dropped. Record the suppressed count. This matches the persona instructions and the schema's confidence thresholds.
-3. **Deduplicate.** Compute fingerprint: `normalize(file) + line_bucket(line, +/-3) + normalize(title)`. When fingerprints match, merge: keep highest severity, keep highest confidence, note which reviewers flagged it.
-4. **Cross-reviewer agreement.** When 2+ independent reviewers flag the same issue (same fingerprint), boost the merged confidence by 0.10 (capped at 1.0). Cross-reviewer agreement is strong signal -- independent reviewers converging on the same issue is more reliable than any single reviewer's confidence. Note the agreement in the Reviewer column of the output (e.g., "security, correctness").
+Before applying the confidence gate, assign every finding in a valid return a stable parent-owned `input_id` of `<reviewer>#<1-based finding index>`. Keep an input ledger through every later stage. The ledger is the authoritative reconciliation record in the synthesis artifact; it is not part of the persona's returned payload. If a return is rejected but its parsed `findings` array can be safely enumerated, assign IDs and record every enumerated input as `rejected`. If the return is malformed JSON or has no safely enumerable findings, record no synthetic input findings; the persona-level dispatch record and its exact safe rejection reason still record the rejection.
+
+1. **Validate before any write.** Treat every persona return as untrusted input. Parse the returned text as JSON without logging the raw text, then validate the complete parsed object against `references/findings-schema.json`, including `why_it_matters` and `evidence`.
+   - **Top-level required:** reviewer (string), findings (array), residual_risks (array), testing_gaps (array). Reject the entire persona return if any are missing or wrong type.
+   - **Per-finding required:** title, severity, file, line, why_it_matters, confidence, evidence, autofix_class, owner, requires_verification, pre_existing.
+   - **Schema constraints:** enforce every enum, type, confidence, line, path, evidence count, evidence length, and explicit overflow-marker bound from the schema. Empty evidence, absolute paths, and over-bound evidence are rejection cases, not truncation cases.
+   - **Environment-value detection:** JSON Schema cannot determine where a string came from, so recursively inspect every string leaf in the parsed payload before writing. Reject the payload when a string contains a shell/environment reference (`$NAME`, `${NAME}`, `process.env.NAME`, or `os.environ[...]`), an assignment using a known environment variable (`NAME=value`), or a current environment value as an exact or embedded match. Use a conservative match set of non-empty runtime environment values; never log the matched value. This detector is an additional parent-side check, not a schema claim.
+   - **Safe rejection message:** report only `Rejected persona <name> return: field <JSON path> failed <reason>.` Derive `<JSON path>` from the validator or recursive scan and use a fixed reason such as `schema validation`, `environment-value detection`, or `malformed JSON`; never include the offending value, raw return, or validator parameters.
+   - **No partial writes:** do not write a per-agent record or merge any finding until the entire persona payload passes schema and environment-value validation. A valid payload is then annotated by the parent with `harness` and `dispatch_outcome` and written by the parent only. Revalidate the enriched record before persistence.
+   - **Dispatch outcome:** a valid non-empty return is `findings`; a valid empty return is `empty`; invalid JSON or a rejected schema/environment payload is `malformed`; timeout or no return is `never_returned`. Keep these outcomes separate from finding `disposition`.
+   - **Rejection policy: degrade, do not fail the whole review.** Continue merging conforming returns, record the rejected persona's `dispatch_outcome` and safe rejection reason in the synthesis artifact, and give any rejected input the `rejected` disposition in the later reconciliation. If every persona fails or times out, use the existing degraded-review behavior. This preserves partial review coverage without ever persisting a non-conforming artifact; only an orchestration/storage failure that prevents the parent from producing its required run artifact is run-fatal.
+2. **Confidence gate.** Suppress findings below 0.60 confidence. Exception: P0 findings at 0.50+ confidence survive the gate -- critical-but-uncertain issues must not be silently dropped. Record the suppressed finding's original confidence and an explicit reason in the input ledger. A retained P0 at 0.50+ is recorded as `surviving` unless it later participates in a deduplication merge. This matches the persona instructions and the schema's confidence thresholds.
+3. **Deduplicate.** Compute fingerprint: `normalize(file) + line_bucket(line, +/-3) + normalize(title)`. When fingerprints match, merge: keep highest severity, keep highest confidence, preserve the exact fingerprint, and retain the input IDs that produced the merged entry. A singleton that passes the gate is `surviving`; each input in a multi-input merge is provisionally `merged`.
+4. **Cross-reviewer agreement.** When 2+ independent reviewers flag the same issue (same fingerprint), boost the merged confidence by 0.10 (capped at 1.0). Cross-reviewer agreement is strong signal -- independent reviewers converging on the same issue is more reliable than any single reviewer's confidence. Preserve the distinction in the merged finding's artifact provenance: `submitters` contains only personas with an input finding in that fingerprint group; `agreement_credit` contains only personas credited by the agreement boost without an input finding in that group. A persona with zero findings never appears in `submitters`. Do not infer submission from the report's Reviewer column.
 5. **Separate pre-existing.** Pull out findings with `pre_existing: true` into a separate list.
 6. **Resolve disagreements.** When reviewers flag the same code region but disagree on severity, autofix_class, or owner, annotate the Reviewer column with the disagreement (e.g., "security (P0), correctness (P1) -- kept P0"). This transparency helps the user understand why a finding was routed the way it was.
 7. **Normalize routing.** For each merged finding, set the final `autofix_class`, `owner`, and `requires_verification`. If reviewers disagree, keep the most conservative route. Synthesis may narrow a finding from `safe_auto` to `gated_auto` or `manual`, but must not widen it without new evidence.
@@ -470,10 +478,11 @@ Convert multiple reviewer compact JSON returns into one deduplicated, confidence
 9. **Sort.** Order by severity (P0 first) -> confidence (descending) -> file path -> line number.
 10. **Collect coverage data.** Union residual_risks and testing_gaps across reviewers.
 11. **Preserve CE agent artifacts.** Keep the learnings, agent-native, schema-drift, and deployment-verification outputs alongside the merged finding set. Do not drop unstructured agent output just because it does not match the persona JSON schema.
+12. **Keep the input ledger complete.** Every enumerated input finding has exactly one final disposition: `surviving`, `merged`, `suppressed`, `filtered`, or `rejected`, plus a reason. The ledger's disposition counts must sum to its input count. A rejected payload's reason is the exact safe rejection message produced by validation, not a bucket such as "invalid"; never include the offending value.
 
 ### Stage 5b: Validation pass
 
-Run an independent validation pass over the merged finding set before synthesis. This pass annotates each gated finding `validated: true` or `validated: false` with a one-sentence reason. It never deletes a finding — findings with `validated: false` are surfaced in the "Filtered (not validated)" group in Stage 6, not removed from the report.
+Run an independent validation pass over the merged finding set before synthesis. This pass annotates each gated finding `validated: true` or `validated: false` with a one-sentence reason. A `validated: false` finding is dropped from the surviving/actioned set and receives disposition `filtered`, but is retained in the synthesis artifact and surfaced in the "Filtered (not validated)" group in Stage 6. It is not erased from the record.
 
 **Gating band (default):** Validate only findings that are **P0 or P1 severity**, or that have `requires_verification: true`. Findings outside this band pass through to Stage 6 unvalidated and unfiltered — no validator is dispatched for them. This bounds cost: one validator subagent per gated finding.
 
@@ -482,9 +491,9 @@ Run an independent validation pass over the merged finding set before synthesis.
 1. Identify all gated findings from the Stage 5 merged set.
 2. For each gated finding, spawn one validator subagent in parallel using the validator template at `references/validator-template.md`. Pass the finding fields, the intent summary, the file list, and the full diff.
 3. Collect `{validated, reason}` from each validator. Attach both fields to the finding.
-4. **Never drop a finding.** A finding with `validated: false` is routed to the "Filtered (not validated)" group for Stage 6 presentation. It is not removed from the report, not suppressed, and not excluded from the Coverage count.
-5. Findings with `validated: true` flow through to Stage 6 unchanged — they appear in the normal severity tables.
-6. Findings outside the gating band carry no `validated` annotation and appear in Stage 6 severity tables unchanged.
+4. **Reconcile filtered inputs.** A finding with `validated: false` moves to the "Filtered (not validated)" presentation group in Stage 6, and every input ID contributing to that merged finding is updated to disposition `filtered` with the validator's exact one-sentence reason. It is not `suppressed`, `rejected`, or silently excluded from the input ledger.
+5. Findings with `validated: true` flow through to Stage 6 unchanged — they appear in the normal severity tables. Their input ledger dispositions remain `surviving` for singleton findings or `merged` for deduplicated groups.
+6. Findings outside the gating band carry no `validated` annotation and appear in Stage 6 severity tables unchanged; their input ledger dispositions remain `surviving` or `merged`.
 
 **Failure handling:** If a validator subagent fails or times out, treat the finding as `validated: true` (conservative fallback — keep it in the actioned set) and note the validator failure in the Coverage section.
 
@@ -494,7 +503,7 @@ Run an independent validation pass over the merged finding set before synthesis.
 
 Assemble the final report using **pipe-delimited markdown tables for findings** from the review output template included below. The table format is mandatory for finding rows in interactive mode — do not render findings as freeform text blocks or horizontal-rule-separated prose. Other report sections (Applied Fixes, Learnings, Coverage, etc.) use bullet lists and the `---` separator before the verdict, as shown in the template.
 
-1. **Header.** Scope, intent, mode, reviewer team with per-conditional justifications.
+1. **Header.** Scope, intent, mode, harness, reviewer team with per-conditional justifications.
 2. **Findings.** Rendered as pipe-delimited tables grouped by severity (`### P0 -- Critical`, `### P1 -- High`, `### P2 -- Moderate`, `### P3 -- Low`). Each finding row shows `#`, file, issue, reviewer(s), confidence, and synthesized route. Omit empty severity levels. Never render findings as freeform text blocks or numbered lists. Only findings with `validated: true` (or no `validated` annotation) appear in these tables.
 3. **Requirements Completeness.** Include only when a plan was found in Stage 2b. For each requirement (R1, R2, etc.) and implementation unit in the plan, report whether corresponding work appears in the diff. Use a simple checklist: met / not addressed / partially addressed. Routing depends on `plan_source`:
    - **`explicit`** (caller-provided or PR body): Flag unaddressed requirements as P1 findings with `autofix_class: manual`, `owner: downstream-resolver`. These enter the residual actionable queue and can become todos.
@@ -525,7 +534,7 @@ Scope: <scope-line>
 Intent: <intent-summary>
 Reviewers: <reviewer-list with conditional justifications>
 Verdict: <Ready to merge | Ready with fixes | Not ready>
-Artifact: .context/systematic/ce-review/<run-id>/
+Artifact: .context/systematic/ce-review/<run-id>/review-summary.json
 
 Applied N safe_auto fixes.
 
@@ -583,15 +592,15 @@ Coverage:
 Review complete
 ```
 
-**Detail enrichment (headless only):** The headless envelope includes `Why:`, `Evidence:`, and `Suggested fix:` lines. After merge (Stage 5), read the per-agent artifact files from `.context/systematic/ce-review/{run_id}/` for only the findings that survived dedup and confidence gating.
-   - **Field tiers:** `Why:` and `Evidence:` are detail-tier -- load from per-agent artifact files. `Suggested fix:` is merge-tier -- use it directly from the compact return without artifact lookup.
-   - **Artifact matching:** For each surviving finding, look up its detail-tier fields in the artifact files of the contributing reviewers. Match on `file + line_bucket(line, +/-3)` (the same tolerance used in Stage 5 dedup) within each contributing reviewer's artifact. When multiple artifact entries fall within the line bucket, apply `normalize(title)` to both the merged finding's title and each candidate entry's title as a tie-breaker.
-   - **Reviewer order:** Try contributing reviewers in the order they appear in the merged finding's reviewer list; use the first match.
-   - **No-match fallback:** If no artifact file contains a match (all writes failed, or the finding was synthesized during merge), omit the `Why:` and `Evidence:` lines for that finding and note the gap in Coverage. The `Suggested fix:` line can still be populated from the compact return since it is merge-tier.
+**Detail enrichment (headless only):** The headless envelope includes `Why:`, `Evidence:`, and `Suggested fix:` lines. After merge (Stage 5), use the validated full persona returns retained in parent memory for only the findings that survived dedup and confidence gating.
+   - **Field tiers:** `Why:` and `Evidence:` are detail-tier and are already present in the validated inline return. `Suggested fix:` is also available directly from that return and survives merge as optional fix context.
+   - **In-memory matching:** For each surviving finding, look up its detail-tier fields in the validated returns of the contributing reviewers. Match on `file + line_bucket(line, +/-3)` (the same tolerance used in Stage 5 dedup). When multiple entries fall within the line bucket, apply `normalize(title)` to the merged finding's title and each candidate entry's title as a tie-breaker.
+   - **Reviewer order:** Try contributing reviewers in the order they appear in the merged finding's reviewer list; use the first validated match.
+   - **No-match fallback:** If no validated in-memory return contains a match, omit the `Why:` and `Evidence:` lines for that finding and note the gap in Coverage. This should indicate a synthesis/matching gap, not a failed artifact-file write. Never re-read per-agent files to recover detail.
 
 **Formatting rules:**
 - The `[needs-verification]` marker appears only on findings where `requires_verification: true`.
-- The `Artifact:` line gives callers the path to the full run artifact for machine-readable access to the complete findings schema. The text envelope is the primary handoff; the artifact is for debugging and full-fidelity access.
+- The `Artifact:` line gives callers the path to the parent-written `review-summary.json` for machine-readable access to the complete findings schema, provenance, dispatch outcomes, and disposition ledger. The text envelope is the primary handoff; the artifact is for debugging and full-fidelity access.
 - Findings with `owner: release` appear in the Advisory section (they are operational/rollout items, not code fixes).
 - Findings with `pre_existing: true` appear in the Pre-existing section regardless of autofix_class.
 - Findings with `validated: false` from Stage 5b appear in the "Filtered (not validated)" section. They are surfaced for human review — not removed. Include the validator reason on the indented `Validator reason:` line.
@@ -691,18 +700,22 @@ After presenting findings and verdict (Stage 6), route the next steps by mode. R
 
 #### Step 4: Emit artifacts and downstream handoff
 
-- In interactive, autofix, and headless modes, write a per-run artifact under `.context/systematic/ce-review/<run-id>/` containing:
-  - synthesized findings (merged output from Stage 5)
-  - applied fixes
-  - residual actionable work
-  - advisory-only outputs
-  Per-agent full-detail JSON files (`{reviewer_name}.json`) are already present in this directory from Stage 4 dispatch.
+- In interactive, autofix, and headless modes, write **`review-summary.json` unconditionally** under `.context/systematic/ce-review/<run-id>/`, including when every persona returns `empty` and there are zero surviving findings. `mode:report-only` remains exempt: it skips run-id and directory creation and writes nothing.
+- `review-summary.json` is the parent-owned synthesis artifact and must contain, at minimum:
+  - `run_id`, `mode`, `harness` (`opencode`, `pi`, or `claude-code`), and run lifecycle fields;
+  - a `dispatches` entry for every selected persona with `persona`, `dispatch_outcome` (`findings`, `empty`, `malformed`, or `never_returned`), the number of safely enumerated input findings, and the exact safe `rejection_reason` when applicable;
+  - an `input_findings` ledger with one entry per safely enumerated input, its `input_id`, reviewer, original confidence, final `disposition` (`surviving`, `merged`, `suppressed`, `filtered`, or `rejected`), and a stated reason. Its count must reconcile exactly with the sum of disposition counts. A malformed JSON return with no safely enumerable finding has zero ledger entries, not a fabricated finding;
+  - surviving synthesized findings and filtered findings, each retaining their original fields plus `input_finding_ids` and provenance. Every synthesized finding's provenance must include the exact dedup `fingerprint`, `submitters`, and `agreement_credit` arrays. `submitters` means independent input submissions; `agreement_credit` means agreement boost credit without a corresponding input submission;
+  - applied fixes, residual actionable work, advisory-only outputs, coverage data, and the harness value.
+- During the pre-dispatch setup described in Stage 4, initialize the synthesis artifact with lifecycle state `in_progress` and all selected personas initialized as `never_returned`. Update each dispatch entry as returns arrive. Finalize it as `completed` or `degraded` after synthesis; if the parent catches an abort or storage/orchestration failure, finalize it as `abnormal` with the stated termination reason. If the process dies before finalization, the pre-written `in_progress` artifact is itself an explicit incomplete run and must be counted as abnormal rather than treated as a missing or clean run. Never infer a clean run from an absent artifact.
+- Per-agent full-detail JSON files (`{reviewer_name}.json`) are written by the parent only after the persona return passes full-schema and environment-value validation. Rejected or never-returned personas do not produce a per-agent file; their dispatch outcome remains in the synthesis artifact. If a later confidence or validation stage changes an input disposition, update the parent-owned record and synthesis ledger before finalizing `review-summary.json`.
 - Also write `metadata.json` alongside the findings so downstream skills can verify the artifact matches the current branch and HEAD. Minimum fields:
   ```json
   {
     "run_id": "<run-id>",
     "branch": "<git branch --show-current at dispatch time>",
     "head_sha": "<git rev-parse HEAD at dispatch time>",
+    "harness": "<opencode | pi | claude-code>",
     "verdict": "<Ready to merge | Ready with fixes | Not ready>",
     "completed_at": "<ISO 8601 UTC timestamp>"
   }

--- a/skills/ce-review/references/findings-schema.json
+++ b/skills/ce-review/references/findings-schema.json
@@ -4,10 +4,48 @@
   "description": "Structured output schema for code review sub-agents",
   "type": "object",
   "required": ["reviewer", "findings", "residual_risks", "testing_gaps"],
+  "definitions": {
+    "dispatchOutcome": {
+      "type": "string",
+      "enum": ["findings", "empty", "malformed", "never_returned"],
+      "description": "What a persona returned: findings, empty, malformed, or never returned"
+    },
+    "disposition": {
+      "type": "string",
+      "enum": ["surviving", "merged", "suppressed", "filtered", "rejected"],
+      "description": "What happened to an input finding: surviving, merged, suppressed, filtered, or rejected"
+    },
+    "overflowEvidence": {
+      "type": "object",
+      "required": ["overflow", "excerpt"],
+      "properties": {
+        "overflow": {
+          "const": true,
+          "description": "Explicit marker that the complete evidence did not fit in one bounded entry"
+        },
+        "excerpt": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500,
+          "pattern": "\\S",
+          "description": "Bounded excerpt retained when evidence must be shortened"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
   "properties": {
     "reviewer": {
       "type": "string",
       "description": "Persona name that produced this output (e.g., 'correctness', 'security')"
+    },
+    "harness": {
+      "type": "string",
+      "enum": ["opencode", "pi", "claude-code"],
+      "description": "Harness that produced the artifact; populated by the parent orchestrator"
+    },
+    "dispatch_outcome": {
+      "$ref": "#/definitions/dispatchOutcome"
     },
     "findings": {
       "type": "array",
@@ -40,7 +78,9 @@
           },
           "file": {
             "type": "string",
-            "description": "Relative file path from repository root"
+            "minLength": 1,
+            "pattern": "^(?!/)(?![A-Za-z]:[\\\\/])(?!\\\\).+",
+            "description": "Relative file path from repository root; absolute POSIX, drive-letter, and UNC paths are rejected"
           },
           "line": {
             "type": "integer",
@@ -49,7 +89,9 @@
           },
           "why_it_matters": {
             "type": "string",
-            "description": "Impact and failure mode -- not 'what is wrong' but 'what breaks'"
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Non-empty impact and failure mode -- not 'what is wrong' but 'what breaks'"
           },
           "autofix_class": {
             "type": "string",
@@ -77,9 +119,25 @@
           },
           "evidence": {
             "type": "array",
-            "description": "Code-grounded evidence: snippets, line references, or pattern descriptions. At least 1 item.",
-            "items": { "type": "string" },
-            "minItems": 1
+            "description": "Code-grounded evidence. At least 1 and at most 5 bounded entries; split evidence across entries or use an explicit overflow marker rather than silently truncating it.",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 500,
+                  "pattern": "\\S"
+                },
+                {
+                  "$ref": "#/definitions/overflowEvidence"
+                }
+              ]
+            },
+            "minItems": 1,
+            "maxItems": 5
+          },
+          "disposition": {
+            "$ref": "#/definitions/disposition"
           },
           "pre_existing": {
             "type": "boolean",
@@ -126,9 +184,9 @@
       "release": "Operational or rollout follow-up; do not convert into code-fix work automatically."
     },
     "return_tiers": {
-      "description": "Finding fields are split into two tiers. The full schema (with all required fields) applies to the artifact file on disk. The compact return to the orchestrator omits detail-tier fields. Both are valid uses of this schema in different contexts.",
-      "merge_tier": "Returned to orchestrator: title, severity, file, line, confidence, autofix_class, owner, requires_verification, pre_existing, suggested_fix (optional). Plus top-level reviewer, residual_risks, testing_gaps.",
-      "detail_tier": "Required in artifact file, omitted from compact return: why_it_matters, evidence. The artifact file must pass full schema validation including all required fields. Headless output depends on why_it_matters and evidence being present in the artifact."
+      "description": "Finding fields are grouped into two tiers, but both are returned together in one inline payload. Sub-agents do not write to disk; the parent orchestrator validates the complete return against this schema and persists it. The tier names describe how fields are consumed downstream, not separate transports.",
+      "merge_tier": "Consumed during merge and dedup: title, severity, file, line, confidence, autofix_class, owner, requires_verification, pre_existing, suggested_fix (optional). Plus top-level reviewer, residual_risks, testing_gaps.",
+      "detail_tier": "Consumed during synthesis, headless enrichment, and persistence: why_it_matters, evidence. Returned inline alongside merge-tier fields; a return omitting them fails validation and is recorded as a malformed dispatch outcome."
     }
   }
 }

--- a/skills/ce-review/references/findings-schema.json
+++ b/skills/ce-review/references/findings-schema.json
@@ -1,9 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Code Review Findings",
-  "description": "Structured output schema for code review sub-agents",
-  "type": "object",
-  "required": ["reviewer", "findings", "residual_risks", "testing_gaps"],
+  "description": "Structured output schemas for code review sub-agent returns and parent-persisted records",
+  "$ref": "#/definitions/parentRecord",
   "definitions": {
     "dispatchOutcome": {
       "type": "string",
@@ -15,6 +14,32 @@
       "enum": ["surviving", "merged", "suppressed", "filtered", "rejected"],
       "description": "What happened to an input finding: surviving, merged, suppressed, filtered, or rejected"
     },
+    "harness": {
+      "type": "string",
+      "enum": ["opencode", "pi", "claude-code"],
+      "description": "Harness that produced the artifact; populated by the parent orchestrator"
+    },
+    "repoRelativePath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "pattern": "^(?!/)(?![A-Za-z]:[\\\\/])(?!\\\\).+",
+      "description": "Relative file path from repository root; absolute POSIX, drive-letter, and UNC paths are rejected"
+    },
+    "boundedEvidenceString": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 500,
+      "pattern": "^(?!/)(?![A-Za-z]:[\\\\/])(?!\\\\).+",
+      "description": "Bounded code-grounded evidence; absolute POSIX, drive-letter, and UNC paths are rejected"
+    },
+    "overflowExcerpt": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 500,
+      "pattern": "^(?!/)(?![A-Za-z]:[\\\\/])(?!\\\\).+",
+      "description": "Bounded excerpt retained when evidence must be shortened"
+    },
     "overflowEvidence": {
       "type": "object",
       "required": ["overflow", "excerpt"],
@@ -24,169 +49,290 @@
           "description": "Explicit marker that the complete evidence did not fit in one bounded entry"
         },
         "excerpt": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 500,
-          "pattern": "\\S",
-          "description": "Bounded excerpt retained when evidence must be shortened"
+          "$ref": "#/definitions/overflowExcerpt"
         }
       },
       "additionalProperties": false
-    }
-  },
-  "properties": {
-    "reviewer": {
-      "type": "string",
-      "description": "Persona name that produced this output (e.g., 'correctness', 'security')"
     },
-    "harness": {
-      "type": "string",
-      "enum": ["opencode", "pi", "claude-code"],
-      "description": "Harness that produced the artifact; populated by the parent orchestrator"
+    "findingProperties": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "pattern": "\\S",
+          "description": "Short, specific issue title. 10 words or fewer."
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["P0", "P1", "P2", "P3"],
+          "description": "Issue severity level"
+        },
+        "file": {
+          "$ref": "#/definitions/repoRelativePath"
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Primary line number of the issue"
+        },
+        "why_it_matters": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048,
+          "pattern": "\\S",
+          "description": "Non-empty impact and failure mode -- not 'what is wrong' but 'what breaks'"
+        },
+        "autofix_class": {
+          "type": "string",
+          "enum": ["safe_auto", "gated_auto", "manual", "advisory"],
+          "description": "Reviewer's conservative recommendation for how this issue should be handled after synthesis"
+        },
+        "owner": {
+          "type": "string",
+          "enum": ["review-fixer", "downstream-resolver", "human", "release"],
+          "description": "Who should own the next action for this finding after synthesis"
+        },
+        "requires_verification": {
+          "type": "boolean",
+          "description": "Whether any fix for this finding must be re-verified with targeted tests or a follow-up review pass"
+        },
+        "suggested_fix": {
+          "type": ["string", "null"],
+          "maxLength": 2048,
+          "description": "Concrete minimal fix. Omit or null if no good fix is obvious -- a bad suggestion is worse than none."
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0,
+          "description": "Reviewer confidence in this finding, calibrated per persona"
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 5,
+          "description": "Code-grounded evidence. At least 1 and at most 5 bounded entries; split evidence across entries or use an explicit overflow marker rather than silently truncating it.",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/boundedEvidenceString"
+              },
+              {
+                "$ref": "#/definitions/overflowEvidence"
+              }
+            ]
+          }
+        },
+        "disposition": {
+          "$ref": "#/definitions/disposition"
+        },
+        "pre_existing": {
+          "type": "boolean",
+          "description": "True if this issue exists in unchanged code unrelated to the current diff"
+        }
+      }
     },
-    "dispatch_outcome": {
-      "$ref": "#/definitions/dispatchOutcome"
-    },
-    "findings": {
-      "type": "array",
-      "description": "List of code review findings. Empty array if no issues found.",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "severity",
-          "file",
-          "line",
-          "why_it_matters",
-          "autofix_class",
-          "owner",
-          "requires_verification",
-          "confidence",
-          "evidence",
-          "pre_existing"
-        ],
-        "properties": {
-          "title": {
+    "artifactProperties": {
+      "type": "object",
+      "properties": {
+        "reviewer": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "\\S",
+          "description": "Persona name that produced this output (e.g., 'correctness', 'security')"
+        },
+        "harness": {
+          "$ref": "#/definitions/harness"
+        },
+        "dispatch_outcome": {
+          "$ref": "#/definitions/dispatchOutcome"
+        },
+        "findings": {
+          "type": "array",
+          "maxItems": 32,
+          "description": "List of code review findings. Empty array if no issues found."
+        },
+        "residual_risks": {
+          "type": "array",
+          "maxItems": 64,
+          "description": "Risks the reviewer noticed but could not confirm as findings",
+          "items": {
             "type": "string",
-            "description": "Short, specific issue title. 10 words or fewer.",
-            "maxLength": 100
-          },
-          "severity": {
+            "maxLength": 1024
+          }
+        },
+        "testing_gaps": {
+          "type": "array",
+          "maxItems": 64,
+          "description": "Missing test coverage the reviewer identified",
+          "items": {
             "type": "string",
-            "enum": ["P0", "P1", "P2", "P3"],
-            "description": "Issue severity level"
-          },
-          "file": {
-            "type": "string",
-            "minLength": 1,
-            "pattern": "^(?!/)(?![A-Za-z]:[\\\\/])(?!\\\\).+",
-            "description": "Relative file path from repository root; absolute POSIX, drive-letter, and UNC paths are rejected"
-          },
-          "line": {
-            "type": "integer",
-            "description": "Primary line number of the issue",
-            "minimum": 1
-          },
-          "why_it_matters": {
-            "type": "string",
-            "minLength": 1,
-            "pattern": "\\S",
-            "description": "Non-empty impact and failure mode -- not 'what is wrong' but 'what breaks'"
-          },
-          "autofix_class": {
-            "type": "string",
-            "enum": ["safe_auto", "gated_auto", "manual", "advisory"],
-            "description": "Reviewer's conservative recommendation for how this issue should be handled after synthesis"
-          },
-          "owner": {
-            "type": "string",
-            "enum": ["review-fixer", "downstream-resolver", "human", "release"],
-            "description": "Who should own the next action for this finding after synthesis"
-          },
-          "requires_verification": {
-            "type": "boolean",
-            "description": "Whether any fix for this finding must be re-verified with targeted tests or a follow-up review pass"
-          },
-          "suggested_fix": {
-            "type": ["string", "null"],
-            "description": "Concrete minimal fix. Omit or null if no good fix is obvious -- a bad suggestion is worse than none."
-          },
-          "confidence": {
-            "type": "number",
-            "description": "Reviewer confidence in this finding, calibrated per persona",
-            "minimum": 0.0,
-            "maximum": 1.0
-          },
-          "evidence": {
-            "type": "array",
-            "description": "Code-grounded evidence. At least 1 and at most 5 bounded entries; split evidence across entries or use an explicit overflow marker rather than silently truncating it.",
-            "items": {
-              "oneOf": [
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 500,
-                  "pattern": "\\S"
-                },
-                {
-                  "$ref": "#/definitions/overflowEvidence"
-                }
-              ]
-            },
-            "minItems": 1,
-            "maxItems": 5
-          },
-          "disposition": {
-            "$ref": "#/definitions/disposition"
-          },
-          "pre_existing": {
-            "type": "boolean",
-            "description": "True if this issue exists in unchanged code unrelated to the current diff"
+            "maxLength": 1024
           }
         }
       }
     },
-    "residual_risks": {
-      "type": "array",
-      "description": "Risks the reviewer noticed but could not confirm as findings",
-      "items": { "type": "string" }
+    "subAgentFinding": {
+      "type": "object",
+      "required": [
+        "title",
+        "severity",
+        "file",
+        "line",
+        "why_it_matters",
+        "autofix_class",
+        "owner",
+        "requires_verification",
+        "confidence",
+        "evidence",
+        "pre_existing"
+      ],
+      "properties": {
+        "title": { "$ref": "#/definitions/findingProperties/properties/title" },
+        "severity": {
+          "$ref": "#/definitions/findingProperties/properties/severity"
+        },
+        "file": { "$ref": "#/definitions/findingProperties/properties/file" },
+        "line": { "$ref": "#/definitions/findingProperties/properties/line" },
+        "why_it_matters": {
+          "$ref": "#/definitions/findingProperties/properties/why_it_matters"
+        },
+        "autofix_class": {
+          "$ref": "#/definitions/findingProperties/properties/autofix_class"
+        },
+        "owner": { "$ref": "#/definitions/findingProperties/properties/owner" },
+        "requires_verification": {
+          "$ref": "#/definitions/findingProperties/properties/requires_verification"
+        },
+        "suggested_fix": {
+          "$ref": "#/definitions/findingProperties/properties/suggested_fix"
+        },
+        "confidence": {
+          "$ref": "#/definitions/findingProperties/properties/confidence"
+        },
+        "evidence": {
+          "$ref": "#/definitions/findingProperties/properties/evidence"
+        },
+        "pre_existing": {
+          "$ref": "#/definitions/findingProperties/properties/pre_existing"
+        }
+      },
+      "additionalProperties": false
     },
-    "testing_gaps": {
-      "type": "array",
-      "description": "Missing test coverage the reviewer identified",
-      "items": { "type": "string" }
-    }
-  },
-
-  "_meta": {
-    "confidence_thresholds": {
-      "suppress": "Below 0.60 -- do not report. Finding is speculative noise. Exception: P0 findings at 0.50+ may be reported.",
-      "flag": "0.60-0.69 -- include only when the issue is clearly actionable with concrete evidence.",
-      "confident": "0.70-0.84 -- real and important. Report with full evidence.",
-      "certain": "0.85-1.00 -- verifiable from the code alone. Report."
+    "parentFinding": {
+      "type": "object",
+      "required": [
+        "title",
+        "severity",
+        "file",
+        "line",
+        "why_it_matters",
+        "autofix_class",
+        "owner",
+        "requires_verification",
+        "confidence",
+        "evidence",
+        "disposition",
+        "pre_existing"
+      ],
+      "properties": {
+        "title": { "$ref": "#/definitions/findingProperties/properties/title" },
+        "severity": {
+          "$ref": "#/definitions/findingProperties/properties/severity"
+        },
+        "file": { "$ref": "#/definitions/findingProperties/properties/file" },
+        "line": { "$ref": "#/definitions/findingProperties/properties/line" },
+        "why_it_matters": {
+          "$ref": "#/definitions/findingProperties/properties/why_it_matters"
+        },
+        "autofix_class": {
+          "$ref": "#/definitions/findingProperties/properties/autofix_class"
+        },
+        "owner": { "$ref": "#/definitions/findingProperties/properties/owner" },
+        "requires_verification": {
+          "$ref": "#/definitions/findingProperties/properties/requires_verification"
+        },
+        "suggested_fix": {
+          "$ref": "#/definitions/findingProperties/properties/suggested_fix"
+        },
+        "confidence": {
+          "$ref": "#/definitions/findingProperties/properties/confidence"
+        },
+        "evidence": {
+          "$ref": "#/definitions/findingProperties/properties/evidence"
+        },
+        "disposition": {
+          "$ref": "#/definitions/findingProperties/properties/disposition"
+        },
+        "pre_existing": {
+          "$ref": "#/definitions/findingProperties/properties/pre_existing"
+        }
+      },
+      "additionalProperties": false
     },
-    "severity_definitions": {
-      "P0": "Critical breakage, exploitable vulnerability, data loss/corruption. Must fix before merge.",
-      "P1": "High-impact defect likely hit in normal usage, breaking contract. Should fix.",
-      "P2": "Moderate issue with meaningful downside (edge case, perf regression, maintainability trap). Fix if straightforward.",
-      "P3": "Low-impact, narrow scope, minor improvement. User's discretion."
+    "subAgentReturn": {
+      "type": "object",
+      "required": ["reviewer", "findings", "residual_risks", "testing_gaps"],
+      "properties": {
+        "reviewer": {
+          "$ref": "#/definitions/artifactProperties/properties/reviewer"
+        },
+        "findings": {
+          "allOf": [
+            { "$ref": "#/definitions/artifactProperties/properties/findings" },
+            {
+              "items": { "$ref": "#/definitions/subAgentFinding" }
+            }
+          ]
+        },
+        "residual_risks": {
+          "$ref": "#/definitions/artifactProperties/properties/residual_risks"
+        },
+        "testing_gaps": {
+          "$ref": "#/definitions/artifactProperties/properties/testing_gaps"
+        }
+      },
+      "additionalProperties": false
     },
-    "autofix_classes": {
-      "safe_auto": "Local, deterministic code or test fix suitable for the in-skill fixer. Examples: extract duplicated helper, add missing nil check, fix off-by-one, add missing test, remove dead code. Do not default to advisory when a concrete safe fix exists.",
-      "gated_auto": "Concrete fix exists, but it changes behavior, permissions, contracts, or other sensitive areas that deserve explicit approval. Examples: add auth to unprotected endpoint, change API response shape.",
-      "manual": "Actionable issue that requires design decisions or cross-cutting changes. Examples: redesign data model, add pagination strategy, choose between architectural approaches.",
-      "advisory": "Informational or operational item that should be surfaced in the report only. Examples: design asymmetry the PR improves but does not fully resolve, residual risk notes, deployment considerations."
-    },
-    "owners": {
-      "review-fixer": "The in-skill fixer can own this when policy allows.",
-      "downstream-resolver": "Turn this into residual work for later resolution.",
-      "human": "A person must make a judgment call before code changes should continue.",
-      "release": "Operational or rollout follow-up; do not convert into code-fix work automatically."
-    },
-    "return_tiers": {
-      "description": "Finding fields are grouped into two tiers, but both are returned together in one inline payload. Sub-agents do not write to disk; the parent orchestrator validates the complete return against this schema and persists it. The tier names describe how fields are consumed downstream, not separate transports.",
-      "merge_tier": "Consumed during merge and dedup: title, severity, file, line, confidence, autofix_class, owner, requires_verification, pre_existing, suggested_fix (optional). Plus top-level reviewer, residual_risks, testing_gaps.",
-      "detail_tier": "Consumed during synthesis, headless enrichment, and persistence: why_it_matters, evidence. Returned inline alongside merge-tier fields; a return omitting them fails validation and is recorded as a malformed dispatch outcome."
+    "parentRecord": {
+      "type": "object",
+      "required": [
+        "reviewer",
+        "harness",
+        "dispatch_outcome",
+        "findings",
+        "residual_risks",
+        "testing_gaps"
+      ],
+      "properties": {
+        "reviewer": {
+          "$ref": "#/definitions/artifactProperties/properties/reviewer"
+        },
+        "harness": {
+          "$ref": "#/definitions/artifactProperties/properties/harness"
+        },
+        "dispatch_outcome": {
+          "$ref": "#/definitions/artifactProperties/properties/dispatch_outcome"
+        },
+        "findings": {
+          "allOf": [
+            { "$ref": "#/definitions/artifactProperties/properties/findings" },
+            {
+              "items": { "$ref": "#/definitions/parentFinding" }
+            }
+          ]
+        },
+        "residual_risks": {
+          "$ref": "#/definitions/artifactProperties/properties/residual_risks"
+        },
+        "testing_gaps": {
+          "$ref": "#/definitions/artifactProperties/properties/testing_gaps"
+        }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/skills/ce-review/references/persona-catalog.md
+++ b/skills/ce-review/references/persona-catalog.md
@@ -2,6 +2,14 @@
 
 13 reviewer personas organized into always-on, cross-cutting conditional, and stack-specific conditional layers, plus CE-specific agents. The orchestrator uses this catalog to select which reviewers to spawn for each review.
 
+## Shared persona pool
+
+The `agents/review/` directory is a shared persona pool, not `ce:review`'s roster. Directory placement does not imply that a persona is selectable by `ce:review`. These shared personas are dispatched by other workflows and intentionally do not appear in this catalog's `ce:review` selection tables:
+
+- `systematic:review:architecture-strategist` — dispatched by `deepen-plan` and `ce-plan`'s deepening workflow for architectural analysis.
+- `systematic:review:pattern-recognition-specialist` — dispatched by `deepen-plan`, `ce-plan`'s deepening workflow, and `ce-compound` for consistency, duplication, and pattern analysis.
+- `systematic:review:code-simplicity-reviewer` — dispatched by `ce-compound` for code-heavy issues.
+
 ## Always-on (4 personas + 2 CE agents)
 
 Spawned on every review regardless of diff content.

--- a/skills/ce-review/references/review-output-template.md
+++ b/skills/ce-review/references/review-output-template.md
@@ -14,6 +14,7 @@ Use this **exact format** when presenting synthesized review findings. Findings 
 **Mode:** autofix
 
 **Reviewers:** correctness, testing, maintainability, security, api-contract
+- **Harness:** opencode
 - security -- new public endpoint accepts user-provided format parameter
 - api-contract -- new /api/orders/export route with response schema
 
@@ -124,7 +125,7 @@ This fails because: no pipe-delimited tables, no severity-grouped `###` headers,
 - **Pipe-delimited markdown tables** for findings -- never ASCII box-drawing characters or per-finding horizontal-rule separators between entries (the report-level `---` before the verdict is still required)
 - **Severity-grouped sections** -- `### P0 -- Critical`, `### P1 -- High`, `### P2 -- Moderate`, `### P3 -- Low`. Omit empty severity levels.
 - **Always include file:line location** for code review issues
-- **Reviewer column** shows which persona(s) flagged the issue. Multiple reviewers = cross-reviewer agreement.
+- **Reviewer column** shows which persona(s) submitted the issue. Multiple reviewers indicate independent submissions, not merely agreement credit. The machine-readable synthesis artifact keeps `submitters` separate from `agreement_credit`; do not infer submission from an agreement boost or from the display column alone.
 - **Confidence column** shows the finding's confidence score
 - **Route column** shows the synthesized handling decision as ``<autofix_class> -> <owner>``.
 - **Header includes** scope, intent, and reviewer team with per-conditional justifications
@@ -136,7 +137,7 @@ This fails because: no pipe-delimited tables, no severity-grouped `###` headers,
 - **Learnings & Past Solutions section** -- results from learnings-researcher, with links to docs/solutions/ files
 - **Agent-Native Gaps section** -- results from agent-native-reviewer. Omit if no gaps found.
 - **Deployment Notes section** -- key checklist items from deployment-verification-agent. Omit if the agent did not run.
-- **Coverage section** -- suppressed count, residual risks, testing gaps, failed reviewers
+- **Coverage section** -- suppressed count with original confidences, residual risks, testing gaps, failed reviewers, and disposition reconciliation
 - **Summary uses blockquotes** for verdict, reasoning, and fix order
 - **Horizontal rule** (`---`) separates findings from verdict
 - **`###` headers** for each section -- never plain text headers
@@ -148,8 +149,69 @@ In `mode:headless`, replace the interactive pipe-delimited table report with a s
 - **No pipe-delimited tables.** Findings use `[severity][autofix_class -> owner] File: <file:line> -- <title>` line format with indented Why/Evidence/Suggested fix lines.
 - **Findings grouped by autofix_class** (gated-auto, manual, advisory) instead of severity. Within each group, findings are sorted by severity.
 - **Verdict in header** (top of output) instead of bottom, so programmatic callers get it first.
-- **`Artifact:` line** in metadata header gives callers the path to the full run artifact.
+- **`Artifact:` line** in metadata header gives callers the path to `review-summary.json`, the full run artifact with provenance, dispatch outcomes, and disposition reconciliation.
 - **`[needs-verification]` marker** on findings where `requires_verification: true`.
 - **Evidence lines** included per finding.
 - **"Filtered (not validated)" section** included when Stage 5b produced findings with `validated: false`. Uses `[severity][autofix_class -> owner] File: <file:line> -- <title>` format with an indented `Validator reason:` line. These findings are surfaced for human review, not removed.
 - **Completion signal:** "Review complete" as the final line.
+
+## Synthesis Artifact Contract
+
+For interactive, autofix, and headless runs, the parent writes `.context/systematic/ce-review/<run-id>/review-summary.json` even when every selected persona returns `empty` and no finding survives. `mode:report-only` is the deliberate no-write exception.
+
+The artifact must preserve the following distinctions:
+
+```json
+{
+  "run_id": "<run-id>",
+  "mode": "<interactive | autofix | headless>",
+  "harness": "<opencode | pi | claude-code>",
+  "run_status": "<in_progress | completed | degraded | abnormal>",
+  "dispatches": [
+    {
+      "persona": "correctness",
+      "dispatch_outcome": "findings",
+      "input_finding_count": 2
+    },
+    {
+      "persona": "kieran-typescript",
+      "dispatch_outcome": "malformed",
+      "input_finding_count": 1,
+      "rejection_reason": "Rejected persona kieran-typescript return: field findings[0].evidence failed schema validation."
+    }
+  ],
+  "input_findings": [
+    {
+      "input_id": "correctness#1",
+      "reviewer": "correctness",
+      "confidence": 0.55,
+      "disposition": "suppressed",
+      "reason": "confidence 0.55 is below the 0.60 gate"
+    }
+  ],
+  "findings": [
+    {
+      "title": "<merged finding>",
+      "input_finding_ids": ["correctness#2", "testing#1"],
+      "provenance": {
+        "fingerprint": "<normalize(file) + line_bucket(line, +/-3) + normalize(title)>",
+        "submitters": ["correctness", "testing"],
+        "agreement_credit": []
+      }
+    }
+  ],
+  "disposition_counts": {
+    "surviving": 0,
+    "merged": 2,
+    "suppressed": 1,
+    "filtered": 0,
+    "rejected": 0
+  }
+}
+```
+
+- `dispatch_outcome` records what a persona returned: `findings`, `empty`, `malformed`, or `never_returned`. A rejection reason is preserved as the exact safe validation reason, naming persona and field without echoing the offending value.
+- `disposition` records what happened to each input finding: `surviving`, `merged`, `suppressed`, `filtered`, or `rejected`. Every safely enumerable input has exactly one disposition and stated reason; the disposition counts must equal the input-finding count.
+- `submitters` contains only personas with an input finding in the merged fingerprint group. `agreement_credit` contains only personas credited by the cross-reviewer agreement boost without an input finding in that group. A persona returning zero findings never appears in `submitters`.
+- `filtered` findings remain available for human review with the validator's stated reason, but are not part of the surviving/actioned set. A suppressed finding retains its original confidence, including the P0 exception for confidence `0.50` or higher.
+- The parent initializes the artifact as `in_progress` before dispatch. A completed run becomes `completed` or `degraded`; an interrupted or failed run is `abnormal` with its stated termination reason. An unfinished `in_progress` artifact is evidence of an abnormal run, not evidence of a clean run.

--- a/skills/ce-review/references/subagent-template.md
+++ b/skills/ce-review/references/subagent-template.md
@@ -22,23 +22,11 @@ The supplied diff is the primary source of truth. Use the supplied paths and lin
 </bounded-investigation>
 
 <output-contract>
-You produce up to two outputs depending on whether a run ID was provided:
+Return exactly one JSON payload to the parent. The payload contains the complete schema for every finding, including both the merge tier and the detail tier (`why_it_matters`, `evidence`, and `suggested_fix` when present).
 
-1. **Artifact file (when run ID is present).** If a Run ID appears in <review-context> below, WRITE your full analysis (all schema fields, including why_it_matters, evidence, and suggested_fix) as JSON to:
-   .context/systematic/ce-review/{run_id}/{reviewer_name}.json
-   This is the ONE write operation you are permitted to make. Use the platform's file-write tool.
-   If the write fails, continue -- the compact return still provides everything the merge needs.
-   If no Run ID is provided (the field is empty or absent), skip this step entirely -- do not attempt any file write.
+Do not write any file. Do not use a Run ID or an artifact path. Persistence is owned by the parent orchestrator: it validates this returned payload, adds parent-owned provenance, and writes only conforming data. This rule is the same in every supported harness.
 
-2. **Compact return (always).** RETURN compact JSON to the parent with ONLY merge-tier fields per finding:
-   title, severity, file, line, confidence, autofix_class, owner, requires_verification, pre_existing, suggested_fix.
-   Do NOT include why_it_matters or evidence in the returned JSON.
-   Include reviewer, residual_risks, and testing_gaps at the top level.
-
-The full file preserves detail for downstream consumers (headless output, debugging).
-The compact return keeps the orchestrator's context lean for merge and synthesis.
-
-The schema below describes the **full artifact file format** (all fields required). For the compact return, follow the field list above -- omit why_it_matters and evidence even though the schema marks them as required.
+The schema below defines the payload's fields and bounds. Its transport is inline for this contract; any schema metadata describing a compact return or a separate detail artifact is superseded by this output contract.
 
 {schema}
 
@@ -62,9 +50,12 @@ False-positive categories to actively suppress:
 
 Rules:
 - You are a leaf reviewer inside an already-running systematic review workflow. Do not invoke systematic skills or agents unless this template explicitly instructs you to. Perform your analysis directly and return findings in the required output format only.
-- Every finding in the full artifact file MUST include at least one evidence item grounded in the actual code. The compact return omits evidence -- the evidence requirement applies to the disk artifact only.
+- Every returned finding MUST include at least one evidence item grounded in the actual code. Detail fields are part of the returned payload, not a second output.
+- Evidence is bounded to at most 5 entries of at most 500 characters each. Split a longer trail across entries when it fits; otherwise retain a bounded `excerpt` with `{ "overflow": true, "excerpt": "..." }`. Never silently truncate evidence.
+- Finding paths MUST be repository-relative. The schema rejects absolute paths, while the parent-side validator in Unit 3 detects environment values because JSON Schema cannot infer where a string came from.
+- The parent adds `harness`, `dispatch_outcome`, and `disposition` after validating the return. Do not invent those parent-owned fields. The parent uses only the canonical values defined by the schema (`findings`, `empty`, `malformed`, `never_returned` and `surviving`, `merged`, `suppressed`, `filtered`, `rejected`).
 - Set pre_existing to true ONLY for issues in unchanged code that are unrelated to this diff. If the diff makes the issue newly relevant, it is NOT pre-existing.
-- You are operationally read-only. The one permitted exception is writing your full analysis to the `.context/` artifact path when a run ID is provided. You may also use non-mutating inspection commands, including read-oriented `git` / `gh` commands, to gather evidence. Do not edit project files, change branches, commit, push, create PRs, or otherwise mutate the checkout or repository state.
+- You are operationally read-only. You may use non-mutating inspection commands, including read-oriented `git` / `gh` commands, to gather evidence. Do not write files, edit project files, change branches, commit, push, create PRs, or otherwise mutate the checkout or repository state.
 - Set `autofix_class` accurately -- not every finding is `advisory`. Use this decision guide:
   - `safe_auto`: The fix is local and deterministic — the fixer can apply it mechanically without design judgment. Examples: extracting a duplicated helper, adding a missing nil/null check, fixing an off-by-one, adding a missing test for an untested code path, removing dead code.
   - `gated_auto`: A concrete fix exists but it changes contracts, permissions, or crosses a module boundary in a way that deserves explicit approval. Examples: adding authentication to an unprotected endpoint, changing a public API response shape, switching from soft-delete to hard-delete.
@@ -83,7 +74,6 @@ Rules:
 </pr-context>
 
 <review-context>
-Run ID: {run_id}
 Reviewer name: {reviewer_name}
 
 Intent: {intent_summary}
@@ -106,5 +96,4 @@ Diff:
 | `{pr_metadata}` | Stage 1 output | PR title, body, and URL when reviewing a PR. Empty string when reviewing a branch or standalone checkout |
 | `{file_list}` | Stage 1 output | List of changed files from the scope step |
 | `{diff}` | Stage 1 output | The actual diff content to review |
-| `{run_id}` | Stage 4 output | Unique review run identifier for the artifact directory |
-| `{reviewer_name}` | Stage 3 output | Persona or agent name used as the artifact filename stem |
+| `{reviewer_name}` | Stage 3 output | Persona name used in the returned `reviewer` field |

--- a/tests/fixtures/pi-subagents-personas/systematic-architecture-strategist.md
+++ b/tests/fixtures/pi-subagents-personas/systematic-architecture-strategist.md
@@ -1,5 +1,5 @@
 ---
-description: "Analyzes code changes from an architectural perspective for pattern compliance and design integrity. Use when reviewing PRs, adding services, or evaluating structural refactors."
+description: "Analyzes code changes from an architectural perspective for pattern compliance and design integrity. Use when reviewing PRs, adding services, or evaluating structural refactors. Dispatched by deepen-plan and ce-plan's deepening workflow, not by ce:review."
 ---
 
 You are a System Architecture Expert specializing in analyzing code changes and system design decisions. Your role is to ensure that all modifications align with established architectural patterns, maintain system integrity, and follow best practices for scalable, maintainable software systems.

--- a/tests/fixtures/pi-subagents-personas/systematic-code-simplicity-reviewer.md
+++ b/tests/fixtures/pi-subagents-personas/systematic-code-simplicity-reviewer.md
@@ -1,5 +1,5 @@
 ---
-description: "Final review pass to ensure code is as simple and minimal as possible. Use after implementation is complete to identify YAGNI violations and simplification opportunities."
+description: "Final review pass to ensure code is as simple and minimal as possible. Use after implementation is complete to identify YAGNI violations and simplification opportunities. Dispatched by ce-compound for code-heavy issues, not by ce:review."
 ---
 
 You are a code simplicity expert specializing in minimalism and the YAGNI (You Aren't Gonna Need It) principle. Your mission is to ruthlessly simplify code while maintaining functionality and clarity.

--- a/tests/fixtures/pi-subagents-personas/systematic-pattern-recognition-specialist.md
+++ b/tests/fixtures/pi-subagents-personas/systematic-pattern-recognition-specialist.md
@@ -1,5 +1,5 @@
 ---
-description: "Analyzes code for design patterns, anti-patterns, naming conventions, and duplication. Use when checking codebase consistency or verifying new code follows established patterns."
+description: "Analyzes code for design patterns, anti-patterns, naming conventions, and duplication. Use when checking codebase consistency or verifying new code follows established patterns. Dispatched by deepen-plan, ce-plan's deepening workflow, and ce-compound, not by ce:review."
 ---
 
 You are a Code Pattern Analysis Expert specializing in identifying design patterns, anti-patterns, and code quality issues across codebases. Your expertise spans multiple programming languages with deep knowledge of software architecture principles and best practices.

--- a/tests/fixtures/pi-subagents-personas/systematic-personas-manifest.json
+++ b/tests/fixtures/pi-subagents-personas/systematic-personas-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-28T18:12:06.195Z",
+  "generatedAt": "2026-08-17T04:15:56.533Z",
   "entries": [
     {
       "filename": "systematic-best-practices-researcher.md",
@@ -47,7 +47,7 @@
       "filename": "systematic-architecture-strategist.md",
       "status": "exported",
       "sourceRelPath": "agents/review/architecture-strategist.md",
-      "hash": "f4541a4bfe1f3bad713029e34267aa327740f322594f4f83d2ea1a5870099241"
+      "hash": "fc5126a2dfb721f7e392f46f0a3dcb11ab5faf71bd901c3f250e85142d69bfcd"
     },
     {
       "filename": "systematic-cli-readiness-reviewer.md",
@@ -59,7 +59,7 @@
       "filename": "systematic-code-simplicity-reviewer.md",
       "status": "exported",
       "sourceRelPath": "agents/review/code-simplicity-reviewer.md",
-      "hash": "9afa4b84c2421ed6958568f88489d1495a1db02bb3e1b5b9f3150872d7115a13"
+      "hash": "7e1c6cc284b7799221bf4d3dfa99d14e804b45f08d612ef5a1f265bad3d90554"
     },
     {
       "filename": "systematic-correctness-reviewer.md",
@@ -89,7 +89,7 @@
       "filename": "systematic-pattern-recognition-specialist.md",
       "status": "exported",
       "sourceRelPath": "agents/review/pattern-recognition-specialist.md",
-      "hash": "c642aaa1905600d8fcf4a889e707cd6c610a2dacadee80f39c20f52603479bab"
+      "hash": "7a76f6f9ddee25b4741673768360ead2574751d2648ebb3ad8d30239e4b8fe5c"
     },
     {
       "filename": "systematic-performance-reviewer.md",

--- a/tests/unit/ce-review-findings-schema.test.ts
+++ b/tests/unit/ce-review-findings-schema.test.ts
@@ -217,6 +217,123 @@ describe('ce:review findings schema', () => {
     )
   })
 
+  test('rejects whitespace-only strings with the pattern constraint', () => {
+    for (const [field, pathSuffix] of [
+      ['title', '/findings/0/title'],
+      ['why_it_matters', '/findings/0/why_it_matters'],
+    ] as const) {
+      expect(validateParent(artifactWithFinding({ [field]: ' ' }))).toBe(false)
+      expect(hasKeyword(validateParent, 'pattern', pathSuffix)).toBe(true)
+    }
+
+    expect(validateParent({ ...baseArtifact, reviewer: ' ' })).toBe(false)
+    expect(hasKeyword(validateParent, 'pattern', '/reviewer')).toBe(true)
+  })
+
+  test('accepts findings at the maxItems boundary', () => {
+    expect(
+      validateParent({
+        ...baseArtifact,
+        findings: Array.from({ length: 32 }, () => baseFinding),
+      }),
+    ).toBe(true)
+  })
+
+  test('rejects findings beyond the maxItems boundary', () => {
+    expect(
+      validateParent({
+        ...baseArtifact,
+        findings: Array.from({ length: 33 }, () => baseFinding),
+      }),
+    ).toBe(false)
+    expect(hasKeyword(validateParent, 'maxItems', '/findings')).toBe(true)
+  })
+
+  test('accepts a title at the maxLength boundary', () => {
+    expect(
+      validateParent(artifactWithFinding({ title: 'x'.repeat(256) })),
+    ).toBe(true)
+  })
+
+  test('rejects a title beyond the maxLength boundary', () => {
+    expect(
+      validateParent(artifactWithFinding({ title: 'x'.repeat(257) })),
+    ).toBe(false)
+    expect(hasKeyword(validateParent, 'maxLength', '/findings/0/title')).toBe(
+      true,
+    )
+  })
+
+  test('accepts a suggested_fix at the maxLength boundary', () => {
+    expect(
+      validateParent(artifactWithFinding({ suggested_fix: 'x'.repeat(2048) })),
+    ).toBe(true)
+  })
+
+  test('rejects a suggested_fix beyond the maxLength boundary', () => {
+    expect(
+      validateParent(artifactWithFinding({ suggested_fix: 'x'.repeat(2049) })),
+    ).toBe(false)
+    expect(
+      hasKeyword(validateParent, 'maxLength', '/findings/0/suggested_fix'),
+    ).toBe(true)
+  })
+
+  test('accepts a reviewer at the maxLength boundary', () => {
+    expect(validateParent({ ...baseArtifact, reviewer: 'x'.repeat(64) })).toBe(
+      true,
+    )
+  })
+
+  test('rejects a reviewer beyond the maxLength boundary', () => {
+    expect(validateParent({ ...baseArtifact, reviewer: 'x'.repeat(65) })).toBe(
+      false,
+    )
+    expect(hasKeyword(validateParent, 'maxLength', '/reviewer')).toBe(true)
+  })
+
+  test('accepts a residual risk item at the maxLength boundary', () => {
+    expect(
+      validateParent({
+        ...baseArtifact,
+        residual_risks: ['x'.repeat(1024)],
+      }),
+    ).toBe(true)
+  })
+
+  test('rejects a residual risk item beyond the maxLength boundary', () => {
+    expect(
+      validateParent({
+        ...baseArtifact,
+        residual_risks: ['x'.repeat(1025)],
+      }),
+    ).toBe(false)
+    expect(hasKeyword(validateParent, 'maxLength', '/residual_risks/0')).toBe(
+      true,
+    )
+  })
+
+  test('accepts a testing gap item at the maxLength boundary', () => {
+    expect(
+      validateParent({
+        ...baseArtifact,
+        testing_gaps: ['x'.repeat(1024)],
+      }),
+    ).toBe(true)
+  })
+
+  test('rejects a testing gap item beyond the maxLength boundary', () => {
+    expect(
+      validateParent({
+        ...baseArtifact,
+        testing_gaps: ['x'.repeat(1025)],
+      }),
+    ).toBe(false)
+    expect(hasKeyword(validateParent, 'maxLength', '/testing_gaps/0')).toBe(
+      true,
+    )
+  })
+
   test('rejects over-long why_it_matters and names the maxLength constraint', () => {
     expect(
       validateParent(artifactWithFinding({ why_it_matters: 'x'.repeat(2049) })),

--- a/tests/unit/ce-review-findings-schema.test.ts
+++ b/tests/unit/ce-review-findings-schema.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import path from 'node:path'
+import Ajv from 'ajv'
+
+const schemaPath = path.resolve(
+  import.meta.dir,
+  '../../skills/ce-review/references/findings-schema.json',
+)
+const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8')) as Record<
+  string,
+  unknown
+>
+const validate = new Ajv({ strict: false }).compile(schema)
+
+const baseFinding = {
+  title: 'Missing deployment ordering',
+  severity: 'P1',
+  file: 'src/deploy/migrate.ts',
+  line: 42,
+  why_it_matters: 'The deployment can fail when the migration runs too late.',
+  autofix_class: 'gated_auto',
+  owner: 'downstream-resolver',
+  requires_verification: true,
+  confidence: 0.75,
+  evidence: [
+    'src/deploy/migrate.ts:42 runs the deployment before the migration.',
+  ],
+  pre_existing: false,
+  suggested_fix: 'Specify the migration and deployment ordering.',
+  disposition: 'surviving',
+}
+
+const baseArtifact = {
+  reviewer: 'correctness',
+  harness: 'opencode',
+  dispatch_outcome: 'findings',
+  findings: [baseFinding],
+  residual_risks: [],
+  testing_gaps: [],
+}
+
+function artifactWithFinding(changes: Record<string, unknown>) {
+  return {
+    ...baseArtifact,
+    findings: [{ ...baseFinding, ...changes }],
+  }
+}
+
+function errorMentions(pathSuffix: string): boolean {
+  return (validate.errors ?? []).some((error) => {
+    const fieldPath = error.instancePath ?? ''
+    return (
+      fieldPath.endsWith(pathSuffix) ||
+      (error.params as { missingProperty?: string }).missingProperty ===
+        pathSuffix.split('/').at(-1)
+    )
+  })
+}
+
+describe('ce:review findings schema', () => {
+  test('accepts a bounded finding with provenance and disposition', () => {
+    expect(validate(baseArtifact)).toBe(true)
+  })
+
+  test('accepts every dispatch outcome and disposition vocabulary value', () => {
+    for (const dispatch_outcome of [
+      'findings',
+      'empty',
+      'malformed',
+      'never_returned',
+    ]) {
+      expect(validate({ ...baseArtifact, dispatch_outcome })).toBe(true)
+    }
+
+    for (const disposition of [
+      'surviving',
+      'merged',
+      'suppressed',
+      'filtered',
+      'rejected',
+    ]) {
+      expect(validate(artifactWithFinding({ disposition }))).toBe(true)
+    }
+  })
+
+  test('rejects an unknown dispatch outcome or disposition', () => {
+    expect(validate({ ...baseArtifact, dispatch_outcome: 'dropped' })).toBe(
+      false,
+    )
+    expect(errorMentions('/dispatch_outcome')).toBe(true)
+
+    expect(validate(artifactWithFinding({ disposition: 'dropped' }))).toBe(
+      false,
+    )
+    expect(errorMentions('/findings/0/disposition')).toBe(true)
+  })
+
+  test('rejects empty why_it_matters and names the field', () => {
+    expect(validate(artifactWithFinding({ why_it_matters: '' }))).toBe(false)
+    expect(errorMentions('/findings/0/why_it_matters')).toBe(true)
+  })
+
+  test('rejects empty evidence and names the field', () => {
+    expect(validate(artifactWithFinding({ evidence: [] }))).toBe(false)
+    expect(errorMentions('/findings/0/evidence')).toBe(true)
+  })
+
+  test('rejects evidence longer than the entry cap', () => {
+    expect(
+      validate(
+        artifactWithFinding({
+          evidence: ['x'.repeat(501)],
+        }),
+      ),
+    ).toBe(false)
+    expect(errorMentions('/findings/0/evidence/0')).toBe(true)
+  })
+
+  test('accepts a bounded excerpt with an explicit overflow marker', () => {
+    expect(
+      validate(
+        artifactWithFinding({
+          evidence: [
+            {
+              overflow: true,
+              excerpt: 'x'.repeat(500),
+            },
+          ],
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  test('rejects evidence exceeding the entry-count cap', () => {
+    expect(
+      validate(
+        artifactWithFinding({
+          evidence: Array.from(
+            { length: 6 },
+            (_, index) => `Evidence ${index}`,
+          ),
+        }),
+      ),
+    ).toBe(false)
+    expect(errorMentions('/findings/0/evidence')).toBe(true)
+  })
+
+  test('rejects absolute paths but accepts repo-relative paths', () => {
+    expect(
+      validate(
+        artifactWithFinding({ file: '/Users/example/repo/src/file.ts' }),
+      ),
+    ).toBe(false)
+    expect(errorMentions('/findings/0/file')).toBe(true)
+
+    expect(validate(artifactWithFinding({ file: 'src/file.ts' }))).toBe(true)
+  })
+
+  test('rejects a location without its line and names the missing field', () => {
+    const { line: _line, ...locationWithoutLine } = baseFinding
+    expect(
+      validate({
+        ...baseArtifact,
+        findings: [locationWithoutLine],
+      }),
+    ).toBe(false)
+    expect(errorMentions('/findings/0/line')).toBe(true)
+  })
+
+  test('rejects unknown harness provenance', () => {
+    expect(validate({ ...baseArtifact, harness: 'unknown' })).toBe(false)
+    expect(errorMentions('/harness')).toBe(true)
+  })
+})

--- a/tests/unit/ce-review-findings-schema.test.ts
+++ b/tests/unit/ce-review-findings-schema.test.ts
@@ -11,7 +11,12 @@ const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8')) as Record<
   string,
   unknown
 >
-const validate = new Ajv({ strict: false }).compile(schema)
+const ajv = new Ajv({ strict: false })
+const validateParent = ajv.compile(schema)
+const validateSubAgent = ajv.compile({
+  ...schema,
+  $ref: '#/definitions/subAgentReturn',
+})
 
 const baseFinding = {
   title: 'Missing deployment ordering',
@@ -40,6 +45,14 @@ const baseArtifact = {
   testing_gaps: [],
 }
 
+const { disposition: _disposition, ...baseSubAgentFinding } = baseFinding
+const baseSubAgentArtifact = {
+  reviewer: 'correctness',
+  findings: [baseSubAgentFinding],
+  residual_risks: [],
+  testing_gaps: [],
+}
+
 function artifactWithFinding(changes: Record<string, unknown>) {
   return {
     ...baseArtifact,
@@ -47,20 +60,65 @@ function artifactWithFinding(changes: Record<string, unknown>) {
   }
 }
 
-function errorMentions(pathSuffix: string): boolean {
+function subAgentWithFinding(changes: Record<string, unknown>) {
+  return {
+    ...baseSubAgentArtifact,
+    findings: [{ ...baseSubAgentFinding, ...changes }],
+  }
+}
+
+function errorMentions(
+  validate: typeof validateParent,
+  pathSuffix: string,
+): boolean {
   return (validate.errors ?? []).some((error) => {
     const fieldPath = error.instancePath ?? ''
+    const params = error.params as {
+      missingProperty?: string
+      additionalProperty?: string
+    }
     return (
       fieldPath.endsWith(pathSuffix) ||
-      (error.params as { missingProperty?: string }).missingProperty ===
-        pathSuffix.split('/').at(-1)
+      params.missingProperty === pathSuffix.split('/').at(-1) ||
+      params.additionalProperty === pathSuffix.split('/').at(-1)
+    )
+  })
+}
+
+function hasKeyword(
+  validate: typeof validateParent,
+  keyword: string,
+  pathSuffix: string,
+): boolean {
+  return (validate.errors ?? []).some(
+    (error) =>
+      error.keyword === keyword &&
+      (error.instancePath ?? '').endsWith(pathSuffix),
+  )
+}
+
+function hasAdditionalProperty(
+  validate: typeof validateParent,
+  property: string,
+  instancePath: string,
+): boolean {
+  return (validate.errors ?? []).some((error) => {
+    const params = error.params as { additionalProperty?: string }
+    return (
+      error.keyword === 'additionalProperties' &&
+      error.instancePath === instancePath &&
+      params.additionalProperty === property
     )
   })
 }
 
 describe('ce:review findings schema', () => {
-  test('accepts a bounded finding with provenance and disposition', () => {
-    expect(validate(baseArtifact)).toBe(true)
+  test('accepts a bounded parent finding with provenance and disposition', () => {
+    expect(validateParent(baseArtifact)).toBe(true)
+  })
+
+  test('accepts a sub-agent return without parent-owned fields', () => {
+    expect(validateSubAgent(baseSubAgentArtifact)).toBe(true)
   })
 
   test('accepts every dispatch outcome and disposition vocabulary value', () => {
@@ -70,7 +128,7 @@ describe('ce:review findings schema', () => {
       'malformed',
       'never_returned',
     ]) {
-      expect(validate({ ...baseArtifact, dispatch_outcome })).toBe(true)
+      expect(validateParent({ ...baseArtifact, dispatch_outcome })).toBe(true)
     }
 
     for (const disposition of [
@@ -80,46 +138,136 @@ describe('ce:review findings schema', () => {
       'filtered',
       'rejected',
     ]) {
-      expect(validate(artifactWithFinding({ disposition }))).toBe(true)
+      expect(validateParent(artifactWithFinding({ disposition }))).toBe(true)
     }
   })
 
   test('rejects an unknown dispatch outcome or disposition', () => {
-    expect(validate({ ...baseArtifact, dispatch_outcome: 'dropped' })).toBe(
-      false,
-    )
-    expect(errorMentions('/dispatch_outcome')).toBe(true)
+    expect(
+      validateParent({ ...baseArtifact, dispatch_outcome: 'dropped' }),
+    ).toBe(false)
+    expect(errorMentions(validateParent, '/dispatch_outcome')).toBe(true)
 
-    expect(validate(artifactWithFinding({ disposition: 'dropped' }))).toBe(
-      false,
+    expect(
+      validateParent(artifactWithFinding({ disposition: 'dropped' })),
+    ).toBe(false)
+    expect(errorMentions(validateParent, '/findings/0/disposition')).toBe(true)
+  })
+
+  test('rejects parent records missing dispatch_outcome', () => {
+    const { dispatch_outcome: _dispatchOutcome, ...missingDispatchOutcome } =
+      baseArtifact
+    expect(validateParent(missingDispatchOutcome)).toBe(false)
+    expect(errorMentions(validateParent, '/dispatch_outcome')).toBe(true)
+    expect(hasKeyword(validateParent, 'required', '')).toBe(true)
+  })
+
+  test('rejects parent findings missing disposition', () => {
+    const { disposition: _findingDisposition, ...missingDisposition } =
+      baseFinding
+    expect(
+      validateParent({ ...baseArtifact, findings: [missingDisposition] }),
+    ).toBe(false)
+    expect(errorMentions(validateParent, '/findings/0/disposition')).toBe(true)
+    expect(hasKeyword(validateParent, 'required', '/findings/0')).toBe(true)
+  })
+
+  test('rejects sub-agent returns carrying parent-owned fields', () => {
+    expect(
+      validateSubAgent({ ...baseSubAgentArtifact, harness: 'opencode' }),
+    ).toBe(false)
+    expect(hasAdditionalProperty(validateSubAgent, 'harness', '')).toBe(true)
+
+    expect(
+      validateSubAgent(subAgentWithFinding({ disposition: 'surviving' })),
+    ).toBe(false)
+    expect(
+      hasAdditionalProperty(validateSubAgent, 'disposition', '/findings/0'),
+    ).toBe(true)
+  })
+
+  test('rejects an unknown top-level field and names the closure constraint', () => {
+    expect(
+      validateParent({ ...baseArtifact, ROGUE_TOP_LEVEL: 'survives' }),
+    ).toBe(false)
+    expect(hasAdditionalProperty(validateParent, 'ROGUE_TOP_LEVEL', '')).toBe(
+      true,
     )
-    expect(errorMentions('/findings/0/disposition')).toBe(true)
+  })
+
+  test('rejects an unknown finding field and names the closure constraint', () => {
+    expect(
+      validateParent(artifactWithFinding({ EXTRA_INJECTED_FIELD: 'survives' })),
+    ).toBe(false)
+    expect(
+      hasAdditionalProperty(
+        validateParent,
+        'EXTRA_INJECTED_FIELD',
+        '/findings/0',
+      ),
+    ).toBe(true)
   })
 
   test('rejects empty why_it_matters and names the field', () => {
-    expect(validate(artifactWithFinding({ why_it_matters: '' }))).toBe(false)
-    expect(errorMentions('/findings/0/why_it_matters')).toBe(true)
+    expect(validateParent(artifactWithFinding({ why_it_matters: '' }))).toBe(
+      false,
+    )
+    expect(errorMentions(validateParent, '/findings/0/why_it_matters')).toBe(
+      true,
+    )
+  })
+
+  test('rejects over-long why_it_matters and names the maxLength constraint', () => {
+    expect(
+      validateParent(artifactWithFinding({ why_it_matters: 'x'.repeat(2049) })),
+    ).toBe(false)
+    expect(
+      hasKeyword(validateParent, 'maxLength', '/findings/0/why_it_matters'),
+    ).toBe(true)
   })
 
   test('rejects empty evidence and names the field', () => {
-    expect(validate(artifactWithFinding({ evidence: [] }))).toBe(false)
-    expect(errorMentions('/findings/0/evidence')).toBe(true)
+    expect(validateParent(artifactWithFinding({ evidence: [] }))).toBe(false)
+    expect(errorMentions(validateParent, '/findings/0/evidence')).toBe(true)
+  })
+
+  test('accepts evidence at both count and string-length boundaries', () => {
+    expect(
+      validateParent(
+        artifactWithFinding({
+          evidence: Array.from(
+            { length: 5 },
+            (_, index) => `Evidence ${index}`,
+          ),
+        }),
+      ),
+    ).toBe(true)
+    expect(
+      validateParent(
+        artifactWithFinding({
+          evidence: ['x'.repeat(500)],
+        }),
+      ),
+    ).toBe(true)
   })
 
   test('rejects evidence longer than the entry cap', () => {
     expect(
-      validate(
+      validateParent(
         artifactWithFinding({
           evidence: ['x'.repeat(501)],
         }),
       ),
     ).toBe(false)
-    expect(errorMentions('/findings/0/evidence/0')).toBe(true)
+    expect(errorMentions(validateParent, '/findings/0/evidence/0')).toBe(true)
+    expect(
+      hasKeyword(validateParent, 'maxLength', '/findings/0/evidence/0'),
+    ).toBe(true)
   })
 
   test('accepts a bounded excerpt with an explicit overflow marker', () => {
     expect(
-      validate(
+      validateParent(
         artifactWithFinding({
           evidence: [
             {
@@ -132,9 +280,29 @@ describe('ce:review findings schema', () => {
     ).toBe(true)
   })
 
+  test('rejects absolute paths in overflow excerpts', () => {
+    for (const excerpt of [
+      '/Users/example/repo/src/file.ts',
+      'C:\\repo\\src\\file.ts',
+      'C:/repo/src/file.ts',
+      '\\\\server\\share\\file.ts',
+    ]) {
+      expect(
+        validateParent(
+          artifactWithFinding({
+            evidence: [{ overflow: true, excerpt }],
+          }),
+        ),
+      ).toBe(false)
+      expect(
+        errorMentions(validateParent, '/findings/0/evidence/0/excerpt'),
+      ).toBe(true)
+    }
+  })
+
   test('rejects evidence exceeding the entry-count cap', () => {
     expect(
-      validate(
+      validateParent(
         artifactWithFinding({
           evidence: Array.from(
             { length: 6 },
@@ -143,33 +311,71 @@ describe('ce:review findings schema', () => {
         }),
       ),
     ).toBe(false)
-    expect(errorMentions('/findings/0/evidence')).toBe(true)
+    expect(errorMentions(validateParent, '/findings/0/evidence')).toBe(true)
+    expect(hasKeyword(validateParent, 'maxItems', '/findings/0/evidence')).toBe(
+      true,
+    )
+  })
+
+  test('rejects over-count residual risks', () => {
+    expect(
+      validateParent({
+        ...baseArtifact,
+        residual_risks: Array.from({ length: 65 }, () => 'risk'),
+      }),
+    ).toBe(false)
+    expect(hasKeyword(validateParent, 'maxItems', '/residual_risks')).toBe(true)
   })
 
   test('rejects absolute paths but accepts repo-relative paths', () => {
     expect(
-      validate(
+      validateParent(
         artifactWithFinding({ file: '/Users/example/repo/src/file.ts' }),
       ),
     ).toBe(false)
-    expect(errorMentions('/findings/0/file')).toBe(true)
+    expect(errorMentions(validateParent, '/findings/0/file')).toBe(true)
 
-    expect(validate(artifactWithFinding({ file: 'src/file.ts' }))).toBe(true)
+    for (const file of [
+      'C:\\repo\\src\\file.ts',
+      'C:/repo/src/file.ts',
+      '\\\\server\\share\\file.ts',
+    ]) {
+      expect(validateParent(artifactWithFinding({ file }))).toBe(false)
+      expect(errorMentions(validateParent, '/findings/0/file')).toBe(true)
+    }
+
+    expect(validateParent(artifactWithFinding({ file: 'src/file.ts' }))).toBe(
+      true,
+    )
+  })
+
+  test('rejects absolute paths inside evidence', () => {
+    for (const evidence of [
+      '/Users/example/repo/src/file.ts',
+      'C:\\repo\\src\\file.ts',
+      'C:/repo/src/file.ts',
+      '\\\\server\\share\\file.ts',
+    ]) {
+      expect(
+        validateParent(artifactWithFinding({ evidence: [evidence] })),
+      ).toBe(false)
+      expect(errorMentions(validateParent, '/findings/0/evidence/0')).toBe(true)
+    }
   })
 
   test('rejects a location without its line and names the missing field', () => {
     const { line: _line, ...locationWithoutLine } = baseFinding
     expect(
-      validate({
+      validateParent({
         ...baseArtifact,
         findings: [locationWithoutLine],
       }),
     ).toBe(false)
-    expect(errorMentions('/findings/0/line')).toBe(true)
+    expect(errorMentions(validateParent, '/findings/0/line')).toBe(true)
   })
 
   test('rejects unknown harness provenance', () => {
-    expect(validate({ ...baseArtifact, harness: 'unknown' })).toBe(false)
-    expect(errorMentions('/harness')).toBe(true)
+    expect(validateParent({ ...baseArtifact, harness: 'unknown' })).toBe(false)
+    expect(errorMentions(validateParent, '/harness')).toBe(true)
   })
 })


### PR DESCRIPTION
`ce:review` artifacts could not answer questions asked of them.

Across 24 recorded runs, 11 of 19 qualifying runs have any synthesis artifact and only 5 record which reviewers contributed to a merged finding. One run recorded 22 findings and 8 named outcomes, leaving 14 with no disposition at all. Of 252 findings in the corpus, 60 have blank `why_it_matters`, 58 have empty evidence, and 3 artifacts are Markdown wearing a `.json` extension.

Three separate analyses tried to answer one question — do any review personas overlap enough to merge? — and none could. That is a data-collection gap, not an analysis gap, so no further analysis of that corpus would have fixed it.

## Move persistence to the parent

Sub-agents wrote artifacts directly and nothing validated what landed. On Pi that never worked at all: every review persona declares `tools: Read, Grep, Glob, Bash`, which `resolveToolAllowlist` maps to `['read', 'grep', 'find', 'bash']` — no write capability — while the sub-agent template instructed them to write a file and called it "the ONE write operation you are permitted to make." Pi review runs have never produced artifacts.

Sub-agents now return one inline payload carrying both tiers; the parent validates against the schema and writes.

A guarded write path would have had to be both reachable and mandatory, and it is neither. Pi rejects unknown tools at catalog-build time, so a validating tool never becomes callable there. OpenCode can register a tool but cannot require it. Deleting the sub-agent write path removes the bypass by construction and behaves identically on all three harnesses, including Claude Code, which has no plugin runtime at all.

## Make the schema enforce what it claims

Review of the first commit found the central claim empirically false. A payload carrying a 50,000-character `why_it_matters`, an absolute path inside `evidence[]`, 10,000 `residual_risks` entries, and unknown fields injected at two levels validated with `valid: true, errors: none`.

The schema bounded one field well and left the rest open — its only `additionalProperties: false` sat on the overflow-marker definition, and three `maxLength` constraints covered the overflow excerpt, `file`, and evidence strings.

Now closed and bounded, with caps derived from the corpus rather than guessed (observed maxima: `title` 170, `why_it_matters` 907, `suggested_fix` 666, 7 findings per return). Path rejection applies wherever a path can appear. The contract splits in two: `subAgentReturn` forbids parent-owned provenance, `parentRecord` requires it — previously a sub-agent could forge those fields and a persisted record could omit them.

Caps sit above the observed maxima rather than at them — `title` 256, `why_it_matters` and `suggested_fix` 2048, `findings` 32 — so a legitimately longer finding is not rejected for being slightly unusual. The one exception is `evidence` maxItems, which sits exactly at the observed 5; the overflow marker exists for that case.

Schema tests go from 11 to 35. Each constraint is pinned by the AJV keyword that enforces it rather than by a bare `valid === false`, and every bound is pinned on both sides so a later edit cannot silently loosen or tighten it. Whitespace-only strings are asserted to fail on `pattern`, not `minLength` — they pass `minLength: 1`, so asserting only rejection would pass for the wrong reason.

## Record what synthesis already knows

`submitters` now holds only personas with an input finding; `agreement_credit` holds personas credited by the cross-reviewer agreement boost without one. One run credits two personas on a merged finding when both submitted nothing of their own — under the old contract those were indistinguishable, so every overlap measurement drawn from these artifacts over-counts.

Every input finding reconciles to a disposition with its stated reason. Dispatch outcome is recorded per persona. Runs ending abnormally are recorded rather than vanishing, which is the survivor bias behind every count above. A rejected payload degrades the review rather than failing it, so one malformed persona cannot destroy a whole run.

## Correct three misfiled personas

`architecture-strategist`, `pattern-recognition-specialist`, and `code-simplicity-reviewer` live in `agents/review/` but appear in no `ce:review` selection table and were dispatched zero times across 24 runs. Their real consumers are `ce-compound`, `deepen-plan`, and `ce-plan`'s deepening workflow. Their descriptions now say so, and the catalog records that `agents/review/` is a shared pool rather than a roster.

No identifier moves. Editing one bundled description cascades into the OCX registry and the committed Pi-export fixtures, both regenerated here.

## Verification

- 1833 unit tests, 0 failures
- 49 host-independent integration tests, 0 failures
- typecheck, build, content-integrity, registry drift, Pi fixture drift all clean
- lint unchanged from `main`

The receipt-workflow and eval-runner suites could not run locally — `which opencode` resolves to a mise shim that fails on invocation, so the PATH-only availability guard lets them execute instead of skip, and they hang. CI has a working host. That trap is now documented in `docs/solutions/`.

## Known follow-ups

Filed rather than folded in: #793 schema versioning and the historical corpus, #794 degrade-on-rejection hiding an uncovered critical surface, #795 no executable coverage for the orchestration flow, #796 artifact retention, #797 contract duplication and the description cascade.

`mode:report-only` keeps its no-write contract throughout.
