### PR TITLE
docs(solutions): record three verification lessons from the prior-art survey work

### DIFF
--- a/docs/solutions/best-practices/a-stop-condition-needs-a-recorded-fact-2026-08-18.md
+++ b/docs/solutions/best-practices/a-stop-condition-needs-a-recorded-fact-2026-08-18.md
@@ -1,0 +1,93 @@
+---
+title: A stop condition that compares now against then requires the contract to record then
+date: 2026-08-18
+category: best-practices
+module: prior-art-survey
+problem_type: best_practice
+component: development_workflow
+severity: high
+applies_when:
+  - "A downstream step refuses to proceed when an earlier step's result may be stale"
+  - "A contract defines a check but not the field the check reads"
+  - "A rule must work in environments where version control or history may be unavailable"
+tags:
+  - contract-design
+  - staleness
+  - workflow-contract
+  - schema-design
+  - verification
+---
+
+# A stop condition that compares now against then requires the contract to record then
+
+## Context
+
+A planning workflow gained a prior-art survey: an earlier step establishes what already exists, and a later step consumes that result. The consuming step was specified to stop when the survey had gone stale:
+
+> Work execution does not begin on a plan whose surveyed scope has changed since the survey ran.
+
+The survey's schema recorded exactly these top-level fields: `verdict`, `scope`, `budget`, `candidates`, `scopes_considered`, `acceptance`.
+
+Nothing there says *when* the survey ran, or against what state. No timestamp, no revision, no digest. The consuming step was told to compare current state against the survey's state, and the survey never recorded its state.
+
+The instruction tried to paper over this by naming possible evidence sources — version-control history, "any recorded baseline, manifest, timestamps, or other portable local evidence." None of them were things the survey produced. Every execution would reach the same dead end: freshness unknown.
+
+## Guidance
+
+**When you write a rule of the form "stop if X has changed since Y," the artifact must record what Y was.** Otherwise the rule is not strict or lenient — it is unevaluable, and an unevaluable rule degrades into whatever the implementer guesses.
+
+Specify four things together, in the same change:
+
+1. **What baseline is recorded**, and by whom.
+2. **How current state is computed** for comparison.
+3. **What happens when comparison is impossible** — and it must not be "assume fresh."
+4. **What scope the comparison covers** — the whole repository is usually wrong and always expensive.
+
+The fix added a required freshness record supporting either path:
+
+```json
+"freshness": {
+  "vcs_reference": { "kind": "git", "head": "<revision>" }
+}
+```
+
+```json
+"freshness": {
+  "scope_baseline": { "digest": "<hash of the surveyed scope>" }
+}
+```
+
+At least one must be present. A repository with version control compares revisions; one without compares a portable digest. Neither available means the result is *unverifiable*, which stops execution and asks for a fresh survey rather than proceeding on an assumption.
+
+## Why This Matters
+
+This is a contract hole, not an implementation bug, and it is invisible to the usual gates. The schema compiled. Its tests passed. The consuming instruction read as a reasonable, even careful, rule. Nothing failed, because nothing yet tried to evaluate the condition.
+
+The failure surfaces only in use, as a step that always reports the same non-answer — and the natural repair at that point is to weaken the rule, since it "never works," rather than to notice the missing field.
+
+## When to Apply
+
+- Any rule containing "since", "still valid", "out of date", "has changed", or "no longer matches".
+- Any handoff where one step's output is consumed by a later step that may run much later.
+- Any contract that must hold in environments you do not control — no version control, shallow clones, exported archives.
+
+Write the check and the recorded evidence in the same change. If they are split across two changes, the first one ships a rule nothing can satisfy.
+
+## Examples
+
+**Unevaluable:**
+
+> Refuse to proceed if the analyzed files have changed since the analysis ran.
+
+Nothing says what the analysis observed, so "changed since" has no referent.
+
+**Evaluable:**
+
+> The analysis records the scope it examined and either the revision it observed or a digest of that scope. Refuse to proceed when the current revision or digest differs. When neither can be computed, report that freshness is unverifiable and request a fresh analysis — do not assume the result still holds.
+
+The second version can actually run, and its failure mode is explicit rather than emergent.
+
+## Related
+
+- [Compiling the real schema proves it parses, not that it rejects](schemas-need-adversarial-probes-not-just-compilation-2026-08-16.md) — a schema can be well-tested against the payloads it defines and still omit a field a downstream rule depends on.
+- [A deletion gate must observe every field the deleted code wrote](deletion-gates-must-observe-every-field-the-deleted-code-wrote-2026-08-16.md) — the sibling case, where a check watches fewer fields than the thing it guards.

