### PR TITLE
feat(ce-review): name where an unrun validation gets recorded

### DIFF
--- a/skills/ce-review/references/review-summary-schema.json
+++ b/skills/ce-review/references/review-summary-schema.json
@@ -606,6 +606,23 @@
         "intent_uncertainty"
       ],
       "additionalProperties": false
+    },
+    "validation": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["passed", "failed", "unavailable", "not_attempted"]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048,
+          "pattern": "\\S"
+        }
+      },
+      "required": ["status"],
+      "additionalProperties": false
     }
   },
   "required": [

--- a/skills/ce-review/references/synthesis-artifact-contract.md
+++ b/skills/ce-review/references/synthesis-artifact-contract.md
@@ -216,7 +216,10 @@ When it is available, the parent runs
 `systematic validate-review-artifact <path>` against it. The executable ships
 through the npm package's `bin` entry; a harness that installs bundled
 markdown without that package will not have it. When it is unavailable, the
-parent records that validation did not run and why in the run record.
+parent records `validation.status: "unavailable"` and a `validation.reason` in
+the run record. The `validation.status` values are `passed`, `failed`,
+`unavailable`, and `not_attempted`; `validation.reason` is required for every
+status except `passed`, where it is forbidden.
 Unavailable validation is distinct from skipped validation, and the parent
 does not represent the artifact as validated. A nonzero exit means the run is
 not complete. The [executable schema](./review-summary-schema.json) is
@@ -235,6 +238,11 @@ in either direction. That is why the command exists as an independently
 runnable check rather than as a self-validation instruction, and why its result
 belongs in the run record. An unavailable validator is recorded as unavailable,
 not as skipped or validated.
+The `validation` field is self-reported: an agent can write `status: passed`
+without running anything, so it is a claim rather than evidence. Its value is
+that it distinguishes states that were previously one indistinguishable
+silence: a check that passed, one that failed, one that could not run, and one
+that was skipped.
 
 `mode:report-only` writes no artifact and therefore performs no validation.
 

--- a/skills/ce-review/references/synthesis-artifact-contract.md
+++ b/skills/ce-review/references/synthesis-artifact-contract.md
@@ -217,14 +217,17 @@ When it is available, the parent runs
 through the npm package's `bin` entry; a harness that installs bundled
 markdown without that package will not have it. When it is unavailable, the
 parent records `validation.status: "unavailable"` and a `validation.reason` in
-the run record. The `validation.status` values are `passed`, `failed`,
-`unavailable`, and `not_attempted`; `validation.reason` is required for every
-status except `passed`, where it is forbidden.
-Unavailable validation is distinct from skipped validation, and the parent
-does not represent the artifact as validated. A nonzero exit means the run is
-not complete. The [executable schema](./review-summary-schema.json) is
-generated from a Zod source and is the machine-checkable form of the shape
-described here.
+the run record. When the executable is available and the parent does not run
+it, that is `validation.status: "not_attempted"`, also with a reason. The
+`validation.status` values are `passed`, `failed`, `unavailable`, and
+`not_attempted`; `validation.reason` is required for every status except
+`passed`, where it is forbidden.
+
+Unavailable validation is distinct from skipped validation — `unavailable`
+versus `not_attempted` — and in neither case does the parent represent the
+artifact as validated. A nonzero exit means the run is not complete. The
+[executable schema](./review-summary-schema.json) is generated from a Zod
+source and is the machine-checkable form of the shape described here.
 
 On validation failure, the parent repairs the artifact and re-runs the
 validator. It does not report a verdict over an artifact that failed

--- a/src/lib/review-artifact-schema.ts
+++ b/src/lib/review-artifact-schema.ts
@@ -14,6 +14,7 @@ export const REVIEW_ARTIFACT_CUSTOM_MESSAGES = [
   'risk-critical dispatches require a non-empty selection surface',
   'satisfied risk coverage requires a citing input finding ID',
   'unsatisfied risk coverage must not cite an input finding ID',
+  'passed validation must not include a reason; non-passed validation requires a reason',
 ] as const
 
 const boundedText = (maxLength: number) =>
@@ -269,6 +270,35 @@ const DeclinedMergeSchema = z
   })
   .strict()
 
+const ValidationSchema = z
+  .object({
+    status: z.enum([
+      'passed',
+      'failed',
+      'unavailable',
+      'not_attempted',
+    ] as const),
+    reason: ReasonSchema.optional(),
+  })
+  .strict()
+  .superRefine((validation, ctx) => {
+    if (validation.status === 'passed' && validation.reason !== undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['reason'],
+        message: REVIEW_ARTIFACT_CUSTOM_MESSAGES[5],
+      })
+    }
+
+    if (validation.status !== 'passed' && validation.reason === undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['reason'],
+        message: REVIEW_ARTIFACT_CUSTOM_MESSAGES[5],
+      })
+    }
+  })
+
 const RiskCoverageSchema = z
   .object({
     persona: RiskCriticalPersonaSchema,
@@ -322,6 +352,7 @@ export const ReviewArtifactSchema = z
     residual_actionable_work: z.array(ReasonSchema).max(MAX_FINDINGS),
     advisory_outputs: z.array(ReasonSchema).max(MAX_FINDINGS),
     coverage: CoverageSchema,
+    validation: ValidationSchema.optional(),
   })
   .strict()
 

