### PR TITLE
fix(ce-review): stop telling operators to run a command they may not have

### DIFF
--- a/skills/ce-review/references/synthesis-artifact-contract.md
+++ b/skills/ce-review/references/synthesis-artifact-contract.md
@@ -210,10 +210,17 @@ validating it. This ordering makes the artifact validatable at all: without
 `schema_version`, the validator reports the legacy status (exit 3) rather than
 a real validation result.
 
-After writing `review-summary.json`, the parent runs
-`systematic validate-review-artifact <path>` against it. A nonzero exit means
-the run is not complete. The [executable schema](./review-summary-schema.json)
-is generated from a Zod source and is the machine-checkable form of the shape
+After writing `review-summary.json`, the parent checks whether the
+`systematic` executable is available on the invoking environment's `PATH`.
+When it is available, the parent runs
+`systematic validate-review-artifact <path>` against it. The executable ships
+through the npm package's `bin` entry; a harness that installs bundled
+markdown without that package will not have it. When it is unavailable, the
+parent records that validation did not run and why in the run record.
+Unavailable validation is distinct from skipped validation, and the parent
+does not represent the artifact as validated. A nonzero exit means the run is
+not complete. The [executable schema](./review-summary-schema.json) is
+generated from a Zod source and is the machine-checkable form of the shape
 described here.
 
 On validation failure, the parent repairs the artifact and re-runs the
@@ -226,7 +233,8 @@ This is enforcement by visible failure, not by containment. An agent that
 never runs the command can still finalize an artifact, but produces no evidence
 in either direction. That is why the command exists as an independently
 runnable check rather than as a self-validation instruction, and why its result
-belongs in the run record.
+belongs in the run record. An unavailable validator is recorded as unavailable,
+not as skipped or validated.
 
 `mode:report-only` writes no artifact and therefore performs no validation.
 


### PR DESCRIPTION
A defect shipped in v3.13.x, found while scoping #795.

## The problem

`synthesis-artifact-contract.md` told the parent, unconditionally:

> After writing `review-summary.json`, the parent runs `systematic validate-review-artifact <path>` against it.

That file ships to every harness. `scripts/build-claude-code-plugin.ts` walks each skill directory and copies every subfile into the Claude Code bundle, and that bundle is deliberately built with no npm coupling — markdown, an output style, and a hook. No `dist/`, no `bin`, no executable.

The `systematic` command reaches consumers only through `package.json`'s `bin` entry. A Claude Code operator never installs that package, so the contract instructed a command that cannot exist there.

## Why it was worth fixing immediately rather than noting

The same section states that an agent which never runs the command "produces no evidence in either direction". That makes an *impossible* command and a *skipped* one identical in the record. A harness that structurally cannot validate looked exactly like an agent that chose not to.

## The fix

The instruction now states the condition under which the validator is reachable, and what to record when it is not — so unavailable is distinguishable from skipped.

The condition is expressed as something checkable at runtime rather than as a list of harness names. An enumeration would go stale, and it would assert per-harness availability that has not been verified. A condition the agent can check is durable.

Everything else in the section is unchanged: writing `schema_version: 1` first, nonzero exit meaning the run is incomplete, repair-and-re-run on failure, never reporting a verdict over a failed artifact, never deleting one, an absent artifact never being evidence of a clean run, and `mode:report-only` writing nothing and therefore validating nothing.

The honest-limitation paragraph stays. It gets more accurate with this change.

## Scope

Prose only. No schema change, no CLI change, no regeneration.

One other CLI invocation exists in bundled prose — `skills/using-systematic/references/pi-profile.md` — and it is already correct, because it lives in a harness-specific profile. That is the pattern this class of instruction should follow when it genuinely is harness-specific; this one is not, so it takes a condition instead.
