### PR TITLE
docs(plans): mark the Claude Code MCP server plan superseded

### DIFF
--- a/docs/plans/2026-08-23-001-feat-claude-code-mcp-server-plan.md
+++ b/docs/plans/2026-08-23-001-feat-claude-code-mcp-server-plan.md
@@ -1,11 +1,22 @@
 ---
 title: 'feat: Ship an MCP server with the Claude Code plugin bundle'
 type: feat
-status: active
+status: superseded
+superseded_at: 2026-08-24
+superseded_by: docs/solutions/best-practices/entry-point-scope-decides-what-a-plugin-can-ship-2026-08-24.md
+superseded_reason: "The premise was measured false. This plan assumed a Claude Code bundle cannot carry an executable, so it routed the validator through an MCP server. A local install against Claude Code 2.1.163 showed marketplace install copies the entire plugin directory including non-declared directories, preserves the executable bit, and puts bin/ on the Bash tool's PATH. The real constraint is entry-point scope, not transport: the full CLI is unshippable because jsonc-parser's UMD branch emits a runtime require no bundler resolves, while a purpose-built entry importing only the review-artifact schema builds to a 0.50 MB self-contained file. A successor plan replaces the MCP server with a bundled bin/ entry, dropping the Node 20 floor bump, the npx launch pin, and the new runtime dependency this plan required."
 date: 2026-08-23
 deepened: 2026-08-23
 origin: docs/brainstorms/2026-08-23-claude-code-mcp-server-requirements.md
 ---
+
+> **Status: superseded.** This plan's central assumption — that a Claude Code bundle cannot
+> carry an executable — was measured false against a real install. `bin/` is copied intact,
+> stays executable, and is added to the Bash tool's `PATH`, so no MCP transport is needed to
+> reach a bundled validator. The measurements and the three packaging failures behind them
+> are recorded in
+> [entry-point scope decides what a plugin bundle can ship](../solutions/best-practices/entry-point-scope-decides-what-a-plugin-can-ship-2026-08-24.md).
+> Everything below is retained for the research and the decision record; do not implement it.
 
 # feat: Ship an MCP server with the Claude Code plugin bundle
 


### PR DESCRIPTION
Marks `docs/plans/2026-08-23-001-feat-claude-code-mcp-server-plan.md` superseded. The plan is retained behind a status banner rather than deleted — its research and decision record are still useful, and the reversal should be traceable rather than silently overwritten by a successor.

## Why

The plan assumed a Claude Code bundle cannot carry an executable, and routed a validator through an MCP server to work around that. The assumption was never measured. It is false.

Measured against a real install of Claude Code 2.1.163:

| Assumption | Result |
|---|---|
| Install copies only manifest-declared components | **False** — the entire plugin directory is copied, including directories the manifest never mentions |
| The executable bit may not survive | **Preserved** — `-rwxr-xr-x` intact in the plugin cache |
| Reaching a bundled executable needs a transport | **False** — `bin/` is documented as "added to the Bash tool's `PATH`... invokable as bare commands" |

The real constraint is entry-point scope, not transport. Three packaging attempts failed before that was clear:

1. Shipping `dist/cli.js` alone — `ERR_MODULE_NOT_FOUND`, it imports a sibling chunk
2. Shipping all of `dist/` — still fails, it externalises `js-yaml`, `zod`, and `jsonc-parser`, and a bundle has no `node_modules`
3. Bundling the full CLI — `jsonc-parser`'s UMD branch emits a runtime `require("./impl/format")` that no bundler resolves statically; forcing `--conditions=module,import` does not change resolution

An entry importing only `src/lib/review-artifact-schema.ts` builds to a 0.50 MB self-contained file with zero dynamic requires, and returns correct verdicts and exit codes from a foreign working directory with nothing installed.

That drops the MCP server, the Node 20 floor bump, the npx launch pin, and the new runtime dependency the plan required.

## What changes

Frontmatter gains `status: superseded` with `superseded_at`, `superseded_by`, and `superseded_reason`, matching the convention already used by six other plans. A status blockquote after the frontmatter states the reversal and links the measurements. No plan content is removed.

`superseded_by` points at the learning doc rather than a successor plan, because that is what actually invalidated this one — the successor does not exist yet, and pointing at a file that is not there would be the same class of dangling reference this repository just fixed in #860.

## Verification

- `bun scripts/content-integrity.ts` — clean
- The relative link resolves from `docs/plans/`
- Plan status counts moved from 9 active / 6 superseded to 8 / 7

Documentation only.
