### PR TITLE
ci(content-integrity): fail when prose tells an orchestrator to pass a model argument

### DIFF
--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -270,6 +270,12 @@ export interface ArgumentHintViolation {
   message: string
 }
 
+export interface DispatchArgumentViolation {
+  file: string
+  line: number
+  message: string
+}
+
 export interface MigratedSkillIdentifierViolation {
   file: string
   line: number
@@ -331,6 +337,7 @@ export interface CheckResult {
   removedNamesOverlapViolations: RemovedNamesOverlapViolation[]
   hookParityViolations: HookParityViolation[]
   codemapCompletenessViolations: CodemapCompletenessViolation[]
+  dispatchArgumentViolations: DispatchArgumentViolation[]
   exemptHits: ExemptHit[]
   scanStats: {
     markdownFiles: number
@@ -1726,6 +1733,92 @@ export function checkArgumentHint(
   return violations
 }
 
+/**
+ * Matches a `model: <value>` assignment. The value is required: `model` with no
+ * value (`` `model:` ``, or a table cell naming the field) is documentation of
+ * the frontmatter field, not an instruction to pass an argument.
+ */
+const MODEL_ARGUMENT_ASSIGNMENT = /\bmodel\s*:\s*["'`]?([A-Za-z0-9][\w./-]*)/
+
+/**
+ * `model: inherit` is a frontmatter literal, never a dispatch argument. Skills
+ * document it precisely to prohibit it, and that guidance sits in prose about
+ * subagents -- so the assignment shape and dispatch vocabulary both appear on a
+ * line that is telling readers *not* to do something. The agent-model check
+ * already enforces the frontmatter rule itself.
+ */
+const FRONTMATTER_ONLY_MODEL_VALUES = new Set(['inherit'])
+
+/**
+ * Vocabulary that marks a line as being about dispatching a sub-agent.
+ *
+ * Deliberately excludes the bare word `agent`: bundled content discusses
+ * "bundled agents" and "agent markdown" constantly while documenting the
+ * frontmatter rules, and pairing that with a `model:` example is legitimate.
+ */
+const DISPATCH_VOCABULARY = [
+  'agent tool',
+  'task tool',
+  'dispatch',
+  'spawn',
+  'launch',
+  'sub-agent',
+  'subagent',
+]
+
+/**
+ * Check that no bundled prose instructs an orchestrator to pass a `model`
+ * argument when dispatching a sub-agent.
+ *
+ * OpenCode's `task` tool accepts `subagent_type`, `description`, `prompt`,
+ * `task_id`, `command`, and `background` -- there is no `model` parameter.
+ * An instruction to pass one degrades the dispatch to a generic sub-agent with
+ * no configured model, which then inherits the session model and silently
+ * discards the user's per-agent and per-category assignments.
+ *
+ * Detection requires BOTH an assignment shape and dispatch vocabulary on the
+ * same line. Either signal alone is common in legitimate content: skills
+ * document the real skill-level `model` frontmatter field, and dispatch prose
+ * correctly discusses "the inherited model" without naming an argument.
+ * Fenced code blocks and blockquotes are stripped first, so third-party SDK
+ * samples that legitimately pass `model` to their own APIs are out of scope.
+ */
+export function checkDispatchArguments(
+  rootDir: string,
+  markdownFiles: readonly string[],
+): DispatchArgumentViolation[] {
+  const violations: DispatchArgumentViolation[] = []
+
+  for (const relPath of markdownFiles) {
+    const content = readFileSafe(path.join(rootDir, relPath))
+    if (content === null) continue
+    const parsed = parseFrontmatter(content)
+
+    const originalLines = content.split('\n')
+    for (const rawLine of stripMarkdownNonAssertions(parsed.body).split('\n')) {
+      const assignment = MODEL_ARGUMENT_ASSIGNMENT.exec(rawLine)
+      if (assignment === null) continue
+      if (FRONTMATTER_ONLY_MODEL_VALUES.has(assignment[1].toLowerCase()))
+        continue
+      const lowered = rawLine.toLowerCase()
+      if (!DISPATCH_VOCABULARY.some((token) => lowered.includes(token)))
+        continue
+
+      const trimmed = rawLine.trim()
+      const index = originalLines.findIndex((line) => line.trim() === trimmed)
+      violations.push({
+        file: relPath,
+        line: index === -1 ? 0 : index + 1,
+        message:
+          `Prose instructs passing a \`model\` argument when dispatching a sub-agent, which the task tool does not accept. ` +
+          `Dispatch the bundled agent by name instead so the user's configured assignment applies; model policy is user-owned configuration.`,
+      })
+    }
+  }
+
+  return violations
+}
+
 // These are deliberately lexical tokens only; the gate does not attempt to
 // detect paraphrases of harness-specific instructions.
 const MIGRATED_SKILL_IDENTIFIER_PATTERNS: ReadonlyArray<{
@@ -2084,6 +2177,10 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
   )
   const hookParityViolations = checkHookParity(rootDir, targets.rootDocuments)
   const codemapCompletenessViolations = checkCodemapCompleteness(rootDir)
+  const dispatchArgumentViolations = checkDispatchArguments(
+    rootDir,
+    targets.markdown,
+  )
   const { hits: bannedPatterns, exempt: exemptHits } = checkBannedPatterns(
     rootDir,
     allScannedFiles,
@@ -2111,6 +2208,7 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     removedNamesOverlapViolations,
     hookParityViolations,
     codemapCompletenessViolations,
+    dispatchArgumentViolations,
     exemptHits,
     scanStats: {
       markdownFiles: targets.markdown.length,
@@ -2169,6 +2267,7 @@ function printResult(result: CheckResult, verbose: boolean): void {
   printRemovedNamesOverlapViolations(result.removedNamesOverlapViolations)
   printHookParityViolations(result.hookParityViolations)
   printCodemapCompletenessViolations(result.codemapCompletenessViolations)
+  printDispatchArgumentViolations(result.dispatchArgumentViolations)
 
   if (totalViolations(result) === 0) {
     process.stdout.write(
@@ -2376,6 +2475,20 @@ function printHookParityViolations(
   }
 }
 
+function printDispatchArgumentViolations(
+  violations: readonly DispatchArgumentViolation[],
+): void {
+  if (violations.length === 0) return
+  process.stderr.write(
+    `\nUnsupported dispatch argument violations (${violations.length}):\n`,
+  )
+  for (const violation of violations) {
+    process.stderr.write(
+      `  ${violation.file}:${violation.line} ${violation.message}\n`,
+    )
+  }
+}
+
 function printCodemapCompletenessViolations(
   violations: readonly CodemapCompletenessViolation[],
 ): void {
@@ -2406,7 +2519,8 @@ function totalViolations(result: CheckResult): number {
     result.migratedSkillIdentifierViolations.length +
     result.removedNamesOverlapViolations.length +
     result.hookParityViolations.length +
-    result.codemapCompletenessViolations.length
+    result.codemapCompletenessViolations.length +
+    result.dispatchArgumentViolations.length
   )
 }
 

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -1697,6 +1697,28 @@ function stripMarkdownNonAssertions(body: string): string {
 }
 
 /**
+ * Like {@link stripMarkdownNonAssertions}, but preserves the line count so a
+ * caller can map an index back to a real line number. Fenced-block and
+ * blockquote lines become empty rather than disappearing.
+ */
+function blankMarkdownNonAssertions(body: string): string {
+  const lines = body.split('\n')
+  const blanked: string[] = []
+  let inFence = false
+
+  for (const line of lines) {
+    if (/^[ \t]*(?:```|~~~)/.test(line)) {
+      inFence = !inFence
+      blanked.push('')
+      continue
+    }
+    blanked.push(inFence || /^[ \t]*>/.test(line) ? '' : line)
+  }
+
+  return blanked.join('\n')
+}
+
+/**
  * Check that every bundled skill whose body references the literal `$ARGUMENTS`
  * outside fenced code blocks or blockquotes also declares a non-empty
  * `argument-hint` field in its frontmatter. Skills that only document
@@ -1738,7 +1760,16 @@ export function checkArgumentHint(
  * value (`` `model:` ``, or a table cell naming the field) is documentation of
  * the frontmatter field, not an instruction to pass an argument.
  */
-const MODEL_ARGUMENT_ASSIGNMENT = /\bmodel\s*:\s*["'`]?([A-Za-z0-9][\w./-]*)/
+const MODEL_ARGUMENT_ASSIGNMENT = /\bmodel\s*:\s*["']?([A-Za-z0-9][\w./-]*)/i
+
+/**
+ * Inline-code spans. A supplied argument is written as code; prose that merely
+ * uses a colon after the word "model" is not an instruction to pass one.
+ * Requiring the assignment to sit inside a span keeps sentences such as
+ * "when you spawn a task, note the reasoning model: it varies" from failing a
+ * gate that has no advisory channel.
+ */
+const INLINE_CODE_SPAN = /`([^`]+)`/g
 
 /**
  * `model: inherit` is a frontmatter literal, never a dispatch argument. Skills
@@ -1766,23 +1797,6 @@ const DISPATCH_VOCABULARY = [
   'subagent',
 ]
 
-/**
- * Check that no bundled prose instructs an orchestrator to pass a `model`
- * argument when dispatching a sub-agent.
- *
- * OpenCode's `task` tool accepts `subagent_type`, `description`, `prompt`,
- * `task_id`, `command`, and `background` -- there is no `model` parameter.
- * An instruction to pass one degrades the dispatch to a generic sub-agent with
- * no configured model, which then inherits the session model and silently
- * discards the user's per-agent and per-category assignments.
- *
- * Detection requires BOTH an assignment shape and dispatch vocabulary on the
- * same line. Either signal alone is common in legitimate content: skills
- * document the real skill-level `model` frontmatter field, and dispatch prose
- * correctly discusses "the inherited model" without naming an argument.
- * Fenced code blocks and blockquotes are stripped first, so third-party SDK
- * samples that legitimately pass `model` to their own APIs are out of scope.
- */
 export function checkDispatchArguments(
   rootDir: string,
   markdownFiles: readonly string[],
@@ -1794,21 +1808,19 @@ export function checkDispatchArguments(
     if (content === null) continue
     const parsed = parseFrontmatter(content)
 
-    const originalLines = content.split('\n')
-    for (const rawLine of stripMarkdownNonAssertions(parsed.body).split('\n')) {
-      const assignment = MODEL_ARGUMENT_ASSIGNMENT.exec(rawLine)
-      if (assignment === null) continue
-      if (FRONTMATTER_ONLY_MODEL_VALUES.has(assignment[1].toLowerCase()))
-        continue
-      const lowered = rawLine.toLowerCase()
-      if (!DISPATCH_VOCABULARY.some((token) => lowered.includes(token)))
-        continue
+    // `parsed.body` is a suffix of `content`, so the difference in line counts
+    // is exactly the frontmatter offset. Blanking (rather than deleting)
+    // non-assertion lines keeps body indexes aligned with real line numbers,
+    // so repeated occurrences of the same sentence each report their own line.
+    const offset =
+      content.split('\n').length - parsed.body.split('\n').length + 1
+    const bodyLines = blankMarkdownNonAssertions(parsed.body).split('\n')
 
-      const trimmed = rawLine.trim()
-      const index = originalLines.findIndex((line) => line.trim() === trimmed)
+    for (const [index, rawLine] of bodyLines.entries()) {
+      if (!isDispatchArgumentInstruction(rawLine)) continue
       violations.push({
         file: relPath,
-        line: index === -1 ? 0 : index + 1,
+        line: offset + index,
         message:
           `Prose instructs passing a \`model\` argument when dispatching a sub-agent, which the task tool does not accept. ` +
           `Dispatch the bundled agent by name instead so the user's configured assignment applies; model policy is user-owned configuration.`,
@@ -1817,6 +1829,25 @@ export function checkDispatchArguments(
   }
 
   return violations
+}
+
+/**
+ * True when a single line both shows a `model` argument being supplied and
+ * talks about dispatching a sub-agent.
+ */
+function isDispatchArgumentInstruction(rawLine: string): boolean {
+  const lowered = rawLine.toLowerCase()
+  if (!DISPATCH_VOCABULARY.some((token) => lowered.includes(token)))
+    return false
+
+  for (const span of rawLine.matchAll(INLINE_CODE_SPAN)) {
+    const assignment = MODEL_ARGUMENT_ASSIGNMENT.exec(span[1])
+    if (assignment === null) continue
+    if (FRONTMATTER_ONLY_MODEL_VALUES.has(assignment[1].toLowerCase())) continue
+    return true
+  }
+
+  return false
 }
 
 // These are deliberately lexical tokens only; the gate does not attempt to

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -15,6 +15,7 @@ import {
   checkBannedPatterns,
   checkCodemapCompleteness,
   checkContentIntegrity,
+  checkDispatchArguments,
   checkDispatchIdentifiers,
   checkFrontmatter,
   checkFrontmatterParseSafety,
@@ -4202,5 +4203,107 @@ describe('checkRemovedNamesOverlap', () => {
     )
     expect(violations.length).toBeGreaterThan(0)
     expect(violations.some((v) => v.name === 'orchestrating-swarms')).toBe(true)
+  })
+})
+
+describe('checkDispatchArguments', () => {
+  const cases: [string, string][] = [
+    [
+      'names the Agent tool explicitly',
+      'In OpenCode, pass `model: "sonnet"` in the Agent tool call.',
+    ],
+    [
+      'sits inside a markdown table cell',
+      '| **Recommended** | Research first. | In OpenCode, use the Agent tool with `model: "haiku"` for each search. |',
+    ],
+    [
+      'never names a tool, only dispatch vocabulary',
+      '1. **Quick scan** — dispatch a general-purpose sub-agent using the platform\'s cheapest capable model (e.g., `model: "haiku"` in OpenCode) with this prompt:',
+    ],
+  ]
+
+  for (const [label, body] of cases) {
+    test(`flags prose that ${label}`, () => {
+      const root = makeFixtureRepo()
+      try {
+        writeFile(
+          root,
+          'skills/example/SKILL.md',
+          `---\nname: example\n---\n\n${body}\n`,
+        )
+
+        const violations = checkDispatchArguments(root, [
+          'skills/example/SKILL.md',
+        ])
+
+        expect(violations).toHaveLength(1)
+        expect(violations[0]?.file).toBe('skills/example/SKILL.md')
+        expect(violations[0]?.message).toContain('does not accept')
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true })
+      }
+    })
+  }
+
+  const allowed: [string, string][] = [
+    [
+      'documents the frontmatter field without dispatch vocabulary',
+      '| `model` | A skill-level choice for skill execution. | `model: anthropic/claude-haiku-4-5` |',
+    ],
+    [
+      'prohibits the inherit literal while discussing subagents',
+      'Subagents with no `model` inherit from the invoker. Do **not** declare `model: inherit`: that literal is undocumented.',
+    ],
+    [
+      'discusses dispatch and models without naming an argument',
+      'Dispatch 3-4 parallel ideation sub-agents on the inherited model (do not tier down).',
+    ],
+    [
+      'passes a model inside a fenced code sample',
+      'Launch the client:\n\n```ts\nconst res = await client.create({ model: "claude-3-haiku" })\n```\n',
+    ],
+    [
+      'quotes dispatch guidance in a blockquote',
+      '> In OpenCode, pass `model: "sonnet"` in the Agent tool call.',
+    ],
+  ]
+
+  for (const [label, body] of allowed) {
+    test(`allows prose that ${label}`, () => {
+      const root = makeFixtureRepo()
+      try {
+        writeFile(
+          root,
+          'skills/example/SKILL.md',
+          `---\nname: example\n---\n\n${body}\n`,
+        )
+
+        expect(
+          checkDispatchArguments(root, ['skills/example/SKILL.md']),
+        ).toEqual([])
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true })
+      }
+    })
+  }
+
+  test('participates in the aggregate violation count', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'skills/example/SKILL.md',
+        '---\nname: example\n---\n\nIn OpenCode, pass `model: "sonnet"` in the Agent tool call.\n',
+      )
+
+      const violations = checkDispatchArguments(root, [
+        'skills/example/SKILL.md',
+      ])
+
+      expect(violations.length).toBeGreaterThan(0)
+      expect(violations[0]?.line).toBeGreaterThan(0)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
   })
 })

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -4287,6 +4287,80 @@ describe('checkDispatchArguments', () => {
     })
   }
 