--- a/docs/solutions/best-practices/exemption-predicates-must-name-the-uncheckable-condition-2026-08-18.md
+++ b/docs/solutions/best-practices/exemption-predicates-must-name-the-uncheckable-condition-2026-08-18.md
@@ -1,0 +1,103 @@
+---
+title: An exemption must be predicated on the uncheckable condition, not a proxy for it
+date: 2026-08-18
+category: best-practices
+module: content-integrity
+problem_type: best_practice
+component: tooling
+severity: high
+applies_when:
+  - "A fail-closed gate needs an escape hatch for content it genuinely cannot verify"
+  - "The escape hatch is triggered by a wording, marker, or shape that merely correlates with the unverifiable case"
+  - "The gate exists to detect drift between a document and the source it describes"
+tags:
+  - content-integrity
+  - fail-closed
+  - gate-design
+  - exemptions
+  - drift-detection
+---
+
+# An exemption must be predicated on the uncheckable condition, not a proxy for it
+
+## Context
+
+A new fail-closed gate compared the plugin hook set claimed in contributor-facing documents against the set the plugin entry point actually registers. It needed one escape hatch, for a real reason.
+
+`STRUCTURE.md` asserts completeness in prose without enumerating anything:
+
+> `src/index.ts` — plugin factory (`SystematicPlugin`), registers every OpenCode hook Systematic provides (config, tool, the workflow-guard observation hooks, and the system transform)
+
+There is no hook list to compare. Worse, naive extraction pulls the first inline-code span — `src/index.ts` — and reports it as a claimed hook name, producing a false violation on a correct document.
+
+The escape hatch chosen was the assertion's wording:
+
+```ts
+if (/\b(?:every|all)\b[\s\S]{0,30}\bhooks?\b/i.test(assertion[0])) {
+  return [...actualHooks]
+}
+```
+
+Saying "all" or "every" near "hooks" meant the document was declared correct by fiat.
+
+## Guidance
+
+**Predicate an exemption on the condition that makes verification impossible, not on a signal that usually accompanies it.**
+
+Here, the uncheckable condition is *the section names no item that could be compared*. The wording "all hooks" was a proxy for that — and the proxy admitted a case that was fully checkable:
+
+```md
+The plugin registers all six hooks:
+
+- **`config`**
+- **`tool`**
+- **`experimental.chat.system.transform`**
+```
+
+This matched the proxy, so the check returned the source-derived set and never read the list. A document claiming six hooks while listing three passed clean, exit 0 — precisely the drift the gate existed to catch.
+
+The corrected predicate names the actual condition:
+
+```ts
+const claimed = extractClaimedHookNames(assertionSection)
+if (claimed.length > 0) return claimed   // enumerating — compare it
+
+// Names nothing comparable: a prose-only completeness claim.
+if (assertsCompleteness(assertion[0])) return [...actualHooks]
+```
+
+Naming even one real hook means the document is enumerating and the full set must match. `STRUCTURE.md` still passes; the stale document now fails and names the three missing hooks.
+
+## Why This Matters
+
+An exemption is a hole cut in a gate on purpose. The gate's value is bounded by how precisely that hole is cut.
+
+A proxy predicate makes the hole a superset of the intended case, and the extra area is exactly where the gate is blind. Because it is fail-closed with no warning channel, nothing reports the blindness — the gate returns clean and reads as evidence.
+
+This is the second over-broad exemption found in this same gate; an earlier whole-line skip was likewise a bypass, caught only in review. Exemption predicates deserve the same scrutiny as the assertions they exempt.
+
+## When to Apply
+
+- A gate needs an escape hatch and the obvious trigger is a phrase, comment marker, annotation, or file shape.
+- Before writing the exemption, state the condition that makes verification impossible in one sentence. If that sentence and the predicate are not the same thing, the predicate is a proxy.
+- Ask whether any input can satisfy the predicate while still being verifiable. If one can, that input is now unguarded.
+
+## Examples
+
+**Test every exemption from both sides.** An exemption test that only proves the intended case passes is half a test. The other half is the smallest mutation that should invalidate the exemption:
+
+```
+✓ prose-only completeness claim         → exempt, no violation
+✓ completeness claim + partial list     → NOT exempt, violation naming what is missing
+✓ completeness claim + full list        → NOT exempt, no violation
+```
+
+The middle case is the one that matters and the one most likely to be missing.
+
+**Verify against real content, not only fixtures.** The bypass here was found by editing an actual repository document to the failure shape and running the real gate, not by reading the tests. Synthetic fixtures encode what the author already believed.
+
+## Related
+
+- [An allowlist is a claim that the rejected content is correct](an-allowlist-is-a-claim-the-content-is-correct-2026-08-17.md) — decides *whether* an exemption is warranted at all; this doc assumes it is and addresses where to draw its boundary.
+- [neutral-v1 marker + migrated-set identifier gate](neutral-v1-marker-migrated-set-identifier-gate-2026-07-17.md) — records the earlier whole-line-skip bypass in this same gate, plus the policy on scanning fenced code.
+- [Content-integrity has no non-failing warning channel](content-integrity-has-no-warning-channel-2026-06-06.md) — why a silently-passing gate leaves no trace.

