### PR TITLE
docs(solutions): preservation gates need the deleted code's branches

### DIFF
--- a/docs/solutions/best-practices/deletion-gates-must-observe-every-field-the-deleted-code-wrote-2026-08-16.md
+++ b/docs/solutions/best-practices/deletion-gates-must-observe-every-field-the-deleted-code-wrote-2026-08-16.md
@@ -18,8 +18,7 @@ applies_when:
   - Building a test whose purpose is to prove deleted behavior stays deleted
   - The deleted mechanism wrote more than one field
   - A gate's headline assertion names one symptom of a broader capability
-  - Replacing a heuristic, refinement, or schema post-processor with a rewrite that must preserve its behavior
-  - Seeding a compatibility corpus for a byte-identical output check
+  - Seeding a compatibility corpus to prove a rewrite preserves a deleted heuristic, refinement, or schema post-processor
 ---
 
 # A deletion gate must observe every field the deleted code could write
@@ -131,7 +130,7 @@ rg 'variant' src/lib/config-handler.ts
 | `categories.review = {model, variant}` + `agents.x = {model}` | agent model, no variant | agent model **with** the category variant |
 | `categories.review = {model, variant}` + `agents.x = {model: null}` | neither | category variant alone |
 
-These live at `tests/fixtures/config-corpus/013-agent-model-clears-category-variant/` and `014-agent-model-null-clears-category-routing/`. The heuristic's third branch, a variant with no model anywhere, is a rejection rather than an output shape, so it is pinned by a loader test instead of a corpus row.
+These are corpus entries 013 and 014, described in `tests/fixtures/config-corpus/README.md`. The heuristic's third branch, a variant with no model anywhere, is a rejection rather than an output shape, so it is pinned by a loader test instead of a corpus row.
 
 ## Related
 

--- a/docs/solutions/best-practices/deletion-gates-must-observe-every-field-the-deleted-code-wrote-2026-08-16.md
+++ b/docs/solutions/best-practices/deletion-gates-must-observe-every-field-the-deleted-code-wrote-2026-08-16.md
@@ -2,6 +2,7 @@
 title: A deletion gate must observe every field the deleted code could write
 module: evals/cases/opencode/model-inheritance.json + src/lib/config-handler.ts
 date: 2026-08-16
+last_updated: 2026-09-05
 problem_type: best_practice
 component: testing_framework
 severity: medium
@@ -11,10 +12,14 @@ tags:
   - deletion-verification
   - assertion-coverage
   - adversarial-review
+  - compatibility-corpus
+  - byte-identical
 applies_when:
   - Building a test whose purpose is to prove deleted behavior stays deleted
   - The deleted mechanism wrote more than one field
   - A gate's headline assertion names one symptom of a broader capability
+  - Replacing a heuristic, refinement, or schema post-processor with a rewrite that must preserve its behavior
+  - Seeding a compatibility corpus for a byte-identical output check
 ---
 
 # A deletion gate must observe every field the deleted code could write
@@ -60,6 +65,35 @@ Two sources make the enumeration cheap and non-speculative:
 1. **The deleted code itself.** Read what it assigned, from git if it is already gone. `git show <commit-before-deletion>:<path>` gives you the exact write set.
 2. **What still consumes those fields.** If a field survives the deletion with live handling elsewhere, it is reachable, and reachable means a regression can target it.
 
+### Preservation gates need the deleted code's branches, not only its fields
+
+The same rule applies with the sign flipped. An absence gate proves a deleted mechanism stays gone; a preservation gate proves a rewrite still does what the deleted code did. Both are only as complete as the enumeration they are built from, and for a preservation gate the enumeration is the deleted code's **branches**: every condition it checked becomes one input, with the expected output captured from the pre-change build.
+
+The tempting shortcut is to seed the corpus from fixtures that already exist in the test suite. Those fixtures were written to exercise the code that existed, not the behaviors the deleted code enforced, so a corpus built from them reaches the happy path and skips exactly the cases the heuristic was there for. A zero-difference diff against the pre-change build then proves only that the corpus never entered a deleted branch.
+
+The variant-clearing heuristic this doc already names is the case in point. It had three branches:
+
+```ts
+// src/lib/config-handler.ts before the routing resolver replaced it
+const overlayHasModel = Object.hasOwn(overlay, 'model')
+const overlayHasVariant = Object.hasOwn(overlay, 'variant')
+
+if (overlayHasModel && !overlayHasVariant) {
+  delete target.variant
+  // A more specific model clears a less specific variant.
+}
+// `model: null` counts as present, so it clears too.
+// No model anywhere: nothing to clear; the schema refinement rejects it.
+```
+
+The resolver that replaced it was checked against a twelve-entry corpus (entries 001-012) copied from existing fixtures. None of the twelve set a category `variant` and then overrode `model` at the agent level, so the rewrite dropped the first two branches, emitted a category variant alongside an agent model, and passed byte-for-byte. Two corpus rows built from the heuristic's own conditions caught it immediately.
+
+Procedure for a preservation gate:
+
+1. From the recovered source, list each condition it branched on, including the `null` and absent cases it treated specially.
+2. Write one corpus input per condition, named after the behavior rather than the fixture it came from. Copied fixtures may widen coverage afterwards but cannot substitute for branch-derived inputs.
+3. Capture the expected output by running each input through the pre-change build, and assert on a canonical serialization, not deep equality, so key order and absent-versus-`undefined` drift also fail.
+
 ## Why This Matters
 
 A gate's value is entirely in what it would catch. A gate that catches the obvious reintroduction and misses the adjacent one is worse than no gate, because the commit message, the PR, and the next reader all treat it as proof. This one was described as "fails if a source-owned default reappears" — true for `model`, false for `variant`, and nothing in the artifact disclosed the difference.