+  test('reports a distinct line for each repeated occurrence', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'skills/example/SKILL.md',
+        '---\nname: example\n---\n\nIn OpenCode, pass `model: "sonnet"` in the Agent tool call.\n\nfiller\n\nIn OpenCode, pass `model: "sonnet"` in the Agent tool call.\n',
+      )
+
+      const violations = checkDispatchArguments(root, [
+        'skills/example/SKILL.md',
+      ])
+
+      expect(violations).toHaveLength(2)
+      expect(violations[0]?.line).not.toBe(violations[1]?.line)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('matches the argument key regardless of case', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'skills/example/SKILL.md',
+        '---\nname: example\n---\n\nDispatch the sub-agent and set `Model: "sonnet"` explicitly.\n',
+      )
+
+      expect(
+        checkDispatchArguments(root, ['skills/example/SKILL.md']),
+      ).toHaveLength(1)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('allows a prose colon that is not a code assignment', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'skills/example/SKILL.md',
+        '---\nname: example\n---\n\nWhen you spawn a task, note the reasoning model: it varies by category.\n',
+      )
+
+      expect(checkDispatchArguments(root, ['skills/example/SKILL.md'])).toEqual(
+        [],
+      )
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('scans bundled agent files, not only skills', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'agents/research/example.md',
+        '---\nname: example\n---\n\nIn OpenCode, pass `model: "sonnet"` in the Agent tool call.\n',
+      )
+
+      const violations = checkDispatchArguments(root, [
+        'agents/research/example.md',
+      ])
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0]?.file).toBe('agents/research/example.md')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   test('participates in the aggregate violation count', () => {
     const root = makeFixtureRepo()
     try {


### PR DESCRIPTION
feat(content-integrity): fail when prose tells an orchestrator to pass a model argument

The dispatch tool accepts a fixed set of arguments and `model` is not among
them. Prose instructing an orchestrator to pass one degrades the dispatch to a
generic sub-agent with no configured model, which then inherits the session
model and silently discards the user's per-agent and per-category assignments.

Three instances shipped. Two were fixed after the original report, and the third
survived that fix, a ten-persona review, and an automated review pass. It was
found only by reading the published package rather than the source tree, and by
then it had shipped in a release. Nothing gated the class: one check validates
that bundled agents omit a `model` field in frontmatter, another validates
literal dispatch identifiers, and neither reads prose.

Detection requires two signals on the same line — a `model: <value>` assignment
and vocabulary indicating a sub-agent dispatch. Either signal alone is ordinary
in legitimate content. Skills document the real skill-level `model` frontmatter
field, including an example value, and correct dispatch guidance discusses "the
inherited model" without naming any argument. Fenced blocks and blockquotes are
stripped first, so third-party code samples passing `model` to their own APIs
stay out of scope, and frontmatter is excluded because the field is legitimate
there.

Two exclusions are deliberate. The vocabulary list omits the bare word `agent`,
since bundled content discusses "bundled agents" constantly while documenting
these very rules. And `model: inherit` is skipped: it is a frontmatter literal
that skills name precisely in order to prohibit it, in sentences that also
mention subagents. Both were found by running the check against the real tree
rather than against fixtures, and each produced a false positive that would have
broken every build, since this gate has no advisory channel.

Verified against the three historical instances restored from the release that
carried them. Each fails the build and is reported at its own file and line,
including the one whose only dispatch signal is the word "dispatch" next to
"sub-agent", with no tool named at all.

A known limit worth stating: an unquoted future value that is not `inherit` is
still detected, but a paraphrase that never writes the assignment shape is not.
This closes the observed class, not every expressible form of it.
