### PR TITLE
build(dev): update OpenCode to v1.18.21

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,8 +14,8 @@
       "devDependencies": {
         "@biomejs/biome": "2.5.9",
         "@earendil-works/pi-coding-agent": "0.83.0",
-        "@opencode-ai/plugin": "1.18.18",
-        "@opencode-ai/sdk": "1.18.18",
+        "@opencode-ai/plugin": "1.18.21",
+        "@opencode-ai/sdk": "1.18.21",
         "@semantic-release/exec": "7.1.0",
         "@tintinweb/pi-subagents": "0.14.3",
         "@types/bun": "latest",
@@ -432,9 +432,9 @@
 
     "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
 
-    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.18.18", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@opencode-ai/sdk": "1.18.18", "effect": "4.0.0-beta.83", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.4.5", "@opentui/keymap": ">=0.4.5", "@opentui/solid": ">=0.4.5" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-vqQeqJtn9c+J+tIQDzYk88xip/NVNN1hym1ATmckxo6zINHAoXoul4Sw/jgnvL00rLsfAvhja28qax4h3g/5Jg=="],
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.18.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@opencode-ai/sdk": "1.18.21", "effect": "4.0.0-beta.83", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.4.5", "@opentui/keymap": ">=0.4.5", "@opentui/solid": ">=0.4.5" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-wQXMbSvg3pG75F8fYAiJxYuyr6Cl9Hd74lSCY2yznZnejpwa+ksd2kMphmgSo+/UgLhb2AId9KAI6dsRhprzTg=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.18.18", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-zJlwXskIR47V1dkPJqeKBgq7nejG1uU8lJaGIGqbX3MWRCT8vKn0fEotbxuPCKnTdmWsDyNGNg9q1qIliDSMDA=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.18.21", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-k6iHQ5C8wOPglk+LgFyYnst168cGMQYumgpbVoeXJ+iC1AtvwD5zmjuF8CxMze/y9G1K2bOeO6p9yRvA7eHZLA=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 

--- a/package.json
+++ b/package.json
@@ -95,8 +95,8 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.9",
     "@earendil-works/pi-coding-agent": "0.83.0",
-    "@opencode-ai/plugin": "1.18.18",
-    "@opencode-ai/sdk": "1.18.18",
+    "@opencode-ai/plugin": "1.18.21",
+    "@opencode-ai/sdk": "1.18.21",
     "@semantic-release/exec": "7.1.0",
     "@tintinweb/pi-subagents": "0.14.3",
     "@types/bun": "latest",

--- a/scripts/run-evals.ts
+++ b/scripts/run-evals.ts
@@ -1886,7 +1886,7 @@ export function serializeRunManifest(input: unknown): string {
   return serialized
 }
 
-export const EXPECTED_OPENCODE_VERSION = '1.18.18' as const
+export const EXPECTED_OPENCODE_VERSION = '1.18.21' as const
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '..')
 const FIXTURE_CONTRACT_VERSION = 1 as const

--- a/tests/integration/fixtures/receipt-workflow-host.ts
+++ b/tests/integration/fixtures/receipt-workflow-host.ts
@@ -10,7 +10,7 @@ export const OPENCODE_AVAILABLE = (() => {
 })()
 
 export const TIMEOUT_MS = 180_000
-export const EXACT_OPENCODE_VERSION = '1.18.18'
+export const EXACT_OPENCODE_VERSION = '1.18.21'
 let exactNpmCacheDir: string | undefined
 export const MAX_RETRIES = 1
 export const RETRY_DELAY_MS = 3_000


### PR DESCRIPTION
Supersedes #837, which proposed v1.18.19.

## Why not the patch Renovate picked

The OpenCode pin is not a lone constant. Four places have to agree or `tests/unit/eval-contract.test.ts` fails:

```
package.json  @opencode-ai/sdk
package.json  @opencode-ai/plugin
scripts/run-evals.ts                            EXPECTED_OPENCODE_VERSION
tests/integration/fixtures/receipt-workflow-host.ts  EXACT_OPENCODE_VERSION
```

Moving them invalidates the evidence gathered at the old version. From [`version-pinned-evidence-must-be-reproven`](../blob/main/docs/solutions/workflow-issues/version-pinned-evidence-must-be-reproven-2026-08-16.md):

> Treat the version pin and the evidence gathered at that version as a single unit. When the pin moves, the evidence is invalidated until it is collected again at the new version. Bumping the constant to make the guard pass, without re-running the suite, converts a real gate into a rubber stamp.

That re-run takes seventeen minutes against the real host. Landing 1.18.19 when 1.18.21 is published would mean paying it again for .20 and again for .21. One bump, one run.

## Evidence

Re-run at 1.18.21, not assumed:

```
bun test tests/integration/eval-runner.test.ts \
         tests/integration/eval-artifact.test.ts \
         tests/integration/eval-fixture.test.ts

51 pass, 0 fail, 328 expect() calls  [1019.25s]
```

Full unit suite: 1977 pass, 0 fail. Typecheck clean.

The pin-alignment guard is written to demand this rather than just report a mismatch — its failure message names the follow-up action, so the next reader knows the number was never the point.