--- a/docs/solutions/workflow-issues/literal-text-review-catches-what-design-review-cannot-2026-08-18.md
+++ b/docs/solutions/workflow-issues/literal-text-review-catches-what-design-review-cannot-2026-08-18.md
@@ -1,0 +1,81 @@
+---
+title: When prose is the enforcement mechanism, read it literally as a separate pass
+date: 2026-08-18
+category: workflow-issues
+module: code-review
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+applies_when:
+  - "A contract, gate, or workflow rule is expressed in prose rather than code"
+  - "A new rule carries a backward-compatibility exception for artifacts created before it existed"
+  - "A rule distinguishes an absent thing from an invalid present thing"
+tags:
+  - code-review
+  - workflow-contract
+  - prose-enforcement
+  - backward-compatibility
+  - review-coverage
+---
+
+# When prose is the enforcement mechanism, read it literally as a separate pass
+
+## Context
+
+A change added a workflow rule: work execution refuses a plan whose prior-art survey is empty, unaccepted, or stale — but proceeds when the plan has no survey section at all, because such a plan predates the contract. That exemption is load-bearing; without it, every previously written plan becomes unexecutable.
+
+Nine specialist review personas examined the branch. They found real defects: an exemption that defeated its own gate, a stop condition with no recorded evidence, a missing version discriminator, a contract restated across three surfaces.
+
+An automated reviewer then read the shipped paragraph and found something none of the nine had:
+
+> If the plan has a `Prior-Art Survey` section, validate it before environment setup. For a qualifying plan, a missing section or a section without exactly one fenced `json` block is a contract failure. […] stop before setup when any of these conditions applies:
+> 1. **Missing or non-unique survey block:** the section is absent, empty, or …
+
+The first sentence scopes validation to plans that *have* the section. The second calls a missing section a contract failure. The first condition lists "the section is absent" as a stop.
+
+Both readings are supported by the text. One of them makes every pre-existing plan unexecutable — the exact outcome the exemption existed to prevent.
+
+## Guidance
+
+**Design review and literal-text review find different defect classes. Running one does not cover the other.**
+
+Design review asks whether the mechanism is right, where it breaks, what it costs, what it misses. The nine personas did this well, and the design *was* right — the intended behavior was coherent and correctly motivated.
+
+Literal-text review asks a narrower question: taken as written, sentence by sentence, can all of this be true at once? That question is uninteresting for code, because a compiler answers it. It is the only question that matters for prose that governs behavior, because nothing else will.
+
+When prose is the enforcement mechanism, add an explicit pass that reads the final wording as an executable contract, separate from reviewing the design behind it.
+
+## Why This Matters
+
+A contradiction in prose does not fail loudly. It resolves differently depending on who reads it, which means behavior varies by reader while every individual reading looks defensible. For instructions consumed by agents, that variance is invisible until it produces divergent outcomes across sessions.
+
+The reviewers were looking at the design through it. They were the wrong instrument for the question, not inattentive.
+
+## When to Apply
+
+Run a literal-text pass when any of these hold:
+
+- Prose *is* the enforcement mechanism, with no code path behind it.
+- A new rule carries a backward-compatibility exception.
+- A rule distinguishes **absent** from **present but invalid** — this pairing produced the defect here and is a recurring trap.
+- The text contains "all", "only", "exactly", "must", "unless", or "otherwise", each of which partitions behavior.
+- Multiple reviewers approved the design and none quoted the actual wording back.
+
+## Examples
+
+**Ambiguous — two supported readings:**
+
+> If the plan has a survey section, validate it. A missing section is a contract failure. Stop when: the section is absent, empty, or malformed.
+
+**Unambiguous — the partition is explicit and total:**
+
+> If the plan has no survey section at all, it predates this contract — proceed without rejecting it. Otherwise validate the section: it must contain exactly one fenced `json` block that validates against the schema. Stop when the section is present but empty, contains zero or multiple blocks, or fails validation.
+
+The rewrite changes no intent. It makes the state partition — absent, present-and-valid, present-and-invalid — complete and non-overlapping, so there is exactly one reading.
+
+A useful check: enumerate every state the subject can be in, and confirm the text assigns each state to exactly one branch. The defect here was that "absent" appeared in two branches.
+
+## Related
+
+- [Comments and commit messages are claims, not evidence](../best-practices/comments-and-commit-messages-are-claims-not-evidence-2026-08-16.md) — prose asserting a state the code does not back; this doc covers prose that contradicts itself.
+- [An exemption must be predicated on the uncheckable condition](../best-practices/exemption-predicates-must-name-the-uncheckable-condition-2026-08-18.md) — a defect from the same branch that design review *did* catch, for contrast.

