### PR TITLE
docs(structure): record both registration gates for a new lib module

### DIFF
--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -254,8 +254,10 @@ branch ref. Users install via `claude plugin marketplace add marcusrbrown/system
   must be trust-protected (blocked from project-level config), add its name to `SECURITY_OVERLAY_FIELDS`.
 
 - **New core module** → add `src/lib/<name>.ts`. Export only what other modules need. Add a
-  corresponding `tests/unit/<name>.test.ts`, and add the module to `ARCHITECTURE.md`'s codemap. If
-  it is intentionally omitted, record it in the visible codemap exclusions section instead.
+  corresponding `tests/unit/<name>.test.ts`, and register it on both gate-enforced surfaces: the
+  `ARCHITECTURE.md` codemap and the matching module-table row in `src/lib/AGENTS.md`. If it is
+  intentionally omitted from either, record it in that document's visible exclusions section
+  instead. Verify both with `bun scripts/content-integrity.ts`.
 
 - **New test** → `tests/unit/<module>.test.ts` for unit tests, `tests/integration/<name>.test.ts`
   for integration tests. Use real temp directories for filesystem isolation.


### PR DESCRIPTION
Adding a module under `src/lib/` carries two registration obligations, but `STRUCTURE.md` documented only one.

Both are enforced in `scripts/content-integrity.ts`:

| Surface | Check | Failure kind |
|---|---|---|
| `ARCHITECTURE.md` codemap | `checkCodemapCompleteness` (line 1652) | `missing-from-codemap` |
| `src/lib/AGENTS.md` module table | `checkLibModuleTableCompleteness` (line 1719) | `missing-from-table` |

Both run in the aggregate at lines 2317 and 2319.

The guidance previously named only the codemap, so a contributor following it would satisfy one gate and discover the second from a failing build. The table check is newer, which is why the doc lagged it.

Also names the command that verifies both, and points the intentional-omission escape hatch at whichever document the exclusion actually belongs to rather than assuming the codemap.

No behavior change — documentation catching up to gates that already exist.
