### PR TITLE
build: group the tree-sitter runtime and grammar

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -60,6 +60,20 @@
       groupName: 'Pi',
       semanticCommitType: 'build',
     },
+    {
+      // web-tree-sitter is the WASM runtime; tree-sitter-bash is the grammar it
+      // loads. A grammar is compiled against an ABI version and the runtime
+      // accepts a range, so moving one alone can land the pair outside it. Both
+      // are pinned exactly rather than with a caret for the same reason.
+      //
+      // 0.26.12 also renamed the runtime's exported asset from tree-sitter.wasm
+      // to web-tree-sitter.wasm, which broke every call site resolving the old
+      // path. The command classifier fails closed, so 44 tests failed before a
+      // single parse was attempted. Grouping them makes that class of change
+      // arrive as one reviewable PR.
+      matchPackageNames: ['tree-sitter-bash', 'web-tree-sitter'],
+      groupName: 'tree-sitter',
+    },
   ],
   postUpgradeTasks: {
     // `bun run fix` runs Biome lint --fix to auto-correct formatting drift.


### PR DESCRIPTION
Follow-up to #727.

`web-tree-sitter` is the WASM runtime; `tree-sitter-bash` is the grammar it loads. Both are pinned exactly rather than with a caret:

```json
"tree-sitter-bash": "0.25.1",
"web-tree-sitter": "0.26.12",
```

That pinning is deliberate — a grammar is compiled against an ABI version and the runtime accepts a range, so moving one without the other can land the pair outside it. But no `packageRules` entry tied them together, so Renovate was free to propose either half alone.

## What #727 showed

The ABI turned out to be fine — `tree-sitter-bash@0.25.1` declares ABI 15 and `web-tree-sitter@0.26.12` accepts 13 through 15. I verified that directly by loading the pinned grammar under the new runtime and parsing a real command.

The actual break was narrower and arguably worse, because it was invisible from the version numbers:

```
0.25.10  ->  ./tree-sitter.wasm
0.26.12  ->  ./web-tree-sitter.wasm
```

The runtime renamed its exported asset. Three call sites resolved the old path, resolution failed before `Parser.init()`, and the command classifier — which fails closed by design — reported every shell operation as `parser-asset-unavailable`. Forty-four tests failed without a single parse having been attempted.

That fix belonged in the same PR as the bump. Grouping makes that the default rather than something a reviewer has to notice.

## The rule

Follows the existing `OpenCode` and `Pi` groupings, with the rationale inline the way the `semantic-release` rule carries its own. No `semanticCommitType` override — these are runtime dependencies and `fix(deps)` is already correct for them.
