### PR TITLE
fix(ce-review): move run provenance into the artifact that exists

### DIFF
--- a/skills/ce-review/SKILL.md
+++ b/skills/ce-review/SKILL.md
@@ -706,18 +706,7 @@ After presenting findings and verdict (Stage 6), route the next steps by mode. R
 - `review-summary.json` is the parent-owned synthesis artifact. Its lifecycle, dispatch outcomes, complete input ledger, synthesized and filtered findings with provenance, disposition counts, and downstream work are defined in the [canonical synthesis artifact contract](./references/synthesis-artifact-contract.md), whose vocabulary and bounds are executable in [`findings-schema.json`](./references/findings-schema.json).
 - Before finalizing, follow the [artifact validation and failure path](./references/synthesis-artifact-contract.md).
 - Initialize the artifact before dispatch and persist only validated parent-owned records. Finalize lifecycle and reconciliation after synthesis; preserve the existing degraded and abnormal-run behavior described in the canonical contract.
-- Also write `metadata.json` alongside the findings so downstream skills can verify the artifact matches the current branch and HEAD. Minimum fields:
-  ```json
-  {
-    "run_id": "<run-id>",
-    "branch": "<git branch --show-current at dispatch time>",
-    "head_sha": "<git rev-parse HEAD at dispatch time>",
-    "harness": "<opencode | pi | claude-code>",
-    "verdict": "<Ready to merge | Ready with fixes | Not ready>",
-    "completed_at": "<ISO 8601 UTC timestamp>"
-  }
-  ```
-  Capture `branch` and `head_sha` at dispatch time (before any autofixes land), and write the file after the verdict is finalized. This file is additive -- pre-existing artifacts that predate this field are still valid, and downstream skills fall back to file mtime when it is missing.
+- Capture `branch` and `head_sha` at dispatch time, before any autofixes land, and write them into `review-summary.json` with `completed_at` when the verdict is finalized; see the [canonical synthesis artifact contract](./references/synthesis-artifact-contract.md) for the provenance semantics.
 - In autofix mode, create durable todo files only for unresolved actionable findings whose final owner is `downstream-resolver`. Load the `todos` skill (Create section) for the canonical directory path, naming convention, YAML frontmatter structure, and template. Each todo should map the finding's severity to the todo priority (`P0`/`P1` -> `p1`, `P2` -> `p2`, `P3` -> `p3`) and set `status: ready` since these findings have already been triaged by synthesis.
 - Do not create todos for `advisory` findings, `owner: human`, `owner: release`, or protected-artifact cleanup suggestions.
 - If only advisory outputs remain, create no todos.

--- a/skills/ce-review/references/review-summary-schema.json
+++ b/skills/ce-review/references/review-summary-schema.json
@@ -12,6 +12,14 @@
       "maxLength": 64,
       "pattern": "\\S"
     },
