### PR TITLE
test(claude-code): build the real validator bundle in the integration suite

### DIFF
--- a/scripts/build-claude-code-plugin.ts
+++ b/scripts/build-claude-code-plugin.ts
@@ -629,7 +629,7 @@ export function writePluginFiles(
   }
 }
 
-async function buildValidatorBundle(rootDir: string): Promise<Buffer> {
+export async function buildValidatorBundle(rootDir: string): Promise<Buffer> {
   const result = await Bun.build({
     entrypoints: [path.join(rootDir, 'src/claude-code-validator.ts')],
     minify: true,

--- a/tests/integration/claude-code.test.ts
+++ b/tests/integration/claude-code.test.ts
@@ -29,7 +29,7 @@
  * touches the build script or its inputs. That gate is a manual step, never an
  * automated skip that would masquerade as a passing test.
  */
-import { afterAll, describe, expect, it, test } from 'bun:test'
+import { afterAll, describe, expect, test } from 'bun:test'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -38,6 +38,7 @@ import {
   buildHookFacts,
   buildOutputStyleContent,
   buildValidatorBundle,
+  CLAUDE_CODE_VALIDATOR_BIN,
   generatePluginFiles,
   HOOK_PAYLOAD_CAP,
   writePluginFiles,
@@ -114,20 +115,6 @@ afterAll(() => {
 // ---------------------------------------------------------------------------
 
 describe('claude-code bundle — shared-core content fidelity', () => {
-  it('generated validator file preserves the real bundle after its shebang', () => {
-    const files = generatePluginFiles(REPO_ROOT, VALIDATOR_BUNDLE)
-    const validator = files.get('bin/systematic-validate-review-artifact')
-    const shebang = '#!/usr/bin/env node\n'
-
-    expect(validator).toBeDefined()
-    expect(validator?.subarray(0, Buffer.byteLength(shebang)).toString()).toBe(
-      shebang,
-    )
-    expect(validator?.subarray(Buffer.byteLength(shebang))).toEqual(
-      VALIDATOR_BUNDLE,
-    )
-  })
-
   test('output-style body contains a distinctive using-systematic enforcement line', () => {
     const content = fs.readFileSync(
       path.join(BUILD_DIR, 'output-styles/systematic.md'),
@@ -226,6 +213,24 @@ describe('claude-code bundle — shared-core content fidelity', () => {
 // ---------------------------------------------------------------------------
 
 describe('claude-code bundle — artifact self-containment', () => {
+  test('generated validator file preserves the real bundle after its shebang and is installed executable', () => {
+    const shebang = '#!/usr/bin/env node\n'
+    const validatorPath = path.join(
+      BUILD_DIR,
+      `bin/${CLAUDE_CODE_VALIDATOR_BIN}`,
+    )
+    const validator = fs.readFileSync(validatorPath)
+
+    expect(VALIDATOR_BUNDLE.length).toBeGreaterThan(0)
+    expect(validator.subarray(0, Buffer.byteLength(shebang)).toString()).toBe(
+      shebang,
+    )
+    expect(validator.subarray(Buffer.byteLength(shebang))).toEqual(
+      VALIDATOR_BUNDLE,
+    )
+    expect(fs.statSync(validatorPath).mode & 0o111).not.toBe(0)
+  })
+
   test('.claude-plugin/plugin.json exists, is valid JSON, has a name, no version, and author object', () => {
     const manifestPath = path.join(BUILD_DIR, '.claude-plugin/plugin.json')
     expect(fs.existsSync(manifestPath)).toBe(true)

--- a/tests/integration/claude-code.test.ts
+++ b/tests/integration/claude-code.test.ts
@@ -29,7 +29,7 @@
  * touches the build script or its inputs. That gate is a manual step, never an
  * automated skip that would masquerade as a passing test.
  */
-import { afterAll, describe, expect, test } from 'bun:test'
+import { afterAll, describe, expect, it, test } from 'bun:test'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -37,6 +37,7 @@ import { fileURLToPath } from 'node:url'
 import {
   buildHookFacts,
   buildOutputStyleContent,
+  buildValidatorBundle,
   generatePluginFiles,
   HOOK_PAYLOAD_CAP,
   writePluginFiles,
@@ -46,6 +47,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const REPO_ROOT = path.resolve(__dirname, '../..')
 const SRC_DIR = path.join(REPO_ROOT, 'src')
+const VALIDATOR_BUNDLE = await buildValidatorBundle(REPO_ROOT)
 
 /**
  * Manual, non-automated release gate. Re-run these steps by hand in Claude
@@ -89,7 +91,9 @@ function listSourceAgentStems(): string[] {
   for (const category of categories) {
     const categoryDir = path.join(agentsDir, category.name)
     for (const file of fs.readdirSync(categoryDir)) {
-      if (file.endsWith('.md')) stems.push(path.basename(file, '.md'))
+      if (file.endsWith('.md') && file.toLowerCase() !== 'readme.md') {
+        stems.push(path.basename(file, '.md'))
+      }
     }
   }
   return stems.sort((a, b) => a.localeCompare(b))
@@ -99,7 +103,7 @@ function listSourceAgentStems(): string[] {
 const BUILD_DIR = fs.mkdtempSync(
   path.join(os.tmpdir(), 'claude-code-integration-'),
 )
-writePluginFiles(generatePluginFiles(REPO_ROOT), BUILD_DIR)
+writePluginFiles(generatePluginFiles(REPO_ROOT, VALIDATOR_BUNDLE), BUILD_DIR)
 
 afterAll(() => {
   fs.rmSync(BUILD_DIR, { recursive: true, force: true })
@@ -110,6 +114,20 @@ afterAll(() => {
 // ---------------------------------------------------------------------------
 
 describe('claude-code bundle — shared-core content fidelity', () => {
+  it('generated validator file preserves the real bundle after its shebang', () => {
+    const files = generatePluginFiles(REPO_ROOT, VALIDATOR_BUNDLE)
+    const validator = files.get('bin/systematic-validate-review-artifact')
+    const shebang = '#!/usr/bin/env node\n'
+
+    expect(validator).toBeDefined()
+    expect(validator?.subarray(0, Buffer.byteLength(shebang)).toString()).toBe(
+      shebang,
+    )
+    expect(validator?.subarray(Buffer.byteLength(shebang))).toEqual(
+      VALIDATOR_BUNDLE,
+    )
+  })
+
   test('output-style body contains a distinctive using-systematic enforcement line', () => {
     const content = fs.readFileSync(
       path.join(BUILD_DIR, 'output-styles/systematic.md'),
@@ -319,7 +337,7 @@ describe('claude-code bundle — no regression on OpenCode/Pi', () => {
       path.join(os.tmpdir(), 'claude-code-build-isolated-'),
     )
     try {
-      const files = generatePluginFiles(REPO_ROOT)
+      const files = generatePluginFiles(REPO_ROOT, VALIDATOR_BUNDLE)
       writePluginFiles(files, tempOut)
 
       expect(fs.readFileSync(indexPath, 'utf8')).toBe(beforeIndex)

--- a/tests/integration/claude-code.test.ts
+++ b/tests/integration/claude-code.test.ts
@@ -228,7 +228,7 @@ describe('claude-code bundle — artifact self-containment', () => {
     expect(validator.subarray(Buffer.byteLength(shebang))).toEqual(
       VALIDATOR_BUNDLE,
     )
-    expect(fs.statSync(validatorPath).mode & 0o111).not.toBe(0)
+    expect(fs.statSync(validatorPath).mode & 0o111).toBe(0o111)
   })
 
   test('.claude-plugin/plugin.json exists, is valid JSON, has a name, no version, and author object', () => {


### PR DESCRIPTION
`tests/integration/claude-code.test.ts` has failed on `main` since the bundled validator landed: `generatePluginFiles` gained a required second argument (the built validator `Buffer`) and the integration suite still called it with one, so module load threw `TypeError: The "list[1]" argument must be an instance of Buffer or Uint8Array` at `scripts/build-claude-code-plugin.ts:534` before any test ran. The unit suite passes a placeholder bundle; the integration suite is the real build and now uses the real one.

Changes:
- `buildValidatorBundle` is exported so the suite can build the bundle once at module load.
- Both `generatePluginFiles` call sites pass it.
- New assertion: the generated `bin/systematic-validate-review-artifact` is exactly one `#!/usr/bin/env node` line followed by the bundle bytes.
- Agent stem discovery skips `agents/review/README.md`, which the build already excludes — a second latent failure hidden behind the TypeError.

Verified: `bun test tests/integration/claude-code.test.ts` 18 pass / 0 fail (this file needs no `opencode`); unit build tests 48 pass; typecheck, lint (0 errors), content-integrity clean.
