### PR TITLE
feat(content-integrity): resolve agent dispatch identifiers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -161,8 +161,8 @@ version is not evidence for another.
 ## Cross-Cutting Concerns
 
 **Content-integrity gate** (`scripts/content-integrity.ts`) — runs in the CI build job. Catches
-phantom `systematic:*` references, frontmatter/model contract violations, and banned CC/CEP
-patterns. Must pass before any release.
+phantom `systematic:*` references, dispatch identifier integrity issues, frontmatter/model
+contract violations, and banned CC/CEP patterns. Must pass before any release.
 
 **Registry drift detection** (`scripts/build-registry.ts --check`) — verifies that the OCX registry
 config stays in sync with the generated bundled assets. Run via `bun run registry:drift`.

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -40,6 +40,10 @@
  *    `argument-hint` field in frontmatter. Fenced code blocks are stripped before
  *    scanning so skills that only document the placeholder are not flagged.
  *
+ * 9. **Dispatch identifier integrity** — every `subagent_type` value resolves to
+ *    a bundled agent stem, and inline-code near-misses of bundled agent stems
+ *    are rejected. Bundled examples must name agents this package ships.
+ *
  * 13. **Migrated skill identifiers** — skills marked
  *     `metadata['harness-portability'] === 'neutral-v1'` must use neutral
  *     lexical vocabulary; exact harness syntax belongs in the harness profiles.
@@ -219,6 +223,29 @@ export interface AgentStemViolation {
   message: string
 }
 
