### PR TITLE
docs(ce-review): state how the parent reaches the artifact validator

### DIFF
--- a/docs/plans/2026-08-24-001-feat-claude-code-bundled-validator-plan.md
+++ b/docs/plans/2026-08-24-001-feat-claude-code-bundled-validator-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: Ship the review-artifact validator in the Claude Code bundle'
 type: feat
-status: active
+status: completed
 date: 2026-08-24
 origin: docs/brainstorms/2026-08-23-claude-code-mcp-server-requirements.md
 ---
@@ -246,7 +246,7 @@ change and are recorded in Scope Boundaries.
 
 ## Implementation Units
 
-- [ ] **Unit 1: Build the validator entry and add it to the bundle**
+- [x] **Unit 1: Build the validator entry and add it to the bundle**
 
 **Goal:** The bundle contains a runnable validator executable.
 
@@ -300,7 +300,7 @@ codemap and `src/lib/AGENTS.md` module-table obligations, both gate-enforced by
 - Running the built artifact against a valid and an invalid artifact returns the same
   verdicts and exit codes as the CLI subcommand.
 
-- [ ] **Unit 2: Preserve the executable bit when writing the bundle**
+- [x] **Unit 2: Preserve the executable bit when writing the bundle**
 
 **Goal:** The shipped executable is executable.
 
@@ -327,7 +327,7 @@ codemap and `src/lib/AGENTS.md` module-table obligations, both gate-enforced by
 - `stat` on the built `bin/` entry shows an executable mode.
 - Existing bundle tests still pass unchanged.
 
-- [ ] **Unit 3: Assert the executable before publishing**
+- [x] **Unit 3: Assert the executable before publishing**
 
 **Goal:** A build that lost the executable cannot reach the branch users install from.
 
@@ -356,7 +356,7 @@ codemap and `src/lib/AGENTS.md` module-table obligations, both gate-enforced by
 - On a real install, the bundled command runs as a bare command in a Bash tool call. Confirmed
   at Claude Code 2.1.163; re-confirm when the host major version moves.
 
-- [ ] **Unit 4: State reachability in the contract**
+- [x] **Unit 4: State reachability in the contract**
 
 **Goal:** The parent knows how to reach the validator on Claude Code, and what to record when
 it cannot.
@@ -389,7 +389,7 @@ it cannot.
 - `bun scripts/content-integrity.ts` is clean.
 - The contract no longer claims a bundled-markdown harness cannot have the executable.
 
-- [ ] **Unit 5: Correct the stale no-executable claim**
+- [x] **Unit 5: Correct the stale no-executable claim**
 
 **Goal:** No shipped doc asserts the bundle carries no executable.
 

--- a/docs/solutions/best-practices/entry-point-scope-decides-what-a-plugin-can-ship-2026-08-24.md
+++ b/docs/solutions/best-practices/entry-point-scope-decides-what-a-plugin-can-ship-2026-08-24.md
@@ -1,6 +1,7 @@
 ---
 title: Entry-point scope decides what a plugin bundle can ship
 date: 2026-08-24
+last_updated: 2026-08-24
 category: best-practices
 module: claude-code-harness
 problem_type: tooling_decision
@@ -136,4 +137,4 @@ cd / && .../bin/systematic-validate '{"schema_version":1}'
 
 - [Build and publish a harness plugin from CI instead of committing it](./claude-code-plugin-build-and-publish-architecture-2026-07-18.md) — the build and publish topology this packaging decision sits inside
 - [Verify installed artifacts, not just build gates](../workflow-issues/verify-installed-artifacts-not-just-build-gates-2026-07-18.md) — the general form of the probe used here
-- [An unvalidated artifact contract has no conforming producers](./unvalidated-artifact-contracts-have-no-conforming-producers-2026-08-23.md) — states that the bundle carries no executable, which this qualifies as a build choice rather than a property
+- [An unvalidated artifact contract has no conforming producers](./unvalidated-artifact-contracts-have-no-conforming-producers-2026-08-23.md) — explains why artifact contracts need runtime-checkable availability conditions; the Claude Code bundle now ships its own validator alongside the prose

--- a/docs/solutions/best-practices/unvalidated-artifact-contracts-have-no-conforming-producers-2026-08-23.md
+++ b/docs/solutions/best-practices/unvalidated-artifact-contracts-have-no-conforming-producers-2026-08-23.md
@@ -1,7 +1,7 @@
 ---
 title: An artifact contract with no validated write path has no conforming producers
 date: 2026-08-23
-last_updated: 2026-08-23
+last_updated: 2026-08-24
 category: best-practices
 module: ce-review
 problem_type: best_practice
@@ -124,10 +124,10 @@ validation went into `src/cli.ts` at zero dependency cost.
 
 The second half of that rule cost a follow-up fix. Placing the validator correctly does
 not mean every reader of the contract can run it. Bundled instruction prose is copied
-into all three harness packages, but the `bin` entry only reaches the ones that install
-the npm package — the Claude Code bundle is built deliberately without npm coupling and
-carries no executable. A contract sentence naming a command therefore has a reach the
-contract file itself does not.
+into all three harness packages, but the npm `bin` entry only reaches the ones that install
+the npm package — the Claude Code bundle is built deliberately without npm coupling but
+ships its own validator executable. A contract sentence naming a command therefore has a
+reach the contract file itself does not.
 
 Write the instruction as a condition the agent can check at runtime rather than an
 unconditional command, and say what to record when the condition fails. A list of

