### PR TITLE
ci(renovate): regenerate Zod-derived schemas in post-upgrade tasks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -78,10 +78,10 @@
   postUpgradeTasks: {
     // `bun run fix` runs Biome lint --fix to auto-correct formatting drift.
     // `bun run postupgrade` regenerates every artifact derived from a dependency:
-    // skills/agent-browser/SKILL.md from the pinned agent-browser package, and the
-    // config and review-summary JSON schemas from zod's toJSONSchema output. A bump
-    // that changes any of them lands the regenerated file in the same Renovate PR
-    // instead of failing the drift gates.
+    // skills/agent-browser/SKILL.md from the pinned package, then registry/registry.jsonc
+    // from skill/agent frontmatter, plus the config/review-summary JSON schemas from
+    // zod's toJSONSchema output. A bump that changes any of them lands the regenerated
+    // file in the same Renovate PR instead of failing the drift gates.
     commands: ['bun install', 'bun run fix', 'bun run postupgrade'],
     executionMode: 'branch',
   },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -77,9 +77,11 @@
   ],
   postUpgradeTasks: {
     // `bun run fix` runs Biome lint --fix to auto-correct formatting drift.
-    // `bun run postupgrade` regenerates all necessary build artifacts, including
-    // skills/agent-browser/SKILL.md from the pinned package so an agent-browser
-    // bump lands the new stub in the same Renovate PR.
+    // `bun run postupgrade` regenerates every artifact derived from a dependency:
+    // skills/agent-browser/SKILL.md from the pinned agent-browser package, and the
+    // config and review-summary JSON schemas from zod's toJSONSchema output. A bump
+    // that changes any of them lands the regenerated file in the same Renovate PR
+    // instead of failing the drift gates.
     commands: ['bun install', 'bun run fix', 'bun run postupgrade'],
     executionMode: 'branch',
   },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "registry:drift": "bun scripts/generate-registry.ts --check",
     "registry:validate": "bun scripts/build-registry.ts --validate-only",
     "claude-code:build": "bun scripts/build-claude-code-plugin.ts",
-    "postupgrade": "bun run build && bun run agent-browser:build && bun run schema:generate && bun run review-schema:generate",
+    "postupgrade": "bun run build && bun run agent-browser:build && bun run schema:generate && bun run review-schema:generate && bun scripts/generate-registry.ts",
     "prepublishOnly": "bun run build && bun run schema:generate"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "registry:drift": "bun scripts/generate-registry.ts --check",
     "registry:validate": "bun scripts/build-registry.ts --validate-only",
     "claude-code:build": "bun scripts/build-claude-code-plugin.ts",
-    "postupgrade": "bun run build && bun run agent-browser:build",
+    "postupgrade": "bun run build && bun run agent-browser:build && bun run schema:generate && bun run review-schema:generate",
     "prepublishOnly": "bun run build && bun run schema:generate"
   },
   "keywords": [


### PR DESCRIPTION
Renovate PR #891 (zod 4.4.3 → 4.5.4) arrived with a failing Build check: `skills/ce-review/references/review-summary-schema.json is out of date`. The bump changed `z.toJSONSchema()` output and nothing in the Renovate pass regenerated the committed schema.

`postUpgradeTasks` already runs `bun run postupgrade`, but that script only rebuilt `dist/` and the agent-browser stub. This adds `schema:generate` and `review-schema:generate` to it, so a dependency bump that changes generated schema output ships the regenerated file in the same PR.

Verified in a worktree at the pinned zod: `bun run postupgrade` exits 0 and changes no generated file; both `schema:drift` and `review-schema:drift` pass; lint 0 errors; the two schema generator test files pass (93/93).

Live test after merge: rebasing #891 should turn it green with no manual commit.