--- a/docs/solutions/workflow-issues/registry-drift-on-skill-description-change-2026-05-20.md
+++ b/docs/solutions/workflow-issues/registry-drift-on-skill-description-change-2026-05-20.md
@@ -1,7 +1,7 @@
 ---
-title: Generated-artifact drift when a skill or agent description changes
+title: Generated-artifact drift when bundled skill or agent content changes
 date: 2026-05-20
-last_updated: 2026-08-16
+last_updated: 2026-08-18
 category: workflow-issues
 module: registry
 problem_type: workflow_issue
@@ -10,6 +10,8 @@ severity: medium
 applies_when:
   - Editing a SKILL.md description field
   - Editing an agent frontmatter description field
+  - Editing the body of a bundled skill or agent, not only its frontmatter
+  - Adding, removing, or renaming a file under a skill's references directory
   - Running the build without also running registry or Pi fixture generation
   - CI fails on a drift check after an otherwise clean build
 tags:
@@ -17,18 +19,30 @@ tags:
   - drift
   - skill-description
   - agent-description
+  - skill-body
+  - generated-artifacts
   - generate-registry
   - pi-subagents
   - ci-gate
 ---
 
-# Generated-artifact drift when a skill or agent description changes
+# Generated-artifact drift when bundled skill or agent content changes
 
 ## Context
 
 `scripts/generate-registry.ts` reads each skill's frontmatter `description` into `registry/registry.jsonc`. The CI "Registry drift check" step (`bun scripts/generate-registry.ts --check`) compares the generated output against the committed file and fails if they differ. `bun run build` does not include registry generation, so a description change that passes `build` + `typecheck` + `lint` + `test` locally will fail CI.
 
 **Agent descriptions reach a second generated surface.** Personas listed in `CURATED_PERSONAS` (`src/lib/pi-subagents-personas.ts`) are also exported as committed Pi fixtures under `tests/fixtures/pi-subagents-personas/`, which embed the description verbatim. That surface has its own source-side drift gate, run as `bun scripts/generate-pi-subagents-personas.ts --check`. It is not covered by `registry:drift` and has no npm script alias, so it is the easier of the two to miss — editing one agent description turned a four-file change into eight.
+
+### The trigger is any bundled-content edit, not only a description
+
+Descriptions are the most common cause, not the only one. Two broader triggers reach the same generated surfaces:
+
+**A body edit drifts the Pi fixtures.** The Pi export embeds the full persona text, not just its metadata, so editing an agent's body — with frontmatter untouched — still changes the generated fixture. A branch that added a research scope to one agent's body left `tests/fixtures/pi-subagents-personas/` stale while every targeted test passed; it surfaced only when the full unit suite ran.
+
+**A new file under a skill's `references/` drifts the registry.** The generator walks each skill directory recursively and records a per-component file list, so adding a reference file changes registry output even when no description moved. On the same branch this produced seven test failures plus a `registry:drift` failure, all from one added schema file.
+
+Both are invisible to targeted tests by construction: the drift is between committed generated output and source, and a test that exercises the generator does not compare its output to what is checked in.
 
 ## Guidance
 
