### PR TITLE
docs: capture two learnings from the review artifact contract work

### DIFF
--- a/docs/solutions/best-practices/unvalidated-artifact-contracts-have-no-conforming-producers-2026-08-23.md
+++ b/docs/solutions/best-practices/unvalidated-artifact-contracts-have-no-conforming-producers-2026-08-23.md
@@ -1,0 +1,270 @@
+---
+title: An artifact contract with no validated write path has no conforming producers
+date: 2026-08-23
+category: best-practices
+module: ce-review
+problem_type: best_practice
+component: tooling
+severity: high
+applies_when:
+  - A persisted artifact crosses an agent, process, or package boundary
+  - An issue proposes versioning or a compatibility window for a documented contract
+  - The producer is a model that can ignore instructions rather than a deterministic writer
+  - A validator must reach consumers, not just the development checkout
+  - Validation errors could echo user or artifact content
+tags:
+  - contract-enforcement
+  - artifact-validation
+  - schema-drift
+  - zod
+  - codegen
+  - agent-boundary
+---
+
+# An artifact contract with no validated write path has no conforming producers
+
+## Context
+
+Issue #793 asked for a `schema_version` field on `ce:review`'s persisted artifacts,
+plus an in-flight compatibility window, on the premise that version drift breaks
+reviewers mid-run and leaves the historical corpus unreadable.
+
+Measuring the artifacts before scoping the work inverted that premise. Across 26 run
+directories there were seven synthesis artifacts, written under two different filenames
+(`review-summary.json` and `summary.json`), and no two shared a shape. The three ledger
+fields the contract documented — `input_findings`, `disposition_counts`, `run_status` —
+appeared in zero of them. `verdict`, which the contract never mentioned, appeared in all
+four `review-summary.json` files.
+
+The contract had not drifted; it had never been honored. Adding `schema_version` would
+have stamped a version onto a shape no producer emitted.
+
+A second measurement, taken inside the same system, pointed at the cause:
+
+| Path | Files | Distinct shapes | Shapes per file |
+| --- | --- | --- | --- |
+| Per-persona, parent-validated | 138 | 21 | 0.15 |
+| Run-level, unvalidated | 7 | 7 | 1.00 |
+
+111 of the 138 per-persona files shared a single shape. No two run-level artifacts
+ever shared one. Same repository, same authors, same period.
+
+Treat that as correlation, not proof. The two surfaces differ in cardinality — many
+persona files per run against one run-level file — and the run-level shape had been
+redesigned shortly before the measurement. The direction is still stark enough to act
+on, and the honest framing matters: the evidence supports "validated paths converge"
+as a working hypothesis, not as a demonstrated causal law.
+
+## Guidance
+
+### Measure what producers emit before accepting a contract issue's framing
+
+An issue describing a contract problem states a premise. Check it against the artifacts
+on disk before scoping any work. Count how many producers exist, how many distinct
+shapes they emit, and which documented fields actually appear. That measurement is
+cheap and it can invert the entire request — here it turned "add versioning and a
+compatibility window" into "there is nothing conforming to version yet."
+
+The same discipline applies to your own evidence. An early claim in this work stated
+that "0 of 26 runs wrote `metadata.json`." Twenty of those runs predated the field's
+specification and could never have written it. The honest figure was roughly 0 of 4,
+which is weak evidence rather than a verdict. Always check that the denominator could
+have produced the thing you are counting.
+
+### Verify the failure mode is reachable before designing for it
+
+The issue assumed producer/consumer version skew. Tracing the dispatch path showed it
+was unreachable in the ordinary case: the parent inlines
+`skills/ce-review/references/findings-schema.json` into every persona prompt through
+`{schema}` in `skills/ce-review/references/subagent-template.md`, then validates the
+return against that same bundled file. Producer and consumer are the same version by
+construction within a run.
+
+The reachable failure was a model ignoring the contract — which a version field cannot
+detect, because a noncompliant model will happily echo whatever version string the
+prompt showed it. Designing a compatibility window would have addressed a failure that
+does not occur while leaving the one that does.
+
+### An agent cannot enforce a contract on itself
+
+This repository already learned that enforcing a contract through agent-facing
+instruction text does not work; see
+[cross-harness tools frontmatter divergence](../integration-issues/cross-harness-tools-frontmatter-divergence-2026-08-16.md),
+where the fix was architectural rather than instructional.
+
+The first version of this plan said "make the parent validate at the write boundary."
+That repeats the same mistake one level up, because the parent is also an agent and can
+skip its own validation step silently. The shipped design has the parent *invoke* a
+command whose failure is visible, rather than perform validation internally.
+
+State the limit honestly rather than implying a guarantee. The shipped contract in
+`skills/ce-review/references/synthesis-artifact-contract.md` says:
+
+> This is enforcement by visible failure, not by containment.
+
+An agent that never runs the command produces no evidence in either direction. The
+durable value is that the command is independently runnable — a human or a CI job can
+check any artifact without the producing agent's cooperation.
+
+### Packaging determines where a validator can live
+
+A validator in `scripts/` cannot reach a single consumer. `package.json`'s `files`
+array ships only `dist`, `skills`, `agents`, and two markdown files. AJV is a
+development dependency and is absent at runtime.
+
+Check the publish surface before choosing a home for enforcement code. Here the CLI
+ships through `bin` into `dist/`, and `zod` was already a runtime dependency, so
+validation went into `src/cli.ts` at zero dependency cost.
+
+### Generate the schema from one runtime source and gate the drift
+
+The repository already had the pattern, in `scripts/generate-config-schema.ts`: a Zod
+source of truth, a `z.toJSONSchema()` generator supporting `--check`, a committed
+generated schema, and a CI drift gate.
+
+`src/lib/review-artifact-schema.ts` is the source:
+
+```ts
+export const ReviewArtifactSchema = z
+  .object({
+    schema_version: z.literal(1),
+    run_id: boundedText(MAX_RUN_ID_LENGTH),
+    mode: z.enum(['interactive', 'autofix', 'headless'] as const),
+    harness: HarnessSchema,
+    run_status: z.enum([
+```
+
+`scripts/generate-review-artifact-schema.ts` emits the committed artifact from it:
+
+```ts
+const result = z.toJSONSchema(ReviewArtifactSchema, getGenerationOptions())
+```
+
+One consequence is easy to miss: because the generated schema is a parent-side artifact,
+it is never inlined into a persona prompt and costs no dispatch tokens — unlike the
+persona findings schema, which is.
+
+Two traps documented in
+[typed config validation build-time codegen](typed-config-validation-build-time-codegen-2026-05-16.md)
+apply directly: the generator must not read its own previously-written output through a
+cached import, and the `--check` path must build its options through the same helper as
+the write path. Here both paths call `getGenerationOptions()`, and the checker reads
+the committed file from disk.
+
+### Project validation errors to an explicit allowlist
+
+Zod's error output is **not** inherently safe to print. Verified on zod 4.4.3, a
+`too_big` issue emits `{origin, code, maximum, inclusive, path, message}` and
+`invalid_type` emits `{expected, code, path, message}`; `message` is descriptive prose,
+and enabling `reportInput` adds the raw offending input.
+
+An artifact containing review findings may quote source. A no-echo validator therefore
+has to project each issue explicitly:
+
+```ts
+const authoredMessage =
+  issue.code === 'custom' ? `: ${issue.message}` : ''
+errorSink(`${issuePath} ${issue.code}${authoredMessage}`)
+```
+
+The `custom` exception is narrow and deliberate: custom refinement messages in this
+repository are author-written constants containing no artifact data, and without the
+exception every cross-field refinement collapses to an undiagnosable `custom`. The
+residual risk is that a future refinement written with a template literal would widen
+the leak path silently.
+
+### Distinguish "legacy" from "malformed"
+
+Excluding a historical corpus is reasonable. Excusing malformed content as merely old
+is not. A code review caught this classifier admitting far more than intended:
+
+```ts
+// Wrong: a parsed array, string, or number is reported as legacy
+value === null || typeof value !== 'object' || !Object.hasOwn(value, 'schema_version')
+```
+
+Legacy means *an object* that predates the contract. Everything else belongs in the
+failure path:
+
+```ts
+function isLegacyReviewArtifact(value: unknown): boolean {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    !Object.hasOwn(value, 'schema_version')
+  )
+}
+```
+
+Give the exclusion its own exit status so a caller can tell "predates the contract"
+from "this is broken" — here exit 3, distinct from 1 for a validation failure and 2 for
+an operational failure. That turns a prose decision into an executable one.
+
+## Why This Matters
+
+Versioning an unenforced contract is worse than leaving it alone: the version field
+implies a conformance guarantee that nothing checks, and a model will emit
+`schema_version: 1` alongside any shape it likes.
+
+The packaging constraint is the kind that wastes a full implementation cycle when found
+late. A validator written into `scripts/` passes every local test and reaches no user.
+
+## When to Apply
+
+Apply this when:
+
+- A persisted artifact crosses an agent, process, or package boundary, and its writer
+  can ignore instructions — true of every model-backed producer.
+- An issue proposes versioning, migration, or a compatibility window for a contract.
+  Measure the producers first; the premise may not survive.
+- Validation errors could contain user or artifact content.
+
+Do **not** apply it when a deterministic code path is the only writer and a type already
+constrains it, or when the mode writes no artifact at all — `mode:report-only` performs
+no validation precisely because it persists nothing.
+
+And never read a version field as evidence that a producer complied. It is not.
+
+## Examples
+
+**Before** — the parent is asked to validate its own output:
+
+```text
+After writing review-summary.json, validate it against the contract.
+```
+
+Nothing observes whether this happened.
+
+**After** — the parent invokes a command whose failure is visible and whose result
+belongs in the run record:
+
+```text
+1. Write review-summary.json with schema_version: 1.
+2. Run systematic validate-review-artifact <path>.
+3. If it fails, repair the artifact and re-run the command.
+4. Do not report a verdict over a failing artifact.
+5. Keep the failing artifact on disk as evidence.
+```
+
+The same shape applies to the schema itself: replace a hand-written JSON Schema kept
+beside a runtime schema with one Zod source, a generated committed artifact, and
+`--check` in CI, so the two cannot silently diverge.
+
+## Related
+
+- [The same tools frontmatter is permissive on OpenCode and restrictive on Pi](../integration-issues/cross-harness-tools-frontmatter-divergence-2026-08-16.md)
+  — the architectural precedent this design follows: do not enforce a contract through
+  instructions an agent can decline.
+- [Behavior-first AJV contract verification](behavior-first-ajv-contract-verification-2026-07-21.md)
+  — prove the producer/consumer boundary with real emissions rather than stated intent.
+- [Typed config validation with build-time codegen](typed-config-validation-build-time-codegen-2026-05-16.md)
+  — the generator parity and stale-self-read traps that apply to any committed
+  generated schema.
+- [Content integrity gates should mirror runtime drop rules](content-integrity-mirror-runtime-drop-rules-2026-05-17.md)
+  — a gate that checks a prettier subset than the runtime accepts is worse than none.
+- Issues: [#793](https://github.com/marcusrbrown/systematic/issues/793) (source),
+  [#832](https://github.com/marcusrbrown/systematic/issues/832) (a second contract
+  field with no producer), [#834](https://github.com/marcusrbrown/systematic/issues/834)
+  (validator placement constraint), delivered in
+  [PR #830](https://github.com/marcusrbrown/systematic/pull/830).

--- a/docs/solutions/workflow-issues/clean-checkout-baselines-before-quoting-metrics-2026-08-17.md
+++ b/docs/solutions/workflow-issues/clean-checkout-baselines-before-quoting-metrics-2026-08-17.md
@@ -1,7 +1,7 @@
 ---
-title: A measured count is not a project fact until the input set is defined
+title: A repository claim is not a fact until the input set is defined
 date: 2026-08-17
-last_updated: 2026-08-18
+last_updated: 2026-08-23
 category: workflow-issues
 module: lint-baseline
 problem_type: workflow_issue
@@ -10,21 +10,21 @@ severity: medium
 applies_when:
   - "A local metric disagrees with CI and tool versions already match"
   - "Generated or gitignored output may exist in the working tree"
-  - "A lint, test, or warning count is about to be quoted in a PR or commit message"
+  - "A count, inventory, or tree claim is about to be quoted in docs, a PR, or a commit message"
   - "A repository-wide command traverses the filesystem rather than tracked files"
   - "A tool under test reads ambient user configuration from outside the repository"
 tags:
-  - lint
   - baseline
   - gitignored-artifacts
-  - generated-output
   - reproducibility
   - metrics
   - test-isolation
   - user-config
+  - branch-state
+  - exhaustive-verification
 ---
 
-# A measured count is not a project fact until the input set is defined
+# A repository claim is not a fact until the input set is defined
 
 ## Context
 
@@ -45,7 +45,7 @@ The number 17 was quoted repeatedly as "the baseline" — in a PR description an
 
 ## Guidance
 
-Treat a repository-wide count as a project fact only when its input set is defined by the repository rather than by whoever last ran a build.
+Treat a repository-wide count as a project fact only when its input set is defined by the repository rather than by whoever last ran a build — or by whichever branch happens to be checked out.
 
 Before quoting one:
 
@@ -64,6 +64,23 @@ bun run lint
 ```
 
 If generated output *should* be linted, say so explicitly and record which build produced it. What fails is the unstated case, where two people run the same command against different filesystems and both believe they measured the repository.
+
+A checkout on the wrong branch changes the input set too. Stand on the branch the claim will ship on before verifying it:
+
+```bash
+git switch <target-branch>
+git rev-parse --abbrev-ref HEAD
+```
+
+And when the claim is about the tree rather than a number, enumerate the claims rather than searching for one phrasing:
+
+```bash
+grep -oh '`[a-z][a-zA-Z0-9_./-]*`' STRUCTURE.md | tr -d '`' \
+  | grep -E '^(src|scripts|skills|agents|tests)/' | sort -u \
+  | while read -r p; do [ -e "$p" ] || echo "MISSING: $p"; done
+```
+
+Grep finds the phrasing you thought of. An enumeration finds the ones you did not.
 
 A count is only reproducible when reported with its inputs:
 
@@ -99,6 +116,14 @@ OPENCODE_CONFIG_DIR=/tmp/isolated HOME=/tmp/isolated-home bun test tests/unit
 
 The reproducible-input rule is the same; only the contaminating factor moved. Worth noting the sharper trap in this variant: repeating the run on a pristine checkout *confirmed* the failures, because the contaminant lived outside the repository entirely and a clean checkout does not touch it. Checking out clean code is not the same as controlling the input set.
 
+A third instance moved the contaminant *inside* git, and it defeats the check at the top of this page. A documentation PR claimed 56 unit test files where it had counted 59, because the count was taken while a feature branch was checked out that adds three test files.
+
+`git status --short --ignored` reports nothing in that situation. The extra files are tracked and clean — they are simply another branch's tracked files. Stashing does not help, and neither does a pristine checkout, because the working tree already *was* pristine. It was pristine for the wrong branch.
+
+The same contamination produced a second error in the same PR, in a different field: the docs described `scripts/generate-review-artifact-schema.ts`, a file that existed only on that feature branch. So the failure is not specific to counts. Any claim about the tree inherits the branch it was read from.
+
+Verification method compounds it. The correction searched for `59 unit test files` and missed a third occurrence worded `Unit tests (59 files)`. Enumerating every documented path instead then found a fourth error nobody was looking for: a `.opencode/commands/` directory still described long after it was removed.
+
 The practical damage is not the wrong number, it is that the wrong number becomes a shared reference point. "Unchanged from baseline" is unfalsifiable when two people hold different baselines, so a real regression can hide inside a stale delta. Quoting the number in a commit message makes it permanent.
 
 ## When to Apply
@@ -109,6 +134,7 @@ The practical damage is not the wrong number, it is that the wrong number become
 - When a failure reproduces on a pristine checkout. That rules out your working tree, not the environment around it — ambient config in `$HOME` survives any checkout.
 - Before reporting test failures from a checkout of a different major version, where a schema or config contract may have changed underneath a file the tool reads from outside the repository.
 - When generated output uses a different language or ruleset than the source it was generated from, which is exactly when it produces unfamiliar findings.
+- Before documenting any count, script inventory, or directory. Check out the branch the claim will ship on and recount there; a feature branch in the working tree lends its files to the answer.
 
 ## Examples
 
@@ -131,7 +157,18 @@ Better still, when the number carries weight:
 A local `claude-code/` build adds 6 more from generated output.
 ```
 
+**A claim that carried its branch.** Not a fact:
+
+```text
+tests/unit/       # 59 unit test files
+scripts/generate-review-artifact-schema.ts
+```
+
+Both were read from a feature branch. On the branch that shipped them, the count was 56 and the script did not exist.
+
 **Making it structural.** If a single stable number matters, stop relying on working-directory hygiene: scope the command to tracked source, lint generated trees under a separate task, or exclude generated staging in the tool's own configuration. Any of those beats depending on who last ran a build.
+
+For documentation, the structural version is a check that enumerates rather than matches — every documented path tested for existence, so a stale claim fails loudly instead of waiting for a reviewer to notice it.
 
 ## Related
 


### PR DESCRIPTION
Two institutional learnings from the review artifact contract work that shipped in v3.13.0.

## New: an artifact contract with no validated write path has no conforming producers

Issue #793 asked for a `schema_version` field and an in-flight compatibility window, on the premise that version drift was breaking reviewers mid-run. Measuring the artifacts first inverted that premise.

Across 26 run directories there were seven synthesis artifacts, written under two different filenames, and no two shared a shape. The three ledger fields the contract documented appeared in none of them. `verdict`, which the contract never mentioned, appeared in all four `review-summary.json` files. There was nothing conforming to version.

A second measurement pointed at why:

| Path | Files | Distinct shapes | Shapes per file |
| --- | --- | --- | --- |
| Per-persona, parent-validated | 138 | 21 | 0.15 |
| Run-level, unvalidated | 7 | 7 | 1.00 |

The doc states plainly that this is correlation rather than proven causation, and names the confounds.

It also records the design constraint that shaped the fix: an agent cannot enforce a contract on itself, so the parent invokes a command whose failure is visible instead of validating internally. That is observability, not containment, and the doc says so rather than implying a guarantee. Alongside it, the packaging constraint that a validator in `scripts/` reaches no consumer, and the empirical finding that Zod issue objects are not safe to print verbatim.

## Extended: the input-set learning gains a third contaminant

`clean-checkout-baselines-before-quoting-metrics` already covered gitignored build output and ambient user configuration. Wrong-branch contamination belongs beside them, and it is the sharpest of the three because it defeats that doc's own recommended check — `git status --short --ignored` reports nothing when the contaminating files are another branch's tracked, clean files. Stashing does not help. Neither does a pristine checkout, because the tree already was pristine, for the wrong branch.

The update also adds the verification-method half: correcting a repeated fact by searching for one phrasing leaves the differently worded occurrences behind. Enumerating every documented path instead surfaced a directory still described long after it was removed.

Extending the existing doc rather than writing a second one, since two docs both saying "check your working tree before quoting repository facts" would drift apart. The title broadens from counts to repository claims, because the material now covers existence rather than only arithmetic. No incoming link uses the old title as its link text.

## Verification

- Frontmatter on both docs validated against `skills/ce-compound/references/schema.yaml` — required fields, enum membership, and array bounds.
- All cross-links resolve.
- The enumeration command in the updated doc was run against this tree and reports clean.
- `bun scripts/content-integrity.ts` clean.
