### PR TITLE
fix(ce-review): decide surface coverage by set membership, not by reading

### DIFF
--- a/skills/ce-review/SKILL.md
+++ b/skills/ce-review/SKILL.md
@@ -360,6 +360,10 @@ Review team:
 
 This is progress reporting, not a blocking confirmation.
 
+Record each conditional persona's selection reason and triggering file paths
+on its dispatch record; see the [synthesis artifact contract](./references/synthesis-artifact-contract.md)
+for the field semantics.
+
 ### Stage 3b: Discover project standards paths
 
 Before spawning sub-agents, find the file paths (not contents) of all relevant standards files for the `project-standards` persona. Use the native file-search/glob tool to locate:
@@ -520,8 +524,8 @@ Assemble the final report using **pipe-delimited markdown tables for findings** 
 8. **Learnings & Past Solutions.** Surface learnings-researcher results: if past solutions are relevant, flag them as "Known Pattern" with links to docs/solutions/ files.
 9. **Agent-Native Gaps.** Surface agent-native-reviewer results. Omit section if no gaps found.
 10. **Deployment Notes.** If deployment-verification-agent ran, surface the key Go/No-Go items: blocking pre-deploy checks, the most important verification queries, rollback caveats, and monitoring focus areas. Keep the checklist actionable rather than dropping it into Coverage.
-11. **Coverage.** Suppressed count, residual risks, testing gaps, failed/timed-out reviewers, validator failures, and any intent uncertainty carried by non-interactive modes.
-12. **Verdict.** Ready to merge / Ready with fixes / Not ready. Fix order if applicable. When an `explicit` plan has unaddressed requirements, the verdict must reflect it — a PR that's code-clean but missing planned requirements is "Not ready" unless the omission is intentional. When an `inferred` plan has unaddressed requirements, note it in the verdict reasoning but do not block on it alone. Apply the risk-aware degraded verdict rule from the [synthesis artifact contract](./references/synthesis-artifact-contract.md).
+11. **Coverage.** Suppressed count, residual risks, testing gaps, failed/timed-out reviewers, validator failures, risk-coverage entries with citing input finding IDs and exit conditions for blocked entries, and any intent uncertainty carried by non-interactive modes.
+12. **Verdict.** Ready to merge / Ready with fixes / Not ready. Fix order if applicable. When an `explicit` plan has unaddressed requirements, the verdict must reflect it — a PR that's code-clean but missing planned requirements is "Not ready" unless the omission is intentional. When an `inferred` plan has unaddressed requirements, note it in the verdict reasoning but do not block on it alone. Apply the risk-aware degraded verdict rule from the [synthesis artifact contract](./references/synthesis-artifact-contract.md), including the recorded exit condition for a blocked risk-critical verdict.
 
 Do not include time estimates.
 

--- a/skills/ce-review/references/review-output-template.md
+++ b/skills/ce-review/references/review-output-template.md
@@ -137,7 +137,7 @@ This fails because: no pipe-delimited tables, no severity-grouped `###` headers,
 - **Learnings & Past Solutions section** -- results from learnings-researcher, with links to docs/solutions/ files
 - **Agent-Native Gaps section** -- results from agent-native-reviewer. Omit if no gaps found.
 - **Deployment Notes section** -- key checklist items from deployment-verification-agent. Omit if the agent did not run.
-- **Coverage section** -- suppressed count with original confidences, residual risks, testing gaps, failed reviewers, and disposition reconciliation
+- **Coverage section** -- suppressed count with original confidences, residual risks, testing gaps, failed reviewers, disposition reconciliation, and risk-coverage entries with their citing input finding IDs and blocked-entry exit conditions
 - **Summary uses blockquotes** for verdict, reasoning, and fix order
 - **Horizontal rule** (`---`) separates findings from verdict
 - **`###` headers** for each section -- never plain text headers

--- a/skills/ce-review/references/review-summary-schema.json
+++ b/skills/ce-review/references/review-summary-schema.json
@@ -69,6 +69,31 @@
             "minLength": 1,
             "maxLength": 2048,
             "pattern": "\\S"
