### PR TITLE
docs(solutions): record two verification boundaries and an allowlist rule

### DIFF
--- a/docs/solutions/best-practices/an-allowlist-is-a-claim-the-content-is-correct-2026-08-17.md
+++ b/docs/solutions/best-practices/an-allowlist-is-a-claim-the-content-is-correct-2026-08-17.md
@@ -1,0 +1,116 @@
+---
+title: An allowlist is a claim that the rejected content is correct
+date: 2026-08-17
+category: best-practices
+module: content-integrity
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - "A new or tightened fail-closed gate rejects pre-existing content"
+  - "The proposed remedy is an allowlist, exemption, or suppression entry"
+  - "The rejected content is an example intended for readers or downstream users"
+  - "Content may depend on capabilities the package does not itself ship"
+tags:
+  - allowlist
+  - content-integrity
+  - fail-closed
+  - gate-design
+  - root-cause
+---
+
+# An allowlist is a claim that the rejected content is correct
+
+## Context
+
+A new fail-closed gate, `checkDispatchIdentifiers` in `scripts/content-integrity.ts`, requires every `subagent_type` value in bundled content to resolve to a bundled agent filename stem.
+
+It immediately failed on `skills/using-systematic/references/opencode-profile.md`, which demonstrated dispatch with `explorer` and `fixer`. The first response was to add an allowlist constant so those values would pass.
+
+That was the wrong branch. Neither agent ships in this package:
+
+```bash
+ls agents/*/explorer.md agents/*/fixer.md
+# No such file or directory
+```
+
+They came from the maintainer's own OpenCode configuration. The examples worked when *he* read them and failed for everyone else — a reader without those agents would copy the snippet and get an unresolvable dispatch. The gate was right; the content was wrong.
+
+The correction deleted the allowlist constant, its two call sites, a helper function, and its documentation, and changed the examples to bundled agents. The fix removed code rather than adding it.
+
+## Guidance
+
+When a new gate fails on pre-existing content, there are exactly two hypotheses:
+
+1. The gate is too strict.
+2. The content is wrong.
+
+**An allowlist silently selects the first.** Writing one asserts that the rejected content is correct and the gate should tolerate it. That assertion deserves the same scrutiny as any other claim about the codebase — it is easy to make, permanent once written, and it conceals the defect it tolerates.
+
+Rule out hypothesis 2 before writing the entry. For a reference gate, that means checking whether the referenced thing exists:
+
+```bash
+for name in explorer fixer; do
+  ls agents/*/"$name".md >/dev/null 2>&1 || echo "not bundled: $name"
+done
+```
+
+This is not an argument against allowlists. Existing ones in this repo are legitimate — `scripts/.drift-allowlist.json` preserves historical fidelity in third-party skills with a required reason field, and trust-boundary allowlists are how the config overlay stays fail-closed. What distinguishes those from this case is that each documents an *intentional* exception. The narrow rule:
+
+> Do not use an allowlist to avoid deciding whether the rejected content is actually wrong.
+
+A useful tell: if the allowlist entry would need a reason field and you cannot write a truthful one beyond "the gate flags it," you are exempting a defect.
+
+## Why This Matters
+
+The gate found a real bug on its first run — a documented example that could not work for its audience. Adding the allowlist would have converted that signal into permanent silence, and the example would have stayed broken indefinitely with a config entry asserting it was fine.
+
+There is a second cost. An allowlist is a maintenance surface: an entry to keep current, a constant to discover, and an exception every future reader has to reason about. Fixing two example values removed all of it. When the correct fix deletes code and the workaround adds it, that asymmetry is itself evidence about which hypothesis was right.
+
+## When to Apply
+
+- A validation gate is introduced or tightened and pre-existing content fails for the first time.
+- The proposed remedy is an exemption, suppression comment, allowlist entry, or a widened pattern.
+- The failing content is an example, template, or documentation snippet — anything a reader is meant to copy. These fail silently for the reader, not for you.
+- The content depends on something present in your environment but not in the package.
+
+## Examples
+
+**Wrong sequence:**
+
+```text
+new gate rejects `subagent_type: explorer`
+→ add `explorer` to HOST_PROVIDED_AGENT_STEMS
+→ gate passes, example stays broken for every reader
+```
+
+**Right sequence:**
+
+```text
+new gate rejects `subagent_type: explorer`
+→ check: does agents/*/explorer.md exist?  no
+→ conclude: the example cannot work for anyone without that host config
+→ replace with a bundled agent
+→ gate stays fail-closed with no exception to maintain
+```
+
+**The diff shapes differ, and that is the signal:**
+
+```diff
+- export const HOST_PROVIDED_AGENT_STEMS: ReadonlySet<string> = new Set([
+-   'explorer',
+-   'fixer',
+- ])
+```
+
+```diff
+- subagent_type: "explorer",
++ subagent_type: "repo-research-analyst",
+```
+
+## Related
+
+- [`docs/solutions/best-practices/content-integrity-has-no-warning-channel-2026-06-06.md`](content-integrity-has-no-warning-channel-2026-06-06.md) — gates here fail closed or do nothing, which is why an exemption is the only escape valve and why writing one deserves scrutiny.
+- [`docs/solutions/best-practices/third-party-bundled-skills-light-adaptation-2026-05-17.md`](third-party-bundled-skills-light-adaptation-2026-05-17.md) — the contrasting case: drift-allowlist entries that are legitimate because they preserve intentional historical fidelity and carry a reason.
+- [`docs/solutions/best-practices/neutral-v1-marker-migrated-set-identifier-gate-2026-07-17.md`](neutral-v1-marker-migrated-set-identifier-gate-2026-07-17.md) — exemptions in a lexical gate kept deliberately narrow and identifier-aware.
+- [`docs/solutions/best-practices/qualified-persona-ids-are-canonical-validated-references-2026-07-17.md`](qualified-persona-ids-are-canonical-validated-references-2026-07-17.md) — the same gate family; its addendum covers the inverse failure, where unvalidated forms rot unnoticed.

