### PR TITLE
docs(solutions): record three release and verification learnings

### DIFF
--- a/docs/solutions/best-practices/one-shot-release-for-an-older-major-2026-08-18.md
+++ b/docs/solutions/best-practices/one-shot-release-for-an-older-major-2026-08-18.md
@@ -1,0 +1,94 @@
+---
+title: Ship a one-shot release for an older major without moving the default install
+date: 2026-08-18
+category: best-practices
+module: npm-release-management
+problem_type: best_practice
+component: tooling
+severity: high
+applies_when:
+  - Publishing a single fix for users pinned to a previous major version
+  - The latest dist-tag must keep pointing at the current major
+  - No ongoing support channel for the older major is wanted
+  - Release automation is configured for the mainline branch only
+tags:
+  - npm
+  - dist-tags
+  - semver
+  - maintenance-release
+  - release-management
+---
+
+# Ship a one-shot release for an older major without moving the default install
+
+## Context
+
+A fix was needed for users still on the previous major, who could not upgrade because the new major removed bundled content they depended on. The requirement was to reach those users without creating a maintenance line — no standing channel, no public support commitment, no change to what a fresh install receives.
+
+The hazard is that `npm publish` defaults to `--tag latest` **regardless of semver ordering**. Publishing `2.33.4` while `latest` pointed at `3.12.1` would have moved `latest` backward, so every subsequent `npm install <pkg>` would have delivered the old major. npm does not protect against this.
+
+## Guidance
+
+Dist-tags do not participate in semver range resolution. A consumer with `^2.33.0` or `^2` resolves to the highest published version matching that range whether or not a tag points at it. That single fact is what makes a one-shot possible:
+
+1. Publish under a throwaway dist-tag, never `latest`.
+2. Verify the version resolves and that `latest` is unchanged.
+3. Delete the throwaway tag.
+4. Re-verify — the version must still resolve by range and by exact reference.
+
+Scope the release-automation change to the maintenance branch. If the tool is configured for one branch, add the maintenance entry **on that branch only** and never merge it, so mainline publishing behavior is untouched.
+
+Prefer publishing through CI rather than locally. A local publish loses provenance attestation if the package publishes with it enabled, which would make the maintenance version the only one in the package's history without one.
+
+## Why This Matters
+
+Leaving the temporary tag in place converts a one-off into an advertised channel with unclear ownership and no stated lifecycle. Users discover it, depend on it, and reasonably expect it to keep receiving fixes.
+
+Skipping the tag entirely is worse: the publish silently retargets `latest` to an older major, and the symptom appears as new users installing outdated software with no error anywhere.
+
+The step most likely to be skipped is the final verification. Deleting a dist-tag is a mutation on the same registry metadata that governs installs, so confirm the range still resolves afterward rather than assuming deletion only removed the tag.
+
+## When to Apply
+
+- Backporting a fix to a major version the mainline has moved past.
+- Any publish of a version lower than the current `latest`.
+- Serving users blocked from upgrading by breaking changes, without committing to a support line.
+- Running release automation from a branch that must not alter mainline release behavior.
+
+## Examples
+
+Publish to a throwaway channel, verify, then retract the tag:
+
+```bash
+# Publish under a temporary channel — never `latest` for an older major
+npm publish --tag v2-temp
+
+# Confirm the version landed and `latest` did not move
+npm view <pkg>@2.33.4 version          # → 2.33.4
+npm view <pkg> dist-tags               # → { "latest": "3.12.1", "v2-temp": "2.33.4" }
+
+# Retract the temporary channel
+npm dist-tag rm <pkg> v2-temp
+
+# Re-verify after deletion — this is the step that proves the one-shot worked
+npm view '<pkg>@^2.33.0' version       # → resolves to 2.33.4
+npm view <pkg>@2.33.4 version          # → 2.33.4
+npm view <pkg> dist-tags               # → { "latest": "3.12.1" }
+```
+
+Branch-scoped automation config, with the constraint stated where an editor will see it:
+
+```yaml
+# This entry publishes a single maintenance release and exists only on the
+# maintenance branch. It must never be merged to the mainline branch.
+branches:
+  - main
+  - name: fix/v2-dispatch-identifiers
+    range: 2.33.x
+    channel: v2-temp
+```
+
+## Related
+
+- [`../workflow-issues/pr-title-selects-release-type-under-squash-merge-2026-08-16.md`](../workflow-issues/pr-title-selects-release-type-under-squash-merge-2026-08-16.md) — the mainline counterpart: what decides whether a release happens at all.
+- [`../integration-issues/green-job-is-not-proof-of-publication-2026-08-18.md`](../integration-issues/green-job-is-not-proof-of-publication-2026-08-18.md) — verifying a publish actually occurred, which is the check this practice depends on at every step.

