### PR TITLE
fix(ce-plan): account for an origin path a reader cannot resolve

### DIFF
--- a/skills/ce-plan/SKILL.md
+++ b/skills/ce-plan/SKILL.md
@@ -514,7 +514,7 @@ title: [Plan Title]
 type: [feat|fix|refactor]
 status: active
 date: YYYY-MM-DD
-origin: docs/brainstorms/YYYY-MM-DD-<topic>-requirements.md  # include when planning from a requirements doc
+origin: docs/brainstorms/YYYY-MM-DD-<topic>-requirements.md  # include when planning from a requirements doc; see Sources if the path is untracked
 deepened: YYYY-MM-DD  # optional, set when the confidence check substantively strengthens the plan
 ---
 
@@ -680,6 +680,9 @@ Omit `scopes_considered` unless the verdict is `unscoped`, and omit `acceptance`
 ## Sources & References
 
 - **Origin document:** [docs/brainstorms/YYYY-MM-DD-<topic>-requirements.md](path)
+  <!-- If the origin path is untracked in this repository, say so on this line. A
+       reader cloning the repo will not find it, and a bare link cannot tell them
+       whether they are missing context or whether it was always local. -->
 - Related code: [path or symbol]
 - Related PRs/issues: #[number]
 - External docs: [url]

--- a/skills/ce-plan/references/plan-sections.md
+++ b/skills/ce-plan/references/plan-sections.md
@@ -106,6 +106,14 @@ semantics so downstream tooling can rely on them:
   doc (e.g., `docs/brainstorms/2026-05-12-pagination-requirements.md`).
   Set when planning from an upstream brainstorm; carried for traceability
   and re-resolved when `ce:plan` re-deepens.
+
+  A repository may deliberately not track its brainstorm directory, treating
+  requirements docs as local planning input that the plan supersedes. The
+  field still carries real provenance for whoever wrote the plan, so keep it
+  — but a reader working from a clone will find nothing at that path. Say so
+  in Sources & References rather than leaving a bare link, because a link
+  that resolves to nothing cannot tell a reader whether they are missing
+  context or whether none was ever shared.
 - **`deepened`** — ISO 8601 date marking the first time the confidence
   check substantively strengthened the plan. Presence affects Phase 0.1
   resume fast-path logic (see `references/deepening-workflow.md`).

--- a/skills/deepen-plan/SKILL.md
+++ b/skills/deepen-plan/SKILL.md
@@ -57,6 +57,7 @@ Read the plan file completely.
 If the plan frontmatter includes an `origin:` path:
 - Read the origin document too
 - Use it to check whether the plan still reflects the product intent, scope boundaries, and success criteria
+- If the path does not resolve, continue from the plan alone rather than treating it as a defect. A repository may deliberately not track its brainstorm directory, in which case the origin exists only for whoever wrote the plan. Note that the check could not run instead of reporting a missing file.
 
 #### 0.2 Classify Plan Depth and Topic Risk
 


### PR DESCRIPTION
Closes #859.

`ce:plan`'s template instructs a frontmatter field pointing into a directory this repository deliberately does not track:

```
skills/ce-plan/SKILL.md:517   origin: docs/brainstorms/YYYY-MM-DD-<topic>-requirements.md
.gitignore:45                 docs/brainstorms/
```

Measured on `main`: 42 merged plans carry an `origin` path with no tracked counterpart, against 0 tracked files and 47 local ones.

## The gitignore is correct

A requirements doc is working input that stops being authoritative the moment a plan supersedes it. Committing both gives a reader two documents with equal apparent standing and invites them drifting apart. `docs/plans/` should stay the durable artifact.

The defect is that the template asked for a reference without accounting for where it can be resolved from.

## What changed

**The field contract** (`plan-sections.md`) now states that a repository may deliberately not track its brainstorm directory, that the field still carries real provenance for the plan's author, and that a bare link cannot tell a reader whether they are missing context or whether none was ever shared.

**The Sources template** carries a note to say so on the line itself.

**Deepening** assumed the origin would always be readable — `deepen-plan/SKILL.md:58` said "Read the origin document too" with no other branch. It now continues from the plan alone and records that the fidelity check could not run, rather than reporting a missing file. That was the sharper half: the failure mode belonged to everyone except the person who wrote the plan.

## Scope

The 42 existing plans are untouched. The convention applies going forward; retrofitting would be churn against documents that are already historical.

Prompted by automated review flagging the reference as dangling on #855 and retracting once shown the convention. That round trip is the cost being removed — the reference looked like a defect to anyone who didn't already know, and nothing in the plan explained it.
