### PR TITLE
fix(ce-compound-refresh): restore the frontmatter contract it validates against

### DIFF
--- a/skills/ce-compound-refresh/references/schema.yaml
+++ b/skills/ce-compound-refresh/references/schema.yaml
@@ -23,12 +23,16 @@ tracks:
       - integration_issue
       - logic_error
   knowledge:
-    description: "Best practices, workflow improvements, patterns, and documentation"
+    description: "Best practices, workflow improvements, patterns, conventions, and documentation"
     problem_types:
       - best_practice
       - documentation_gap
       - workflow_issue
       - developer_experience
+      - architecture_pattern
+      - design_pattern
+      - tooling_decision
+      - convention
 
 # --- Fields required by BOTH tracks -----------------------------------------
 required_fields:
@@ -57,7 +61,18 @@ required_fields:
       - workflow_issue
       - best_practice
       - documentation_gap
-    description: "Primary category — determines track (bug vs knowledge)"
+      - architecture_pattern
+      - design_pattern
+      - tooling_decision
+      - convention
+    description: >-
+      Primary category — determines track (bug vs knowledge).
+      Prefer the narrowest applicable value; best_practice is the fallback
+      when no narrower knowledge-track value fits.
+      architecture_pattern: structural decisions about how components relate.
+      design_pattern: reusable solutions to recurring design problems.
+      tooling_decision: choices about tools, libraries, or build infrastructure.
+      convention: agreed-upon naming, formatting, or style rules.
 
   component:
     type: enum
@@ -220,3 +235,13 @@ validation_rules:
   - "date must match YYYY-MM-DD format"
   - "rails_version, if provided, must match X.Y.Z format and only applies to bug-track docs"
   - "tags should be lowercase and hyphen-separated"
+  - |-
+    YAML quoting: scalar values that contain ' #' (space-hash) must be
+    double-quoted to prevent silent YAML comment truncation (the YAML parser
+    treats ' #' as an inline comment, silently dropping the rest of the value
+    with parseError: false). Example: problem: "cache miss # under load".
+  - |-
+    YAML quoting: array-of-strings frontmatter items must be double-quoted when
+    the value starts with a YAML reserved indicator (e.g., '{', '[', '|', '>',
+    '!', '&', '*', '?', ':', '-') or contains ': ' (colon-space). Example:
+    symptoms: - "[mdx-js/rollup] Could not parse expression"

--- a/skills/ce-compound-refresh/references/yaml-schema.md
+++ b/skills/ce-compound-refresh/references/yaml-schema.md
@@ -16,7 +16,14 @@ The `problem_type` determines which **track** applies. Each track has different 
 | Track | problem_types | Description |
 |-------|--------------|-------------|
 | **Bug** | `build_error`, `test_failure`, `runtime_error`, `performance_issue`, `database_issue`, `security_issue`, `ui_bug`, `integration_issue`, `logic_error` | Defects and failures that were diagnosed and fixed |
-| **Knowledge** | `best_practice`, `documentation_gap`, `workflow_issue`, `developer_experience` | Practices, patterns, workflow improvements, and documentation |
+| **Knowledge** | `best_practice`, `documentation_gap`, `workflow_issue`, `developer_experience`, `architecture_pattern`, `design_pattern`, `tooling_decision`, `convention` | Practices, patterns, workflow improvements, and documentation |
+
+Prefer the narrowest applicable value. `best_practice` is the fallback when no narrower knowledge-track value fits.
+
+- `architecture_pattern` — structural decisions about how components relate
+- `design_pattern` — reusable solutions to recurring design problems
+- `tooling_decision` — choices about tools, libraries, or build infrastructure
+- `convention` — agreed-upon naming, formatting, or style rules
 
 ## Required Fields (both tracks)
 
@@ -34,6 +41,8 @@ Required:
 - **resolution_type**: One of `code_fix`, `migration`, `config_change`, `test_fix`, `dependency_update`, `environment_setup`, `workflow_improvement`, `documentation_update`, `tooling_addition`, `seed_data_update`
 
 ## Knowledge Track Fields
+
+Applies to every knowledge-track `problem_type` listed in the Tracks table above.
 
 No additional required fields beyond the shared ones. All fields below are optional:
 
