### PR TITLE
docs: document the CLI surface and the review artifact contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ bun install              # Install deps
 bun run build            # Build to dist/
 bun run typecheck        # Type check (strict)
 bun run lint             # Biome linter
-bun test tests/unit      # Unit tests (56 files)
+bun test tests/unit      # Unit tests (60 files)
 bun test tests/integration  # Integration tests (11 files)
 bun test                 # All tests
 bun test --filter "pattern"  # Filter tests

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,11 +32,11 @@ these hooks:
 The last four are the receipt-backed workflow guard (see Cross-Cutting Concerns). The registered set
 is authoritative in `src/index.ts`; do not restate a count here.
 
-The CLI (`src/cli.ts`) is a separate entry point exposing `list`, `config`, and `setup --harness`
-subcommands. It does not participate in the plugin hook lifecycle. `setup --harness opencode|pi`
-performs project-local, atomic, idempotent config writes for those two harnesses; Claude Code has no
-equivalent CLI setup step because it is delivered as a prebuilt plugin (see below), not a runtime
-config write.
+The CLI (`src/cli.ts`) is a separate entry point exposing `list`, `capabilities`,
+`validate-review-artifact`, `config`, `setup --harness`, and `pi-subagents` subcommands. It does not
+participate in the plugin hook lifecycle. `setup --harness opencode|pi` performs project-local,
+atomic, idempotent config writes for those two harnesses; Claude Code has no equivalent CLI setup
+step because it is delivered as a prebuilt plugin (see below), not a runtime config write.
 
 Systematic is delivered to three harnesses from this same source tree, with different packaging per
 harness:
@@ -224,6 +224,16 @@ registers no guard, and the Claude Code bundle ships no runtime.
 
 **Registry drift detection** (`scripts/generate-registry.ts --check`) — verifies that the OCX registry
 config stays in sync with the generated bundled assets. Run via `bun run registry:drift`.
+
+**Review artifact contract** (`src/lib/review-artifact-schema.ts`) — Zod source of truth for the
+`ce:review` run-level `review-summary.json` artifact. `scripts/generate-review-artifact-schema.ts`
+generates the committed JSON Schema at `skills/ce-review/references/review-summary-schema.json` and
+is gated against drift via `--check` (`bun run review-schema:drift`). `systematic
+validate-review-artifact <path>` (`src/cli.ts`) validates any artifact against it and ships in
+`dist/`. `ce:review` stamps `schema_version` on the artifact it writes and runs the validator against
+it before reporting a verdict; a failing artifact is repaired and re-validated, never deleted or
+reported over. Artifacts without `schema_version` predate the contract and are excluded (exit 3,
+"legacy").
 
 **Claude Code plugin build** (`scripts/build-claude-code-plugin.ts`) — generates the CC bundle from
 `skills/` and `agents/` on every CI run; the build fails on any leftover source-namespace identifier

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -10,7 +10,7 @@ systematic/
 ├── src/              # TypeScript plugin + CLI source
 │   ├── index.ts      # OpenCode plugin entry — default export only
 │   ├── pi.ts         # Pi extension entry — default export only
-│   ├── cli.ts        # CLI entry (list / config / setup --harness)
+│   ├── cli.ts        # CLI entry (list / capabilities / validate-review-artifact / config / setup --harness / pi-subagents)
 │   └── lib/          # Core modules
 ├── skills/           # 31 bundled skills (one directory per skill, SKILL.md format)
 ├── agents/           # 37 bundled agents (5 category subdirectories)
@@ -23,7 +23,7 @@ systematic/
 ├── scripts/          # Build-time + CI scripts (integrity, schema codegen, registry, CC plugin build, evals)
 ├── assets/           # Static assets (banner SVG)
 ├── tests/
-│   ├── unit/         # 56 unit test files
+│   ├── unit/         # 60 unit test files
 │   └── integration/  # 11 integration test files
 ├── .opencode/        # Project-specific OpenCode config (theme, TUI)
 ├── .claude-plugin/   # marketplace.json — Claude Code marketplace catalog entry
@@ -44,8 +44,9 @@ subdirectory of core modules.
   provides (config, tool, the workflow-guard observation hooks, and the system transform)
 - `src/pi.ts` — Pi extension factory (`systematicPiExtension`), registers `before_agent_start` for
   bootstrap injection plus the `systematic_skill` and `systematic_delegate` tools. No workflow guard.