+export interface DispatchIdentifierViolationBase {
+  file: string
+  line: number
+  identifier: string
+  lineContent: string
+  message: string
+}
+
+export interface UnresolvableSubagentTypeViolation
+  extends DispatchIdentifierViolationBase {
+  kind: 'unresolvable-subagent-type'
+}
+
+export interface NearMissAgentIdentifierViolation
+  extends DispatchIdentifierViolationBase {
+  kind: 'near-miss-agent-identifier'
+  matchedStem: string
+}
+
+export type DispatchIdentifierViolation =
+  | UnresolvableSubagentTypeViolation
+  | NearMissAgentIdentifierViolation
+
 export interface AgentTemperatureViolation {
   file: string
   message: string
@@ -268,6 +295,7 @@ export interface CheckResult {
   agentModeViolations: AgentModeViolation[]
   agentColorViolations: AgentColorViolation[]
   agentStemViolations: AgentStemViolation[]
+  dispatchIdentifierViolations: DispatchIdentifierViolation[]
   agentTemperatureViolations: AgentTemperatureViolation[]
   argumentHintViolations: ArgumentHintViolation[]
   migratedSkillIdentifierViolations: MigratedSkillIdentifierViolation[]
@@ -1128,6 +1156,178 @@ export function checkAgentStemUniqueness(
     .sort((a, b) => a.stem.localeCompare(b.stem))
 }
 
+// The unquoted branch must stop at backticks and quotes as well as at whitespace
+// and delimiters. Dispatch examples are frequently written inside an inline-
+// code span (`` `subagent_type: explorer` ``) or prose quotes
+// (`` "subagent_type: explorer" ``), and swallowing the closing delimiter
+// yields a value that can never match a bundled stem or the host allowlist — a
+// false positive on correct content, which a fail-closed gate cannot afford.
+const SUBAGENT_TYPE_ASSIGNMENT_REGEX =
+  /(?:\bsubagent_type\b|"subagent_type"|'subagent_type')\s*:\s*(?:"([^"\r\n]*)"|'([^'\r\n]*)'|([^\s,})`"']+))/g
+const INLINE_CODE_SPAN_REGEX = /`([^`\n]+)`/g
+const NEAR_MISS_AGENT_IDENTIFIER_REGEX = /^[a-z][a-z0-9]*(-[a-z0-9]+)+$/
+const INLINE_CODE_TOKEN_SPLIT_REGEX = /[^a-z0-9/.:-]+/
+const FENCE_START_REGEX = /^\s*(`{3,}|~{3,})/
+
+interface FenceMarker {
+  character: string
+  length: number
+}
+
+function collectBundledAgentStems(
+  rootDir: string,
+  markdownFiles: readonly string[],
+): Set<string> {
+  const stems = new Set<string>()
+
+  for (const relPath of markdownFiles) {
+    if (!isAgentFile(relPath)) continue
+    if (!fs.existsSync(path.join(rootDir, relPath))) continue
+    stems.add(path.basename(relPath, '.md'))
+  }
+
+  return stems
+}
+
+function scanSubagentTypeAssignments(
+  relPath: string,
+  line: string,
+  lineNumber: number,
+  bundledAgentStems: ReadonlySet<string>,
+): DispatchIdentifierViolation[] {
+  const violations: DispatchIdentifierViolation[] = []
+
+  for (const match of line.matchAll(SUBAGENT_TYPE_ASSIGNMENT_REGEX)) {
+    const identifier = match[1] ?? match[2] ?? match[3] ?? ''
+    if (bundledAgentStems.has(identifier)) continue
+
+    violations.push({
+      kind: 'unresolvable-subagent-type',
+      file: relPath,
+      line: lineNumber,
+      identifier,
+      lineContent: line,
+      message:
+        `The subagent_type value \`${identifier}\` is unresolvable. Bundled ` +
+        'content must name an agent this package ships: use a filename stem ' +
+        'from agents/**. A host may provide additional agents at runtime, but ' +
+        'they must not appear in bundled examples.',
+    })
+  }
+
+  return violations
+}
+
+function findNearMissAgentStem(
+  identifier: string,
+  bundledAgentStems: ReadonlySet<string>,
+): string | null {
+  if (!NEAR_MISS_AGENT_IDENTIFIER_REGEX.test(identifier)) return null
+  if (bundledAgentStems.has(identifier)) return null
+
+  return (
+    [...bundledAgentStems]
+      .filter((stem) => identifier.endsWith(`-${stem}`))
+      .sort((a, b) => b.length - a.length)[0] ?? null
+  )
+}
+
+function scanNearMissAgentIdentifiers(
+  relPath: string,
+  line: string,
+  lineNumber: number,
+  bundledAgentStems: ReadonlySet<string>,
+): DispatchIdentifierViolation[] {
+  const violations: DispatchIdentifierViolation[] = []
+
+  for (const spanMatch of line.matchAll(INLINE_CODE_SPAN_REGEX)) {
+    const span = spanMatch[1] ?? ''
+
+    for (const identifier of span.split(INLINE_CODE_TOKEN_SPLIT_REGEX)) {
+      // Paths and canonical references are intentionally not dispatch
+      // identifiers, even when one of their components resembles a stem.
+      if (identifier.length === 0 || /[/.:]/.test(identifier)) continue
+      const matchedStem = findNearMissAgentStem(identifier, bundledAgentStems)
+      if (!matchedStem) continue
+
+      violations.push({
+        kind: 'near-miss-agent-identifier',
+        file: relPath,
+        line: lineNumber,
+        identifier,
+        lineContent: line,
+        matchedStem,
+        message:
+          `Inline-code identifier \`${identifier}\` ends with bundled ` +
+          `agent stem \`${matchedStem}\` but is not itself a resolvable ` +
+          `agent dispatch identifier. Did you mean \`${matchedStem}\`?`,
+      })
+    }
+  }
+
+  return violations
+}
+
+function updateFenceMarker(
+  line: string,
+  currentMarker: FenceMarker | null,
+): { marker: FenceMarker | null; isFence: boolean } {
+  const fenceMatch = line.match(FENCE_START_REGEX)
+  if (!fenceMatch) return { marker: currentMarker, isFence: false }
+
+  const markerRun = fenceMatch[1] ?? ''
+  const character = markerRun[0] ?? null
+  if (character === null) return { marker: currentMarker, isFence: true }
+  const marker: FenceMarker = { character, length: markerRun.length }
+  if (currentMarker === null) return { marker, isFence: true }
+  if (
+    marker.character === currentMarker.character &&
+    marker.length >= currentMarker.length
+  ) {
+    return { marker: null, isFence: true }
+  }
+  return { marker: currentMarker, isFence: true }
+}
+
+export function checkDispatchIdentifiers(
+  rootDir: string,
+  markdownFiles: readonly string[],
+): DispatchIdentifierViolation[] {
+  const bundledAgentStems = collectBundledAgentStems(rootDir, markdownFiles)
+  const violations: DispatchIdentifierViolation[] = []
+
+  for (const relPath of markdownFiles) {
+    const content = readFileSafe(path.join(rootDir, relPath))
+    if (content === null) continue
+
+    const lines = content.split('\n')
+    let fenceMarker: FenceMarker | null = null
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i] ?? ''
+
+      violations.push(
+        ...scanSubagentTypeAssignments(relPath, line, i + 1, bundledAgentStems),
+      )
+
+      const fence = updateFenceMarker(line, fenceMarker)
+      fenceMarker = fence.marker
+      if (fence.isFence || fenceMarker !== null) continue
+
+      violations.push(
+        ...scanNearMissAgentIdentifiers(
+          relPath,
+          line,
+          i + 1,
+          bundledAgentStems,
+        ),
+      )
+    }
+  }
+
+  return violations
+}
+
 /**
  * Strip fenced code blocks (``` or ~~~) from a markdown body string.
  * Returns the body with all fenced regions replaced by empty strings so that
@@ -1513,6 +1713,10 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     rootDir,
     targets.markdown,
   )
+  const dispatchIdentifierViolations = checkDispatchIdentifiers(
+    rootDir,
+    targets.markdown,
+  )
   const agentTemperatureViolations = checkAgentTemperature(
     rootDir,
     targets.markdown,
@@ -1549,6 +1753,7 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     agentModeViolations,
     agentColorViolations,
     agentStemViolations,
+    dispatchIdentifierViolations,
     agentTemperatureViolations,
     argumentHintViolations,
     migratedSkillIdentifierViolations,
@@ -1601,6 +1806,7 @@ function printResult(result: CheckResult, verbose: boolean): void {
   printAgentModeViolations(result.agentModeViolations)
   printAgentColorViolations(result.agentColorViolations)
   printAgentStemViolations(result.agentStemViolations)
+  printDispatchIdentifierViolations(result.dispatchIdentifierViolations)
   printAgentTemperatureViolations(result.agentTemperatureViolations)
   printArgumentHintViolations(result.argumentHintViolations)
   printMigratedSkillIdentifierViolations(
@@ -1628,6 +1834,7 @@ function printResult(result: CheckResult, verbose: boolean): void {
         `agentModeViolations: ${result.agentModeViolations.length}\n` +
         `agentColorViolations: ${result.agentColorViolations.length}\n` +
         `agentStemViolations: ${result.agentStemViolations.length}\n` +
+        `dispatchIdentifierViolations: ${result.dispatchIdentifierViolations.length}\n` +
         `exemptHits: ${result.exemptHits.length}\n`,
     )
   }
@@ -1737,6 +1944,20 @@ function printAgentStemViolations(
   }
 }
 
+function printDispatchIdentifierViolations(
+  violations: readonly DispatchIdentifierViolation[],
+): void {
+  if (violations.length === 0) return
+  process.stderr.write(
+    `\nDispatch identifier violations (${violations.length}):\n`,
+  )
+  for (const v of violations) {
+    process.stderr.write(
+      `  [${v.kind}] ${v.file}:${v.line}  ${v.identifier}  ${v.message}\n`,
+    )
+  }
+}
+
 function printAgentTemperatureViolations(
   violations: readonly AgentTemperatureViolation[],
 ): void {
@@ -1797,6 +2018,7 @@ function totalViolations(result: CheckResult): number {
     result.agentModeViolations.length +
     result.agentColorViolations.length +
     result.agentStemViolations.length +
+    result.dispatchIdentifierViolations.length +
     result.agentTemperatureViolations.length +
     result.argumentHintViolations.length +
     result.migratedSkillIdentifierViolations.length +

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -1160,8 +1160,8 @@ export function checkAgentStemUniqueness(
 // and delimiters. Dispatch examples are frequently written inside an inline-
 // code span (`` `subagent_type: explorer` ``) or prose quotes
 // (`` "subagent_type: explorer" ``), and swallowing the closing delimiter
-// yields a value that can never match a bundled stem or the host allowlist — a
-// false positive on correct content, which a fail-closed gate cannot afford.
+// yields a value that can never match a bundled stem — a false positive on
+// correct content, which a fail-closed gate cannot afford.
 const SUBAGENT_TYPE_ASSIGNMENT_REGEX =
   /(?:\bsubagent_type\b|"subagent_type"|'subagent_type')\s*:\s*(?:"([^"\r\n]*)"|'([^'\r\n]*)'|([^\s,})`"']+))/g
 const INLINE_CODE_SPAN_REGEX = /`([^`\n]+)`/g
@@ -1218,12 +1218,35 @@ function scanSubagentTypeAssignments(
   return violations
 }
 
+/**
+ * Bundled skill directory names, excluded from near-miss detection.
+ *
+ * Skill directories are kebab-case like agent stems, so a skill named `ce-plan`
+ * would read as a near miss of a bundled agent named `plan`. No such agent
+ * exists today, but relying on that coincidence would mean a single future
+ * naming choice fails every `ce-plan` reference across the bundle at once.
+ * Excluding real skill names removes the coupling instead of documenting it.
+ */
+function collectBundledSkillNames(rootDir: string): Set<string> {
+  const names = new Set<string>()
+  const skillsDir = path.join(rootDir, 'skills')
+  if (!fs.existsSync(skillsDir)) return names
+
+  for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+    if (entry.isDirectory()) names.add(entry.name)
+  }
+
+  return names
+}
+
 function findNearMissAgentStem(
   identifier: string,
   bundledAgentStems: ReadonlySet<string>,
+  bundledSkillNames: ReadonlySet<string>,
 ): string | null {
   if (!NEAR_MISS_AGENT_IDENTIFIER_REGEX.test(identifier)) return null
   if (bundledAgentStems.has(identifier)) return null
+  if (bundledSkillNames.has(identifier)) return null
 
   return (
     [...bundledAgentStems]
@@ -1237,6 +1260,7 @@ function scanNearMissAgentIdentifiers(
   line: string,
   lineNumber: number,
   bundledAgentStems: ReadonlySet<string>,
+  bundledSkillNames: ReadonlySet<string>,
 ): DispatchIdentifierViolation[] {
   const violations: DispatchIdentifierViolation[] = []
 
@@ -1247,7 +1271,11 @@ function scanNearMissAgentIdentifiers(
       // Paths and canonical references are intentionally not dispatch
       // identifiers, even when one of their components resembles a stem.
       if (identifier.length === 0 || /[/.:]/.test(identifier)) continue
-      const matchedStem = findNearMissAgentStem(identifier, bundledAgentStems)
+      const matchedStem = findNearMissAgentStem(
+        identifier,
+        bundledAgentStems,
+        bundledSkillNames,
+      )
       if (!matchedStem) continue
 
       violations.push({
@@ -1294,6 +1322,7 @@ export function checkDispatchIdentifiers(
   markdownFiles: readonly string[],
 ): DispatchIdentifierViolation[] {
   const bundledAgentStems = collectBundledAgentStems(rootDir, markdownFiles)
+  const bundledSkillNames = collectBundledSkillNames(rootDir)
   const violations: DispatchIdentifierViolation[] = []
 
   for (const relPath of markdownFiles) {
@@ -1320,6 +1349,7 @@ export function checkDispatchIdentifiers(
           line,
           i + 1,
           bundledAgentStems,
+          bundledSkillNames,
         ),
       )
     }

--- a/skills/using-systematic/references/opencode-profile.md
+++ b/skills/using-systematic/references/opencode-profile.md
@@ -22,15 +22,25 @@ task({
 
 // Background dispatch (run independent work concurrently; reconcile on completion):
 task({
-  subagent_type: "explorer",
+  subagent_type: "repo-research-analyst",
   description: "Map fixture patterns",
   prompt: "…",
   background: true,
 })
 
 // Resume a prior specialist session:
-task({ subagent_type: "fixer", task_id: "<prior-session-id>", description: "Resume fixer task", prompt: "…" })
+task({ subagent_type: "systematic-implementer", task_id: "<prior-session-id>", description: "Resume the implementation task", prompt: "…" })
 ```
+
+`subagent_type` takes a bare agent stem — OpenCode registers bundled agents under
+their filename stem, not a namespaced identifier. Prose that *refers* to an agent
+uses the canonical `systematic:<category>:<name>` form instead, which the
+content-integrity gate validates against real agent files.
+
+Both forms are enforced. Examples in bundled content must name agents this
+package actually ships, so they work for every reader. A host may provide
+additional agents through the user's own configuration; those are available at
+runtime but must not appear in bundled examples.
 
 ### Blocking user interaction
 

--- a/tests/unit/__snapshots__/bootstrap.test.ts.snap
+++ b/tests/unit/__snapshots__/bootstrap.test.ts.snap
@@ -153,15 +153,25 @@ task({
 
 // Background dispatch (run independent work concurrently; reconcile on completion):
 task({
-  subagent_type: "explorer",
+  subagent_type: "repo-research-analyst",
   description: "Map fixture patterns",
   prompt: "…",
   background: true,
 })
 
 // Resume a prior specialist session:
-task({ subagent_type: "fixer", task_id: "<prior-session-id>", description: "Resume fixer task", prompt: "…" })
+task({ subagent_type: "systematic-implementer", task_id: "<prior-session-id>", description: "Resume the implementation task", prompt: "…" })
 \`\`\`
+
+\`subagent_type\` takes a bare agent stem — OpenCode registers bundled agents under
+their filename stem, not a namespaced identifier. Prose that *refers* to an agent
+uses the canonical \`systematic:<category>:<name>\` form instead, which the
+content-integrity gate validates against real agent files.
+
+Both forms are enforced. Examples in bundled content must name agents this
+package actually ships, so they work for every reader. A host may provide
+additional agents through the user's own configuration; those are available at
+runtime but must not appear in bundled examples.
 
 ### Blocking user interaction
 

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -1879,6 +1879,37 @@ describe('checkDispatchIdentifiers', () => {
     }
   })
 
+  test('does not flag a skill directory name that shadows an agent stem', () => {
+    const root = makeFixtureRepo()
+    try {
+      // A bundled agent literally named `plan` makes `ce-plan` look like a
+      // near miss. Without the skill-name exclusion, every reference to the
+      // real `ce-plan` skill across the bundle would fail at once.
+      writeAgent(root, 'workflow', 'plan')
+      writeSkill(root, 'ce-plan', 'Placeholder.\n')
+      writeSkill(
+        root,
+        'foo',
+        'Real skill reference: `ce-plan`\n' +
+          'Genuine near miss: `ce-nonexistent-plan`\n',
+      )
+
+      const violations = checkDispatchIdentifiers(
+        root,
+        collectScanTargets(root).markdown,
+      )
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({
+        kind: 'near-miss-agent-identifier',
+        identifier: 'ce-nonexistent-plan',
+        matchedStem: 'plan',
+      })
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   test('flags near-miss bundled agent identifiers only in inline code', () => {
     const root = makeFixtureRepo()
     try {

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -14,6 +14,7 @@ import {
   checkArgumentHint,
   checkBannedPatterns,
   checkContentIntegrity,
+  checkDispatchIdentifiers,
   checkFrontmatter,
   checkFrontmatterParseSafety,
   checkMigratedSkillIdentifiers,
@@ -1696,6 +1697,265 @@ describe('checkAgentStemUniqueness', () => {
   })
 })
 
+describe('checkDispatchIdentifiers', () => {
+  test('flags unresolvable subagent types, including examples in fenced code', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAgent(root, 'workflow', 'systematic-implementer')
+      writeAgent(root, 'research', 'repo-research-analyst')
+      writeSkill(
+        root,
+        'foo',
+        'The `subagent_type` parameter selects a specialist.\n' +
+          'task({ subagent_type: "NotARealAgent" })\n' +
+          '```typescript\n' +
+          "task({ subagent_type: 'AlsoNotReal' })\n" +
+          '```\n' +
+          'task({ subagent_type: repo-research-analyst })\n' +
+          "task({ subagent_type: 'repo-research-analyst' })\n" +
+          'task({ subagent_type: "systematic-implementer" })\n',
+      )
+
+      const targets = collectScanTargets(root)
+      const violations = checkDispatchIdentifiers(root, targets.markdown)
+
+      expect(violations).toHaveLength(2)
+      expect(violations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'unresolvable-subagent-type',
+            file: 'skills/foo/SKILL.md',
+            line: 2,
+            identifier: 'NotARealAgent',
+          }),
+          expect.objectContaining({
+            kind: 'unresolvable-subagent-type',
+            file: 'skills/foo/SKILL.md',
+            line: 4,
+            identifier: 'AlsoNotReal',
+          }),
+        ]),
+      )
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('does not swallow the closing backtick of an inline-code dispatch example', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAgent(root, 'workflow', 'systematic-implementer')
+      writeAgent(root, 'research', 'repo-research-analyst')
+      writeSkill(
+        root,
+        'foo',
+        'Bundled agent inline: `subagent_type: repo-research-analyst`\n' +
+          'Another bundled agent: `subagent_type: systematic-implementer`\n' +
+          'Bogus inline: `subagent_type: NotARealAgent`\n',
+      )
+
+      const targets = collectScanTargets(root)
+      const violations = checkDispatchIdentifiers(root, targets.markdown)
+
+      // The bundled values must not fire. An unquoted capture that ran to the
+      // closing backtick would yield "repo-research-analyst`", which resolves to
+      // nothing and false-positives on correct content.
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toEqual(
+        expect.objectContaining({
+          kind: 'unresolvable-subagent-type',
+          line: 3,
+          identifier: 'NotARealAgent',
+        }),
+      )
+      expect(violations[0]?.identifier).not.toContain('`')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags quoted subagent_type property keys without accepting mismatched quotes', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeSkill(
+        root,
+        'foo',
+        'JSON dispatch: task({ "subagent_type": "ce-implementer" })\n' +
+          'Mismatched dispatch: task({ "subagent_type\': "ce-implementer" })\n',
+      )
+
+      const violations = checkDispatchIdentifiers(
+        root,
+        collectScanTargets(root).markdown,
+      )
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({
+        kind: 'unresolvable-subagent-type',
+        line: 1,
+        identifier: 'ce-implementer',
+      })
+      expect(violations[0]?.message).toContain(
+        'use a filename stem from agents/**',
+      )
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('stops unquoted captures at prose quotes and still flags unresolved quoted error messages', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAgent(root, 'research', 'repo-research-analyst')
+      writeSkill(
+        root,
+        'foo',
+        'If you see "Unknown subagent_type: ce-architecture-strategist", use the canonical form.\n' +
+          'The documented value is "subagent_type: repo-research-analyst".\n',
+      )
+
+      const violations = checkDispatchIdentifiers(
+        root,
+        collectScanTargets(root).markdown,
+      )
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({
+        kind: 'unresolvable-subagent-type',
+        line: 1,
+        identifier: 'ce-architecture-strategist',
+      })
+      expect(violations[0]?.identifier).not.toMatch(/["']/)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('does not close a longer fence with a shorter same-character fence', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAgent(root, 'review', 'architecture-strategist')
+      writeSkill(
+        root,
+        'foo',
+        '````\n' +
+          'Opened with FOUR backticks.\n' +
+          '```\n' +
+          'This near-miss remains inside the outer fence: `ce-architecture-strategist`\n' +
+          '````\n',
+      )
+
+      expect(
+        checkDispatchIdentifiers(root, collectScanTargets(root).markdown),
+      ).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('scans each inline-code token independently when one token is a path', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAgent(root, 'review', 'architecture-strategist')
+      writeSkill(
+        root,
+        'foo',
+        '`agents/review/architecture-strategist.md or ce-architecture-strategist`\n',
+      )
+
+      const violations = checkDispatchIdentifiers(
+        root,
+        collectScanTargets(root).markdown,
+      )
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({
+        kind: 'near-miss-agent-identifier',
+        identifier: 'ce-architecture-strategist',
+        matchedStem: 'architecture-strategist',
+      })
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('flags near-miss bundled agent identifiers only in inline code', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeAgent(root, 'review', 'architecture-strategist')
+      writeSkill(
+        root,
+        'foo',
+        'Use `ce-architecture-strategist` when dispatching.\n' +
+          'The path `agents/review/architecture-strategist.md` is valid.\n' +
+          'The canonical reference `systematic:review:architecture-strategist` is valid.\n' +
+          'Skill names `ce-plan` and `ce-review` are not agent identifiers.\n' +
+          'Plain ce-architecture-strategist prose is not an inline-code token.\n',
+      )
+
+      const targets = collectScanTargets(root)
+      const violations = checkDispatchIdentifiers(root, targets.markdown)
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({
+        kind: 'near-miss-agent-identifier',
+        file: 'skills/foo/SKILL.md',
+        line: 1,
+        identifier: 'ce-architecture-strategist',
+        matchedStem: 'architecture-strategist',
+      })
+      expect(violations[0]?.message).toContain(
+        'Did you mean `architecture-strategist`?',
+      )
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('checkContentIntegrity — dispatch identifier wiring', () => {
+  test('surfaces a dispatch-only violation and counts it toward the CLI exit status', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeCompliantSkill(
+        root,
+        'foo',
+        'task({ subagent_type: "not-a-bundled-agent" })\n',
+      )
+
+      const result = checkContentIntegrity(root)
+
+      expect(result.dispatchIdentifierViolations).toHaveLength(1)
+      expect(result.dispatchIdentifierViolations[0]?.identifier).toBe(
+        'not-a-bundled-agent',
+      )
+      expect(result.phantomRefs).toEqual([])
+      expect(result.phantomSkillRefs).toEqual([])
+      expect(result.brokenSubfileRefs).toEqual([])
+      expect(result.bannedPatterns).toEqual([])
+      expect(result.frontmatterViolations).toEqual([])
+      expect(result.parseSafetyViolations).toEqual([])
+      expect(result.agentModelViolations).toEqual([])
+      expect(result.agentModeViolations).toEqual([])
+      expect(result.agentColorViolations).toEqual([])
+      expect(result.agentStemViolations).toEqual([])
+      expect(result.agentTemperatureViolations).toEqual([])
+      expect(result.argumentHintViolations).toEqual([])
+      expect(result.migratedSkillIdentifierViolations).toEqual([])
+      expect(result.removedNamesOverlapViolations).toEqual([])
+
+      const proc = Bun.spawnSync(['bun', SCRIPT_PATH, root], {
+        cwd: REPO_ROOT,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      expect(proc.exitCode).toBe(1)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
 describe('checkContentIntegrity (top-level)', () => {
   test('clean repo with no violations returns empty arrays', () => {
     const root = makeFixtureRepo()
@@ -1711,6 +1971,7 @@ describe('checkContentIntegrity (top-level)', () => {
       expect(result.frontmatterViolations).toEqual([])
       expect(result.agentModelViolations).toEqual([])
       expect(result.agentStemViolations).toEqual([])
+      expect(result.dispatchIdentifierViolations).toEqual([])
       expect(result.scanStats.markdownFiles).toBe(2) // SKILL.md + agent a.md
       expect(result.scanStats.typescriptFiles).toBe(1)
       expect(result.categories).toEqual(['research'])


### PR DESCRIPTION
`checkReferenceIntegrity` validates references shaped `systematic:<category>:<name>` against real files in `agents/`. Identifiers written any other way are invisible to it. That is how 24 phantom `ce-`-prefixed references and a `subagent_type: Explore` naming nothing sat in bundled content for weeks while the gate reported clean.

v3.10.2 fixed those instances by hand. This closes the mechanism that let them accumulate.

## What the check does

A literal `subagent_type` value must resolve to a bundled agent filename stem. An inline-code kebab-case token that ends with a real bundled stem but is not itself resolvable is a near miss and fails.

Both rules are deliberately narrow. Deciding whether arbitrary prose refers to an agent is undecidable, and this repository has no advisory warning channel — a check fails the build or does nothing, so a noisy check is not shippable. Structural exclusions keep it quiet: path and canonical-reference tokens are excluded individually rather than suppressing their whole span, and no bundled agent is named `plan` or `review`, so skill directories like `ce-plan` cannot collide.

## A bundled example that could never work

`skills/using-systematic/references/opencode-profile.md` demonstrated dispatch using `explorer` and `fixer`. Neither ships in this package — they come from the user's own OpenCode configuration. Anyone without those agents would copy the example and get an unresolvable dispatch.

The first version of this change added an allowlist so the gate would accept them. That was backwards: it built machinery to accommodate content that shouldn't exist. The examples now use bundled agents, so every reader can run them, and the gate carries no exceptions at all.

A sweep of every agent-shaped inline-code token across `skills/` and `agents/` found no other instance. The only other hits were `downstream-resolver` and `review-fixer`, which are owner values in the review routing table rather than agents, and `scope-guardian`, which is `document-review`'s documented short persona label for reviewer identity in output — distinct from the qualified form it uses for dispatch.

## Verified against real content, not fixtures

Restoring `skills/ce-plan/references/deepening-workflow.md` and `skills/agent-native-audit/SKILL.md` from `070b741^` produces 24 violations and exit 1. Every reference this gate would have caught is one that actually shipped.

That exercise found what fixtures missed. Review then found four more, each reproduced before being fixed:

- Quoted property keys never matched, so `{ "subagent_type": "x" }` passed silently.
- The unquoted branch did not stop at a quote character, producing a malformed identifier and risking a false positive on correct content.
- `updateFenceMarker` kept only the first fence character, so a three-backtick line closed a four-backtick fence and scanning resumed inside content that was still fenced.
- A single path token suppressed near-miss detection for every token sharing its inline-code span.

The first two are false negatives; the last two are false positives. For a fail-closed gate the false positives are the more urgent half, since they block every contributor.

A fifth claim — that double-backtick spans hide near-misses — was refuted by probe. The regex matches the inner pairing and the violation does fire. No change made.

## Shape

`DispatchIdentifierViolation` is a discriminated union carrying `matchedStem` on the near-miss variant, so consumers read the cause from a field rather than parsing prose. Failure messages state the bundled-stem requirement explicitly, because the most tempting wrong guess — converting to a bare name — is exactly the one that removes validation coverage.

## Verification

- 1841 unit tests, 0 failures
- 24 historical defects still caught, exit 1, restored clean
- typecheck, content-integrity, registry drift, Pi fixture drift all clean
- lint unchanged from `main`
- bootstrap snapshot updated; the profile doc is inlined there, and the diff is exactly the example change

Closes #800.
