### PR TITLE
fix(skills): resolve bundled helper scripts against the skill's own directory

### DIFF
--- a/skills/ce-review/SKILL.md
+++ b/skills/ce-review/SKILL.md
@@ -254,7 +254,7 @@ When this skill loads, its own directory is stated in the surrounding instructio
 
 ```
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 RESOLVE_OUT=$(bash "$SKILL_DIR/references/resolve-base.sh") || { echo "ERROR: resolve-base.sh failed"; exit 1; }
 if [ -z "$RESOLVE_OUT" ] || echo "$RESOLVE_OUT" | grep -q '^ERROR:'; then echo "${RESOLVE_OUT:-ERROR: resolve-base.sh produced no output}"; exit 1; fi
 BASE=$(echo "$RESOLVE_OUT" | sed 's/^BASE://')
@@ -276,7 +276,7 @@ Detect the review base branch and compute the merge-base using the same `referen
 
 ```
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 RESOLVE_OUT=$(bash "$SKILL_DIR/references/resolve-base.sh") || { echo "ERROR: resolve-base.sh failed"; exit 1; }
 if [ -z "$RESOLVE_OUT" ] || echo "$RESOLVE_OUT" | grep -q '^ERROR:'; then echo "${RESOLVE_OUT:-ERROR: resolve-base.sh produced no output}"; exit 1; fi
 BASE=$(echo "$RESOLVE_OUT" | sed 's/^BASE://')

--- a/skills/ce-review/SKILL.md
+++ b/skills/ce-review/SKILL.md
@@ -250,8 +250,12 @@ git checkout <branch>
 
 Then detect the review base branch and compute the merge-base. Run the `references/resolve-base.sh` script, which handles fork-safe remote resolution with multi-fallback detection (PR metadata -> `origin/HEAD` -> `gh repo view` -> common branch names):
 
+When this skill loads, its own directory is stated in the surrounding instructions; set `SKILL_DIR` to that directory because the scripts live beside this file.
+
 ```
-RESOLVE_OUT=$(bash references/resolve-base.sh) || { echo "ERROR: resolve-base.sh failed"; exit 1; }
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
+RESOLVE_OUT=$(bash "$SKILL_DIR/references/resolve-base.sh") || { echo "ERROR: resolve-base.sh failed"; exit 1; }
 if [ -z "$RESOLVE_OUT" ] || echo "$RESOLVE_OUT" | grep -q '^ERROR:'; then echo "${RESOLVE_OUT:-ERROR: resolve-base.sh produced no output}"; exit 1; fi
 BASE=$(echo "$RESOLVE_OUT" | sed 's/^BASE://')
 ```
@@ -271,7 +275,9 @@ You may still fetch additional PR metadata with `gh pr view` for title, body, an
 Detect the review base branch and compute the merge-base using the same `references/resolve-base.sh` script as branch mode:
 
 ```
-RESOLVE_OUT=$(bash references/resolve-base.sh) || { echo "ERROR: resolve-base.sh failed"; exit 1; }
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
+RESOLVE_OUT=$(bash "$SKILL_DIR/references/resolve-base.sh") || { echo "ERROR: resolve-base.sh failed"; exit 1; }
 if [ -z "$RESOLVE_OUT" ] || echo "$RESOLVE_OUT" | grep -q '^ERROR:'; then echo "${RESOLVE_OUT:-ERROR: resolve-base.sh produced no output}"; exit 1; fi
 BASE=$(echo "$RESOLVE_OUT" | sed 's/^BASE://')
 ```

--- a/skills/ce-review/references/resolve-base.sh
+++ b/skills/ce-review/references/resolve-base.sh
@@ -2,7 +2,7 @@
 # Resolve the review base branch and compute the merge-base for ce:review.
 # Handles fork-safe remote resolution, PR metadata, and multi-fallback detection.
 #
-# Usage: bash references/resolve-base.sh
+# Usage: bash "$SKILL_DIR/references/resolve-base.sh"
 # Output: BASE:<sha> on success, ERROR:<message> on failure.
 #
 # Detects the base branch from (in priority order):

--- a/skills/git-clean-gone-branches/SKILL.md
+++ b/skills/git-clean-gone-branches/SKILL.md
@@ -17,7 +17,7 @@ When this skill loads, its own directory is stated in the surrounding instructio
 
 ```bash
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 bash "$SKILL_DIR/scripts/clean-gone"
 ```
 

--- a/skills/git-clean-gone-branches/SKILL.md
+++ b/skills/git-clean-gone-branches/SKILL.md
@@ -13,8 +13,12 @@ Delete local branches whose remote tracking branch has been deleted, including a
 
 Run the discovery script to fetch the latest remote state and identify gone branches:
 
+When this skill loads, its own directory is stated in the surrounding instructions; set `SKILL_DIR` to that directory because the scripts live beside this file.
+
 ```bash
