### PR TITLE
ci: honor the dry-run input when releasing from a manual dispatch

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -188,7 +188,12 @@ jobs:
 
   release:
     env:
-      DRY_RUN: ${{ github.event_name == 'pull_request' || github.event.inputs.dry-run && 'true' || 'false' }}
+      # The parentheses are load-bearing. `&&` binds tighter than `||`, and a
+      # workflow_dispatch input arrives as a string, so an unparenthesized
+      # `inputs.dry-run && 'true'` evaluates truthy even when the caller passes
+      # false. Compare against the string explicitly rather than relying on
+      # truthiness.
+      DRY_RUN: ${{ (github.event_name == 'pull_request' || github.event.inputs.dry-run == 'true') && 'true' || 'false' }}
     name: Release
     needs: [build, typecheck, lint, test]
     outputs:
@@ -241,15 +246,6 @@ jobs:
 
       - name: Build
         run: bun run build
-
-      - name: Get Release Options
-        env:
-          INPUT_DRY_RUN: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.dry-run && 'true' || 'false' }}
-          IS_DEFAULT_BRANCH: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-        run: |
-          if [[ $DRY_RUN != 'true' || $IS_DEFAULT_BRANCH == 'true' ]]; then
-            echo "DRY_RUN=false" >> $GITHUB_ENV
-          fi
 
       - name: Semantic Release
         id: semantic-release

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -193,6 +193,11 @@ jobs:
       # `inputs.dry-run && 'true'` evaluates truthy even when the caller passes
       # false. Compare against the string explicitly rather than relying on
       # truthiness.
+      #
+      # This value is the only gate on the dry-run flag. Do not add a step that
+      # overrides it for the default branch: semantic-release already refuses to
+      # publish from anywhere its own `branches` config does not allow, and an
+      # override here silently turns a requested dry run into a real release.
       DRY_RUN: ${{ (github.event_name == 'pull_request' || github.event.inputs.dry-run == 'true') && 'true' || 'false' }}
     name: Release
     needs: [build, typecheck, lint, test]


### PR DESCRIPTION
ci: honor the dry-run input when releasing from a manual dispatch

The release job's dry-run flag ignored the value passed to it, in both
directions. A dispatch from the default branch always published regardless of
what the caller asked for, and a dispatch from any other branch never did.

Two causes, and they masked each other.

The expression relied on operator precedence that does not hold: `&&` binds
tighter than `||`, and a workflow_dispatch input arrives as a string, so
`inputs.dry-run && 'true'` evaluates truthy even when the caller passes false.
The flag was therefore always true. It now compares against the string
explicitly and parenthesizes the intent.

A later step then forced the flag back to false whenever the run was on the
default branch, which is what made real releases work at all and why the first
bug stayed invisible. That override also meant an explicitly requested dry run
on the default branch performed a real release. With the expression corrected
the step is redundant for every event the workflow handles — push, pull request,
and dispatch each arrive with the right value already — so it is removed rather
than left to contradict the input.

The step also computed a variable the shell below it never read, which is why
neither problem showed up as an obvious inconsistency.

Pushes to the default branch are unaffected: they carry no inputs, evaluated
false before, and evaluate false now.
