### PR TITLE
fix(skills): derive the overlap score from the dimension count

### DIFF
--- a/skills/ce-compound/SKILL.md
+++ b/skills/ce-compound/SKILL.md
@@ -133,7 +133,7 @@ Launch research subagents. Each returns text data to the orchestrator.
      - **Low**: 0-1 dimensions match — related but distinct
 
      The score is a function of the count, not a separate judgment about how related the docs feel. Two docs on the same topic that match on one dimension score Low. When the score you are inclined to write disagrees with the count, the count wins.
-   - Returns: Links, relationships, refresh candidates, and overlap assessment. State the per-dimension verdicts, then the resulting count, then the score, in that order. An assessment whose recommendation contradicts its own score — scoring High while recommending a new doc, for instance — is a defect in the assessment rather than a nuance in it. Re-derive it before returning.
+   - Returns: Links, relationships, refresh candidates, and overlap assessment. State the per-dimension verdicts, then the resulting count, then the score, in that order. Two consistency checks apply in sequence and both must hold: the score follows the count, and the recommendation follows the score. High overlap means update the existing doc, so an assessment that scores High while recommending a new doc has broken the second check even if the first one held. Either break is a defect to re-derive, not a nuance to note.
 
    **Search strategy (grep-first filtering for efficiency):**
 
@@ -142,7 +142,7 @@ Launch research subagents. Each returns text data to the orchestrator.
    3. Use the native content-search tool (e.g., Grep in OpenCode) to pre-filter candidate files BEFORE reading any content. Run multiple searches in parallel, case-insensitive, targeting frontmatter fields. These are template patterns -- substitute actual keywords:
       - `title:.*<keyword>`
       - `tags:.*(<keyword1>|<keyword2>)`
-      - `module:.*<module name>`
+      - `module:.*<module name>` — fill from the values enumerated in step 1, not from free-text keywords
       - `component:.*<component>`
    4. If search returns >25 candidates, re-run with more specific patterns. If <3, broaden to full content search
    5. Read only frontmatter (first 30 lines) of candidate files to score relevance

--- a/skills/ce-compound/SKILL.md
+++ b/skills/ce-compound/SKILL.md
@@ -127,15 +127,17 @@ Launch research subagents. Each returns text data to the orchestrator.
    - Identifies cross-references and links
    - Finds related GitHub issues
    - Flags any related learning or pattern docs that may now be stale, contradicted, or overly broad
-   - **Assesses overlap** with the new doc being created across five dimensions: problem statement, root cause, solution approach, referenced files, and prevention rules. Score as:
+   - **Assesses overlap** with the new doc being created across five dimensions: problem statement, root cause, solution approach, referenced files, and prevention rules. Judge each dimension as match or no-match first, then count the matches, then read the score off the count:
      - **High**: 4-5 dimensions match — essentially the same problem solved again
      - **Moderate**: 2-3 dimensions match — same area but different angle or solution
      - **Low**: 0-1 dimensions match — related but distinct
-   - Returns: Links, relationships, refresh candidates, and overlap assessment (score + which dimensions matched)
+
+     The score is a function of the count, not a separate judgment about how related the docs feel. Two docs on the same topic that match on one dimension score Low. When the score you are inclined to write disagrees with the count, the count wins.
+   - Returns: Links, relationships, refresh candidates, and overlap assessment. State the per-dimension verdicts, then the resulting count, then the score, in that order. An assessment whose recommendation contradicts its own score — scoring High while recommending a new doc, for instance — is a defect in the assessment rather than a nuance in it. Re-derive it before returning.
 
    **Search strategy (grep-first filtering for efficiency):**
 
-   1. Extract keywords from the problem context: module names, technical terms, error messages, component types
+   1. Extract keywords from the problem context: technical terms, error messages, component types. Separately, enumerate the `module:` values already in use across `docs/solutions/` and pick the one or two closest to this problem, rather than inferring a module name from the problem text. Module values are curated identifiers that often do not appear in a problem description at all, so keyword search alone will not find docs clustered under one — and docs sharing a module are among the highest-value candidates.
    2. If the problem category is clear, narrow search to the matching `docs/solutions/<category>/` directory
    3. Use the native content-search tool (e.g., Grep in OpenCode) to pre-filter candidate files BEFORE reading any content. Run multiple searches in parallel, case-insensitive, targeting frontmatter fields. These are template patterns -- substitute actual keywords:
       - `title:.*<keyword>`
@@ -422,6 +424,7 @@ What's next?
 
 Overlap detected: docs/solutions/performance-issues/n-plus-one-queries.md
   Matched dimensions: problem statement, root cause, solution, referenced files
+  Count: 4 of 5 -> High
   Action: Updated existing doc with fresher code examples and prevention tips
 
 File updated:


### PR DESCRIPTION
The `ce:compound` related-docs step scores how much a proposed learning overlaps an existing one across five named dimensions, and that score decides whether the round writes a new doc or updates an old one. It got that decision wrong four times in one session, in two distinct ways.

## Nothing connected the score to the dimensions

The rubric listed what each score means in terms of matched dimensions, but it read as description rather than calculation:

```
- **Assesses overlap** ... across five dimensions ... Score as:
  - **High**: 4-5 dimensions match
  - **Moderate**: 2-3 dimensions match
  - **Low**: 0-1 dimensions match
```

Nothing required the count to be stated, or the score to follow from it. So a report could judge the dimensions honestly and then assign a score by how related the two docs *felt*. The observed failure:

> **Headline score**: **High (4/5)** for the measurement doc, **not** a full duplicate
> ...
> - **Create a new doc** rather than updating the measurement doc alone.

High overlap means update the existing doc. The same report recommended creating a new one. Scoring the five dimensions directly gave Low-to-Moderate.

Dimensions are now judged first, counted, and the score read off the count — with the count stated in the returned assessment. When the two disagree, the count wins, and a recommendation contradicting its own score is named as a defect to re-derive rather than a nuance to live with.

## It could not find docs clustered under a shared module

The search step took its module name from keywords in the problem description:

```
1. Extract keywords from the problem context: module names, technical terms, ...
   - `module:.*<module name>`
```

But `module:` values are curated retrieval identifiers — `claude-code-harness`, `skill-authoring`, `docs-solutions`. A description of a problem has no reason to contain one, so the grep looks for a string that is not there.

The step now enumerates the module values actually in use and picks the closest. That is how the doc that mattered was eventually found — by hand, after the automated pass assessed six others and missed it. The missed doc had carried half the relevant rule for five weeks and was correctly tagged for exactly that situation.

## Worked example

The alternate-output sample listed four matched dimensions and updated the doc — internally consistent, but it never showed a count or score, so an agent copying it would omit exactly what the new rule requires. It now shows `Count: 4 of 5 -> High`.

## Verification

- `bun scripts/content-integrity.ts` — clean
- `bun run registry:drift` — up to date, 73 components
- `bun scripts/generate-pi-subagents-personas.ts --check` — up to date
- `tests/unit/compound-contract-parity.test.ts` — 4 pass, confirming `ce-compound-refresh` did not diverge
- Checked for other copies of this rubric across `skills/` — only one exists

One file, six insertions. No source or test changes.