-bash scripts/clean-gone
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
+bash "$SKILL_DIR/scripts/clean-gone"
 ```
 
 [scripts/clean-gone](./scripts/clean-gone)

--- a/skills/git-worktree/SKILL.md
+++ b/skills/git-worktree/SKILL.md
@@ -30,9 +30,13 @@ The script handles critical setup that raw git commands don't:
 3. Ensures `.worktrees` is in `.gitignore`
 4. Creates consistent directory structure
 
+When this skill loads, its own directory is stated in the surrounding instructions; set `SKILL_DIR` to that directory because the scripts live beside this file.
+
 ```bash
 # ✅ CORRECT - Always use the script
-bash scripts/worktree-manager.sh create feature-name
+# Resolve the manager script relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
+bash "$SKILL_DIR/scripts/worktree-manager.sh" create feature-name
 
 # ❌ WRONG - Never do this directly
 git worktree add .worktrees/feature-name -b feature-name main
@@ -63,20 +67,22 @@ The skill is automatically called from `/ce:review` and `/ce:work` commands:
 You can also invoke the skill directly from bash:
 
 ```bash
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
 # Create a new worktree (copies .env files automatically)
-bash scripts/worktree-manager.sh create feature-login
+bash "$SKILL_DIR/scripts/worktree-manager.sh" create feature-login
 
 # List all worktrees
-bash scripts/worktree-manager.sh list
+bash "$SKILL_DIR/scripts/worktree-manager.sh" list
 
 # Switch to a worktree
-bash scripts/worktree-manager.sh switch feature-login
+bash "$SKILL_DIR/scripts/worktree-manager.sh" switch feature-login
 
 # Copy .env files to an existing worktree (if they weren't copied)
-bash scripts/worktree-manager.sh copy-env feature-login
+bash "$SKILL_DIR/scripts/worktree-manager.sh" copy-env feature-login
 
 # Clean up completed worktrees
-bash scripts/worktree-manager.sh cleanup
+bash "$SKILL_DIR/scripts/worktree-manager.sh" cleanup
 ```
 
 ## Commands
@@ -91,7 +97,9 @@ Creates a new worktree with the given branch name.
 
 **Example:**
 ```bash
-bash scripts/worktree-manager.sh create feature-login
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
+bash "$SKILL_DIR/scripts/worktree-manager.sh" create feature-login
 ```
 
 **What happens:**
@@ -111,7 +119,9 @@ Lists all available worktrees with their branches and current status.
 
 **Example:**
 ```bash
-bash scripts/worktree-manager.sh list
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
+bash "$SKILL_DIR/scripts/worktree-manager.sh" list
 ```
 
 **Output shows:**
@@ -126,7 +136,9 @@ Switches to an existing worktree and cd's into it.
 
 **Example:**
 ```bash
-bash scripts/worktree-manager.sh switch feature-login
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
+bash "$SKILL_DIR/scripts/worktree-manager.sh" switch feature-login
 ```
 
 **Optional:**
@@ -138,7 +150,9 @@ Interactively cleans up inactive worktrees with confirmation.
 
 **Example:**
 ```bash
-bash scripts/worktree-manager.sh cleanup
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
+bash "$SKILL_DIR/scripts/worktree-manager.sh" cleanup
 ```
 
 **What happens:**