+          },
+          "selection_surface": {
+            "maxItems": 32,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256,
+              "allOf": [
+                {
+                  "type": "string",
+                  "pattern": "\\S"
+                },
+                {
+                  "type": "string",
+                  "pattern": "^(?!\\/)(?![A-Za-z]:[\\\\/])(?!\\\\).+"
+                }
+              ]
+            }
+          },
+          "selection_reason": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 2048,
+            "pattern": "\\S"
           }
         },
         "required": ["persona", "dispatch_outcome", "input_finding_count"],
@@ -414,6 +439,36 @@
           }
         },
         "required": ["file", "input_finding_ids", "reason"],
+        "additionalProperties": false
+      }
+    },
+    "risk_coverage": {
+      "maxItems": 64,
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "persona": {
+            "type": "string",
+            "enum": [
+              "security",
+              "data-migrations",
+              "api-contract",
+              "reliability",
+              "performance"
+            ]
+          },
+          "satisfied": {
+            "type": "boolean"
+          },
+          "input_finding_id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "\\S"
+          }
+        },
+        "required": ["persona", "satisfied"],
         "additionalProperties": false
       }
     },

--- a/skills/ce-review/references/synthesis-artifact-contract.md
+++ b/skills/ce-review/references/synthesis-artifact-contract.md
@@ -105,7 +105,10 @@ The artifact must preserve these distinctions:
   records what a persona returned: `findings`, `empty`, `malformed`, or
   `never_returned`. A rejection reason is the exact safe validation reason,
   naming persona and field without echoing the offending value. Dispatch
-  outcome is separate from finding disposition.
+  outcome is separate from finding disposition. Conditional selections record
+  their triggering changed-file paths in `selection_surface` and the announced
+  selection explanation in `selection_reason`; always-on personas may omit
+  both fields.
 - `input_findings` is the authoritative parent-owned ledger. Before the
   confidence gate, every admitted finding receives an `input_id` of
   `<reviewer>#<1-based finding index>`. Every admitted input has exactly one
@@ -246,18 +249,20 @@ The risk-critical surfaces are `security`, `data-migrations`, `api-contract`,
 specifically for the matching diff shape in Stage 3. If one of those selected
 personas has `dispatch_outcome: "malformed"` or
 `dispatch_outcome: "never_returned"`, the review verdict must not be clean:
-it is blocking unless another persona covered the same surface and returned
-validated evidence for it. For this rule, validated evidence means at least
+it is blocking unless another persona covered the lost surface with validated
+evidence. For this rule, a validated finding from another persona covers a
+lost risk-critical surface if and only if the finding's `file` appears in the
+lost persona's recorded `selection_surface`; validated evidence means at least
 one finding from that other persona's return passed complete schema and
-environment-value validation and is relevant to the same surface. A coverage
-note alone cannot satisfy this rule; the verdict must reflect the missing
-risk-critical evidence.
+environment-value validation. A coverage note alone cannot satisfy this rule;
+the verdict must reflect the missing risk-critical evidence.
 
 Finding-level rejection is keyed by the severities in
 `rejected_severities`. A selected risk-critical persona whose rejected
 findings include any `P0`, `P1`, or `unknown` severity is treated exactly as a
 rejected persona for this verdict rule: blocking unless another persona
-covered the same surface with validated evidence. A selected risk-critical
+covered the lost surface with a validated finding whose `file` appears in the
+lost persona's recorded `selection_surface`. A selected risk-critical
 persona whose rejected findings are only `P2` or `P3` does not block on that
 basis alone; record it in the Coverage section instead. Unknown severity is
 treated as blocking as deliberate fail-closed behavior because the parent
@@ -265,3 +270,12 @@ could not determine what was lost. Admitted findings and verdict blocking
 are independent: surviving findings from the same return continue through
 synthesis normally. Partial return is not partial coverage when the lost
 part was critical.
