### PR TITLE
fix(ce-plan): drop the last instruction to pass an unsupported model parameter

### DIFF
--- a/skills/ce-plan/references/universal-planning.md
+++ b/skills/ce-plan/references/universal-planning.md
@@ -28,7 +28,7 @@ Evaluate two things before planning:
 | Research need | Signals | Action |
 |--------------|---------|--------|
 | **None** | Generic, timeless, or conceptual plan (study curriculum methodology, project management approach, personal goal breakdown) | Skip research. Model knowledge is sufficient. After structuring the plan, offer: "I based this on general knowledge. Want me to search for [specific thing research would improve]?" — e.g., sourced recipes, current product recommendations, expert frameworks. Only if the user accepts. |
-| **Recommended** | Plan references specific locations, venues, dates, prices, schedules, seasonal availability, or current events — anything where stale information would break the plan (closed restaurants, changed prices, cancelled events, wrong seasonal dates). | Research before planning. Decompose into 2-5 focused research questions and dispatch parallel web searches. In OpenCode, use the Agent tool with `model: "haiku"` for each search to reduce cost. Collate findings before structuring the plan. |
+| **Recommended** | Plan references specific locations, venues, dates, prices, schedules, seasonal availability, or current events — anything where stale information would break the plan (closed restaurants, changed prices, cancelled events, wrong seasonal dates). | Research before planning. Decompose into 2-5 focused research questions and dispatch parallel web searches. Collate findings before structuring the plan. |
 
 When research is recommended, do it — don't just offer. Stale recommendations (closed restaurants, rethemed attractions, outdated prices) are worse than no recommendations. The user invoked `ce:plan` because they want a good plan, not a disclaimer about training data.
 


### PR DESCRIPTION
fix(ce-plan): drop the last instruction to pass an unsupported model parameter

The planning reference still told orchestrators to dispatch research agents with
a `model` argument on the Agent tool. That argument does not exist in the tool's
schema, so the dispatch degrades to a generic sub-agent with no configured model,
which then inherits the session model and silently discards the user's per-agent
and per-category assignments.

This is the same defect reported in #784 and fixed elsewhere in v3.10.2. That
pass corrected the two skills named in the report and missed this one, which is
a reference file rather than a skill body. It was found by inspecting the
published package rather than the source tree, after the same line had already
been corrected on the v2 maintenance branch by a wider sweep.

A full sweep of bundled skills and agents finds no remaining instance.

Worth noting for whoever fixes the next one: the content-integrity gate checks
that bundled agents omit a `model` field in frontmatter, and it validates literal
`subagent_type` values, but nothing inspects prose for instructions to pass an
unsupported argument. That is why this survived a targeted fix and a review.