@@ -152,39 +166,43 @@ bash scripts/worktree-manager.sh cleanup
 ### Code Review with Worktree
 
 ```bash
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
 # OpenCode recognizes you're not on the PR branch
 # Offers: "Use worktree for isolated review? (y/n)"
 
 # You respond: yes
 # Script runs (copies .env files automatically):
-bash scripts/worktree-manager.sh create pr-123-feature-name
+bash "$SKILL_DIR/scripts/worktree-manager.sh" create pr-123-feature-name
 
 # You're now in isolated worktree for review with all env vars
 cd .worktrees/pr-123-feature-name
 
 # After review, return to main:
 cd ../..
-bash scripts/worktree-manager.sh cleanup
+bash "$SKILL_DIR/scripts/worktree-manager.sh" cleanup
 ```
 
 ### Parallel Feature Development
 
 ```bash
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
 # For first feature (copies .env files):
-bash scripts/worktree-manager.sh create feature-login
+bash "$SKILL_DIR/scripts/worktree-manager.sh" create feature-login
 
 # Later, start second feature (also copies .env files):
-bash scripts/worktree-manager.sh create feature-notifications
+bash "$SKILL_DIR/scripts/worktree-manager.sh" create feature-notifications
 
 # List what you have:
-bash scripts/worktree-manager.sh list
+bash "$SKILL_DIR/scripts/worktree-manager.sh" list
 
 # Switch between them as needed:
-bash scripts/worktree-manager.sh switch feature-login
+bash "$SKILL_DIR/scripts/worktree-manager.sh" switch feature-login
 
 # Return to main and cleanup when done:
 cd .
-bash scripts/worktree-manager.sh cleanup
+bash "$SKILL_DIR/scripts/worktree-manager.sh" cleanup
 ```
 
 ## Key Design Principles
@@ -249,8 +267,10 @@ If you see this, the script will ask if you want to switch to it instead.
 Switch out of the worktree first (to main repo), then cleanup:
 
 ```bash
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
 cd $(git rev-parse --show-toplevel)
-bash scripts/worktree-manager.sh cleanup
+bash "$SKILL_DIR/scripts/worktree-manager.sh" cleanup
 ```
 
 ### Lost in a worktree?
@@ -258,7 +278,9 @@ bash scripts/worktree-manager.sh cleanup
 See where you are:
 
 ```bash
-bash scripts/worktree-manager.sh list
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
+bash "$SKILL_DIR/scripts/worktree-manager.sh" list
 ```
 
 ### .env files missing in worktree?
@@ -266,7 +288,9 @@ bash scripts/worktree-manager.sh list
 If a worktree was created without .env files (e.g., via raw `git worktree add`), copy them:
 
 ```bash
-bash scripts/worktree-manager.sh copy-env feature-name
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
+bash "$SKILL_DIR/scripts/worktree-manager.sh" copy-env feature-name
 ```
 
 Navigate back to main:

--- a/skills/git-worktree/SKILL.md
+++ b/skills/git-worktree/SKILL.md
@@ -35,7 +35,7 @@ When this skill loads, its own directory is stated in the surrounding instructio
 ```bash
 # ✅ CORRECT - Always use the script
 # Resolve the manager script relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 bash "$SKILL_DIR/scripts/worktree-manager.sh" create feature-name
 
 # ❌ WRONG - Never do this directly
@@ -68,7 +68,7 @@ You can also invoke the skill directly from bash:
 
 ```bash
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 # Create a new worktree (copies .env files automatically)
 bash "$SKILL_DIR/scripts/worktree-manager.sh" create feature-login
 
@@ -98,7 +98,7 @@ Creates a new worktree with the given branch name.
 **Example:**
 ```bash
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 bash "$SKILL_DIR/scripts/worktree-manager.sh" create feature-login
 ```
 
@@ -120,7 +120,7 @@ Lists all available worktrees with their branches and current status.
 **Example:**
 ```bash
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 bash "$SKILL_DIR/scripts/worktree-manager.sh" list
 ```
 
@@ -137,7 +137,7 @@ Switches to an existing worktree and cd's into it.
 **Example:**
 ```bash
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 bash "$SKILL_DIR/scripts/worktree-manager.sh" switch feature-login
 ```
 
@@ -151,7 +151,7 @@ Interactively cleans up inactive worktrees with confirmation.
 **Example:**
 ```bash
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 bash "$SKILL_DIR/scripts/worktree-manager.sh" cleanup
 ```
 
