### PR TITLE
test(integration): reap OpenCode host process groups after every run

### DIFF
--- a/scripts/eval-cases/opencode.ts
+++ b/scripts/eval-cases/opencode.ts
@@ -1236,7 +1236,22 @@ async function startOpencodeHost(
     },
   )
   activeOpencodeChildren.add(child)
-  child.once('exit', () => activeOpencodeChildren.delete(child))
+  child.once('exit', () => {
+    const pid = child.pid
+    if (pid === undefined) {
+      activeOpencodeChildren.delete(child)
+      return
+    }
+    // A pgid cannot be recycled while its group has members, so this is a safe
+    // ownership probe. Only evict once the group is actually empty; otherwise
+    // the launcher exited but the opencode grandchild is still alive and
+    // needs to stay reachable for cleanup.
+    try {
+      process.kill(-pid, 0)
+    } catch {
+      activeOpencodeChildren.delete(child)
+    }
+  })
   const markerPath = process.env.SYSTEMATIC_EVAL_STARTED_CHILD_MARKER
   if (markerPath) {
     try {

--- a/scripts/eval-cases/opencode.ts
+++ b/scripts/eval-cases/opencode.ts
@@ -1205,18 +1205,44 @@ function buildProviderConfig(
   })
 }
 
-function stopChildProcess(child: ChildProcess): Promise<void> {
+function signalProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
+  const pid = child.pid
+  if (pid === undefined) {
+    try {
+      child.kill(signal)
+    } catch {
+      // Cleanup is best effort; the process may already be gone.
+    }
+    return
+  }
+
+  try {
+    process.kill(-pid, signal)
+  } catch {
+    try {
+      child.kill(signal)
+    } catch {
+      // Cleanup is best effort; the process may already be gone.
+    }
+  }
+}
+
+async function stopChildProcess(child: ChildProcess): Promise<void> {
   if (child.exitCode !== null) return Promise.resolve()
-  return new Promise((resolve) => {
-    const timeout = setTimeout(() => {
-      child.kill('SIGKILL')
-      resolve()
-    }, 5_000)
-    child.once('exit', () => {
+  await new Promise<void>((resolve) => {
+    let settled = false
+    const finish = (): void => {
+      if (settled) return
+      settled = true
       clearTimeout(timeout)
       resolve()
-    })
-    child.kill('SIGTERM')
+    }
+    const timeout = setTimeout(() => {
+      signalProcessGroup(child, 'SIGKILL')
+      finish()
+    }, 5_000)
+    child.once('exit', finish)
+    signalProcessGroup(child, 'SIGTERM')
   })
 }
 
@@ -1245,6 +1271,7 @@ async function startOpencodeHost(
         modelBaseUrl,
         parentEnv,
       }),
+      detached: true,
       stdio: ['ignore', 'pipe', 'pipe'],
     },
   )
@@ -1264,8 +1291,10 @@ async function startOpencodeHost(
     const timeout = setTimeout(() => {
       if (settled) return
       settled = true
-      void stopChildProcess(child)
-      reject(new Error(OPENCODE_HOST_TIMEOUT))
+      void (async () => {
+        await stopChildProcess(child)
+        reject(new Error(OPENCODE_HOST_TIMEOUT))
+      })()
     }, timeoutMs)
     const onChunk = (chunk: Buffer): void => {
       if (settled) return

--- a/scripts/eval-cases/opencode.ts
+++ b/scripts/eval-cases/opencode.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from 'node:url'
 import { createOpencodeClient } from '@opencode-ai/sdk/v2'
 
 import { buildBundledAgentInventory } from '../../src/lib/agent-overlays.js'
+import { stopProcessGroup } from '../lib/process-group.js'
 import {
   buildEvalChildEnv,
   type EvalCaseExecution,
@@ -1205,47 +1206,6 @@ function buildProviderConfig(
   })
 }
 
-function signalProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
-  const pid = child.pid
-  if (pid === undefined) {
-    try {
-      child.kill(signal)
-    } catch {
-      // Cleanup is best effort; the process may already be gone.
-    }
-    return
-  }
-
-  try {
-    process.kill(-pid, signal)
-  } catch {
-    try {
-      child.kill(signal)
-    } catch {
-      // Cleanup is best effort; the process may already be gone.
-    }
-  }
-}
-
-async function stopChildProcess(child: ChildProcess): Promise<void> {
-  if (child.exitCode !== null) return Promise.resolve()
-  await new Promise<void>((resolve) => {
-    let settled = false
-    const finish = (): void => {
-      if (settled) return
-      settled = true
-      clearTimeout(timeout)
-      resolve()
-    }
-    const timeout = setTimeout(() => {
-      signalProcessGroup(child, 'SIGKILL')
-      finish()
-    }, 5_000)
-    child.once('exit', finish)
-    signalProcessGroup(child, 'SIGTERM')
-  })
-}
-
 async function startOpencodeHost(
   fixture: EvalFixture,
   configContent: string,
@@ -1292,7 +1252,7 @@ async function startOpencodeHost(
       if (settled) return
       settled = true
       void (async () => {
-        await stopChildProcess(child)
+        await stopProcessGroup(child, 5_000)
         reject(new Error(OPENCODE_HOST_TIMEOUT))
       })()
     }, timeoutMs)
