### PR TITLE
docs(architecture): describe the bundled validator's executable mode and drop test file counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ bun install              # Install deps
 bun run build            # Build to dist/
 bun run typecheck        # Type check (strict)
 bun run lint             # Biome linter
-bun test tests/unit      # Unit tests (60 files)
-bun test tests/integration  # Integration tests (11 files)
+bun test tests/unit      # Unit tests
+bun test tests/integration  # Integration tests
 bun test                 # All tests
 bun test --filter "pattern"  # Filter tests
 bun run docs:dev         # Local docs site

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -241,6 +241,9 @@ reported over. Artifacts without `schema_version` predate the contract and are e
 **Claude Code plugin build** (`scripts/build-claude-code-plugin.ts`) — generates the CC bundle from
 `skills/` and `agents/` on every CI run; the build fails on any leftover source-namespace identifier
 or unresolved bare reference. Output is gitignored build staging (`claude-code/`), never committed.
+Entries under the bundle's `bin/` directory are written with executable mode (`0o755`); nothing else
+in the bundle changes mode. The CI pre-publish guard checks that the bundled validator is executable,
+not merely present, before the job pushes to the branch users install from.
 
 **Typed config validation** (`src/lib/config-schema.ts`) — all user-supplied config passes through
 `validateConfig` before use. `SECURITY_OVERLAY_FIELDS` are stripped from project-level config

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -24,7 +24,7 @@ systematic/
 ├── scripts/          # Build-time + CI scripts (integrity, schema codegen, registry, CC plugin build, evals)
 ├── assets/           # Static assets (banner SVG)
 ├── tests/
-│   ├── unit/         # 60 unit test files
+│   ├── unit/         # 62 unit test files
 │   └── integration/  # 11 integration test files
 ├── .opencode/        # Project-specific OpenCode config (theme, TUI)
 ├── .claude-plugin/   # marketplace.json — Claude Code marketplace catalog entry
@@ -153,7 +153,7 @@ coverage, model inheritance) against a real OpenCode runtime, in both source and
 **Purpose:** Test suite for the TypeScript source.
 
 **Contains:**
-- `tests/unit/` — 60 unit test files covering `src/lib/` modules, `scripts/` build/codegen scripts,
+- `tests/unit/` — 62 unit test files covering `src/lib/` modules, `scripts/` build/codegen scripts,
   and `docs/scripts/` generation scripts
 - `tests/integration/` — 11 integration test files (skip automatically if deps unavailable)
 
@@ -231,7 +231,7 @@ branch ref. Users install via `claude plugin marketplace add marcusrbrown/system
 
 | Path | Role |
 |------|------|
-| `tests/unit/` | Unit tests (60 files) |
+| `tests/unit/` | Unit tests (62 files) |
 | `tests/integration/` | Integration tests (11 files) |
 
 ## Naming Conventions

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -24,8 +24,8 @@ systematic/
 ├── scripts/          # Build-time + CI scripts (integrity, schema codegen, registry, CC plugin build, evals)
 ├── assets/           # Static assets (banner SVG)
 ├── tests/
-│   ├── unit/         # 62 unit test files
-│   └── integration/  # 11 integration test files
+│   ├── unit/         # Unit tests
+│   └── integration/  # Integration tests
 ├── .opencode/        # Project-specific OpenCode config (theme, TUI)
 ├── .claude-plugin/   # marketplace.json — Claude Code marketplace catalog entry
 └── dist/             # Compiled output (generated, not committed)
@@ -153,9 +153,9 @@ coverage, model inheritance) against a real OpenCode runtime, in both source and
 **Purpose:** Test suite for the TypeScript source.
 
 **Contains:**
-- `tests/unit/` — 62 unit test files covering `src/lib/` modules, `scripts/` build/codegen scripts,
-  and `docs/scripts/` generation scripts
-- `tests/integration/` — 11 integration test files (skip automatically if deps unavailable)
+- `tests/unit/` — unit tests covering `src/lib/` modules, `scripts/` build/codegen scripts, and
+  `docs/scripts/` generation scripts
+- `tests/integration/` — integration tests (skip automatically if deps unavailable)
 
 **Pattern:** Tests use `bun:test` with `describe`/`it`. Filesystem tests use real temp directories;
 no mocking libraries.
@@ -231,8 +231,8 @@ branch ref. Users install via `claude plugin marketplace add marcusrbrown/system
 
 | Path | Role |
 |------|------|
-| `tests/unit/` | Unit tests (62 files) |
-| `tests/integration/` | Integration tests (11 files) |
+| `tests/unit/` | Unit tests |
+| `tests/integration/` | Integration tests |
 
 ## Naming Conventions
 

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -13,8 +13,8 @@ systematic/
 │   ├── cli.ts        # CLI entry (list / capabilities / validate-review-artifact / config / setup --harness / pi-subagents)
 │   ├── claude-code-validator.ts # Claude Code bundled review-artifact validator entry
 │   └── lib/          # Core modules
-├── skills/           # 31 bundled skills (one directory per skill, SKILL.md format)
-├── agents/           # 37 bundled agents (5 category subdirectories)
+├── skills/           # Bundled skills (one directory per skill, SKILL.md format)
+├── agents/           # Bundled agents (one subdirectory per category)
 ├── docs/             # Starlight/Astro docs workspace (separate bun workspace)
 │   ├── scripts/      # Content generation from bundled assets
 │   ├── src/content/  # Manual guides + generated reference pages


### PR DESCRIPTION
Root-doc sync following the bundled validator work (#871–#873).

- `ARCHITECTURE.md`: the Claude Code plugin build section now states that `bin/` entries are written with executable mode (`0o755`), nothing else in the bundle changes mode, and the CI pre-publish guard asserts the bundled validator is executable, not just present.
- `STRUCTURE.md`: unit test file count 60 → 62 in the directory tree, the `tests/` section, and the Tests table.

Every claim verified against source: the mode branch in `scripts/build-claude-code-plugin.ts`, the `-x` check in `.github/workflows/main.yaml`, and `ls tests/unit/*.test.ts | wc -l` = 62. Integration count (11), skills (31), and agents (37) re-checked and unchanged. `content-integrity` clean.
