### PR TITLE
ci(renovate): enhance package rules for semantic-release

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -37,6 +37,20 @@
       semanticCommitType: 'build',
     },
     {
+      // Let release-pipeline packages settle before they reach the release job. A
+      // broken same-day publish (e.g. semantic-release 25.0.4 shipped a missing
+      // @semantic-release/core import) would otherwise break Perform Release before
+      // upstream ships a fix.
+      matchPackageNames: ['/^@semantic-release//', 'conventional-changelog-conventionalcommits', 'semantic-release'],
+      minimumReleaseAge: '3 days',
+    },
+    {
+      matchPackageNames: ['conventional-changelog-conventionalcommits', 'semantic-release'],
+      matchUpdateTypes: ['major'],
+      groupName: 'semantic-release and conventionalcommits',
+      semanticCommitType: 'feat',
+    },
+    {
       matchPackageNames: ['@opencode-ai/{/,}**'],
       groupName: 'OpenCode',
       semanticCommitType: 'build',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -41,7 +41,7 @@
       // broken same-day publish (e.g. semantic-release 25.0.4 shipped a missing
       // @semantic-release/core import) would otherwise break Perform Release before
       // upstream ships a fix.
-      matchPackageNames: ['/^@semantic-release//', 'conventional-changelog-conventionalcommits', 'semantic-release'],
+      matchPackageNames: ['@semantic-release/{/,}**', 'conventional-changelog-conventionalcommits', 'semantic-release', 'semantic-release-export-data'],
       minimumReleaseAge: '3 days',
     },
     {


### PR DESCRIPTION
- Add rules to manage release-pipeline packages with a minimum release age of 3 days.
- Group semantic-release and conventional-changelog-conventionalcommits updates under a single rule for major updates.