-- `src/cli.ts` — CLI commands: `list`, `config show/path`, `setup --harness opencode|pi` (Claude Code
-  has no CLI setup step — it installs as a prebuilt plugin via marketplace, see `scripts/`)
+- `src/cli.ts` — CLI commands: `list`, `capabilities`, `validate-review-artifact <path>`,
+  `config show/path`, `setup --harness opencode|pi`, `pi-subagents <subcommand>` (Claude Code has no
+  CLI setup step — it installs as a prebuilt plugin via marketplace, see `scripts/`)
 - `src/lib/setup.ts` — `setupHarness`: atomic/backed-up/idempotent, project-local-only harness config writes
 - `src/lib/config.ts` — JSONC config loading, 3-source merge
 - `src/lib/config-schema.ts` — canonical Zod schema, `validateConfig`, `SECURITY_OVERLAY_FIELDS`
@@ -118,6 +119,9 @@ bundled assets before editing or building the docs site.
 - `scripts/generate-agent-browser-skill.ts` — generates the agent-browser skill content; pass
   `--check` for drift detection
 - `scripts/generate-config-schema.ts` — JSON Schema codegen + drift check
+- `scripts/generate-review-artifact-schema.ts` — regenerates
+  `skills/ce-review/references/review-summary-schema.json` from the Zod schema in
+  `src/lib/review-artifact-schema.ts`; pass `--check` for drift detection (`bun run review-schema:drift`)
 - `scripts/build-claude-code-plugin.ts` — generates the self-contained Claude Code plugin bundle
   (`claude-code/`, gitignored staging) from `skills/` and `agents/`; CI publishes the output to the
   orphan `claude-code-plugin` branch, never committed to `main`
@@ -147,7 +151,7 @@ coverage, model inheritance) against a real OpenCode runtime, in both source and
 **Purpose:** Test suite for the TypeScript source.
 
 **Contains:**
-- `tests/unit/` — 56 unit test files covering `src/lib/` modules, `scripts/` build/codegen scripts,
+- `tests/unit/` — 60 unit test files covering `src/lib/` modules, `scripts/` build/codegen scripts,
   and `docs/scripts/` generation scripts
 - `tests/integration/` — 11 integration test files (skip automatically if deps unavailable)
 
@@ -181,7 +185,7 @@ branch ref. Users install via `claude plugin marketplace add marcusrbrown/system
 |------|------|
 | `src/index.ts` | OpenCode plugin entry — `SystematicPlugin` default export |
 | `src/pi.ts` | Pi extension entry — `systematicPiExtension` default export |
-| `src/cli.ts` | CLI entry — `list`, `config`, `setup --harness` commands |
+| `src/cli.ts` | CLI entry — `list`, `capabilities`, `validate-review-artifact`, `config`, `setup --harness`, `pi-subagents` commands |
 
 ### Configuration
 
@@ -224,7 +228,7 @@ branch ref. Users install via `claude plugin marketplace add marcusrbrown/system
 
 | Path | Role |
 |------|------|
-| `tests/unit/` | Unit tests (56 files) |
+| `tests/unit/` | Unit tests (60 files) |
 | `tests/integration/` | Integration tests (11 files) |
 
 ## Naming Conventions


### PR DESCRIPTION
The architecture overview described a CLI with three subcommands. It has six.

```
list  capabilities  validate-review-artifact  config  setup --harness  pi-subagents
```

Two of the three missing ones ship user-facing behavior — `capabilities` and `validate-review-artifact` — so the omission was not cosmetic. Verified against `systematic --help` rather than by reading the dispatch table, since the help text is what a user actually sees.

`ARCHITECTURE.md` also gains a cross-cutting entry for the review artifact contract. That surface is now enforceable rather than prose: a Zod source of truth, a generated schema committed under the skill, a CI drift gate, and a validator that ships in `dist/`.

## On the counts

Every count claim in `ARCHITECTURE.md`, `STRUCTURE.md`, and `AGENTS.md` was enumerated and checked against the tree, rather than searched for by value.

That mattered. The same fact — the number of unit test files — appears in four places in three phrasings:

```
STRUCTURE.md:26    unit/  # N unit test files
STRUCTURE.md:154   `tests/unit/` — N unit test files covering...
STRUCTURE.md:231   | `tests/unit/` | Unit tests (N files) |
AGENTS.md:33       bun test tests/unit      # Unit tests (N files)
```

Three read 59 and one read 56. Searching for either value finds a subset. All four now read 60, matching `git ls-files 'tests/unit/*.test.ts'`.

A path-existence sweep over both documents also runs clean — every backticked repository path resolves.

This is the method from [`clean-checkout-baselines-before-quoting-metrics`](../blob/main/docs/solutions/workflow-issues/clean-checkout-baselines-before-quoting-metrics-2026-08-17.md), applied to the documents that prompted writing it down.