@@ -167,7 +167,7 @@ bash "$SKILL_DIR/scripts/worktree-manager.sh" cleanup
 
 ```bash
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 # OpenCode recognizes you're not on the PR branch
 # Offers: "Use worktree for isolated review? (y/n)"
 
@@ -187,7 +187,7 @@ bash "$SKILL_DIR/scripts/worktree-manager.sh" cleanup
 
 ```bash
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 # For first feature (copies .env files):
 bash "$SKILL_DIR/scripts/worktree-manager.sh" create feature-login
 
@@ -268,7 +268,7 @@ Switch out of the worktree first (to main repo), then cleanup:
 
 ```bash
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 cd $(git rev-parse --show-toplevel)
 bash "$SKILL_DIR/scripts/worktree-manager.sh" cleanup
 ```
@@ -279,7 +279,7 @@ See where you are:
 
 ```bash
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 bash "$SKILL_DIR/scripts/worktree-manager.sh" list
 ```
 
@@ -289,7 +289,7 @@ If a worktree was created without .env files (e.g., via raw `git worktree add`),
 
 ```bash
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 bash "$SKILL_DIR/scripts/worktree-manager.sh" copy-env feature-name
 ```
 

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -26,8 +26,12 @@ This skill always regenerates the document from scratch. It does not read or dif
 
 Run the bundled inventory script (`scripts/inventory.mjs`) to get a structural map of the repository without reading every file:
 
+When this skill loads, its own directory is stated in the surrounding instructions; set `SKILL_DIR` to that directory because the scripts live beside this file.
+
 ```bash
-node scripts/inventory.mjs --root .
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
+node "$SKILL_DIR/scripts/inventory.mjs" --root .
 ```
 
 Parse the JSON output. This provides:

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -30,7 +30,7 @@ When this skill loads, its own directory is stated in the surrounding instructio
 
 ```bash
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 node "$SKILL_DIR/scripts/inventory.mjs" --root .
 ```
 

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -41,8 +41,12 @@ gh pr view --json number -q .number
 
 Then fetch all feedback using the GraphQL script at [scripts/get-pr-comments](scripts/get-pr-comments):
 
+When this skill loads, its own directory is stated in the surrounding instructions; set `SKILL_DIR` to that directory because the scripts live beside this file.
+
 ```bash
-bash scripts/get-pr-comments PR_NUMBER
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
+bash "$SKILL_DIR/scripts/get-pr-comments" PR_NUMBER
 ```
 
 Returns a JSON object with three keys:
@@ -240,12 +244,16 @@ For `needs-human` verdicts, post the reply but do NOT resolve the thread. Leave 
 
 1. **Reply** using [scripts/reply-to-pr-thread](scripts/reply-to-pr-thread):
 ```bash
-echo "REPLY_TEXT" | bash scripts/reply-to-pr-thread THREAD_ID
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
+echo "REPLY_TEXT" | bash "$SKILL_DIR/scripts/reply-to-pr-thread" THREAD_ID
 ```
 
 2. **Resolve** using [scripts/resolve-pr-thread](scripts/resolve-pr-thread):
 ```bash
-bash scripts/resolve-pr-thread THREAD_ID
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
+bash "$SKILL_DIR/scripts/resolve-pr-thread" THREAD_ID
 ```
 
 #### PR comments and review bodies
@@ -263,7 +271,9 @@ Include enough quoted context in the reply so the reader can follow which commen
 Re-fetch feedback to confirm resolution:
 
 ```bash
-bash scripts/get-pr-comments PR_NUMBER
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
+bash "$SKILL_DIR/scripts/get-pr-comments" PR_NUMBER
 ```
 
 The `review_threads` array should be empty (except `needs-human` items).
@@ -352,7 +362,9 @@ gh api repos/OWNER/REPO/pulls/comments/COMMENT_ID \
 
 **Step 2** -- Map comment to its thread ID. Use [scripts/get-thread-for-comment](scripts/get-thread-for-comment):
 ```bash
-bash scripts/get-thread-for-comment PR_NUMBER COMMENT_NODE_ID [OWNER/REPO]
+# Resolve helper scripts relative to this skill's directory.
+SKILL_DIR="<skill directory stated when this skill loads>"
+bash "$SKILL_DIR/scripts/get-thread-for-comment" PR_NUMBER COMMENT_NODE_ID [OWNER/REPO]
 ```
 
 This fetches thread IDs and their first comment IDs (minimal fields, no bodies) and returns the matching thread with full comment details.

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -45,7 +45,7 @@ When this skill loads, its own directory is stated in the surrounding instructio
 
 ```bash
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 bash "$SKILL_DIR/scripts/get-pr-comments" PR_NUMBER
 ```
 
