### PR TITLE
fix(ce-plan): carry registration obligations into the unit that triggers them

### DIFF
--- a/skills/ce-plan/SKILL.md
+++ b/skills/ce-plan/SKILL.md
@@ -443,6 +443,8 @@ For each unit, include:
 
 Every feature-bearing unit should include the test file path in `**Files:**`.
 
+When a unit creates a file in a directory that carries registration obligations — a manifest, index, codemap, module table, or generated artifact that must list it — name those surfaces in the same unit's `**Files:**`, and name the regeneration command in its `**Verification**`. Phase 1.1 already collects this from the repository's own contributor guidance; carry it into the unit rather than leaving it for a failing gate to report. An obligation that no gate enforces is the one most likely to be missed, so state it even when nothing will fail.
+
 Use `Execution note` sparingly. Good uses include:
 - `Execution note: Start with a failing integration test for the request/response contract.`
 - `Execution note: Add characterization coverage before modifying this legacy parser.`


### PR DESCRIPTION
The planning half of #833. The enforcement half is #844.

A plan unit lists the file it creates and the test that covers it, and looks complete. If that directory requires the file to be registered somewhere else — a codemap, a module table, a manifest, a generated artifact — nothing in the plan says so. The obligation surfaces when a gate fails mid-implementation, or it does not surface at all.

That is what happened in #830. The unit named the module, its test, and its fixtures. The codemap entry was missing and the gate caught it after the module was written. The module-table row was missing and a ten-persona review did not catch it, including the persona whose job is auditing against project standards.

## The change

One paragraph in section 3.5, beside the existing rule that feature-bearing units name their test file. A unit that creates a file in a directory with registration obligations names those surfaces in its own `**Files:**` and the regeneration command in its `**Verification**`.

Phase 1.1 already collects contributor guidance from the repository, so this asks the planner to carry information it has rather than to go find more.

## Deliberately generic

No repository-specific paths. `ce:plan` is bundled and runs against any codebase, so it names the shape — manifest, index, codemap, module table, generated artifact — rather than this repository's instances of it.

The paragraph closes on the case that matters most: an obligation no gate enforces is the one most likely to be missed, and is worth stating even when nothing will fail.