@@ -44,7 +58,7 @@ Then commit the updated `registry/registry.jsonc` alongside the skill change. Th
 bun run build && bun run typecheck && bun run lint && bun test tests/unit && bun scripts/generate-registry.ts --check
 ```
 
-For an **agent** description change, regenerate and check both surfaces:
+For an **agent** change of any kind — description or body — and for any change to a skill's file set, regenerate and check both surfaces:
 
 ```bash
 bun scripts/generate-registry.ts

--- a/docs/solutions/workflow-issues/registry-drift-on-skill-description-change-2026-05-20.md
+++ b/docs/solutions/workflow-issues/registry-drift-on-skill-description-change-2026-05-20.md
@@ -38,9 +38,9 @@ tags:
 
 Descriptions are the most common cause, not the only one. Two broader triggers reach the same generated surfaces:
 
-**A body edit drifts the Pi fixtures.** The Pi export embeds the full persona text, not just its metadata, so editing an agent's body — with frontmatter untouched — still changes the generated fixture. A branch that added a research scope to one agent's body left `tests/fixtures/pi-subagents-personas/` stale while every targeted test passed; it surfaced only when the full unit suite ran.
+**A body edit drifts the Pi fixtures.** The Pi export embeds the full persona text, not just its metadata, and its drift gate compares a SHA-256 hash of the generated content against the committed fixture (`scripts/generate-pi-subagents-personas.ts:103-105`). Any body change alters that hash, so editing an agent's body — with frontmatter untouched — leaves the fixture stale. A branch that added a research scope to one agent's body did exactly this while every targeted test passed; it surfaced only when the full unit suite ran.
 
-**A new file under a skill's `references/` drifts the registry.** The generator walks each skill directory recursively and records a per-component file list, so adding a reference file changes registry output even when no description moved. On the same branch this produced seven test failures plus a `registry:drift` failure, all from one added schema file.
+**A new file under a skill's `references/` drifts the registry.** The generator calls `walkDir` on each skill directory (`scripts/generate-registry.ts:149`) and records the resulting per-component file list, so adding a reference file changes registry output even when no description moved. On the same branch this produced seven test failures plus a `registry:drift` failure, all from one added schema file.
 
 Both are invisible to targeted tests by construction: the drift is between committed generated output and source, and a test that exercises the generator does not compare its output to what is checked in.
 


### PR DESCRIPTION
docs(solutions): record three verification lessons from the prior-art survey work

Three learnings from building a prior-art survey and two documentation-parity
CI checks, plus one existing document broadened to match what the round showed.

An exemption must be predicated on the condition that makes verification
impossible, not on a signal that usually accompanies it. A gate comparing
documented plugin hooks against registered ones exempted any assertion saying
"all" or "every" — a proxy for "asserts completeness without enumerating". A
document claiming all six hooks while listing three matched the proxy, was
fully checkable, and passed clean. The predicate now names the real condition:
the section enumerates nothing comparable.

A stop condition comparing current state against earlier state requires the
contract to record that earlier state. A rule refusing stale survey results
shipped against a schema with no timestamp, revision, or digest, so the check
could only ever report that freshness was unknown. Specify the recorded
baseline, how current state is computed, and what happens when comparison is
impossible — in the same change as the rule.

Design review and literal-text review find different defect classes. Nine
specialist reviewers assessed a change and found real defects; an automated
reviewer then found that the shipped paragraph contradicted itself, scoping
validation to plans that have a section and then treating an absent section as
a halt. The design was right and the reviewers were reviewing the design. When
prose is the enforcement mechanism, reading the final wording as an executable
contract is a separate pass.

The generated-artifact drift document previously covered description edits
only. Editing an agent or skill body drifts the Pi export fixtures too, because
the export embeds full persona text, and adding a file under a skill's
references directory drifts the registry, which records per-component file
lists. Both are invisible to targeted tests by construction.