@@ -245,14 +245,14 @@ For `needs-human` verdicts, post the reply but do NOT resolve the thread. Leave 
 1. **Reply** using [scripts/reply-to-pr-thread](scripts/reply-to-pr-thread):
 ```bash
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 echo "REPLY_TEXT" | bash "$SKILL_DIR/scripts/reply-to-pr-thread" THREAD_ID
 ```
 
 2. **Resolve** using [scripts/resolve-pr-thread](scripts/resolve-pr-thread):
 ```bash
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 bash "$SKILL_DIR/scripts/resolve-pr-thread" THREAD_ID
 ```
 
@@ -272,7 +272,7 @@ Re-fetch feedback to confirm resolution:
 
 ```bash
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 bash "$SKILL_DIR/scripts/get-pr-comments" PR_NUMBER
 ```
 
@@ -363,7 +363,7 @@ gh api repos/OWNER/REPO/pulls/comments/COMMENT_ID \
 **Step 2** -- Map comment to its thread ID. Use [scripts/get-thread-for-comment](scripts/get-thread-for-comment):
 ```bash
 # Resolve helper scripts relative to this skill's directory.
-SKILL_DIR="<skill directory stated when this skill loads>"
+SKILL_DIR="<skill directory stated when this skill loads>";
 bash "$SKILL_DIR/scripts/get-thread-for-comment" PR_NUMBER COMMENT_NODE_ID [OWNER/REPO]
 ```
 