+    "branch": {
+      "type": "string",
+      "maxLength": 256
+    },
+    "head_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
     "mode": {
       "type": "string",
       "enum": ["interactive", "autofix", "headless"]
@@ -29,6 +37,11 @@
       "minLength": 1,
       "maxLength": 256,
       "pattern": "\\S"
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
     },
     "dispatches": {
       "maxItems": 64,
@@ -500,10 +513,13 @@
   "required": [
     "schema_version",
     "run_id",
+    "branch",
+    "head_sha",
     "mode",
     "harness",
     "run_status",
     "verdict",
+    "completed_at",
     "dispatches",
     "input_findings",
     "findings",

--- a/skills/ce-review/references/synthesis-artifact-contract.md
+++ b/skills/ce-review/references/synthesis-artifact-contract.md
@@ -136,12 +136,12 @@ The artifact must preserve these distinctions:
   or higher.
 
 The artifact also includes applied fixes, residual actionable work,
-advisory-only outputs, coverage data, and the harness value. Alongside the
-findings, the parent writes `metadata.json` with the run ID, branch and HEAD
-captured at dispatch time, harness, verdict, and completion timestamp. The
-branch and HEAD are captured before autofixes land; metadata is written after
-the verdict is finalized. Existing artifacts without this additive metadata
-remain valid, with downstream consumers falling back to file mtime.
+advisory-only outputs, coverage data, and the harness value. The run artifact
+itself carries the branch and HEAD provenance alongside the run ID, harness,
+verdict, and completion timestamp. The parent captures `branch` and `head_sha`
+at dispatch, before autofixes land, and writes the artifact after the verdict
+is finalized; consumers can therefore tell whether the artifact describes the
+current checkout.
 
 Validation and persistence remain parent-side: no per-agent record or finding
 is written or merged until that finding passes schema and environment-value

--- a/src/lib/review-artifact-schema.ts
+++ b/src/lib/review-artifact-schema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 const MAX_REVIEWER_LENGTH = 64
 const MAX_RUN_ID_LENGTH = 64
+const MAX_BRANCH_LENGTH = 256
 const MAX_INPUT_ID_LENGTH = 128
 const MAX_REASON_LENGTH = 2048
 const MAX_FINDINGS = 32
@@ -39,6 +40,9 @@ export const RepoRelativePathSchema = boundedText(256).regex(
 )
 
 const ReviewerSchema = boundedText(MAX_REVIEWER_LENGTH)
+const BranchSchema = z.string().max(MAX_BRANCH_LENGTH)
+const HeadShaSchema = z.string().regex(/^[0-9a-f]{40}$/)
+const CompletedAtSchema = z.iso.datetime({ offset: false })
 const ReasonSchema = boundedText(MAX_REASON_LENGTH)
 const FindingTitleSchema = boundedText(256)
 const SeveritySchema = z.enum(['P0', 'P1', 'P2', 'P3', 'unknown'] as const)
@@ -228,6 +232,8 @@ export const ReviewArtifactSchema = z
   .object({
     schema_version: z.literal(1),
     run_id: boundedText(MAX_RUN_ID_LENGTH),
+    branch: BranchSchema,
+    head_sha: HeadShaSchema,
     mode: z.enum(['interactive', 'autofix', 'headless'] as const),
     harness: HarnessSchema,
     run_status: z.enum([
@@ -237,6 +243,7 @@ export const ReviewArtifactSchema = z
       'abnormal',
     ] as const),
     verdict: boundedText(256),
+    completed_at: CompletedAtSchema,
     dispatches: z.array(DispatchSchema).max(MAX_PERSONAS),
     input_findings: z
       .array(InputFindingSchema)

--- a/tests/fixtures/review-artifacts/conforming-review-summary.json
+++ b/tests/fixtures/review-artifacts/conforming-review-summary.json
@@ -5,6 +5,9 @@
   "harness": "opencode",
   "run_status": "completed",
   "verdict": "Ready to merge",
+  "branch": "fix/example",
+  "head_sha": "0123456789abcdef0123456789abcdef01234567",
+  "completed_at": "2026-08-21T00:00:00Z",
   "dispatches": [
     {
       "persona": "correctness",

--- a/tests/unit/review-artifact-schema.test.ts
+++ b/tests/unit/review-artifact-schema.test.ts
@@ -64,6 +64,9 @@ const baseArtifact: JsonObject = {
   harness: 'opencode',
   run_status: 'completed',
   verdict: 'Ready to merge',
+  branch: 'fix/example',
+  head_sha: '0123456789abcdef0123456789abcdef01234567',
+  completed_at: '2026-08-21T00:00:00Z',
   dispatches: [
     {
       persona: 'correctness',
@@ -223,6 +226,42 @@ describe('review artifact schema', () => {
     expect(result.success).toBe(false)
   })
 
+  test('accepts an empty branch for detached HEAD artifacts', () => {
+    const result = ReviewArtifactSchema.safeParse(artifactWith({ branch: '' }))
+
+    expect(result.success).toBe(true)
+  })
+
+  test('rejects short and uppercase head SHAs', () => {
+    for (const head_sha of [
+      '0123456789abcdef',
+      '0123456789ABCDEF0123456789abcdef01234567',
+    ]) {
+      const result = ReviewArtifactSchema.safeParse(artifactWith({ head_sha }))
+
+      expect(result.success).toBe(false)
+    }
+  })
+
+  test('rejects a malformed completion timestamp', () => {
+    const result = ReviewArtifactSchema.safeParse(
+      artifactWith({ completed_at: 'not-a-timestamp' }),
+    )
+
+    expect(result.success).toBe(false)
+  })
+
+  test('requires branch, head SHA, and completion timestamp', () => {
+    for (const field of ['branch', 'head_sha', 'completed_at'] as const) {
+      const artifact = { ...baseArtifact }
+      delete artifact[field]
+
+      const result = ReviewArtifactSchema.safeParse(artifact)
+
+      expect(result.success, `${field} should be required`).toBe(false)
+    }
+  })
+
   test('rejects an unknown top-level key', () => {
     const result = ReviewArtifactSchema.safeParse(
       artifactWith({ unknown_key: 'not part of the contract' }),
@@ -253,8 +292,11 @@ describe('review artifact schema', () => {
     const expectedIssues: Record<string, readonly string[]> = {
       'historical-review-summary-20260713.json': [
         'schema_version invalid_value',
+        'branch invalid_type',
+        'head_sha invalid_type',
         'harness invalid_value',
         'run_status invalid_value',
+        'completed_at invalid_type',
         'dispatches invalid_type',
         'input_findings invalid_type',
         'findings.0.why_it_matters invalid_type',
@@ -278,8 +320,11 @@ describe('review artifact schema', () => {
       ],
       'historical-review-summary-20260714-181943.json': [
         'schema_version invalid_value',
+        'branch invalid_type',
+        'head_sha invalid_type',
         'harness invalid_value',
         'run_status invalid_value',
+        'completed_at invalid_type',
         'dispatches invalid_type',
         'input_findings invalid_type',
         'findings.0.why_it_matters invalid_type',
@@ -300,8 +345,11 @@ describe('review artifact schema', () => {
       ],
       'historical-review-summary-20260714.json': [
         'schema_version invalid_value',
+        'branch invalid_type',
+        'head_sha invalid_type',
         'harness invalid_value',
         'run_status invalid_value',
+        'completed_at invalid_type',
         'dispatches invalid_type',
         'input_findings invalid_type',
         ...Array.from({ length: 5 }, (_, index) => [
@@ -333,8 +381,11 @@ describe('review artifact schema', () => {
       'historical-review-summary-20260817.json': [
         'schema_version invalid_value',
         'run_id invalid_type',
+        'branch invalid_type',
+        'head_sha invalid_type',
         'mode invalid_value',
         'run_status invalid_value',
+        'completed_at invalid_type',
         ...Array.from({ length: 9 }, (_, index) => [
           `dispatches.${index}.persona invalid_type`,
           `dispatches.${index}.input_finding_count invalid_type`,
@@ -352,8 +403,10 @@ describe('review artifact schema', () => {
       'historical-summary-20260731-140958.json': [
         'schema_version invalid_value',
         'run_id invalid_type',
+        'head_sha invalid_type',
         'harness invalid_value',
         'run_status invalid_value',
+        'completed_at invalid_type',
         'dispatches invalid_type',
         'input_findings invalid_type',
         'findings invalid_type',
@@ -372,8 +425,10 @@ describe('review artifact schema', () => {
       'historical-summary-20260731-212644.json': [
         'schema_version invalid_value',
         'run_id invalid_type',
+        'head_sha invalid_type',
         'harness invalid_value',
         'run_status invalid_value',
+        'completed_at invalid_type',
         'dispatches invalid_type',
         'input_findings invalid_type',
         'disposition_counts invalid_type',
@@ -387,8 +442,10 @@ describe('review artifact schema', () => {
       'historical-summary-20260801.json': [
         'schema_version invalid_value',
         'run_id invalid_type',
+        'head_sha invalid_type',
         'harness invalid_value',
         'run_status invalid_value',
+        'completed_at invalid_type',
         'dispatches invalid_type',
         'input_findings invalid_type',
         'findings.0.why_it_matters invalid_type',


### PR DESCRIPTION
Closes #832.

`ce:review`'s contract specified two run-level artifacts. One of them has never existed.

## Why consolidate rather than enforce

#832 left both answers open, because the original argument for deleting `metadata.json` rested on a bad denominator — zero writes across 26 runs, where 20 of those runs predated the field's specification and could never have written it. That reasoning was withdrawn.

The case now rests on evidence that does not depend on the count:

| Finding | |
| --- | --- |
| The run artifact's schema already defines `run_id`, `harness`, and `verdict` | Three of the six fields had already moved |
| Every `review-summary.json` on disk carries `verdict`, though the contract placed it in `metadata.json` | Producers had already chosen where it belongs |
| No file under `skills/`, `agents/`, `src/`, `scripts/`, or `tests/` reads `metadata.json` | Nothing depends on the separation |

The instruction also promised that "downstream skills fall back to file mtime when it is missing." There is no such downstream skill. A file nothing writes, nothing reads, with a documented fallback for a consumer that was never built.

Keeping it would have meant giving a second artifact its own schema and validation step to describe fields three of which already live in the first one.

## What is preserved

The separation had one real justification: `branch` and `head_sha` are captured **at dispatch**, before autofixes land, while the file is written **after** the verdict is final. That gap is what lets a reader tell whether an artifact describes the current checkout.

It survives unchanged. `review-summary.json` is also written at finalize, so "capture early, write late" carries over intact — only the destination file differs. The contract states the distinction explicitly rather than leaving it implied by the file split.

`head_sha` is now constrained to 40 lowercase hex characters instead of free text. `branch` accepts the empty string, because `git branch --show-current` returns nothing on a detached HEAD and a review can legitimately run there.

## Also removed

The old instruction carried its own compatibility clause, saying artifacts predating the field remain valid. The contract's corpus-exclusion rule already covers pre-contract artifacts through `schema_version`. Two overlapping compatibility statements drift apart, so the narrower one goes.