@@ -73,6 +82,14 @@ Docs created before the track system may have `symptoms`/`root_cause`/`resolutio
 - `workflow_issue` -> `docs/solutions/workflow-issues/`
 - `best_practice` -> `docs/solutions/best-practices/`
 - `documentation_gap` -> `docs/solutions/documentation-gaps/`
+- `architecture_pattern` -> `docs/solutions/best-practices/`
+- `design_pattern` -> `docs/solutions/best-practices/`
+- `tooling_decision` -> `docs/solutions/best-practices/`
+- `convention` -> `docs/solutions/best-practices/`
+
+The four narrower knowledge-track types share the `best-practices/` directory rather than each
+getting their own. That matches where such docs are already filed, and avoids single-document
+directories that fragment search.
 
 ## Validation Rules
 

--- a/tests/unit/compound-contract-parity.test.ts
+++ b/tests/unit/compound-contract-parity.test.ts
@@ -1,0 +1,92 @@
+// Claude Code flattens each skill into a self-contained bundle, so these files must stay duplicated.
+// Parity tests are safer than cross-skill references that would not survive that build.
+import { describe, expect, it } from 'bun:test'
+import fs from 'node:fs'
+import path from 'node:path'
+import yaml from 'js-yaml'
+
+const REPO_ROOT = path.resolve(import.meta.dir, '../..')
+const SOURCE_SKILL = 'skills/ce-compound'
+const REFRESH_SKILL = 'skills/ce-compound-refresh'
+
+type RecordValue = Record<string, unknown>
+
+function isRecord(value: unknown): value is RecordValue {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function asRecord(value: unknown, label: string): RecordValue {
+  if (!isRecord(value)) {
+    throw new Error(`${label} must be a mapping`)
+  }
+  return value
+}
+
+function readContract(skill: string, relativePath: string): Buffer {
+  return fs.readFileSync(path.join(REPO_ROOT, skill, relativePath))
+}
+
+function assertContractParity(relativePath: string): void {
+  const sourcePath = `${SOURCE_SKILL}/${relativePath}`
+  const refreshPath = `${REFRESH_SKILL}/${relativePath}`
+  if (
+    !readContract(SOURCE_SKILL, relativePath).equals(
+      readContract(REFRESH_SKILL, relativePath),
+    )
+  ) {
+    throw new Error(
+      `${sourcePath} and ${refreshPath} diverged. Copy the ce-compound version to ce-compound-refresh.`,
+    )
+  }
+}
+
+function readKnowledgeProblemTypes(skill: string): Set<string> {
+  const relativePath = 'references/schema.yaml'
+  const filePath = `${skill}/${relativePath}`
+  const parsed = yaml.load(readContract(skill, relativePath).toString('utf8'))
+  const schema = asRecord(parsed, filePath)
+  const tracks = asRecord(schema.tracks, `${filePath}: tracks`)
+  const knowledge = asRecord(tracks.knowledge, `${filePath}: tracks.knowledge`)
+  const values = knowledge.problem_types
+
+  if (
+    !Array.isArray(values) ||
+    !values.every((value): value is string => typeof value === 'string')
+  ) {
+    throw new Error(
+      `${filePath}: tracks.knowledge.problem_types must be an array of strings`,
+    )
+  }
+
+  return new Set(values)
+}
+
+describe('ce:compound contract parity', () => {
+  it('keeps schema.yaml identical', () => {
+    assertContractParity('references/schema.yaml')
+  })
+
+  it('keeps yaml-schema.md identical', () => {
+    assertContractParity('references/yaml-schema.md')
+  })
+
+  it('keeps resolution-template.md identical', () => {
+    assertContractParity('assets/resolution-template.md')
+  })
+
+  it('keeps knowledge-track problem_type values equal', () => {
+    const sourceTypes = readKnowledgeProblemTypes(SOURCE_SKILL)
+    const refreshTypes = readKnowledgeProblemTypes(REFRESH_SKILL)
+    const setsMatch =
+      sourceTypes.size === refreshTypes.size &&
+      [...sourceTypes].every((value) => refreshTypes.has(value))
+
+    if (!setsMatch) {
+      throw new Error(
+        `${SOURCE_SKILL}/references/schema.yaml and ${REFRESH_SKILL}/references/schema.yaml have different knowledge-track problem_type values. Copy the ce-compound version to ce-compound-refresh.`,
+      )
+    }
+
+    expect([...refreshTypes].sort()).toEqual([...sourceTypes].sort())
+  })
+})


### PR DESCRIPTION
Closes #840.

`ce:compound-refresh` audits `docs/solutions/` for correctness while validating against its own stale copy of the contract.

## What was wrong

Its `schema.yaml` was a strict subset of `ce:compound`'s — the same file, 25 lines behind:

| Missing | Consequence |
| --- | --- |
| `architecture_pattern`, `design_pattern`, `tooling_decision`, `convention` | Three existing documents use two of these. The skill that judges document correctness would read them as invalid. |
| Two YAML quoting rules | A value containing space-hash is silently truncated by the parser with no error raised. |

The second one is the worse of the two. Refresh **rewrites** documents, so it is precisely the surface where losing that rule reintroduces the truncation bug the rule exists to prevent.

That the two skills' `assets/resolution-template.md` files were already byte-identical is what confirms these are meant to be one contract rather than two variants.

## The fix

Both files are now byte-identical to their `ce:compound` counterparts, and `tests/unit/compound-contract-parity.test.ts` asserts that all three shared files stay that way, plus a parsed comparison of the two knowledge-track enums so the invariant survives future reformatting.

## Why not deduplicate

Pointing one skill at another's file would be the tidier answer, and there is precedent — `ce:work` references `ce:plan`'s prior-art survey schema by path. But the Claude Code plugin build flattens each skill into a self-contained bundle, so a cross-skill file reference is not safe across all three harnesses. The duplication is not the defect; its silence was. A test removes the silence at a fraction of the risk.

## Out of scope

`skills/compound-docs/` carries a third copy and is untouched. It has no `tracks:` section at all, predates the track system, and its skill is marked `disable-model-invocation: true`. Aligning or retiring it is a separate decision rather than something to settle inside this fix.
