### PR TITLE
feat(claude-code): ship the bundled validator as an executable

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -313,6 +313,7 @@ jobs:
             "claude-code/skills/using-systematic/SKILL.md"
             "claude-code/output-styles/systematic.md"
             "claude-code/hooks/hooks.json"
+            "claude-code/bin/systematic-validate-review-artifact"
           )
           for f in "${required[@]}"; do
             if [[ ! -f "$f" ]]; then
@@ -320,6 +321,10 @@ jobs:
               exit 1
             fi
           done
+          if [[ ! -x "claude-code/bin/systematic-validate-review-artifact" ]]; then
+            echo "::error::Required artifact is not executable: claude-code/bin/systematic-validate-review-artifact"
+            exit 1
+          fi
           if ! find claude-code/agents -mindepth 1 -type f | grep -q .; then
             echo "::error::No files found under claude-code/agents/"
             exit 1

--- a/scripts/build-claude-code-plugin.ts
+++ b/scripts/build-claude-code-plugin.ts
@@ -590,7 +590,11 @@ export function writePluginFiles(
     for (const [relPath, content] of files) {
       const outPath = path.join(tempDir, relPath)
       fs.mkdirSync(path.dirname(outPath), { recursive: true })
-      fs.writeFileSync(outPath, content)
+      if (relPath.startsWith('bin/')) {
+        fs.writeFileSync(outPath, content, { mode: 0o755 })
+      } else {
+        fs.writeFileSync(outPath, content)
+      }
     }
   } catch (err) {
     fs.rmSync(tempDir, { recursive: true, force: true })

--- a/tests/unit/build-claude-code-plugin.test.ts
+++ b/tests/unit/build-claude-code-plugin.test.ts
@@ -630,6 +630,40 @@ describe('writePluginFiles — atomic staging write', () => {
     expect(fs.existsSync(path.join(outDir, 'agents/bar.md'))).toBe(true)
   })
 
+  test('writes bin entries with the executable bit set', () => {
+    const root = makeFixtureRepo()
+    writeUsingSystematicAndProfile(root)
+    writeSkill(root, 'foo', 'Foo skill.')
+
+    const outDir = path.join(root, 'out')
+    writePluginFiles(
+      new Map<string, Buffer>([
+        [`bin/${CLAUDE_CODE_VALIDATOR_BIN}`, Buffer.from('validator')],
+      ]),
+      outDir,
+    )
+
+    expect(
+      fs.statSync(path.join(outDir, `bin/${CLAUDE_CODE_VALIDATOR_BIN}`)).mode &
+        0o111,
+    ).toBe(0o111)
+  })
+
+  test('keeps non-bin entries at the default file mode', () => {
+    const root = makeFixtureRepo()
+    const outDir = path.join(root, 'out')
+
+    writePluginFiles(
+      new Map<string, Buffer>([['regular.txt', Buffer.from('regular')]]),
+      outDir,
+    )
+
+    const expectedMode = 0o666 & ~process.umask()
+    expect(fs.statSync(path.join(outDir, 'regular.txt')).mode & 0o777).toBe(
+      expectedMode,
+    )
+  })
+
   test('leaves no stray staging temp dir or backup dir behind after a successful write', () => {
     const root = makeFixtureRepo()
     writeUsingSystematicAndProfile(root)
@@ -839,6 +873,10 @@ describe('build — real repo, temp dir', () => {
       expect(
         fs.existsSync(path.join(tempOut, '.claude-plugin/plugin.json')),
       ).toBe(true)
+      expect(
+        fs.statSync(path.join(tempOut, `bin/${CLAUDE_CODE_VALIDATOR_BIN}`))
+          .mode & 0o111,
+      ).toBe(0o111)
     } finally {
       fs.rmSync(tempOut, { recursive: true, force: true })
     }


### PR DESCRIPTION
Units 2 and 3 of `docs/plans/2026-08-24-001-feat-claude-code-bundled-validator-plan.md`. They ship together because they are the same defect from two sides — the fix, and the thing that catches its absence.

## The problem

`writePluginFiles` created every bundle file with `fs.writeFileSync(outPath, content)` and no mode, so the validator #871 added arrived as `-rw-r--r--`:

```
$ stat -f '%Sp' claude-code/bin/systematic-validate-review-artifact
-rw-r--r--
```

A command that can only be invoked by naming an interpreter in front of it is not reachable as a bare command, which is the whole reason it lives in `bin/`.

## What changed

Entries under `bin/` are written `0o755`. Nothing else changes mode — restoring source modes across the whole bundle is a broader behavior change with no demand behind it, since bundled skill scripts are invoked as `bash <path>` by design.

The pre-publish guard gains the entry and checks that it is **executable**, not merely present:

```yaml
+            "claude-code/bin/systematic-validate-review-artifact"
+          if [[ ! -x "claude-code/bin/systematic-validate-review-artifact" ]]; then
+            echo "::error::Required artifact is not executable: ..."
+            exit 1
+          fi
```

Presence was never the interesting property. The failure this guards against produces a file that exists, passes every other check, and cannot run. That job pushes to the branch users install from.

## Verification

Gates: typecheck clean, `content-integrity` clean, **1987 pass / 0 fail** (+2). Lint matches the clean-`main` baseline exactly — 17 warnings, 3 infos, zero errors.

Mode, verified on the real build and after `cp -p` to a directory outside the repository:

| File | Mode |
|---|---|
| `bin/systematic-validate-review-artifact` | `-rwxr-xr-x` |
| `hooks/hooks.json` (control) | `-rw-r--r--` |

Executed **as a bare command** — `./systematic-validate-review-artifact <path>`, no interpreter named:

| Input | Exit |
|---|---|
| valid | 0 |
| invalid | 1 |
| legacy | 3 |
| malformed JSON | 2 |
| missing file | 2 |

Invoking it through `node` would have passed even with the bit missing. That is the false green this unit exists to remove, so the check deliberately does not use one.

Guard proven in both directions:

```
with +x:     guard passed
without +x:  ::error::Required artifact is not executable
restored:    guard passed
```

## Remaining

Units 4 and 5 — the contract reachability wording and correcting the doc that still claims the bundle carries no executable.