@@ -90,8 +124,20 @@ rg 'variant' src/lib/config-handler.ts
 
 **The resulting assertion shape.** Inheritance scenarios require both absent; overlay scenarios assert the expected value, so the gate distinguishes "user asked for this variant" from "something pinned it."
 
+**A preservation corpus seeded from the deleted branches.** Each row is one condition the heuristic checked, with output captured from the pre-change build:
+
+| Input | Pre-change output | Rewrite before the corpus rows existed |
+|---|---|---|
+| `categories.review = {model, variant}` + `agents.x = {model}` | agent model, no variant | agent model **with** the category variant |
+| `categories.review = {model, variant}` + `agents.x = {model: null}` | neither | category variant alone |
+
+These live at `tests/fixtures/config-corpus/013-agent-model-clears-category-variant/` and `014-agent-model-null-clears-category-routing/`. The heuristic's third branch, a variant with no model anywhere, is a rejection rather than an output shape, so it is pinned by a loader test instead of a corpus row.
+
 ## Related
 
 - [`docs/solutions/best-practices/provider-availability-source-defaults-2026-05-12.md`](provider-availability-source-defaults-2026-05-12.md) — the mechanism this gate guards, now retired
 - [`docs/solutions/workflow-issues/version-pinned-evidence-must-be-reproven-2026-08-16.md`](../workflow-issues/version-pinned-evidence-must-be-reproven-2026-08-16.md) — the other half of trusting a gate: its evidence expires when the pinned runtime moves
-- PR #790 — where the gap was found and closed
+- [`docs/solutions/best-practices/a-perfect-measurement-means-a-broken-instrument-2026-08-16.md`](a-perfect-measurement-means-a-broken-instrument-2026-08-16.md) — a zero-difference result is evidence about the corpus before it is evidence about the rewrite
+- `tests/fixtures/config-corpus/README.md` — the corpus, its canonical-serialization assertion, and the pre-change reconstruction method
+- PR #790 — where the absence-gate gap was found and closed
+- PR #903 — where the preservation-gate gap was found and closed


### PR DESCRIPTION
## Summary

Extends `deletion-gates-must-observe-every-field-the-deleted-code-wrote-2026-08-16.md` with the sign-flipped case found while landing #903: a preservation gate (a corpus proving a rewrite still matches deleted code) is only as complete as the deleted code's **branches**, not just its fields.

The variant-clearing heuristic that doc already names as a live regression target was replaced by the routing resolver in #903. The twelve-entry compatibility corpus was seeded from existing fixtures, none of which set a category `variant` and then overrode `model` at the agent level, so the rewrite dropped two of the heuristic's three branches and passed byte-for-byte. Two rows built from the heuristic's own conditions (corpus entries 013/014, expected output captured from pre-change `main`) caught it.

## Changes

- New Guidance subsection with the three-branch heuristic, why fixture-seeded corpora miss deleted branches, and a three-step procedure
- New Examples table (input → pre-change output → rewrite output before the rows existed) pointing at the real corpus entries
- Frontmatter: `last_updated`, two tags, two `applies_when` entries (within schema limits)
- Related: measurement doc, corpus README, #903

Update rather than a new doc: overlap scored High on all five dimensions (same deleted code, same root cause — gate derived from something other than the deleted code itself — same enumerate-from-`git show` remedy, same files, same prevention rule generalised from fields to branches). content-integrity clean.