--- a/tests/unit/review-artifact-schema.test.ts
+++ b/tests/unit/review-artifact-schema.test.ts
@@ -216,6 +216,80 @@ describe('review artifact schema', () => {
     expect(result.success).toBe(true)
   })
 
+  test('accepts an artifact that omits validation', () => {
+    const result = ReviewArtifactSchema.safeParse(baseArtifact)
+
+    expect(result.success).toBe(true)
+  })
+
+  test('accepts passed validation without a reason', () => {
+    const result = ReviewArtifactSchema.safeParse(
+      artifactWith({ validation: { status: 'passed' } }),
+    )
+
+    expect(result.success).toBe(true)
+  })
+
+  test('rejects passed validation with a reason', () => {
+    const result = ReviewArtifactSchema.safeParse(
+      artifactWith({
+        validation: { status: 'passed', reason: 'The check completed.' },
+      }),
+    )
+
+    expect(result.success).toBe(false)
+  })
+
+  test('requires a reason for every non-passed validation status', () => {
+    for (const status of ['failed', 'unavailable', 'not_attempted'] as const) {
+      const result = ReviewArtifactSchema.safeParse(
+        artifactWith({ validation: { status } }),
+      )
+
+      expect(result.success, `${status} should require a reason`).toBe(false)
+    }
+  })
+
+  test('accepts a reason for every non-passed validation status', () => {
+    for (const status of ['failed', 'unavailable', 'not_attempted'] as const) {
+      const result = ReviewArtifactSchema.safeParse(
+        artifactWith({
+          validation: { status, reason: 'The check was not successful.' },
+        }),
+      )
+
+      expect(result.success, `${status} should accept a reason`).toBe(true)
+    }
+  })
+
+  test('rejects an unknown validation status', () => {
+    const result = ReviewArtifactSchema.safeParse(
+      artifactWith({ validation: { status: 'unknown' } }),
+    )
+
+    expect(result.success).toBe(false)
+  })
+
+  test('rejects extra keys inside validation', () => {
+    const result = ReviewArtifactSchema.safeParse(
+      artifactWith({
+        validation: { status: 'passed', extra: 'not part of the contract' },
+      }),
+    )
+
+    expect(result.success).toBe(false)
+  })
+
+  test('enforces the validation reason length bound', () => {
+    const result = ReviewArtifactSchema.safeParse(
+      artifactWith({
+        validation: { status: 'failed', reason: 'x'.repeat(2049) },
+      }),
+    )
+
+    expect(result.success).toBe(false)
+  })
+
   test('enforces selection surface path and array bounds', () => {
     const tooLongPath = ReviewArtifactSchema.safeParse(
       artifactWith({
@@ -752,6 +826,10 @@ describe('review artifact schema', () => {
           },
         ],
       }),
+      artifactWith({ validation: { status: 'failed' } }),
+      artifactWith({
+        validation: { status: 'passed', reason: 'The check completed.' },
+      }),
     ]
 
     const issues = cases.flatMap((value) => {
@@ -762,7 +840,7 @@ describe('review artifact schema', () => {
         : result.error.issues.filter((issue) => issue.code === 'custom')
     })
 
-    expect(issues.length).toBe(5)
+    expect(issues.length).toBe(7)
     for (const issue of issues) {
       expect(customMessages.has(issue.message)).toBe(true)
     }


### PR DESCRIPTION
Closes the remaining review note from #851.

That PR made the validator instruction conditional, because the Claude Code bundle ships no npm package and therefore no `systematic` binary. It told the parent to record that validation did not run "in the run record" — without naming where. Every neighbouring rule in that contract names its field.

## The field

A `validation` object on the run artifact, optional, with an explicit status:

| Status | Meaning | Reason |
| --- | --- | --- |
| `passed` | The validator ran and the artifact conformed | Forbidden |
| `failed` | The validator ran and rejected the artifact | Required |
| `unavailable` | The executable was not on PATH | Required |
| `not_attempted` | The parent did not run it | Required |

A reason is forbidden on `passed` because a check that succeeded has nothing to explain, and an open prose field there only invites narration.

## Why not `coverage`

`coverage.validator_failures` already exists and refers to Stage 5b's per-finding validators — a different mechanism that happens to share the word "validator". Folding artifact validation into it would merge two distinct things under one name, which is the ambiguity this change exists to remove. `CoverageSchema` is untouched.

## What this field is not

It is self-reported, and the contract now says so. An agent can write `passed` without having run anything, so this is a claim rather than evidence — the distinction in [comments and commit messages are claims, not evidence](https://github.com/marcusrbrown/systematic/blob/main/docs/solutions/best-practices/comments-and-commit-messages-are-claims-not-evidence-2026-08-16.md).

What it buys is narrower and still worth having. Before this, four outcomes produced one identical silence: a passing check, a failing one, a harness that structurally could not run it, and an agent that skipped it. The contract already required unavailable and skipped to be recorded differently; now there is somewhere to record them.
