### PR TITLE
fix(ce-compound): map the four knowledge types that had no category

### DIFF
--- a/skills/ce-compound/references/yaml-schema.md
+++ b/skills/ce-compound/references/yaml-schema.md
@@ -16,7 +16,14 @@ The `problem_type` determines which **track** applies. Each track has different 
 | Track | problem_types | Description |
 |-------|--------------|-------------|
 | **Bug** | `build_error`, `test_failure`, `runtime_error`, `performance_issue`, `database_issue`, `security_issue`, `ui_bug`, `integration_issue`, `logic_error` | Defects and failures that were diagnosed and fixed |
-| **Knowledge** | `best_practice`, `documentation_gap`, `workflow_issue`, `developer_experience` | Practices, patterns, workflow improvements, and documentation |
+| **Knowledge** | `best_practice`, `documentation_gap`, `workflow_issue`, `developer_experience`, `architecture_pattern`, `design_pattern`, `tooling_decision`, `convention` | Practices, patterns, workflow improvements, and documentation |
+
+Prefer the narrowest applicable value. `best_practice` is the fallback when no narrower knowledge-track value fits.
+
+- `architecture_pattern` — structural decisions about how components relate
+- `design_pattern` — reusable solutions to recurring design problems
+- `tooling_decision` — choices about tools, libraries, or build infrastructure
+- `convention` — agreed-upon naming, formatting, or style rules
 
 ## Required Fields (both tracks)
 
@@ -34,6 +41,8 @@ Required:
 - **resolution_type**: One of `code_fix`, `migration`, `config_change`, `test_fix`, `dependency_update`, `environment_setup`, `workflow_improvement`, `documentation_update`, `tooling_addition`, `seed_data_update`
 
 ## Knowledge Track Fields
+
+Applies to every knowledge-track `problem_type` listed in the Tracks table above.
 
 No additional required fields beyond the shared ones. All fields below are optional:
 
@@ -73,6 +82,14 @@ Docs created before the track system may have `symptoms`/`root_cause`/`resolutio
 - `workflow_issue` -> `docs/solutions/workflow-issues/`
 - `best_practice` -> `docs/solutions/best-practices/`
 - `documentation_gap` -> `docs/solutions/documentation-gaps/`
+- `architecture_pattern` -> `docs/solutions/best-practices/`
+- `design_pattern` -> `docs/solutions/best-practices/`
+- `tooling_decision` -> `docs/solutions/best-practices/`
+- `convention` -> `docs/solutions/best-practices/`
+
+The four narrower knowledge-track types share the `best-practices/` directory rather than each
+getting their own. That matches where such docs are already filed, and avoids single-document
+directories that fragment search.
 
 ## Validation Rules
 


### PR DESCRIPTION
`skills/ce-compound/references/schema.yaml` accepts eight knowledge-track `problem_type` values. Its companion reference guide documented four.

`architecture_pattern`, `design_pattern`, `tooling_decision`, and `convention` were absent from the Tracks table and absent from the Category Mapping. An author picking one of them had a value the schema validates and no directory to file the document in.

## The mapping

All four go to `best-practices/`. That is not a default — it is where the documents already using them live:

```
architecture_pattern -> best-practices   (claude-code-plugin-build-and-publish-architecture)
architecture_pattern -> best-practices   (vendor-npm-packaged-skill-as-generated-artifact)
convention           -> best-practices   (qualified-persona-ids-are-canonical-validated-references)
```

Giving each of the four its own directory would produce four directories holding one document apiece, which fragments search for no benefit.

The change also carries over the schema's stated preference for the narrowest applicable value, with a one-line gloss on each of the four, and makes explicit that the knowledge-track field rules apply to every type in the table rather than only the original four.

## Verified

Every knowledge-track value in `schema.yaml` now appears in both the Tracks table and the Category Mapping. `bun run registry:drift` and `bun scripts/content-integrity.ts` are clean.

## Not in this change

Two adjacent things turned up while checking whether other copies of this contract would diverge, both left alone deliberately:

- `skills/ce-compound-refresh/references/schema.yaml` is a stale copy that accepts only the original four knowledge types. Since that skill audits `docs/solutions/` for accuracy, it would treat `architecture_pattern` as invalid on documents that legitimately use it. That is a worse problem than this one and deserves its own change.
- `docs/solutions/code-quality/` and `docs/solutions/workflow-patterns/` have no mapping entry. Their documents predate the track system and declare no `problem_type` at all, so they are unrelated to this gap.