--- a/skills/ce-review/references/synthesis-artifact-contract.md
+++ b/skills/ce-review/references/synthesis-artifact-contract.md
@@ -210,15 +210,27 @@ validating it. This ordering makes the artifact validatable at all: without
 `schema_version`, the validator reports the legacy status (exit 3) rather than
 a real validation result.
 
-After writing `review-summary.json`, the parent checks whether the
-`systematic` executable is available on the invoking environment's `PATH`.
-When it is available, the parent runs
-`systematic validate-review-artifact <path>` against it. The executable ships
-through the npm package's `bin` entry; a harness that installs bundled
-markdown without that package will not have it. When it is unavailable, the
-parent records `validation.status: "unavailable"` and a `validation.reason` in
-the run record. When the executable is available and the parent does not run
-it, that is `validation.status: "not_attempted"`, also with a reason. The
+After writing `review-summary.json`, the parent resolves and runs a validator
+in this order: the bundled `systematic-validate-review-artifact <path>` command
+first, then the npm-installed `systematic validate-review-artifact <path>`
+command. Both can be present at once. The bundled command ships beside the
+prose being executed, so it is the one whose behavior matches the contract.
+The parent runs the first command it resolves and reads its result; it does not
+merely test whether a name is on `PATH`, because a version-manager shim can be
+present there and fail on every invocation.
+
+The command runs from the repository root. Containment resolves
+`.context/systematic/ce-review` relative to the working directory. If it runs
+elsewhere, the CLI reports that the directory is unavailable and the parent
+records that reason. This is visible degradation rather than silent success,
+so it is acceptable. If neither command is available, the parent records
+`validation.status: "unavailable"` with a reason that the validator is absent.
+If a resolved command is present but cannot be started or otherwise fails
+before returning a validation result, the parent records the same status with
+a distinct invocation-failure reason. Neither case is `failed`: that value is
+reserved for a validator that ran and found that the artifact did not conform.
+When a validator is available and the parent does not run it, that is
+`validation.status: "not_attempted"`, also with a reason. The
 `validation.status` values are `passed`, `failed`, `unavailable`, and
 `not_attempted`; `validation.reason` is required for every status except
 `passed`, where it is forbidden.


### PR DESCRIPTION
Units 4 and 5 of `docs/plans/2026-08-24-001-feat-claude-code-bundled-validator-plan.md`, completing it.

**Merge #872 first.** That PR ships the executable bit. Landing this prose ahead of it would tell the parent to run a command that is present and unrunnable — the ordering hazard the plan names explicitly.

## Unit 4 — reachability in the contract

`skills/ce-review/references/synthesis-artifact-contract.md` said the parent checks whether `systematic` is on `PATH`, and that the executable "ships through the npm package's `bin` entry; a harness that installs bundled markdown without that package will not have it."

True when written. False now — the Claude Code bundle ships `bin/systematic-validate-review-artifact` beside the prose that names it. Leaving it would reintroduce the #851 defect inverted.

The revision establishes four things:

- **Resolution order, stated.** Bundled command first, then the npm subcommand. Both can be present; the bundled one travels with the contract being executed, so its behavior matches what the contract describes.
- **Run it, don't test for presence.** A name on `PATH` can be a shim that fails on every invocation — documented in `docs/solutions/integration-issues/availability-guards-must-check-executability-2026-08-16.md`.
- **Absent and present-but-broken are distinct reasons.** Both record `validation.status: "unavailable"`; neither is ever `failed`, which means an artifact was read and did not conform. A validator that could not run has said nothing about the artifact.
- **It runs from the repository root**, where `.context/` lives. Elsewhere the CLI reports the directory unavailable and that reason is recorded — visible, not silent.

The `validation.status` contract is unchanged: `passed`, `failed`, `unavailable`, `not_attempted`, with `reason` required for all but `passed`.

### One plan gap, decided

The plan did not say what happens when the bundled command resolves but fails to run. It does **not** fall through to the npm subcommand — that would answer with a version that may not match the prose being executed, which is exactly what the separate command name exists to prevent. It records `unavailable` with a distinct reason.

## Unit 5 — the stale premise

Two shipped learnings claimed the bundle carries no executable:

| Doc | Fix |
|---|---|
| `unvalidated-artifact-contracts-have-no-conforming-producers-2026-08-23.md:128-129` | Premise corrected |
| `entry-point-scope-decides-what-a-plugin-can-ship-2026-08-24.md:139` | Related-note rewritten |

The second was flagged by the implementer rather than named in the plan, and belongs here — a live learning asserting something false is the same defect Unit 5 exists to fix. Historical plan files keep their claims; a plan is a record of what was believed at the time.

In both, only the premise changed. Each doc's actual recommendation — write instructions as runtime-checkable conditions — survives and is strengthened, since an availability check is correct whether or not an executable ships. Both gained `last_updated: 2026-08-24`, matching the convention twelve other solution docs use.

## Verification

- `bun scripts/content-integrity.ts` — clean
- `bun run registry:drift` — up to date, 73 components
- `bun scripts/generate-pi-subagents-personas.ts --check` — up to date
- `tests/unit/compound-contract-parity.test.ts` — 4 pass, confirming `ce-compound-refresh` did not diverge
- Lint matches the clean-`main` baseline — 17 warnings, 3 infos, zero errors
- Frontmatter within limits on both edited docs; every relative link resolves

Documentation only. No source or test changes.