+
+Record each lost risk-critical persona in the optional `risk_coverage` array
+with `satisfied: true` and `input_finding_id` set to the citing input finding
+ID when coverage is satisfied, or `satisfied: false` without an
+`input_finding_id` otherwise. A blocked verdict must name its exit condition
+in the report: re-run the lost persona, or supply a validated finding from
+another persona whose `file` appears in the lost persona's recorded
+`selection_surface`. Derive that condition from the dispatch and risk-coverage
+records, not from a coverage note.

--- a/src/lib/review-artifact-schema.ts
+++ b/src/lib/review-artifact-schema.ts
@@ -203,8 +203,8 @@ const DispatchSchema = z
   .strict()
   .superRefine((dispatch, ctx) => {
     if (
-      RISK_CRITICAL_PERSONAS.includes(
-        dispatch.persona as (typeof RISK_CRITICAL_PERSONAS)[number],
+      (RISK_CRITICAL_PERSONAS as readonly string[]).includes(
+        dispatch.persona,
       ) &&
       (!dispatch.selection_surface || dispatch.selection_surface.length === 0)
     ) {

--- a/src/lib/review-artifact-schema.ts
+++ b/src/lib/review-artifact-schema.ts
@@ -11,6 +11,9 @@ const MAX_PERSONAS = 64
 export const REVIEW_ARTIFACT_CUSTOM_MESSAGES = [
   'severity count must match rejected finding count',
   'filtered findings require a validation reason',
+  'risk-critical dispatches require a non-empty selection surface',
+  'satisfied risk coverage requires a citing input finding ID',
+  'unsatisfied risk coverage must not cite an input finding ID',
 ] as const
 
 const boundedText = (maxLength: number) =>
@@ -44,6 +47,14 @@ const BranchSchema = z.string().max(MAX_BRANCH_LENGTH)
 const HeadShaSchema = z.string().regex(/^[0-9a-f]{40}$/)
 const CompletedAtSchema = z.iso.datetime({ offset: false })
 const ReasonSchema = boundedText(MAX_REASON_LENGTH)
+const RISK_CRITICAL_PERSONAS = [
+  'security',
+  'data-migrations',
+  'api-contract',
+  'reliability',
+  'performance',
+] as const
+const RiskCriticalPersonaSchema = z.enum(RISK_CRITICAL_PERSONAS)
 const FindingTitleSchema = boundedText(256)
 const SeveritySchema = z.enum(['P0', 'P1', 'P2', 'P3', 'unknown'] as const)
 const FindingSeveritySchema = SeveritySchema.exclude(['unknown'])
@@ -183,8 +194,27 @@ const DispatchSchema = z
     dispatch_outcome: DispatchOutcomeSchema,
     input_finding_count: z.number().int().nonnegative().max(MAX_FINDINGS),
     rejection_reason: ReasonSchema.optional(),
+    selection_surface: z
+      .array(RepoRelativePathSchema)
+      .max(MAX_FINDINGS)
+      .optional(),
+    selection_reason: ReasonSchema.optional(),
   })
   .strict()
+  .superRefine((dispatch, ctx) => {
+    if (
+      RISK_CRITICAL_PERSONAS.includes(
+        dispatch.persona as (typeof RISK_CRITICAL_PERSONAS)[number],
+      ) &&
+      (!dispatch.selection_surface || dispatch.selection_surface.length === 0)
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['selection_surface'],
+        message: REVIEW_ARTIFACT_CUSTOM_MESSAGES[2],
+      })
+    }
+  })
 
 const DispositionCountsSchema = z
   .object({
@@ -239,6 +269,31 @@ const DeclinedMergeSchema = z
   })
   .strict()
 
