### PR TITLE
docs(architecture): correct the documented plugin hook set

### DIFF
--- a/.agents/skills/generating-project-docs/SKILL.md
+++ b/.agents/skills/generating-project-docs/SKILL.md
@@ -103,11 +103,11 @@ Do NOT add: skill tables, agent category tables, CLI reference tables, Mermaid d
 Following matklad's "Bird's Eye" pattern. Audience: contributors who need to understand how the plugin works at a system level.
 
 1. `# Architecture` — H1 title + 1–2 sentence orientation that points at `STRUCTURE.md` and `AGENTS.md`
-2. `## Bird's Eye Overview` — two-paragraph summary of plugin shape and the three OpenCode hooks
+2. `## Bird's Eye Overview` — two-paragraph summary of plugin shape and the hooks the plugin registers. Enumerate the hooks from the object returned in `src/index.ts`; never carry a count forward from the existing document.
 3. `## Codemap` — pipeline diagram + symbol table mapping roles to file paths
 4. `## Invariants` — numbered list of invariants CI enforces
 5. `## Data Flow` — ASCII tree from plugin load through hooks
-6. `## Cross-Cutting Concerns` — content-integrity gate, registry drift, config validation, memoization, config priority
+6. `## Cross-Cutting Concerns` — the gates and invariant-enforcing systems that span modules. Derive the current set from `scripts/` and the CI workflow rather than reproducing the list in the existing document.
 
 ### `STRUCTURE.md`
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -120,11 +120,14 @@ import { vi } from 'vitest'
 
 ## Plugin Architecture
 
-The plugin exposes three hooks. Changes to any of these are high-risk:
+The plugin exposes these hooks. Changes to any of these are high-risk:
 
 - **`config`** — merges bundled skills/agents/commands into OpenCode config