--- a/tests/unit/skill-script-invocation.test.ts
+++ b/tests/unit/skill-script-invocation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import path from 'node:path'
+import { walkDir } from '../../src/lib/walk-dir.js'
+
+const SKILLS_DIR = path.resolve(import.meta.dirname, '../../skills')
+
+interface SkillDoc {
+  readonly file: string
+  readonly text: string
+}
+
+interface FencedBlock {
+  readonly file: string
+  readonly startLine: number
+  readonly body: string
+}
+
+function collectSkillMarkdown(): SkillDoc[] {
+  return walkDir(SKILLS_DIR, {
+    maxDepth: 20,
+    filter: (entry) => !entry.isDirectory && entry.path.endsWith('.md'),
+  }).map((entry) => ({
+    file: path.relative(SKILLS_DIR, entry.path),
+    text: fs.readFileSync(entry.path, 'utf8'),
+  }))
+}
+
+function blocksIn(doc: SkillDoc): FencedBlock[] {
+  const blocks: FencedBlock[] = []
+  let startLine = 0
+  let buffer: string[] | undefined
+
+  for (const [index, line] of doc.text.split('\n').entries()) {
+    if (!line.startsWith('```')) {
+      buffer?.push(line)
+      continue
+    }
+    if (buffer === undefined) {
+      startLine = index + 1
+      buffer = []
+    } else {
+      blocks.push({ file: doc.file, startLine, body: buffer.join('\n') })
+      buffer = undefined
+    }
+  }
+  return blocks
+}
+
+function linesMatching(pattern: RegExp): string[] {
+  const hits: string[] = []
+  for (const doc of collectSkillMarkdown()) {
+    for (const [index, line] of doc.text.split('\n').entries()) {
+      if (pattern.test(line))
+        hits.push(`${doc.file}:${index + 1}: ${line.trim()}`)
+    }
+  }
+  return hits
+}
+
+describe('bundled skill script invocation', () => {
+  // A shell resolves a bare relative path against the agent's working directory,
+  // which is the consumer's project -- never the directory the skill installed
+  // into. `bash references/resolve-base.sh` failed everywhere, including in this
+  // repository, because no `references/` exists at any project root.
+  test('no skill invokes a bundled script through a bare relative path', () => {
+    expect(
+      linesMatching(
+        /(?:^|\s)(?:bash|sh|node|python3?)\s+(?:references|scripts)\//,
+      ),
+    ).toEqual([])
+  })
+
+  // Shell state does not persist between separate Bash tool calls, and each
+  // fenced block is copied and run on its own. A block that reads $SKILL_DIR
+  // without setting it expands the variable to empty and rebuilds the same
+  // broken path in a new shape: `/scripts/foo` instead of `scripts/foo`.
+  test('every block reading SKILL_DIR also assigns it', () => {
+    const offenders = collectSkillMarkdown()
+      .flatMap(blocksIn)
+      .filter(
+        (b) =>
+          /\$\{?SKILL_DIR\}?\//.test(b.body) && !b.body.includes('SKILL_DIR='),
+      )
+      .map((b) => `${b.file}:${b.startLine}`)
+    expect(offenders).toEqual([])
+  })
+
+  // Some hosts flatten a fenced block into a single line, turning newlines into
+  // spaces. Without a terminating `;` the assignment becomes the env-var-prefix
+  // form `SKILL_DIR="..." bash "$SKILL_DIR/x"`, where the shell expands
+  // $SKILL_DIR from the *outer* scope before the assignment takes effect, and
+  // the path collapses to `/x`.
+  test('every SKILL_DIR assignment terminates with a semicolon', () => {
+    expect(linesMatching(/SKILL_DIR=(?!"[^"]*";)/)).toEqual([])
+  })
+
+  // The anchor is deliberately model-filled rather than ${CLAUDE_SKILL_DIR}:
+  // that substitution is Claude-Code-only and expands to nothing on every other
+  // harness, so a guarded call silently never fires off-Claude. Systematic ships
+  // to three harnesses, so a Claude-only mechanism would be a silent skip on two.
+  test('no skill depends on a harness-specific skill-directory variable', () => {
+    expect(
+      linesMatching(/\$\{?(?:CLAUDE_SKILL_DIR|CLAUDE_PLUGIN_ROOT)\}?/),
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
Found while auditing bundled prose for capability assumptions that do not hold on every harness.

## The defect

Five skills invoked helper scripts using bare relative paths inside fenced shell blocks. A shell resolves those against the agent's working directory — the user's project — not the directory the skill was installed into.

Verified from this repository's own root:

```
$ bash references/resolve-base.sh
bash: references/resolve-base.sh: No such file or directory
```

`references/` does not exist at repo root. `scripts/` does, but it holds build scripts, so `bash scripts/get-pr-comments` failed confusingly inside a directory that legitimately exists.

This was broken on every harness, in every project. Not a Claude Code gap — a universal one, which is likely why it survived: there was no working case to compare against.

## What was not wrong

The scripts. All seven exist beside their skills and ship everywhere, including the Claude Code bundle — `collectSkillFiles` copies every skill file verbatim. Only the path was wrong.

## The sharpest instance

`skills/git-worktree/SKILL.md` labelled its broken invocation as the correct approach, directly above a working `git` command labelled as wrong:

```bash
# ✅ CORRECT - Always use the script
bash scripts/worktree-manager.sh create feature-name

# ❌ WRONG - Never do this directly
git worktree add .worktrees/feature-name -b feature-name main
```

The advice was sound. The only line on the page that would actually run was the one being warned against.

## The fix

Each invocation resolves through `SKILL_DIR`, set from the directory the harness states when the skill loads.

Every fenced block that uses the variable also sets it. That is the part that matters: blocks get copied and executed one at a time, so a variable set in an earlier block does not exist in a later one. An unset variable expands to empty and produces `/scripts/worktree-manager.sh` — the same class of broken path in a new costume.

A first pass set it once per file. Verified before commit and corrected: 24 invocations across 15 blocks were still broken that way.

| skill | blocks using `$SKILL_DIR` | broken before | broken now |
|---|---|---|---|
| `ce-review` | 2 | 1 | 0 |
| `onboarding` | 1 | 0 | 0 |
| `git-worktree` | 11 | 10 | 0 |
| `git-clean-gone-branches` | 1 | 0 | 0 |
| `resolve-pr-feedback` | 5 | 4 | 0 |

## Verification

End to end, three states of the same command:

```
as shipped     bash: references/resolve-base.sh: No such file or directory
fixed          BASE:afc3e0bdbaf644342eac1cb10eb45363e9852b64
unset variable bash: /references/resolve-base.sh: No such file or directory
```

The middle line is a real merge-base from a script that now actually runs.

- 29 invocations rewritten across 5 skills, plus one `# Usage:` comment
- Zero bare invocations remain
- `bun scripts/content-integrity.ts` — clean
- `bun run registry:drift` — up to date