--- a/docs/solutions/developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md
+++ b/docs/solutions/developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md
@@ -1,8 +1,8 @@
 ---
-title: semantic-release release-notes-generator ignores commit bodies; patch with gh release edit
+title: The release pipeline has two stages with opposite commit-body ingestion
 module: .releaserc.yaml + release-pipeline
 date: 2026-05-17
-last_updated: 2026-08-16
+last_updated: 2026-08-17
 problem_type: developer_experience
 component: tooling
 severity: medium
@@ -17,11 +17,14 @@ applies_when:
   - A release needs an audience-facing narrative (deprecation cycle, migration steps, breaking changes) beyond the auto-generated commit-subject bullets
   - Authoring a squash-commit message body intending for it to appear in the GitHub release notes
   - Validating release-notes content after a semantic-release publish
+  - Writing any commit subject, commit body, or PR description that will land between two releases
 ---
 
-> **Note (2026-05-23):** The manual `gh release edit` workflow described here is now automated for this repo. As of v2.23.4, `scripts/dispatch-release-notes.sh` (wired via `@semantic-release/exec` in `.releaserc.yaml`) dispatches the `release-notes-narrative` skill on every successful publish from `main`. See [`docs/solutions/best-practices/release-notes-narrative-ci-automation-architecture-2026-05-23.md`](../best-practices/release-notes-narrative-ci-automation-architecture-2026-05-23.md) for the v2 CI automation architecture and [`docs/solutions/best-practices/release-notes-narrative-procedure-2026-05-23.md`](../best-practices/release-notes-narrative-procedure-2026-05-23.md) for the v1 manual procedure both modes inherit. The myth itself — that release-notes-generator ingests commit bodies — remains true. Manual `gh release edit` is still the right answer when the automation fails-soft or for backfilling historical releases.
+> **Note (2026-05-23):** The manual `gh release edit` workflow described here is now automated for this repo. As of v2.23.4, `scripts/dispatch-release-notes.sh` (wired via `@semantic-release/exec` in `.releaserc.yaml`) dispatches the `release-notes-narrative` skill on every successful publish from `main`. See [`docs/solutions/best-practices/release-notes-narrative-ci-automation-architecture-2026-05-23.md`](../best-practices/release-notes-narrative-ci-automation-architecture-2026-05-23.md) for the v2 CI automation architecture and [`docs/solutions/best-practices/release-notes-narrative-procedure-2026-05-23.md`](../best-practices/release-notes-narrative-procedure-2026-05-23.md) for the v1 manual procedure both modes inherit. Manual `gh release edit` is still the right answer when the automation fails-soft or for backfilling historical releases.
 