-- **`tool`** — registers the `systematic_skill` tool
-- **`system.transform`** — injects bootstrap prompt into conversations
+- **`tool`** — registers the `systematic_skill` tool and the workflow-guard tools
+- **`tool.execute.before`** — workflow-guard observation; can block an operation by throwing
+- **`tool.execute.after`** — workflow-guard observation of results
+- **`event`** — workflow-guard observation of host events
+- **`experimental.chat.system.transform`** — injects bootstrap prompt into conversations
 
 Treat modifications to `src/index.ts` hook implementations as breaking-change candidates.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Systematic is a plugin providing compound-engineering loops (brainstorm, plan, w
 | Question | Go to |
 |----------|-------|
 | How does the plugin work? | [`ARCHITECTURE.md`](ARCHITECTURE.md) |
-| What are the three plugin hooks? | [`ARCHITECTURE.md`](ARCHITECTURE.md) |
+| Which plugin hooks are registered? | [`ARCHITECTURE.md`](ARCHITECTURE.md) |
 | What invariants must hold? | [`ARCHITECTURE.md`](ARCHITECTURE.md) |
 | What is the config priority order? | [`ARCHITECTURE.md`](ARCHITECTURE.md) |
 | Where do I put new code? | [`STRUCTURE.md`](STRUCTURE.md) |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,13 +13,24 @@ Systematic ships as an npm package with two distinct parts:
 2. **Bundled assets** (`skills/`, `agents/`) — Markdown content shipped alongside the compiled code
 
 At runtime, OpenCode loads the plugin via its default export (`src/index.ts`). The plugin registers
-three hooks:
+these hooks:
 
 - **`config`** — discovers bundled agents, skills, and commands, then merges them into the OpenCode
   config. Existing user config wins; Systematic fills in what's missing.
-- **`tool`** — registers the `systematic_skill` tool, which lets agents load skill content on demand.
+- **`tool`** — registers the `systematic_skill` tool, which lets agents load skill content on demand,
+  alongside the workflow-guard tools (`systematic_workflow_start`, `_status`, `_complete`,
+  `_control`).
+- **`tool.execute.before`** — workflow-guard observation of pending operations. Blocks execution by
+  rethrowing a guard error when a guarded transition is unsatisfied.
+- **`tool.execute.after`** — workflow-guard observation of completed operations, feeding receipt
+  classification. Fail-closed; never blocks the host.
+- **`event`** — workflow-guard observation of host events, including skill loads that activate an
+  epoch. Fail-closed; never blocks the host.
 - **`experimental.chat.system.transform`** — injects a bootstrap prompt into the system message and
   suppresses title generation for internal agents.
+
+The last four are the receipt-backed workflow guard (see Cross-Cutting Concerns). The registered set
+is authoritative in `src/index.ts`; do not restate a count here.
 
 The CLI (`src/cli.ts`) is a separate entry point exposing `list`, `config`, and `setup --harness`
 subcommands. It does not participate in the plugin hook lifecycle. `setup --harness opencode|pi`
@@ -163,6 +174,15 @@ version is not evidence for another.
 **Content-integrity gate** (`scripts/content-integrity.ts`) — runs in the CI build job. Catches
 phantom `systematic:*` references, dispatch identifier integrity issues, frontmatter/model
 contract violations, and banned CC/CEP patterns. Must pass before any release.
+
+**Receipt-backed workflow guard** (`src/lib/workflow-guard.ts` plus the OpenCode adapter in
+`src/lib/opencode-workflow-guard.ts`, `opencode-operation-observer.ts`, and `receipt-classifier.ts`
+/ `receipt-ledger.ts` / `receipt-readback.ts`) — observes tool executions through the
+`tool.execute.before` / `tool.execute.after` / `event` hooks, classifies them into operations
+(implementation, verification, commit, push, pr-creation, check-readback, review-readback),
+validates each claim against observed workspace state, and mints integrity-checked receipts. A
+guarded transition that lacks its required receipts is rejected. OpenCode only — `src/pi.ts`
+registers no guard, and the Claude Code bundle ships no runtime.
 
 **Registry drift detection** (`scripts/build-registry.ts --check`) — verifies that the OCX registry
 config stays in sync with the generated bundled assets. Run via `bun run registry:drift`.

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -38,7 +38,8 @@ systematic/
 **Contains:** Plugin entry point, CLI entry point, and the `lib/` subdirectory of core modules.
 
 **Key files:**
-- `src/index.ts` — plugin factory (`SystematicPlugin`), registers all three OpenCode hooks
+- `src/index.ts` — plugin factory (`SystematicPlugin`), registers every OpenCode hook Systematic
+  provides (config, tool, the workflow-guard observation hooks, and the system transform)
 - `src/cli.ts` — CLI commands: `list`, `config show/path`, `setup --harness opencode|pi` (Claude Code
   has no CLI setup step — it installs as a prebuilt plugin via marketplace, see `scripts/`)
 - `src/lib/setup.ts` — `setupHarness`: atomic/backed-up/idempotent, project-local-only harness config writes


### PR DESCRIPTION
Four contributor-facing documents each stated that the plugin registers three hooks. It registers six.

| File | Claimed |
|---|---|
| `ARCHITECTURE.md` | "three hooks:" followed by three entries |
| `STRUCTURE.md` | "registers all three OpenCode hooks" |
| `.github/copilot-instructions.md` | "The plugin exposes three hooks" followed by three entries |
| `AGENTS.md` | routing question reading "What are the three plugin hooks?" |

The three none of them mentioned — `tool.execute.before`, `tool.execute.after`, and `event` — are the hooks the receipt-backed workflow guard runs on. Anyone orienting from these documents would conclude the plugin has no operation-observation layer and no enforcement path, which is the opposite of what `src/index.ts` registers.

The Copilot instructions were wrong a second way: they named the transform hook `system.transform` rather than `experimental.chat.system.transform`.

## What changed

`ARCHITECTURE.md` now lists all six hooks with what each does, and its Cross-Cutting Concerns section covers the workflow guard — which appeared nowhere in that document or `STRUCTURE.md` before. The new entry states what the observation hooks feed, which operations get classified, what a receipt proves, and that it is OpenCode-only: `src/pi.ts` registers no guard and the Claude Code bundle ships no runtime.

`.agents/skills/generating-project-docs/SKILL.md` hardcoded "the three OpenCode hooks" into its `ARCHITECTURE.md` template while instructing its reader to derive every fact from the live repository. Regenerating the document from that skill would have restored the error. The template now enumerates hooks from `src/index.ts` and derives cross-cutting concerns from `scripts/` and CI configuration instead of carrying a frozen list. Its stale `memoization` entry is gone for the same reason.

The routing question in `AGENTS.md` no longer embeds a count. A count in a routing table is a fact with no upside that eventually becomes wrong.

## Why the count was wrong for so long

Nothing compared these documents against source. Four files, four chances to notice, and the checks that exist compare prose against prose. The hook set is mechanically derivable from the object `src/index.ts` returns, so this is a decidable CI check rather than a matter of diligence — that check is not in this change.

## Verification

- `bun test tests/unit` — 1842 pass, 0 fail
- `bun scripts/content-integrity.ts` — clean
- `bun run registry:drift` — up to date
- Documented hook names verified against `src/index.ts` line by line
- The OpenCode-only claim verified: `src/pi.ts` contains zero guard references

No behavior changes. Documentation only.
