### PR TITLE
docs(solutions): record that a working capability has not named its cause

### DIFF
--- a/docs/solutions/workflow-issues/a-capability-that-works-has-not-named-its-cause-2026-08-24.md
+++ b/docs/solutions/workflow-issues/a-capability-that-works-has-not-named-its-cause-2026-08-24.md
@@ -1,0 +1,137 @@
+---
+title: A capability that works has not yet named its cause
+date: 2026-08-24
+category: workflow-issues
+module: claude-code-harness
+problem_type: workflow_issue
+component: development_workflow
+severity: high
+tags:
+  - negative-control
+  - capability-claim
+  - platform-boundary
+  - claude-code
+  - bin-path
+  - mechanism-isolation
+  - empirical-probing
+  - install-behavior
+applies_when:
+  - A design depends on a platform or harness not supporting something
+  - A positive probe result is being used to infer which component supplied a capability
+  - A measurement is being generalized past the exact path or environment it covered
+  - Deciding whether a limit belongs to the host or to your own build
+---
+
+# A capability that works has not yet named its cause
+
+## Context
+
+Three claims about what the Claude Code harness could not do were asserted in one session.
+All three were false, and each was actually this repository's own choice:
+
+| Claim | What was actually true |
+|---|---|
+| The bundle cannot run an executable | `scripts/build-claude-code-plugin.ts` emits only markdown. Nothing stops it emitting more. |
+| The workflow guard is impossible there | `PreToolUse`/`PostToolUse` observe and can block. The blocker is that `src/lib/workflow-guard.ts` holds state in-process. |
+| Reaching a bundled executable needs MCP | Marketplace install copies the whole directory and `bin/` lands on the Bash tool's `PATH`. |
+
+The first claim carried real cost. An MCP server, a Node version floor bump, an `npx` launch
+pin, and a new runtime dependency were designed on top of it, reviewed by six personas, and
+merged as a plan. One local install retired the whole thing.
+
+This repository already had the rule that would have prevented it:
+[Verify installed artifacts, not just build gates](./verify-installed-artifacts-not-just-build-gates-2026-07-18.md)
+said, five weeks earlier, *"Probe unproven runtime channels empirically before designing
+around them. Don't assume a host honors a mechanism."* It was tagged `claude-code` and
+`empirical-probing`, and it was not consulted.
+
+## Guidance
+
+A claim that a system *cannot* do something is a boundary claim, and your own build choices
+are easiest to mistake for the platform's right there. Before designing around one, name the
+boundary — build output, install behavior, process lifetime, hook visibility, transport, state
+persistence — and test that against the installed artifact.
+
+Then separate capability from implementation. "Claude Code cannot observe tool calls" is a
+capability claim; "our guard's in-process state cannot survive hook invocation" is a design
+problem with a cost.
+
+**A positive result does not identify a mechanism.** This is the operative half the earlier
+doc stops short of. A command that runs might be ambient. Confirm by removing the suspected
+cause and re-testing:
+
+```
+plugin installed    -> PROBE_BIN_RAN_OK marker=livetest   exit 0
+plugin uninstalled  -> command not found                  exit 127
+shell's own PATH    -> never present, either way
+```
+
+Only the pair proves the plugin put the command there; either line alone fits another
+explanation.
+
+Keep every measurement scoped to what it actually covered. Two builds on one machine under
+one toolchain are not reproducibility. A result about `process.cwd()`, which is
+realpath-resolved, says nothing about an injected root on a different code path.
+
+## Why This Matters
+
+A boundary mistake does not produce a small error. It produces architecture: a transport, a
+dependency, a version floor, and every failure mode those carry, all to route around a
+constraint that was never there. Review misses it because each step looks plausible — six
+personas reviewed the design without questioning the premise.
+
+Attribution errors are quieter and survive longer. An unverified capability keeps working
+right up until the thing actually responsible for it changes, and then the failure appears
+somewhere unrelated to the assumption that caused it.
+
+## When to Apply
+
+Whenever a design rests on a platform "not supporting" something. Whenever a probe comes back
+positive and is about to be written down as a property. Whenever a measurement is about to be
+stated more generally than the conditions it was taken under.
+
+The cost asymmetry is the whole argument. Probing install behavior took one local install.
+The design built on not probing it took a brainstorm, a plan, a six-persona review, and a
+merge — and then had to be retired.
+
+## Examples
+
+Before:
+
+> Claude Code bundles cannot run executables, so validation requires an MCP server.
+
+After:
+
+> The builder emits a static bundle, so executable support is untested. Build a minimal
+> bundled entry, install it, run it, then uninstall and run it again.
+
+Before:
+
+> Claude Code cannot observe or block workflow tools.
+
+After:
+
+> Its hooks can. The guard's in-process state has to be externalized before it survives
+> hook-driven invocation.
+
+Before:
+
+> A symlinked ancestor is never a problem.
+
+After:
+
+> `process.cwd()` is realpath-resolved on the path that was tested. An injected root is a
+> different path and needs its own test.
+
+## Related
+
+- [Verify installed artifacts, not just build gates](./verify-installed-artifacts-not-just-build-gates-2026-07-18.md)
+  — carries the probe-before-designing half of this rule, five weeks earlier. This doc adds
+  the mechanism-isolation half it stops short of.
+- [Entry-point scope decides what a plugin bundle can ship](../best-practices/entry-point-scope-decides-what-a-plugin-can-ship-2026-08-24.md)
+  — the measurements from this same arc, and what they said about packaging.
+- [A perfect measurement means a broken instrument](../best-practices/a-perfect-measurement-means-a-broken-instrument-2026-08-16.md)
+  — a clean result indicting the instrument. Adjacent: that one distrusts the result, this one
+  distrusts the attribution.
+- [Version-pinned evidence must be re-proven](../workflow-issues/version-pinned-evidence-must-be-reproven-2026-08-16.md)
+  — evidence and the version it was taken at move together.