-# semantic-release release-notes-generator ignores commit bodies; patch with gh release edit
+> **Correction (2026-08-17):** The 2026-05-23 note above originally ended "The myth itself — that release-notes-generator ignores commit bodies — remains true." That is true of the *plugin* and false of the *pipeline*, and the difference is not academic — see [Stage 2 reversed the ingestion rule](#stage-2-reversed-the-ingestion-rule-2026-08-17) below. Reading only the original claim leads to "commit bodies are internal," which published internal planning vocabulary to a real release.
+
+# The release pipeline has two stages with opposite commit-body ingestion
 
 ## Context
 
@@ -71,11 +74,85 @@ The detailed PR body is reviewer-facing, not audience-facing. The squash-commit 
 
 The cost of the patch is small: a `gh release edit` call after the release-pipeline run completes. The cost of skipping it is users hitting v3.0.0 surprised, opening issues, and the maintainer linking them to a commit body they didn't know existed.
 
+## Stage 2 reversed the ingestion rule (2026-08-17)
+
+The pipeline has two stages, and they ingest different things. Conflating them is
+what makes this doc's original framing dangerous rather than merely incomplete.
+
+| Stage | Mechanism | Reads |
+|---|---|---|
+| 1 | `@semantic-release/release-notes-generator` | commit **subjects** only |
+| 2 | `release-notes-narrative` skill via `successCmd` | commit **bodies** (`%b`) and PR descriptions |
+
+Stage 2 is dispatched by `scripts/dispatch-release-notes.sh` on every successful
+publish and pulls the full body of every commit in the range:
+
+```bash
+# .agents/skills/release-notes-narrative/SKILL.md
+git log "${PREV}..${TARGET}" --pretty=format:'%H%x1f%s%x1f%b%x1e'
+```
+
+It also reads the PR description when a commit body is thin. So the practical
+answer to "does my commit body reach the published release notes?" is **yes** —
+via stage 2 — even though the plugin in stage 1 never touches it.
+
+### Non-releasing commits are not private commits
+
+Two settings in `.releaserc.yaml` answer different questions, and only one of
+them is scope-aware:
+
+| Setting | Question | Scope-aware |
+|---|---|---|
+| `releaseRules` | Does this commit trigger a release? | **Yes** — `docs` releases only for `readme`/`skill`/`skills`/`agents`/`commands` |
+| `presetConfig.types` | Which notes section does it get? | **No** — `docs` → "Documentation", unconditionally |
+
+A `docs(plans)` commit therefore triggers nothing and still earns a Documentation
+section in whatever release does fire. Stage 2 then expands that section into
+prose.
+
+That is not hypothetical. The v3.11.0 notes opened their Documentation section
+with "Plan item I5 is marked complete." `I5` is an initiative label from an
+internal planning document. It reached the public record from commit `3463491`,
+subject `docs(plans): mark I5 complete and scope its residual to reference
+integrity (#801)` — the only commit in `v3.10.2..v3.11.0` mentioning it, and a
+non-releasing one.
+
+The reasoning that failed was: *`docs(plans)` publishes nothing, so its wording is
+internal.* Both halves were individually correct about stage 1 and wrong about the
+pipeline.
+
+### What this means for writing commits
+
+Treat every commit subject, commit body, and PR description that lands between two
+releases as **public prose**. This repo squash-merges with
+`squash_merge_commit_title=COMMIT_OR_PR_TITLE`, so a PR title becomes a commit
+subject, and a PR body becomes stage 2 input.
+
+Before committing or opening a PR, check for internal vocabulary:
+
+```bash
+git log -1 --format='%B' | grep -nEi \
+  'plan item|initiative|\bI[0-9]+\b|wedge|phase [0-9]|unit [0-9]|persona|entry gate'
+```
+
+The fix is not to stop writing informative bodies — stage 2 exists precisely to use
+them. The fix is to write them in the vocabulary of someone who has never read the
+plan: describe the change and its consequence, not the plan coordinate it occupies.
+
+```text
+# Leaks planning taxonomy
+docs(plans): mark I5 complete and scope its residual to reference integrity
+
+# Same commit, public vocabulary
+docs(plans): record model-routing retirement as complete
+```
+
 ## When to Apply
 
 - Whenever a release ships a deprecation cycle, a migration step, a breaking change, or any other audience-facing narrative
 - When validating any release that has more substance than a routine bugfix or dependency bump
 - During release-pipeline monitoring: after the workflow reports success, check `gh release view <tag> --json body --jq '.body'` and verify the narrative is present
+- Before writing any commit subject, body, or PR description — stage 2 will read it if it lands in a release range
 
 ## Examples
 

--- a/docs/solutions/developer-experience/typecheck-does-not-cover-ci-gate-scripts-2026-08-17.md
+++ b/docs/solutions/developer-experience/typecheck-does-not-cover-ci-gate-scripts-2026-08-17.md
@@ -1,0 +1,117 @@
+---
+title: Typecheck covers src/ only, so every CI gate is unchecked
+date: 2026-08-17
+category: developer-experience
+module: typecheck-boundary
+problem_type: developer_experience
+component: tooling
+severity: high
+applies_when:
+  - "Refactoring or adding TypeScript anywhere outside src/"
+  - "Treating a green `bun run typecheck` as evidence that a change is complete"
+  - "Reviewing changes to content-integrity, the registry builder, codegen, the plugin build, or the eval runner"
+  - "Deciding what a verification command actually proves before quoting it"
+tags:
+  - typescript
+  - typecheck
+  - tsconfig
+  - ci-gates
+  - scripts
+  - false-green
+---
+
+# Typecheck covers src/ only, so every CI gate is unchecked
+
+## Context
+
+`tsconfig.json` scopes the compiler to one directory:
+
+```json
+"include": ["src/**/*"],
+"exclude": ["node_modules", "dist", "lib", ".opencode"]
+```
+
+`package.json`'s `typecheck` script is `tsc --noEmit`, which uses that project. Nothing else typechecks TypeScript in this repo.
+
+`scripts/` is not in `include`. It holds eight files, and they are not incidental — they are the machinery that enforces the repository's invariants:
+
+| Script | Enforces |
+|---|---|
+| `content-integrity.ts` | phantom references, frontmatter contracts, dispatch identifiers, banned patterns |
+| `build-registry.ts` | OCX registry, drift detection |
+| `generate-config-schema.ts` | JSON Schema codegen + drift |
+| `build-claude-code-plugin.ts` | the entire Claude Code bundle |
+| `run-evals.ts` | the eval harness |
+
+So the code that gates every other change is the least verified code in the repository.
+
+## Guidance
+
+**A green typecheck is scoped to `include`, and that scope is easy to not know.** Do not read a passing `tsc --noEmit` as "the TypeScript in my change is valid." Read it as "the TypeScript under `src/` is valid."
+
+Verify the real boundary with a probe rather than by reading config. Config can be read wrong; a probe cannot:
+
+```bash
+cp scripts/content-integrity.ts /tmp/ci-probe.bak
+printf '\nconst probe: number = "definitely not a number"\nthisDoesNotExist()\n' \
+  >> scripts/content-integrity.ts
+
+bun run typecheck; echo "exit: $?"
+
+cp /tmp/ci-probe.bak scripts/content-integrity.ts
+```
+
+The probe must modify the real file in place. Copying it to `/tmp` and typechecking proves nothing — `/tmp` is outside `include` no matter how the project is configured, so that variant passes whether or not `scripts/` is covered.
+
+Result at time of writing: **exit 0, no diagnostics.** Both a blatant type error and a call to an undefined function are invisible.
+
+Until the boundary changes, the practical substitute for `scripts/` is the unit suite, which imports these modules and will surface a `ReferenceError` at runtime:
+
+```bash
+bun test tests/unit
+```
+
+**The fix direction is deliberately not prescribed here.** Either extend `include` to cover `scripts/`, or add a second tsconfig for it. There may be a reason `scripts/` was excluded — it was not established when this was written, and assuming there is none is how a config change turns into an afternoon of unrelated errors.
+
+## Why This Matters
+
+The failure mode is not "a type error slipped through." It is that a passing check was read as evidence of something it never covered.
+
+A refactor deleted a helper from `scripts/content-integrity.ts` and left one call site behind. `bun run typecheck` reported clean. That clean result was taken as confirmation the refactor was complete. The unit suite caught it moments later:
+
+```text
+ReferenceError: isResolvableDispatchIdentifier is not defined
+    at findNearMissAgentStem (scripts/content-integrity.ts:1226:7)
+```
+
+An undefined function is the most basic thing a typechecker catches. Getting a green result on one is a strong signal the check is not looking where you think — which is worth more attention than the missed error itself.
+
+## When to Apply
+
+- Before trusting `bun run typecheck` on any change touching `scripts/`.
+- When a refactor deletes or renames something used by build tooling. The compiler will not find the orphaned call sites.
+- When quoting verification evidence in a PR or commit. "Typecheck clean" is a claim about `src/`, and saying so is more accurate and no longer.
+- Whenever a verification command is repo-wide in appearance but config-scoped in fact.
+
+## Examples
+
+**Misleading:**
+
+```text
+typecheck clean, so the refactor is complete
+```
+
+**Accurate:**
+
+```text
+typecheck clean (covers src/ only — tsconfig include is ["src/**/*"]);
+scripts/ changes verified by `bun test tests/unit`
+```
+
+**Establishing coverage for an unfamiliar repo.** The general form of the probe: introduce an unmissable error in the file you care about, run the check, and confirm it fails. A check you have never seen fail on the file you are changing has not been shown to cover that file.
+
+## Related
+
+- [`docs/solutions/workflow-issues/clean-checkout-baselines-before-quoting-metrics-2026-08-17.md`](../workflow-issues/clean-checkout-baselines-before-quoting-metrics-2026-08-17.md) — the same shape with a different mechanism: there the scope was the filesystem, here it is compiler config. Both produce a green signal narrower than assumed.
+- [`docs/solutions/best-practices/a-perfect-measurement-means-a-broken-instrument-2026-08-16.md`](../best-practices/a-perfect-measurement-means-a-broken-instrument-2026-08-16.md) — the general principle: ask what the instrument cannot see before trusting a clean result.
+- [`docs/solutions/best-practices/comments-and-commit-messages-are-claims-not-evidence-2026-08-16.md`](../best-practices/comments-and-commit-messages-are-claims-not-evidence-2026-08-16.md) — quoting a verification result is a claim; it inherits the check's real scope.

--- a/docs/solutions/workflow-issues/clean-checkout-baselines-before-quoting-metrics-2026-08-17.md
+++ b/docs/solutions/workflow-issues/clean-checkout-baselines-before-quoting-metrics-2026-08-17.md
@@ -114,6 +114,7 @@ A local `claude-code/` build adds 6 more from generated output.
 
 ## Related
 
+- [`docs/solutions/developer-experience/typecheck-does-not-cover-ci-gate-scripts-2026-08-17.md`](../developer-experience/typecheck-does-not-cover-ci-gate-scripts-2026-08-17.md) — the same shape with a different mechanism: there the green signal is narrowed by `tsconfig` `include` rather than by working-directory state, and it hides an undefined function rather than extra warnings.
 - [`docs/solutions/best-practices/comments-and-commit-messages-are-claims-not-evidence-2026-08-16.md`](../best-practices/comments-and-commit-messages-are-claims-not-evidence-2026-08-16.md) — the same failure in prose: a written number that the repository does not support.
 - [`docs/solutions/best-practices/a-perfect-measurement-means-a-broken-instrument-2026-08-16.md`](../best-practices/a-perfect-measurement-means-a-broken-instrument-2026-08-16.md) — ask what the instrument measures before trusting its output; here it measured more than intended.
 - [`docs/solutions/workflow-issues/version-pinned-evidence-must-be-reproven-2026-08-16.md`](version-pinned-evidence-must-be-reproven-2026-08-16.md) — adjacent: evidence invalidated by a moving pin rather than by working-directory state.


### PR DESCRIPTION
Three learnings from shipping the dispatch-identifier gate. All three are the same species: a signal that covered less than it appeared to.

## The release pipeline reads commit bodies after all

`docs/solutions/developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md` established that `@semantic-release/release-notes-generator` reads commit subject lines and never bodies. That is still true of the plugin. It is no longer true of the pipeline, and the doc's own 2026-05-23 note — "the myth itself remains true" — now reads as reassurance that bodies are private.

There are two stages:

| Stage | Mechanism | Reads |
|---|---|---|
| 1 | `@semantic-release/release-notes-generator` | commit subjects only |
| 2 | `release-notes-narrative` skill via `successCmd` | commit bodies (`%b`) and PR descriptions |

Stage 2 is wired through `@semantic-release/exec` and runs `git log "${PREV}..${TARGET}" --pretty=format:'%H%x1f%s%x1f%b%x1e'` across the range. Commit bodies reach the published notes; they just take a second path to get there.

A second asymmetry compounds it. In `.releaserc.yaml`, `releaseRules` is scope-aware — `docs` releases only for `readme`, `skill`, `skills`, `agents`, `commands` — while `presetConfig.types` maps `docs` to a "Documentation" section with no scope filter at all. A `docs(plans)` commit triggers no release and still earns a section in whatever release does fire, which stage 2 then expands into prose.

That is how the v3.11.0 notes came to open their Documentation section by quoting an internal planning label. The reasoning that failed was "this commit publishes nothing, so its wording is internal" — correct about stage 1, wrong about the pipeline. The doc is retitled and corrected rather than left to keep teaching it.

## Typecheck covers `src/` only

`tsconfig.json` sets `include: ["src/**/*"]`. The eight files under `scripts/` — content integrity, the registry builder and drift check, schema codegen, the Claude Code plugin build, the eval runner — are never typechecked. The code gating every other change is the least verified code in the repository.

Appending both `const probe: number = "definitely not a number"` and a call to an undefined function to `scripts/content-integrity.ts`, then running `bun run typecheck`, exits 0 with no diagnostics.

This surfaced during the gate work: a refactor deleted a helper and left one call site behind, typecheck reported clean, and the unit suite caught it as a `ReferenceError`. Getting a green result on an undefined function is a strong signal the check is not looking where you think.

The doc's probe modifies the file in place, and says why — the obvious variant, copying to `/tmp` and typechecking, passes whether or not `scripts/` is covered, so it proves nothing. It does not prescribe the fix. Extending `include` and adding a second tsconfig are both reasonable, and whether the exclusion was deliberate was not established.

## An allowlist is a claim that the content is correct

When the new gate failed on `opencode-profile.md`, which demonstrated dispatch using `explorer` and `fixer`, the first response was an allowlist so those values would pass. Neither agent ships in this package — they come from the maintainer's own OpenCode configuration, so the examples worked for him and failed for every other reader.

The correction deleted the allowlist constant, its call sites, a helper, and its documentation, and fixed the two example values. The asymmetry is the tell: the right fix removed code and the workaround added it.

Written narrowly. This repo has legitimate allowlists — `scripts/.drift-allowlist.json` preserves historical fidelity with a required reason field — and the rule is only that an allowlist should not substitute for deciding whether the rejected content is wrong.

## Notes

Corpus 69 → 71: two new docs, one corrected, one reciprocal cross-link added between the two verification-boundary docs, which share a shape but not a mechanism.

Content-integrity clean, frontmatter schema-valid, all cross-links resolve. `docs(solutions)` publishes nothing, so this triggers no release — which, per the first learning, is not the same as saying its commit body is private, and it is written accordingly.
