### PR TITLE
ci: stop reinstalling system packages the docs runner already has

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -43,8 +43,16 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      # Keep this install in step with the docs job in `main.yaml`; `--with-deps`
+      # is omitted there for the same reason. See that comment for the detail.
       - name: Install Playwright Chromium
-        run: bun playwright install --with-deps chromium
+        run: bun playwright install chromium
         working-directory: docs
 
       - name: Generate reference content

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -179,8 +179,19 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      # `--with-deps` is deliberately omitted. On ubuntu-latest every system
+      # library Playwright requires is already present, so the flag spends most
+      # of a minute on `apt-get update` to install CJK, Thai, and Cyrillic fonts
+      # that the diagrams do not use. Chromium fails loudly at launch if that
+      # ever stops being true.
       - name: Install Playwright Chromium
-        run: bun playwright install --with-deps chromium
+        run: bun playwright install chromium
         working-directory: docs
 
       - name: Build docs


### PR DESCRIPTION
ci: stop reinstalling system packages the docs runner already has

The docs job spent sixty seconds preparing a browser to render two Mermaid
diagrams, and ten seconds building the site.

Almost all of that came from `--with-deps`, which runs `apt-get update` and then
reports that essentially every library Playwright wants is already the newest
version on the runner. The packages it does install are CJK, Thai, and Cyrillic
fonts, plus a fontconfig trigger pass, for diagrams whose labels are English.
The flag is dropped. If a required library ever does go missing, Chromium fails
at launch rather than degrading quietly, so the failure stays visible.

The browser download itself is the remaining cost and is now cached against the
lockfile, which pins Playwright. A cache hit skips it; a version bump changes the
key and downloads once.

The rendering strategy is unchanged. Diagrams are still rasterized at build time,
so the site ships no Mermaid runtime and the diagrams do not depend on client
JavaScript.