+const RiskCoverageSchema = z
+  .object({
+    persona: RiskCriticalPersonaSchema,
+    satisfied: z.boolean(),
+    input_finding_id: boundedText(MAX_INPUT_ID_LENGTH).optional(),
+  })
+  .strict()
+  .superRefine((coverage, ctx) => {
+    if (coverage.satisfied && coverage.input_finding_id === undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['input_finding_id'],
+        message: REVIEW_ARTIFACT_CUSTOM_MESSAGES[3],
+      })
+    }
+
+    if (!coverage.satisfied && coverage.input_finding_id !== undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['input_finding_id'],
+        message: REVIEW_ARTIFACT_CUSTOM_MESSAGES[4],
+      })
+    }
+  })
+
 export const ReviewArtifactSchema = z
   .object({
     schema_version: z.literal(1),
@@ -261,6 +316,7 @@ export const ReviewArtifactSchema = z
       .max(MAX_FINDINGS * MAX_PERSONAS),
     findings: z.array(SynthesizedFindingSchema).max(MAX_FINDINGS),
     declined_merges: z.array(DeclinedMergeSchema).max(MAX_FINDINGS).optional(),
+    risk_coverage: z.array(RiskCoverageSchema).max(MAX_PERSONAS).optional(),
     disposition_counts: DispositionCountsSchema,
     applied_fixes: z.array(ReasonSchema).max(MAX_FINDINGS),
     residual_actionable_work: z.array(ReasonSchema).max(MAX_FINDINGS),

--- a/tests/unit/review-artifact-schema.test.ts
+++ b/tests/unit/review-artifact-schema.test.ts
@@ -130,6 +130,150 @@ describe('review artifact schema', () => {
     expect(result.success).toBe(true)
   })
 
+  test('rejects a risk-critical dispatch without a selection surface', () => {
+    const result = ReviewArtifactSchema.safeParse(
+      artifactWith({
+        dispatches: [
+          {
+            persona: 'security',
+            dispatch_outcome: 'findings',
+            input_finding_count: 1,
+          },
+        ],
+      }),
+    )
+
+    expect(result.success).toBe(false)
+  })
+
+  test('rejects a risk-critical dispatch with an empty selection surface', () => {
+    const result = ReviewArtifactSchema.safeParse(
+      artifactWith({
+        dispatches: [
+          {
+            persona: 'security',
+            dispatch_outcome: 'findings',
+            input_finding_count: 1,
+            selection_surface: [],
+          },
+        ],
+      }),
+    )
+
+    expect(result.success).toBe(false)
+  })
+
+  test('accepts an always-on dispatch without a selection surface', () => {
+    const result = ReviewArtifactSchema.safeParse(
+      artifactWith({
+        dispatches: [
+          {
+            persona: 'correctness',
+            dispatch_outcome: 'findings',
+            input_finding_count: 1,
+          },
+        ],
+      }),
+    )
+
+    expect(result.success).toBe(true)
+  })
+
+  test('rejects satisfied risk coverage without a citing input finding ID', () => {
+    const result = ReviewArtifactSchema.safeParse(
+      artifactWith({
+        risk_coverage: [
+          {
+            persona: 'security',
+            satisfied: true,
+          },
+        ],
+      }),
+    )
+
+    expect(result.success).toBe(false)
+  })
+
+  test('rejects unsatisfied risk coverage with a citing input finding ID', () => {
+    const result = ReviewArtifactSchema.safeParse(
+      artifactWith({
+        risk_coverage: [
+          {
+            persona: 'security',
+            satisfied: false,
+            input_finding_id: 'correctness#1',
+          },
+        ],
+      }),
+    )
+
+    expect(result.success).toBe(false)
+  })
+
+  test('accepts an artifact that omits risk coverage', () => {
+    const result = ReviewArtifactSchema.safeParse(baseArtifact)
+
+    expect(result.success).toBe(true)
+  })
+
+  test('enforces selection surface path and array bounds', () => {
+    const tooLongPath = ReviewArtifactSchema.safeParse(
+      artifactWith({
+        dispatches: [
+          {
+            persona: 'security',
+            dispatch_outcome: 'findings',
+            input_finding_count: 1,
+            selection_surface: [`src/${'x'.repeat(253)}`],
+          },
+        ],
+      }),
+    )
+    expect(tooLongPath.success).toBe(false)
+
+    const tooManyPaths = ReviewArtifactSchema.safeParse(
+      artifactWith({
+        dispatches: [
+          {
+            persona: 'security',
+            dispatch_outcome: 'findings',
+            input_finding_count: 1,
+            selection_surface: Array.from(
+              { length: 33 },
+              (_, index) => `src/example-${index}.ts`,
+            ),
+          },
+        ],
+      }),
+    )
+    expect(tooManyPaths.success).toBe(false)
+
+    const tooLongReason = ReviewArtifactSchema.safeParse(
+      artifactWith({
+        dispatches: [
+          {
+            persona: 'security',
+            dispatch_outcome: 'findings',
+            input_finding_count: 1,
+            selection_surface: ['src/example.ts'],
+            selection_reason: 'x'.repeat(2049),
+          },
+        ],
+      }),
+    )
+    expect(tooLongReason.success).toBe(false)
+
+    const tooManyCoverageEntries = ReviewArtifactSchema.safeParse(
+      artifactWith({
+        risk_coverage: Array.from({ length: 65 }, () => ({
+          persona: 'security',
+          satisfied: false,
+        })),
+      }),
+    )
+    expect(tooManyCoverageEntries.success).toBe(false)
+  })
+
   test('requires a validation reason in the type for unvalidated findings', () => {
     const requirement: UnvalidatedFindingRequiresReason = true
 
@@ -582,6 +726,32 @@ describe('review artifact schema', () => {
           },
         ],
       }),
+      artifactWith({
+        dispatches: [
+          {
+            persona: 'security',
+            dispatch_outcome: 'findings',
+            input_finding_count: 1,
+          },
+        ],
+      }),
+      artifactWith({
+        risk_coverage: [
+          {
+            persona: 'security',
+            satisfied: true,
+          },
+        ],
+      }),
+      artifactWith({
+        risk_coverage: [
+          {
+            persona: 'security',
+            satisfied: false,
+            input_finding_id: 'correctness#1',
+          },
+        ],
+      }),
     ]
 
     const issues = cases.flatMap((value) => {
@@ -592,7 +762,7 @@ describe('review artifact schema', () => {
         : result.error.issues.filter((issue) => issue.code === 'custom')
     })
 
-    expect(issues.length).toBe(2)
+    expect(issues.length).toBe(5)
     for (const issue of issues) {
       expect(customMessages.has(issue.message)).toBe(true)
     }


### PR DESCRIPTION
Closes #819.

The risk-aware degraded verdict blocked unless another persona "covered the same surface and returned validated evidence for it", with validated evidence being a finding "relevant to the same surface".

Every other term in that rule is mechanical — five named surfaces, an outcome enum, a severity enum. That one phrase was pure judgement, and it was the term deciding whether the verdict blocked. Same diff, same returns, opposite verdicts depending on the reader. Four independent reviewers of the change that introduced the rule hit this.

## Stage 3 already knew the answer

`SKILL.md` Stage 3 computes and announces why each conditional persona was selected:

```
- security -- new endpoint in routes.rb accepts user-provided redirect URL
- data-migrations -- adds migration 20260303_add_index_to_orders
```

That names the surface. It was printed to the user and discarded — `DispatchSchema` recorded the outcome and the finding count, but nothing about what triggered the selection.

So the fix required no new signal, only retaining one that already existed.

## What changed

The dispatch record now carries the paths that triggered the selection and the reason Stage 3 already states. Coverage is set membership: a validated finding covers a lost risk-critical surface when its file is one of those paths.

The schema enforces the precondition. A dispatch for any of the five risk-critical personas must carry a non-empty selection surface, because the verdict rule cannot be evaluated without it. Always-on personas are selected automatically and carry none.

Two consequences fall out of the same recorded data:

- **A blocked verdict states its exit.** Re-run the lost persona, or supply a validated finding on one of these paths. Previously an operator could see that a review blocked but not what would clear it.
- **The verdict cites the finding that satisfied coverage**, so the decision is reproducible from the artifact rather than taken on trust.

## Unchanged

Everything else in that section stands: the five surfaces, the `malformed` and `never_returned` conditions, the `rejected_severities` rules with P0/P1/unknown blocking and P2/P3 not, unknown treated as blocking to fail closed, and a coverage note alone never satisfying the rule.