--- a/docs/solutions/integration-issues/green-job-is-not-proof-of-publication-2026-08-18.md
+++ b/docs/solutions/integration-issues/green-job-is-not-proof-of-publication-2026-08-18.md
@@ -1,0 +1,104 @@
+---
+title: A green release job is not evidence that anything was published
+date: 2026-08-18
+category: integration-issues
+module: release-workflow
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - A workflow_dispatch release run concluded successfully but published nothing
+  - The release log ended with a success line naming a version that does not exist in the registry
+  - The same log contained an earlier warning that the publish step was skipped
+  - Dispatches from the default branch always published; dispatches from other branches never did, regardless of the input
+root_cause: config_error
+resolution_type: config_change
+severity: critical
+tags:
+  - github-actions
+  - semantic-release
+  - expression-precedence
+  - npm-publishing
+  - dry-run
+---
+
+# A green release job is not evidence that anything was published
+
+## Problem
+
+A release workflow triggered with `-f dry-run=false` finished with conclusion `success` and logged `✔ Published release 2.33.4 on v2-temp channel`. Nothing reached the registry. The dry-run input had been ignored for every manual dispatch since the expression was written.
+
+## Symptoms
+
+- `gh workflow run main.yaml --ref <branch> -f dry-run=false` completed with all jobs green.
+- The log's closing line named a published version and channel.
+- Earlier in the same log: `⚠ Skip step "publish" of plugin "@semantic-release/npm" in dry-run mode`.
+- `npm view <pkg>@<version>` returned nothing, and the named dist-tag did not exist.
+- Behavior split by branch: dispatches from the default branch always published for real, dispatches from anywhere else never did — in both cases ignoring what the caller asked for.
+
+## What Didn't Work
+
+Reading the job conclusion. A green check means the workflow completed without erroring, which it did — semantic-release ran successfully in dry-run mode and exited zero.
+
+Reading the tool's own closing line. `✔ Published release …` is emitted in dry-run mode too; it reports the action that *would* be taken. Taken alone it is indistinguishable from a real publish.
+
+## Solution
+
+Two defects, one masking the other.
+
+The expression relied on precedence that does not hold:
+
+```yaml
+DRY_RUN: ${{ github.event_name == 'pull_request' || github.event.inputs.dry-run && 'true' || 'false' }}
+```
+
+`&&` binds tighter than `||`, and a `workflow_dispatch` input arrives as a **string**. With `dry-run=false` this evaluates as:
+
+```text
+false || ('false' && 'true') || 'false'   →   'true'
+```
+
+The string `'false'` is truthy, so the flag was `'true'` for every dispatch.
+
+A later step then forced it back:
+
+```yaml
+- name: Get Release Options
+  env:
+    INPUT_DRY_RUN: ${{ ... }}          # computed, never read
+    IS_DEFAULT_BRANCH: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+  run: |
+    if [[ $DRY_RUN != 'true' || $IS_DEFAULT_BRANCH == 'true' ]]; then
+      echo "DRY_RUN=false" >> $GITHUB_ENV
+    fi
+```
+
+That override is why ordinary releases worked at all, and therefore why the first bug stayed invisible. It also meant a deliberately requested dry run on the default branch performed a **real release**.
+
+The fix parenthesizes the intent and compares against the string explicitly:
+
+```yaml
+DRY_RUN: ${{ (github.event_name == 'pull_request' || github.event.inputs.dry-run == 'true') && 'true' || 'false' }}
+```
+
+The override step is then deleted rather than left to contradict the input — once the expression is correct, every event the workflow handles already arrives with the right value.
+
+## Why This Works
+
+The corrected expression enables dry-run only when the event is a pull request or the input is exactly the string `"true"`. Push events carry no inputs, so they evaluated false before and evaluate false now — ordinary releases are unaffected.
+
+The deeper point is about evidence. Three separate signals all indicated success: the job conclusion, the closing log line, and the absence of any error. None of them observed the artifact. The only check that could distinguish the two outcomes was querying the registry.
+
+## Prevention
+
+- **Verify the artifact, not the job.** After a release run, query the registry or release API for the version and channel. A workflow conclusion describes the workflow, not its effect.
+- **Never rely on truthiness for a dispatch input.** Inputs arrive as strings, so `'false'` is truthy. Compare explicitly: `inputs.x == 'true'`.
+- **Parenthesize any expression mixing `&&` and `||`.** The ternary idiom `cond && 'a' || 'b'` is only safe when `cond` is a single parenthesized expression.
+- **Suspect a masking override when a bug is branch-dependent.** Behavior that differs by branch for a branch-independent input means something downstream is rewriting the value.
+- **Treat a computed-but-unread variable as a defect signal.** `INPUT_DRY_RUN` existed and was never referenced, which is what allowed two contradictory sources of truth to coexist unnoticed.
+- **Prove a CI expression fix by running it**, not only by tracing it. A truth table catches precedence errors; only an actual dispatch proves the pipeline behaves.
+
+## Related Issues
+
+- [`../workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md`](../workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md) — the same shape one layer out: every mechanical gate passed while the produced artifact was defective. There the fix was to read the artifact as installed; here it is to query the registry.
+- [`../workflow-issues/pr-title-selects-release-type-under-squash-merge-2026-08-16.md`](../workflow-issues/pr-title-selects-release-type-under-squash-merge-2026-08-16.md) — another way a release pipeline completes successfully while shipping nothing, decided by the commit subject rather than a workflow input.
+- [`../developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md`](../developer-experience/semantic-release-body-ingestion-myth-2026-05-17.md) — on trusting what the release tooling appears to report versus what it actually does.