@@ -1326,7 +1286,7 @@ async function startOpencodeHost(
     async stop(): Promise<void> {
       if (stopped) return
       stopped = true
-      await stopChildProcess(child)
+      await stopProcessGroup(child, 5_000)
     },
   }
 }
@@ -1335,7 +1295,7 @@ export async function stopActiveEvalResources(): Promise<void> {
   const children = [...activeOpencodeChildren]
   await Promise.all(
     children.map(async (child) => {
-      await stopChildProcess(child)
+      await stopProcessGroup(child, 5_000)
       activeOpencodeChildren.delete(child)
     }),
   )

--- a/scripts/lib/process-group.ts
+++ b/scripts/lib/process-group.ts
@@ -4,7 +4,14 @@ const DEFAULT_STOP_TIMEOUT_MS = 5_000
 
 function signalProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
   const pid = child.pid
-  if (pid === undefined) return
+  if (pid === undefined) {
+    try {
+      child.kill(signal)
+    } catch {
+      // Cleanup is best effort; the process may already be gone.
+    }
+    return
+  }
 
   try {
     process.kill(-pid, signal)
@@ -21,9 +28,7 @@ export async function stopProcessGroup(
   child: ChildProcess,
   timeoutMs = DEFAULT_STOP_TIMEOUT_MS,
 ): Promise<void> {
-  const pid = child.pid
-  if (pid === undefined) return
-  if (child.exitCode !== null) {
+  if (child.exitCode !== null || child.signalCode !== null) {
     signalProcessGroup(child, 'SIGKILL')
     return
   }

--- a/scripts/lib/process-group.ts
+++ b/scripts/lib/process-group.ts
@@ -2,9 +2,25 @@ import type { ChildProcess } from 'node:child_process'
 
 const DEFAULT_STOP_TIMEOUT_MS = 5_000
 
+// Signal 0 sends nothing; it only probes whether a process group with this
+// pgid currently has any live member. A pgid cannot be recycled while its
+// group has members, so this is a safe leadership/ownership check -- and
+// unlike `process.getpgid` (unimplemented on Bun, and only answers whether
+// the literal leader pid is still alive, not whether its group survives it)
+// it also stays correct once the original leader has exited but a
+// detached grandchild keeps the group alive.
+function processGroupIsPopulated(pid: number): boolean {
+  try {
+    process.kill(-pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
 function signalProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
   const pid = child.pid
-  if (pid === undefined) {
+  if (pid === undefined || !processGroupIsPopulated(pid)) {
     try {
       child.kill(signal)
     } catch {

--- a/scripts/lib/process-group.ts
+++ b/scripts/lib/process-group.ts
@@ -4,14 +4,7 @@ const DEFAULT_STOP_TIMEOUT_MS = 5_000
 
 function signalProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
   const pid = child.pid
-  if (pid === undefined) {
-    try {
-      child.kill(signal)
-    } catch {
-      // Cleanup is best effort; the process may already be gone.
-    }
-    return
-  }
+  if (pid === undefined) return
 
   try {
     process.kill(-pid, signal)
@@ -28,7 +21,12 @@ export async function stopProcessGroup(
   child: ChildProcess,
   timeoutMs = DEFAULT_STOP_TIMEOUT_MS,
 ): Promise<void> {
-  if (child.exitCode !== null) return
+  const pid = child.pid
+  if (pid === undefined) return
+  if (child.exitCode !== null) {
+    signalProcessGroup(child, 'SIGKILL')
+    return
+  }
 
   await new Promise<void>((resolve) => {
     let settled = false

--- a/tests/integration/fixtures/process-group.ts
+++ b/tests/integration/fixtures/process-group.ts
@@ -1,0 +1,49 @@
+import type { ChildProcess } from 'node:child_process'
+
+const DEFAULT_STOP_TIMEOUT_MS = 5_000
+
+function signalProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
+  const pid = child.pid
+  if (pid === undefined) {
+    try {
+      child.kill(signal)
+    } catch {
+      // Cleanup is best effort; the process may already be gone.
+    }
+    return
+  }
+
+  try {
+    process.kill(-pid, signal)
+  } catch {
+    try {
+      child.kill(signal)
+    } catch {
+      // Cleanup is best effort; the process may already be gone.
+    }
+  }
+}
+
+export async function stopProcessGroup(
+  child: ChildProcess,
+  timeoutMs = DEFAULT_STOP_TIMEOUT_MS,
+): Promise<void> {
+  if (child.exitCode !== null) return
+
+  await new Promise<void>((resolve) => {
+    let settled = false
+    const finish = (): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      resolve()
+    }
+    const timeout = setTimeout(() => {
+      signalProcessGroup(child, 'SIGKILL')
+      finish()
+    }, timeoutMs)
+
+    child.once('exit', finish)
+    signalProcessGroup(child, 'SIGTERM')
+  })
+}

--- a/tests/integration/fixtures/receipt-workflow-host.ts
+++ b/tests/integration/fixtures/receipt-workflow-host.ts
@@ -587,7 +587,17 @@ async function startOpencodeProcess(
     },
   }
   liveOpencodeHosts.add(host)
-  server.once('exit', () => liveOpencodeHosts.delete(host))
+  server.once('exit', () => {
+    // A pgid cannot be recycled while its group has members, so this is a safe
+    // ownership probe. Only evict once the group is actually empty; otherwise
+    // the launcher exited but the opencode grandchild is still alive and
+    // needs to stay reachable for stopAllOpencodeHosts/the terminal-signal guard.
+    try {
+      process.kill(-pid, 0)
+    } catch {
+      liveOpencodeHosts.delete(host)
+    }
+  })
   installTerminalSignalHandlers()
   return host
 }

--- a/tests/integration/fixtures/receipt-workflow-host.ts
+++ b/tests/integration/fixtures/receipt-workflow-host.ts
@@ -1,12 +1,33 @@
-import { type ChildProcess, spawn } from 'node:child_process'
+import { type ChildProcess, spawn, spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
+import { stopProcessGroup } from './process-group.js'
+
 export const OPENCODE_AVAILABLE = (() => {
-  const result = Bun.spawnSync(['which', 'opencode'])
-  return result.exitCode === 0
+  const probeRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'systematic-opencode-probe-'),
+  )
+  try {
+    // Fixtures redirect HOME/XDG paths, so a PATH shim must also run in that environment.
+    const result = spawnSync('opencode', ['--version'], {
+      env: {
+        ...process.env,
+        HOME: probeRoot,
+        XDG_CONFIG_HOME: probeRoot,
+        XDG_DATA_HOME: probeRoot,
+        XDG_CACHE_HOME: probeRoot,
+        XDG_STATE_HOME: probeRoot,
+      },
+      encoding: 'utf8',
+      timeout: 15_000,
+    })
+    return result.status === 0 && /\d+\.\d+\.\d+/.test(result.stdout)
+  } finally {
+    fs.rmSync(probeRoot, { recursive: true, force: true })
+  }
 })()
 
 export const TIMEOUT_MS = 180_000
@@ -509,10 +530,11 @@ async function startOpencodeProcess(
   const url = await new Promise<string>((resolve, reject) => {
     let buffer = ''
     const timeout = setTimeout(() => {
-      server.kill('SIGTERM')
-      reject(
-        new Error(`OpenCode server start timed out: ${buffer.slice(-500)}`),
-      )
+      void stopOpencodeProcess(server).then(() => {
+        reject(
+          new Error(`OpenCode server start timed out: ${buffer.slice(-500)}`),
+        )
+      })
     }, timeoutMs)
 
     const onChunk = (chunk: Buffer): void => {
@@ -538,15 +560,22 @@ async function startOpencodeProcess(
   })
 
   let stopped = false
-  return {
+  let host: OpencodeServer
+  host = {
     url,
     pid,
     async stop(): Promise<void> {
       if (stopped) return
       stopped = true
-      await stopOpencodeProcess(server)
+      try {
+        await stopOpencodeProcess(server)
+      } finally {
+        liveOpencodeHosts.delete(host)
+      }
     },
   }
+  liveOpencodeHosts.add(host)
+  return host
 }
 
 export async function startOpencodeServer(
@@ -588,19 +617,14 @@ export interface OpencodeServer {
   stop(): Promise<void>
 }
 
+const liveOpencodeHosts = new Set<OpencodeServer>()
+
 async function stopOpencodeProcess(server: ChildProcess): Promise<void> {
-  if (server.exitCode !== null) return
-  await new Promise<void>((resolve) => {
-    const timeout = setTimeout(() => {
-      server.kill('SIGKILL')
-      resolve()
-    }, 10_000)
-    server.once('exit', () => {
-      clearTimeout(timeout)
-      resolve()
-    })
-    server.kill('SIGTERM')
-  })
+  await stopProcessGroup(server, 10_000)
+}
+
+export async function stopAllOpencodeHosts(): Promise<void> {
+  await Promise.all([...liveOpencodeHosts].map((host) => host.stop()))
 }
 
 let packedTarballPath: string | null = null

--- a/tests/integration/fixtures/receipt-workflow-host.ts
+++ b/tests/integration/fixtures/receipt-workflow-host.ts
@@ -151,11 +151,17 @@ export const OPENCODE_AVAILABLE = (() => {
       encoding: 'utf8',
       timeout: 15_000,
     })
-    const available = result.status === 0 && /\d+\.\d+\.\d+/.test(result.stdout)
+    const available =
+      !result.error &&
+      result.status === 0 &&
+      /\d+\.\d+\.\d+/.test(result.stdout ?? '')
     if (!available) {
-      const stderr = result.stderr.slice(0, 200).replaceAll(/\s+/g, ' ').trim()
+      const stderr = (result.stderr ?? '')
+        .slice(0, 200)
+        .replaceAll(/\s+/g, ' ')
+        .trim()
       console.warn(
-        `[systematic] opencode availability probe failed: status=${result.status ?? 'null'} signal=${result.signal ?? 'null'} stderr=${stderr}`,
+        `[systematic] opencode availability probe failed: status=${result.status ?? 'null'} signal=${result.signal ?? 'null'} error=${result.error?.message ?? 'none'} stderr=${stderr}`,
       )
     }
     return available
@@ -581,6 +587,8 @@ async function startOpencodeProcess(
     },
   }
   liveOpencodeHosts.add(host)
+  server.once('exit', () => liveOpencodeHosts.delete(host))
+  installTerminalSignalHandlers()
   return host
 }
 
@@ -643,16 +651,16 @@ function installTerminalSignalHandlers(): void {
 
   process.on('SIGINT', () => {
     killLiveOpencodeHostsSync()
+    // Exiting here skips remaining afterAll hooks (temp dirs may leak); orphaned host processes cost more than temp dirs.
     process.exit(130)
   })
   process.on('SIGTERM', () => {
     killLiveOpencodeHostsSync()
+    // Exiting here skips remaining afterAll hooks (temp dirs may leak); orphaned host processes cost more than temp dirs.
     process.exit(143)
   })
   process.on('exit', killLiveOpencodeHostsSync)
 }
-
-installTerminalSignalHandlers()
 
 async function stopOpencodeProcess(server: ChildProcess): Promise<void> {
   await stopProcessGroup(server, 10_000)

--- a/tests/integration/fixtures/receipt-workflow-host.ts
+++ b/tests/integration/fixtures/receipt-workflow-host.ts
@@ -4,31 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
-import { stopProcessGroup } from './process-group.js'
-
-export const OPENCODE_AVAILABLE = (() => {
-  const probeRoot = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'systematic-opencode-probe-'),
-  )
-  try {
-    // Fixtures redirect HOME/XDG paths, so a PATH shim must also run in that environment.
-    const result = spawnSync('opencode', ['--version'], {
-      env: {
-        ...process.env,
-        HOME: probeRoot,
-        XDG_CONFIG_HOME: probeRoot,
-        XDG_DATA_HOME: probeRoot,
-        XDG_CACHE_HOME: probeRoot,
-        XDG_STATE_HOME: probeRoot,
-      },
-      encoding: 'utf8',
-      timeout: 15_000,
-    })
-    return result.status === 0 && /\d+\.\d+\.\d+/.test(result.stdout)
-  } finally {
-    fs.rmSync(probeRoot, { recursive: true, force: true })
-  }
-})()
+import { stopProcessGroup } from '../../../scripts/lib/process-group.js'
 
 export const TIMEOUT_MS = 180_000
 export const EXACT_OPENCODE_VERSION = '1.18.21'
@@ -157,6 +133,36 @@ export function buildChildEnv(
   }
   return { ...base, ...overrides }
 }
+
+export const OPENCODE_AVAILABLE = (() => {
+  const probeRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'systematic-opencode-probe-'),
+  )
+  try {
+    // Fixtures redirect HOME/XDG paths, so a PATH shim must also run in that environment.
+    const result = spawnSync('opencode', ['--version'], {
+      env: buildChildEnv({
+        HOME: probeRoot,
+        XDG_CONFIG_HOME: probeRoot,
+        XDG_DATA_HOME: probeRoot,
+        XDG_CACHE_HOME: probeRoot,
+        XDG_STATE_HOME: probeRoot,
+      }),
+      encoding: 'utf8',
+      timeout: 15_000,
+    })
+    const available = result.status === 0 && /\d+\.\d+\.\d+/.test(result.stdout)
+    if (!available) {
+      const stderr = result.stderr.slice(0, 200).replaceAll(/\s+/g, ' ').trim()
+      console.warn(
+        `[systematic] opencode availability probe failed: status=${result.status ?? 'null'} signal=${result.signal ?? 'null'} stderr=${stderr}`,
+      )
+    }
+    return available
+  } finally {
+    fs.rmSync(probeRoot, { recursive: true, force: true })
+  }
+})()
 
 export function buildIsolatedOpencodeEnv(
   fixture: IsolatedFixture,
@@ -523,6 +529,7 @@ async function startOpencodeProcess(
   const server = spawn(command, [...args], {
     env,
     cwd: fixture.projectDir,
+    detached: true,
   })
   const pid = server.pid
   if (!pid) throw new Error('opencode server did not expose a process id')
@@ -560,8 +567,7 @@ async function startOpencodeProcess(
   })
 
   let stopped = false
-  let host: OpencodeServer
-  host = {
+  const host: OpencodeServer = {
     url,
     pid,
     async stop(): Promise<void> {
@@ -618,6 +624,35 @@ export interface OpencodeServer {
 }
 
 const liveOpencodeHosts = new Set<OpencodeServer>()
+
+let terminalSignalHandlersInstalled = false
+
+function killLiveOpencodeHostsSync(): void {
+  for (const host of liveOpencodeHosts) {
+    try {
+      process.kill(-host.pid, 'SIGKILL')
+    } catch {
+      // Cleanup is best effort; the process may already be gone.
+    }
+  }
+}
+
+function installTerminalSignalHandlers(): void {
+  if (terminalSignalHandlersInstalled) return
+  terminalSignalHandlersInstalled = true
+
+  process.on('SIGINT', () => {
+    killLiveOpencodeHostsSync()
+    process.exit(130)
+  })
+  process.on('SIGTERM', () => {
+    killLiveOpencodeHostsSync()
+    process.exit(143)
+  })
+  process.on('exit', killLiveOpencodeHostsSync)
+}
+
+installTerminalSignalHandlers()
 
 async function stopOpencodeProcess(server: ChildProcess): Promise<void> {
   await stopProcessGroup(server, 10_000)

--- a/tests/integration/question-attestation-opencode.test.ts
+++ b/tests/integration/question-attestation-opencode.test.ts
@@ -418,8 +418,8 @@ describe.skipIf(!OPENCODE_AVAILABLE)('OpenCode Question attestation', () => {
     packTarballOnce()
   }, 200_000)
 
-  afterAll(stopAllOpencodeHosts)
-  afterAll(() => {
+  afterAll(async () => {
+    await stopAllOpencodeHosts()
     cleanupPackedTarball()
   })
 

--- a/tests/integration/question-attestation-opencode.test.ts
+++ b/tests/integration/question-attestation-opencode.test.ts
@@ -12,6 +12,7 @@ import {
   OPENCODE_AVAILABLE,
   packTarballOnce,
   startOpencodeServer,
+  stopAllOpencodeHosts,
   TIMEOUT_MS,
 } from './fixtures/receipt-workflow-host.js'
 
@@ -417,6 +418,7 @@ describe.skipIf(!OPENCODE_AVAILABLE)('OpenCode Question attestation', () => {
     packTarballOnce()
   }, 200_000)
 
+  afterAll(stopAllOpencodeHosts)
   afterAll(() => {
     cleanupPackedTarball()
   })

--- a/tests/integration/receipt-workflow-dogfood.test.ts
+++ b/tests/integration/receipt-workflow-dogfood.test.ts
@@ -484,8 +484,10 @@ describe.skipIf(!OPENCODE_AVAILABLE)('focused real-host dogfood', () => {
     }
     console.log(`U7_PREWARM ${warm.stdout.trim()}`)
   }, 360_000)
-  afterAll(stopAllOpencodeHosts)
-  afterAll(() => cleanupPackedTarball())
+  afterAll(async () => {
+    await stopAllOpencodeHosts()
+    cleanupPackedTarball()
+  })
 
   test(
     'proves decisive shipping flows in isolated observe/protected hosts',

--- a/tests/integration/receipt-workflow-dogfood.test.ts
+++ b/tests/integration/receipt-workflow-dogfood.test.ts
@@ -13,6 +13,7 @@ import {
   packTarballOnce,
   prewarmExactOpencode,
   startExactOpencodeServer,
+  stopAllOpencodeHosts,
   TIMEOUT_MS,
 } from './fixtures/receipt-workflow-host.js'
 
@@ -483,6 +484,7 @@ describe.skipIf(!OPENCODE_AVAILABLE)('focused real-host dogfood', () => {
     }
     console.log(`U7_PREWARM ${warm.stdout.trim()}`)
   }, 360_000)
+  afterAll(stopAllOpencodeHosts)
   afterAll(() => cleanupPackedTarball())
 
   test(

--- a/tests/integration/receipt-workflow-guard-real-host.test.ts
+++ b/tests/integration/receipt-workflow-guard-real-host.test.ts
@@ -12,6 +12,7 @@ import {
   OPENCODE_AVAILABLE,
   packTarballOnce,
   startExactOpencodeServer,
+  stopAllOpencodeHosts,
   TIMEOUT_MS,
 } from './fixtures/receipt-workflow-host.js'
 
@@ -527,6 +528,7 @@ describe.skipIf(!OPENCODE_AVAILABLE)('U7a real host', () => {
     packTarballOnce()
   }, 200_000)
 
+  afterAll(stopAllOpencodeHosts)
   afterAll(() => {
     cleanupPackedTarball()
   })

--- a/tests/integration/receipt-workflow-guard-real-host.test.ts
+++ b/tests/integration/receipt-workflow-guard-real-host.test.ts
@@ -528,8 +528,8 @@ describe.skipIf(!OPENCODE_AVAILABLE)('U7a real host', () => {
     packTarballOnce()
   }, 200_000)
 
-  afterAll(stopAllOpencodeHosts)
-  afterAll(() => {
+  afterAll(async () => {
+    await stopAllOpencodeHosts()
     cleanupPackedTarball()
   })
 

--- a/tests/integration/receipt-workflow-recovery.test.ts
+++ b/tests/integration/receipt-workflow-recovery.test.ts
@@ -581,8 +581,8 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
       packTarballOnce()
     }, 200_000)
 
-    afterAll(stopAllOpencodeHosts)
-    afterAll(() => {
+    afterAll(async () => {
+      await stopAllOpencodeHosts()
       cleanupPackedTarball()
     })
 

--- a/tests/integration/receipt-workflow-recovery.test.ts
+++ b/tests/integration/receipt-workflow-recovery.test.ts
@@ -14,6 +14,7 @@ import {
   packTarballOnce,
   REPO_ROOT,
   startOpencodeServer,
+  stopAllOpencodeHosts,
   TIMEOUT_MS,
 } from './fixtures/receipt-workflow-host.js'
 
@@ -580,6 +581,7 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
       packTarballOnce()
     }, 200_000)
 
+    afterAll(stopAllOpencodeHosts)
     afterAll(() => {
       cleanupPackedTarball()
     })

--- a/tests/unit/process-group-reaping.test.ts
+++ b/tests/unit/process-group-reaping.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'bun:test'
 import { spawn, spawnSync } from 'node:child_process'
+import { once } from 'node:events'
 
-import { stopProcessGroup } from '../integration/fixtures/process-group.js'
+import { stopProcessGroup } from '../../scripts/lib/process-group.js'
 
 function processGroupHasMembers(pgid: number): boolean {
   return (
@@ -33,6 +34,24 @@ describe('process-group reaping', () => {
 
     try {
       expect(processGroupHasMembers(pid)).toBe(true)
+      await stopProcessGroup(child, 1_000)
+      expect(await waitForEmptyProcessGroup(pid, 2_000)).toBe(true)
+    } finally {
+      await stopProcessGroup(child, 1_000)
+    }
+  })
+
+  it('reaps grandchildren after the detached launcher has already exited', async () => {
+    const child = spawn('sh', ['-c', 'sleep 30 & exit 0'], {
+      detached: true,
+      stdio: 'ignore',
+    })
+    const pid = child.pid
+    if (pid === undefined)
+      throw new Error('test child did not expose a process id')
+
+    await once(child, 'exit')
+    try {
       await stopProcessGroup(child, 1_000)
       expect(await waitForEmptyProcessGroup(pid, 2_000)).toBe(true)
     } finally {

--- a/tests/unit/process-group-reaping.test.ts
+++ b/tests/unit/process-group-reaping.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test'
+import { spawn, spawnSync } from 'node:child_process'
+
+import { stopProcessGroup } from '../integration/fixtures/process-group.js'
+
+function processGroupHasMembers(pgid: number): boolean {
+  return (
+    spawnSync('pgrep', ['-g', String(pgid)], { stdio: 'ignore' }).status === 0
+  )
+}
+
+async function waitForEmptyProcessGroup(
+  pgid: number,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (!processGroupHasMembers(pgid)) return true
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  return !processGroupHasMembers(pgid)
+}
+
+describe('process-group reaping', () => {
+  it('terminates detached process groups including grandchildren', async () => {
+    const child = spawn('sh', ['-c', 'sleep 30 & sleep 30 & wait'], {
+      detached: true,
+      stdio: 'ignore',
+    })
+    const pid = child.pid
+    if (pid === undefined)
+      throw new Error('test child did not expose a process id')
+
+    try {
+      expect(processGroupHasMembers(pid)).toBe(true)
+      await stopProcessGroup(child, 1_000)
+      expect(await waitForEmptyProcessGroup(pid, 2_000)).toBe(true)
+    } finally {
+      await stopProcessGroup(child, 1_000)
+    }
+  })
+})

--- a/tests/unit/process-group-reaping.test.ts
+++ b/tests/unit/process-group-reaping.test.ts
@@ -81,4 +81,38 @@ describe('process-group reaping', () => {
       await stopProcessGroup(child, 1_000)
     }
   })
+
+  it('stops a non-detached child via the direct-kill fallback without signalling an unrelated group', async () => {
+    const child = spawn('sh', ['-c', 'sleep 30'], {
+      stdio: 'ignore',
+    })
+    const pid = child.pid
+    if (pid === undefined)
+      throw new Error('test child did not expose a process id')
+
+    await stopProcessGroup(child, 1_000)
+    expect(child.exitCode !== null || child.signalCode !== null).toBe(true)
+  })
+
+  it('keeps a registry-style probe positive while the group is populated and negative once reaped', async () => {
+    const child = spawn('sh', ['-c', 'sleep 30 & exit 0'], {
+      detached: true,
+      stdio: 'ignore',
+    })
+    const pid = child.pid
+    if (pid === undefined)
+      throw new Error('test child did not expose a process id')
+
+    await once(child, 'exit')
+    try {
+      expect(() => process.kill(-pid, 0)).not.toThrow()
+
+      await stopProcessGroup(child, 1_000)
+      await waitForEmptyProcessGroup(pid, 2_000)
+
+      expect(() => process.kill(-pid, 0)).toThrow()
+    } finally {
+      await stopProcessGroup(child, 1_000)
+    }
+  })
 })

--- a/tests/unit/process-group-reaping.test.ts
+++ b/tests/unit/process-group-reaping.test.ts
@@ -58,4 +58,27 @@ describe('process-group reaping', () => {
       await stopProcessGroup(child, 1_000)
     }
   })
+
+  it('returns quickly when the direct child already died from a signal', async () => {
+    const child = spawn('sh', ['-c', 'sleep 30 & sleep 30 & wait'], {
+      detached: true,
+      stdio: 'ignore',
+    })
+    const pid = child.pid
+    if (pid === undefined)
+      throw new Error('test child did not expose a process id')
+
+    child.kill('SIGTERM')
+    await once(child, 'exit')
+    expect(child.signalCode).not.toBeNull()
+
+    try {
+      const started = performance.now()
+      await stopProcessGroup(child, 1_000)
+      expect(performance.now() - started).toBeLessThan(200)
+      expect(await waitForEmptyProcessGroup(pid, 2_000)).toBe(true)
+    } finally {
+      await stopProcessGroup(child, 1_000)
+    }
+  })
 })


### PR DESCRIPTION
Repeated integration runs left orphaned OpenCode servers behind until the machine had to be rebooted. Both host spawn sites (`tests/integration/fixtures/receipt-workflow-host.ts`, `scripts/eval-cases/opencode.ts`) launch through a launcher chain and stopped only the direct child; the server itself outlived every failed, timed-out, or aborted run.

Changes:
- Hosts spawn `detached` in their own process group; `stopProcessGroup` (new `tests/integration/fixtures/process-group.ts`) signals the group with SIGTERM, waits up to 5 s, then SIGKILLs the group. ESRCH falls back to the direct child and cleanup never throws. The eval runner duplicates the helper because no scripts→tests import direction exists.
- Startup-timeout cleanup is awaited before the failure surfaces instead of fire-and-forget.
- A suite-level registry of live hosts is drained by `stopAllOpencodeHosts()` in `afterAll` across the four host-owning suites, so a test that aborts before its own `finally` still leaves nothing behind.
- `OPENCODE_AVAILABLE` probes `opencode --version` under a throwaway HOME/XDG root rather than `which`. The fixtures redirect HOME, so a shim that resolves through it satisfies `which` and then fails in every child; the suite now skips instead of spawning servers that cannot start.
- `tests/unit/process-group-reaping.test.ts` spawns a shell with two background `sleep` grandchildren and asserts none survive the helper. Proven in both directions: with a plain `child.kill()` the grandchildren survived (pids 27191/27192); with the group kill, none.

Verified: unit suite 1988 pass / 0 fail; typecheck; lint 0 errors; content-integrity clean; `pgrep -fl opencode` empty after every run. The integration suite itself was deliberately not executed on this branch.