--- a/docs/solutions/workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md
+++ b/docs/solutions/workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md
@@ -1,6 +1,7 @@
 ---
 title: Verify installed artifacts, not just build gates
 date: 2026-07-18
+last_updated: 2026-08-24
 category: workflow-issues
 module: claude-code-harness
 problem_type: workflow_issue
@@ -43,6 +44,8 @@ Concretely, for a generated/published artifact:
 
 **Probe unproven runtime channels empirically before designing around them.** Don't assume a host honors a mechanism. In this arc, probing the real Claude Desktop revealed that **imperative `SessionStart` hook content is refused as prompt injection**, while **declarative facts and the plugin output-style are honored** — which directly shaped the design (declarative hook, output-style enforcement). Verify the channel behaves as assumed before building on it.
 
+A probe that comes back positive has not finished the job. It shows the capability is reachable; it does not show what made it reachable, and an ambient cause looks identical to the one you intended. See [A capability that works has not yet named its cause](./a-capability-that-works-has-not-named-its-cause-2026-08-24.md) for the negative control that separates them — and for what it cost when this rule was available here and went unconsulted.
+
 **Close the class with a source-side gate where you can.** The arc also added a lexical skill-reference integrity check (`checkSkillReferenceIntegrity`, `SKILL_REF_REGEX = /\bce:([a-z0-9-]+)\b/g`) that fails when a `ce:<name>` reference has no matching `skills/ce-<name>/` directory — catching phantom references (`ce:debug`, `ce:polish-beta`) that had dangled on every harness.
 
 ## Why This Matters
@@ -74,6 +77,7 @@ Empirical channel finding that shaped the design: imperative hook content refuse
 
 ## Related
 
+- [A capability that works has not yet named its cause](./a-capability-that-works-has-not-named-its-cause-2026-08-24.md) — extends the probe rule above with mechanism isolation: removing the suspected cause to prove it was the cause.
 - [Pi real-runtime integration harness](../best-practices/pi-real-runtime-integration-harness-2026-07-16.md) — verify a packaged extension in the *real* host runtime, not against a fake SDK; same "installed artifact ≠ build output" spine.
 - [Cross-harness adapter parity contract tests](../best-practices/cross-harness-adapter-parity-contract-tests-2026-07-14.md) — don't mistake boundary/helper tests for runtime proof.
 - [Pi chained bootstrap composition](../logic-errors/pi-chained-bootstrap-composition-2026-07-14.md) — host-specific prompt composition; the imperative-vs-declarative channel distinction.


### PR DESCRIPTION
A knowledge-track learning from the arc that retired the MCP server plan in #867 and replaced it in #868, plus a bidirectional cross-link into the doc it extends.

## What it records

Three claims about what the Claude Code harness *cannot* do were asserted in one session. All three were false, and each described a choice in this repository rather than a limit of the host:

| Claim | What was actually true |
|---|---|
| The bundle cannot run an executable | The builder emits only markdown. Nothing stops it emitting more. |
| The workflow guard is impossible there | Its hooks observe and can block. The blocker is in-process state. |
| Reaching a bundled executable needs MCP | Install copies the whole directory and `bin/` lands on the Bash tool's `PATH`. |

The first cost a server, a Node floor bump, an `npx` pin, and a new runtime dependency — designed, six-persona reviewed, and merged as a plan before anyone measured the premise. One local install retired it.

## The part worth writing down

`docs/solutions/` already had the rule that would have prevented this. `verify-installed-artifacts-not-just-build-gates-2026-07-18.md`, written five weeks earlier, says *"Probe unproven runtime channels empirically before designing around them."* It is tagged `claude-code` and `empirical-probing`. It was not consulted.

So the new doc does not restate that half. It links it and adds what that doc stops short of: **a positive result does not identify a mechanism.**

```
plugin installed    -> PROBE_BIN_RAN_OK marker=livetest   exit 0
plugin uninstalled  -> command not found                  exit 127
shell's own PATH    -> never present, either way
```

Either line alone is consistent with the command being ambient. Only the pair establishes that the plugin put it there.

## Why the older doc changed too

It gains the pointer in both places a reader would want it — inline at the probe rule it extends, where someone is standing when they need the second half, and in its Related list. A cross-link that only exists in one direction gets found only by the reader who already knew to look. It also gains `last_updated`, matching the convention twelve other solution docs already use.

## Overlap handling

The Related Docs Finder scored `a-perfect-measurement-means-a-broken-instrument-2026-08-16.md` as High (4/5) while recommending a new doc in the same report — score and verdict contradicting each other. Scoring the five dimensions directly gives Low-to-Moderate: different problem statement, different root cause, partial overlap on approach and referenced files. That doc distrusts a *result*; this one distrusts an *attribution*.

The lane never surfaced the 07-18 doc at all, which is the genuine overlap. It was found by checking which docs share the `claude-code-harness` module value.

## Verification

- Frontmatter within limits — 8/8 tags, 4/5 `applies_when`
- Cross-links resolve in both directions
- `bun scripts/content-integrity.ts` — clean, 83 solution docs

Documentation only. No source or test changes.