--- a/docs/solutions/workflow-issues/clean-checkout-baselines-before-quoting-metrics-2026-08-17.md
+++ b/docs/solutions/workflow-issues/clean-checkout-baselines-before-quoting-metrics-2026-08-17.md
@@ -1,6 +1,7 @@
 ---
-title: A lint count is not a project fact until the input set is defined
+title: A measured count is not a project fact until the input set is defined
 date: 2026-08-17
+last_updated: 2026-08-18
 category: workflow-issues
 module: lint-baseline
 problem_type: workflow_issue
@@ -11,6 +12,7 @@ applies_when:
   - "Generated or gitignored output may exist in the working tree"
   - "A lint, test, or warning count is about to be quoted in a PR or commit message"
   - "A repository-wide command traverses the filesystem rather than tracked files"
+  - "A tool under test reads ambient user configuration from outside the repository"
 tags:
   - lint
   - baseline
@@ -18,9 +20,11 @@ tags:
   - generated-output
   - reproducibility
   - metrics
+  - test-isolation
+  - user-config
 ---
 
-# A lint count is not a project fact until the input set is defined
+# A measured count is not a project fact until the input set is defined
 
 ## Context
 
@@ -78,7 +82,22 @@ A warning count reads like a property of the code. It is actually a function of 
 count = tool version × command × configuration × filesystem input set
 ```
 
-Three of those are version-controlled. The fourth is whatever happens to be on disk. When a command is spelled `.` or `**/*`, gitignored build output silently joins the measurement.
+It is tempting to say three of those are version-controlled and only the filesystem is not. That is not reliable either. When a command is spelled `.` or `**/*`, gitignored build output silently joins the measurement — and when a tool reads ambient user configuration, the configuration factor leaves version control too.
+
+A second instance, one day later, took the configuration path. `bun test tests/unit` produced 8 failing plugin-loading tests on a v2.x checkout, and the same 8 on a pristine checkout of the release tag, which made them look like a known-bad property of that release:
+
+```text
+error: Invalid Systematic config in ~/.config/opencode/systematic.jsonc: Unrecognized key: "workflow_guard"
+```
+
+The tests load the developer's real user config. That file carries a `workflow_guard` key introduced in the v3 schema, which v2's stricter validation rejects, so plugin init threw. Nothing was wrong with the branch. CI had been green throughout, because runners have no user config at that path.
+
+```bash
+OPENCODE_CONFIG_DIR=/tmp/isolated HOME=/tmp/isolated-home bun test tests/unit
+# → 1072 pass, 0 fail
+```
+
+The reproducible-input rule is the same; only the contaminating factor moved. Worth noting the sharper trap in this variant: repeating the run on a pristine checkout *confirmed* the failures, because the contaminant lived outside the repository entirely and a clean checkout does not touch it. Checking out clean code is not the same as controlling the input set.
 
 The practical damage is not the wrong number, it is that the wrong number becomes a shared reference point. "Unchanged from baseline" is unfalsifiable when two people hold different baselines, so a real regression can hide inside a stale delta. Quoting the number in a commit message makes it permanent.
 
@@ -87,6 +106,8 @@ The practical damage is not the wrong number, it is that the wrong number become
 - Before writing any count into a PR description, commit message, or review comment.
 - After running a build that emits gitignored output — especially one you then forget about.
 - When local and CI results disagree and the tool versions match. Suspect the input set before suspecting the tool.
+- When a failure reproduces on a pristine checkout. That rules out your working tree, not the environment around it — ambient config in `$HOME` survives any checkout.
+- Before reporting test failures from a checkout of a different major version, where a schema or config contract may have changed underneath a file the tool reads from outside the repository.
 - When generated output uses a different language or ruleset than the source it was generated from, which is exactly when it produces unfamiliar findings.
 
 ## Examples
@@ -118,3 +139,5 @@ A local `claude-code/` build adds 6 more from generated output.
 - [`docs/solutions/best-practices/comments-and-commit-messages-are-claims-not-evidence-2026-08-16.md`](../best-practices/comments-and-commit-messages-are-claims-not-evidence-2026-08-16.md) — the same failure in prose: a written number that the repository does not support.
 - [`docs/solutions/best-practices/a-perfect-measurement-means-a-broken-instrument-2026-08-16.md`](../best-practices/a-perfect-measurement-means-a-broken-instrument-2026-08-16.md) — ask what the instrument measures before trusting its output; here it measured more than intended.
 - [`docs/solutions/workflow-issues/version-pinned-evidence-must-be-reproven-2026-08-16.md`](version-pinned-evidence-must-be-reproven-2026-08-16.md) — adjacent: evidence invalidated by a moving pin rather than by working-directory state.
+- [`docs/solutions/workflow-issues/delegated-verification-needs-a-prepared-environment-2026-08-18.md`](delegated-verification-needs-a-prepared-environment-2026-08-18.md) — the same rule applied to delegation: a gate run in an unprepared environment reports on the environment, not the code.
+- [`docs/solutions/integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md`](../integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md) — the structural fix for ambient-state contamination: isolate `HOME`, XDG roots, and config paths so the input set stops depending on whose machine runs the command.

--- a/docs/solutions/workflow-issues/delegated-verification-needs-a-prepared-environment-2026-08-18.md
+++ b/docs/solutions/workflow-issues/delegated-verification-needs-a-prepared-environment-2026-08-18.md
@@ -1,0 +1,118 @@
+---
+title: Verification delegated into a fresh worktree measures nothing until dependencies exist
+date: 2026-08-18
+category: workflow-issues
+module: delegated-verification
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+applies_when:
+  - Delegating work into a newly created git worktree, clone, or container
+  - A subagent is asked to run gates or tests after making edits
+  - A delegated report contains missing-package or missing-export errors
+  - Interpreting whether a gate failed or could not run
+tags:
+  - git-worktree
+  - delegated-work
+  - verification
+  - subagents
+  - dependencies
+---
+
+# Verification delegated into a fresh worktree measures nothing until dependencies exist
+
+## Context
+
+A subagent was dispatched to apply content edits inside a freshly created `git worktree`. It made the edits correctly, then reported its verification exactly as it found it:
+
+```text
+bun scripts/content-integrity.ts
+→ SyntaxError: js-yaml.mjs missing a default export
+
+bun test tests/unit
+→ 84 passed / 34 failed / 22 errors
+→ missing zod, js-yaml, jsonc-parser
+```
+
+Read quickly, that is a broken branch: a malformed dependency import and three dozen failing tests. Read correctly, it is an empty `node_modules`. A new `git worktree` shares repository history with the primary checkout but not its installed dependencies.
+
+After `bun install --frozen-lockfile`, content-integrity was clean and the suite ran normally.
+
+The subagent did nothing wrong and overclaimed nothing. The defect was in the dispatch: it asked for verification in an environment where verification could not run, and the resulting output was shaped exactly like substantive findings.
+
+## Guidance
+
+A delegation brief that names a fresh environment must also name its preparation, or its verification results carry no information.
+
+State the setup step explicitly, before the gates:
+
+```text
+Before verifying, prepare the worktree:
+  bun install --frozen-lockfile
+
+Then run:
+  bun scripts/content-integrity.ts
+  bun test tests/unit
+```
+
+Require the report to distinguish three states, not two:
+
+- **Passed** — the gate ran against the intended source and found nothing.
+- **Failed** — the gate ran and found a substantive defect.
+- **Blocked** — the gate could not run because the environment was incomplete.
+
+If dependency installation is deliberately out of scope, the brief should say so and instruct the subagent to report verification as blocked rather than presenting resolution errors as findings.
+
+## Why This Matters
+
+A caller who cannot tell "the gate failed" from "the gate could not run" draws the wrong conclusion in the expensive direction: reverting correct changes, or chasing defects that do not exist. In this case the edits were correct and the branch was healthy, and the report read as though neither were true.
+
+The failure mode is specific to environments that look complete. A fresh worktree has the full source tree, correct git metadata, and every config file — everything except the one directory that is gitignored by design. Nothing about it signals "not ready."
+
+This is also why the orchestrator should not accept a delegated verification result at face value. The subagent's report was accurate about what it observed; only the caller had the context to know that what it observed was meaningless.
+
+## When to Apply
+
+- Delegating edits or verification into a new `git worktree`, clone, container, or temp checkout.
+- Reviewing any delegated report whose failures name missing modules, absent exports, or unresolved imports.
+- Comparing results between environments where one is freshly created.
+- Writing a brief that ends in "then run the tests" for an environment the subagent did not build.
+
+## Examples
+
+Insufficient brief — verification looks requested, but cannot succeed:
+
+```text
+Apply the content edits in /tmp/worktree and run the integrity check
+and unit tests.
+```
+
+Usable brief — preparation named, states separated:
+
+```text
+Apply the content edits in /tmp/worktree.
+
+Prepare the environment first:
+  bun install --frozen-lockfile
+
+Then verify:
+  bun scripts/content-integrity.ts
+  bun test tests/unit
+
+Report setup failures separately from gate failures. If dependencies
+cannot be installed, mark verification blocked; do not report missing
+packages or imports as defects in the edited source.
+```
+
+Reconciling a report that arrives anyway:
+
+```bash
+# In the delegated environment, before believing any failure:
+ls node_modules >/dev/null 2>&1 || echo "no dependencies installed — results are void"
+```
+
+## Related
+
+- [`../integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md`](../integration-issues/isolated-opencode-subprocess-fixtures-2026-05-14.md) — the inverse hazard in the same family: there the environment carried *too much* ambient state and had to be isolated; here it carried too little and had to be provisioned. Both make a test result describe the environment rather than the code.
+- [`registry-drift-on-skill-description-change-2026-05-20.md`](registry-drift-on-skill-description-change-2026-05-20.md) — also about delegation briefs being incomplete: there the missing piece was which generator commands to run, here it is whether the gates can run at all.
+- [`../integration-issues/worktree-targeted-receipt-observation-2026-08-02.md`](../integration-issues/worktree-targeted-receipt-observation-2026-08-02.md) — worktree scoping producing observations that do not describe the intended target.


### PR DESCRIPTION
docs(solutions): record three release and verification learnings

A release run reported success and published nothing. The job conclusion was
green, and the release tool's own closing line named a version and channel that
did not exist in the registry, because that line is printed in dry-run mode too.
Two workflow defects produced it and each hid the other, so the behavior split by
branch while ignoring the caller's input in both directions. The durable part is
not the expression bug: it is that three independent success signals all
described the workflow rather than its effect, and only querying the registry
could tell them apart.

Verification delegated into a fresh worktree reported a malformed dependency
import and three dozen failing tests. All of it was an empty node_modules, which
a new worktree does not inherit. The report was accurate and the branch was
healthy. A brief that names a fresh environment has to name its preparation as
well, and has to let the reply distinguish a gate that failed from a gate that
could not run.

Publishing a fix for an older major turns on one fact: dist-tags play no part in
semver range resolution, so a consumer on a caret range receives the newest
matching version whether or not a tag points at it. That allows a one-shot
release under a throwaway tag which is then deleted, leaving the default install
untouched and creating no channel anyone can come to depend on. The default
behavior is the trap, since npm publishes to the latest tag regardless of
version ordering.

The document on measured counts gains a second instance and loses a claim it
should not have made. It held that only the filesystem factor escapes version
control; a test suite reading the developer's own config file showed the
configuration factor escaping too. That variant is harder to catch, because
re-running on a pristine checkout confirms the failures rather than clearing
them — the contaminant is outside the repository, where checking out clean code
never reaches. Its title now covers measurements generally, which is what its
own applicability conditions already described.
