### PR TITLE
fix(config): refresh example model ids and OMO profile routing to current models

### DIFF
--- a/docs/public/schemas/v3/systematic-config.schema.json
+++ b/docs/public/schemas/v3/systematic-config.schema.json
@@ -659,17 +659,17 @@
       "description": "Per-agent configuration overlay",
       "examples": [
         {
-          "model": "anthropic/claude-opus-4-7",
+          "model": "anthropic/claude-opus-5",
           "temperature": 0.1,
           "mode": "subagent"
         },
         {
           "opencode": {
-            "model": "anthropic/claude-opus-4-7",
-            "variant": "v2"
+            "model": "anthropic/claude-opus-5",
+            "variant": "high"
           },
           "pi": {
-            "model": "anthropic/claude-opus-4-7",
+            "model": "anthropic/claude-opus-5",
             "thinking": "high"
           }
         }
@@ -698,7 +698,7 @@
         }
       ],
       "description": "Model identifier in provider/model format, or null to inherit parent model",
-      "examples": ["anthropic/claude-sonnet-4", null]
+      "examples": ["anthropic/claude-sonnet-5", null]
     },
     "__schema8": {
       "trust": "project-or-higher",
@@ -932,8 +932,8 @@
       "description": "OpenCode-specific routing block. When present, model/variant here override the flat model/variant fields for OpenCode only; the flat fields remain the harness-neutral default and still apply to Pi. `variant` is bound to whichever layer supplies `model`: it is used only from that layer or a more specific one, and is dropped when a more specific layer sets (or nulls) `model` without repeating the variant. A `variant` with no `model` anywhere in the merged overlay is a config-load error raised by the routing resolver, not a parse-time error.",
       "examples": [
         {
-          "model": "anthropic/claude-opus-4-7",
-          "variant": "v2"
+          "model": "anthropic/claude-opus-5",
+          "variant": "high"
         },
         {
           "model": null
@@ -984,7 +984,7 @@
       "description": "Pi-specific routing block. When present, model/thinking here override the flat model field and the legacy `pi_subagents.<name>.thinking` value for Pi only; the flat model field remains the harness-neutral default and still applies to OpenCode. Unlike OpenCode's `variant`, `thinking` is independent of `model`: it applies to whatever model the delegate ends up running, including one inherited from the parent session, so `thinking` with no `model` anywhere in the merged overlay is valid and never a config-load error.",
       "examples": [
         {
-          "model": "anthropic/claude-opus-4-7",
+          "model": "anthropic/claude-opus-5",
           "thinking": "high"
         },
         {
@@ -998,7 +998,7 @@
       "examples": [
         {
           "review": {
-            "model": "anthropic/claude-opus-4-7"
+            "model": "anthropic/claude-opus-5"
           }
         },
         {}
@@ -1058,12 +1058,12 @@
         "description": "Per-category configuration overlay (same fields as agent minus disable)",
         "examples": [
           {
-            "model": "anthropic/claude-opus-4-7",
+            "model": "anthropic/claude-opus-5",
             "temperature": 0.1
           },
           {
             "opencode": {
-              "variant": "v2"
+              "variant": "high"
             },
             "pi": {
               "thinking": "high"
@@ -1172,7 +1172,7 @@
           "personal": {
             "agents": {
               "correctness-reviewer": {
-                "model": "openai/gpt-5"
+                "model": "openai/gpt-6-astra"
               }
             }
           }
@@ -1206,7 +1206,7 @@
           {
             "agents": {
               "fixer": {
-                "model": "anthropic/claude-opus-4-7"
+                "model": "anthropic/claude-opus-5"
               }
             },
             "categories": {
@@ -1225,7 +1225,7 @@
       "examples": [
         {
           "correctness-reviewer": {
-            "model": "openai/gpt-5"
+            "model": "openai/gpt-6-astra"
           }
         }
       ],
@@ -1785,11 +1785,11 @@
       "description": "Routing-only overlay fields permitted inside a named profile bundle entry: model, variant, temperature, top_p, and the opencode/pi harness blocks. Non-routing fields (permission, skills, mode, hidden, disable, steps, color) are rejected.",
       "examples": [
         {
-          "model": "anthropic/claude-opus-4-7"
+          "model": "anthropic/claude-opus-5"
         },
         {
           "opencode": {
-            "variant": "v2"
+            "variant": "high"
           },
           "pi": {
             "thinking": "high"
@@ -1850,7 +1850,7 @@
       "examples": [
         {
           "review": {
-            "model": "anthropic/claude-opus-4-7"
+            "model": "anthropic/claude-opus-5"
           }
         }
       ],

--- a/docs/src/content/docs/guides/pi-subagents.mdx
+++ b/docs/src/content/docs/guides/pi-subagents.mdx
@@ -88,15 +88,15 @@ This is a sanitized, repo-portable example — public model identifiers only, no
   "$schema": "https://fro.bot/systematic/schemas/v3/systematic-config.schema.json",
   "categories": {
     "research": {
-      "model": "github-copilot/gpt-5.4-mini"
+      "model": "github-copilot/gpt-5.6-luna"
     },
     "review": {
-      "model": "openai/gpt-5.5"
+      "model": "openai/gpt-6-astra"
     }
   },
   "agents": {
     "repo-research-analyst": {
-      "model": "github-copilot/gpt-5.4-mini"
+      "model": "github-copilot/gpt-5.6-luna"
     }
   },
   "pi_subagents": {
@@ -118,7 +118,7 @@ This is a sanitized, repo-portable example — public model identifiers only, no
 
 Named `tools`/`skills` values must be discoverable by the user's own Pi installation — pi-subagents does not know about Systematic's bundled `ce:*` skill names, so don't reference them here; use `true` to enable all skills, or a comma-separated list of skills the target Pi environment actually has installed.
 
-Here, every exported persona in the `research` category picks up `model: github-copilot/gpt-5.4-mini` and `thinking: medium`, except `repo-research-analyst`, whose exact-agent overlay wins for both `model` and `max_turns`/`tools`/`skills`. Every persona in the `review` category picks up `model: openai/gpt-5.5`.
+Here, every exported persona in the `research` category picks up `model: github-copilot/gpt-5.6-luna` and `thinking: medium`, except `repo-research-analyst`, whose exact-agent overlay wins for both `model` and `max_turns`/`tools`/`skills`. Every persona in the `review` category picks up `model: openai/gpt-6-astra`.
 
 ### Pi-native field values
 

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -48,7 +48,7 @@ When both `.jsonc` and `.json` exist in the same directory, `.jsonc` takes prece
   "agents": {
     "security-reviewer": {
       // User or custom config only; project config cannot choose model/provider routing.
-      "model": "anthropic/claude-sonnet-4-5",
+      "model": "anthropic/claude-sonnet-5",
       "variant": "thinking",
       "temperature": 0.2,
       "steps": 30
@@ -105,10 +105,10 @@ For a task-oriented walkthrough, see the [model profiles guide](/systematic/guid
   "profile": "personal", // your default when nothing else selects one
   "profiles": {
     "work": {
-      "agents": { "correctness-reviewer": { "model": "openai/gpt-5" } }
+      "agents": { "correctness-reviewer": { "model": "openai/gpt-6-astra" } }
     },
     "personal": {
-      "categories": { "review": { "model": "anthropic/claude-opus-4-7" } }
+      "categories": { "review": { "model": "anthropic/claude-opus-5" } }
     }
   }
 }
@@ -137,7 +137,7 @@ Switching which profile is active never changes an agent's visibility, permissio
 {
   "agents": {
     "correctness-reviewer": {
-      "model": "anthropic/claude-sonnet-4-5", // harness-neutral default
+      "model": "anthropic/claude-sonnet-5", // harness-neutral default
       "opencode": { "variant": "thinking" }, // OpenCode-only qualifier
       "pi": { "thinking": "high" } // Pi-only qualifier
     }
@@ -154,13 +154,13 @@ Resolution precedence, evaluated independently for `model` and for the harness's
 ```jsonc
 {
   "categories": {
-    "review": { "model": "openai/gpt-4o", "variant": "v1" }
+    "review": { "model": "openai/gpt-6-astra", "variant": "high" }
   },
   "agents": {
-    // Overrides the category's model. The category's "v1" variant does NOT
+    // Overrides the category's model. The category's "high" variant does NOT
     // carry over -- it was set at a less specific layer than the agent's
     // model override, so it's dropped, not inherited.
-    "correctness-reviewer": { "model": "openai/gpt-5" }
+    "correctness-reviewer": { "model": "openai/gpt-6-astra" }
   }
 }
 ```
@@ -219,7 +219,7 @@ Model identifier in provider/model format, or null to inherit parent model
 **Examples:**
 
 ```json
-anthropic/claude-sonnet-4
+anthropic/claude-sonnet-5
 ```
 
 ```json
@@ -411,8 +411,8 @@ OpenCode-specific routing block. When present, model/variant here override the f
 
 ```json
 {
-  "model": "anthropic/claude-opus-4-7",
-  "variant": "v2"
+  "model": "anthropic/claude-opus-5",
+  "variant": "high"
 }
 ```
 
@@ -431,7 +431,7 @@ Model identifier in provider/model format, or null to inherit parent model
 **Examples:**
 
 ```json
-anthropic/claude-sonnet-4
+anthropic/claude-sonnet-5
 ```
 
 ```json
@@ -464,7 +464,7 @@ Pi-specific routing block. When present, model/thinking here override the flat m
 
 ```json
 {
-  "model": "anthropic/claude-opus-4-7",
+  "model": "anthropic/claude-opus-5",
   "thinking": "high"
 }
 ```
@@ -484,7 +484,7 @@ Model identifier in provider/model format, or null to inherit parent model
 **Examples:**
 
 ```json
-anthropic/claude-sonnet-4
+anthropic/claude-sonnet-5
 ```
 
 ```json
@@ -567,7 +567,7 @@ Per-category configuration overlays keyed by category name
 ```json
 {
   "review": {
-    "model": "anthropic/claude-opus-4-7"
+    "model": "anthropic/claude-opus-5"
   }
 }
 ```
@@ -592,7 +592,7 @@ Named routing-only overlay bundles, selectable by name via the profile field. On
   "personal": {
     "agents": {
       "correctness-reviewer": {
-        "model": "openai/gpt-5"
+        "model": "openai/gpt-6-astra"
       }
     }
   }
@@ -842,7 +842,7 @@ Model identifier in provider/model format, or null to inherit parent model
 **Examples:**
 
 ```json
-anthropic/claude-sonnet-4
+anthropic/claude-sonnet-5
 ```
 
 ```json
@@ -915,8 +915,8 @@ OpenCode-specific routing block. When present, model/variant here override the f
 
 ```json
 {
-  "model": "anthropic/claude-opus-4-7",
-  "variant": "v2"
+  "model": "anthropic/claude-opus-5",
+  "variant": "high"
 }
 ```
 
@@ -935,7 +935,7 @@ Model identifier in provider/model format, or null to inherit parent model
 **Examples:**
 
 ```json
-anthropic/claude-sonnet-4
+anthropic/claude-sonnet-5
 ```
 
 ```json
@@ -968,7 +968,7 @@ Pi-specific routing block. When present, model/thinking here override the flat m
 
 ```json
 {
-  "model": "anthropic/claude-opus-4-7",
+  "model": "anthropic/claude-opus-5",
   "thinking": "high"
 }
 ```
@@ -988,7 +988,7 @@ Model identifier in provider/model format, or null to inherit parent model
 **Examples:**
 
 ```json
-anthropic/claude-sonnet-4
+anthropic/claude-sonnet-5
 ```
 
 ```json

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -154,7 +154,7 @@ Resolution precedence, evaluated independently for `model` and for the harness's
 ```jsonc
 {
   "categories": {
-    "review": { "model": "openai/gpt-6-astra", "variant": "high" }
+    "review": { "model": "anthropic/claude-sonnet-5", "variant": "high" }
   },
   "agents": {
     // Overrides the category's model. The category's "high" variant does NOT

--- a/registry/files/profiles/omo/AGENTS.md
+++ b/registry/files/profiles/omo/AGENTS.md
@@ -202,9 +202,9 @@ The profile comes pre-configured with:
 
 - **Category models** — Optimal model per task type:
   - `quick` → Haiku (fast/cheap)
-  - `visual-engineering` → Gemini 3 Pro (UI excellence)
+  - `visual-engineering` → Gemini 3.1 Pro (UI excellence)
   - `ultrabrain` → GPT-5.3-codex (deep reasoning)
-  - `unspecified-high` → Opus 4.6 (powerful general)
+  - `unspecified-high` → Opus 5 (powerful general)
 
 - **Disabled features**:
   - Prometheus Planner (use Systematic's better planning)

--- a/registry/files/profiles/omo/AGENTS.md
+++ b/registry/files/profiles/omo/AGENTS.md
@@ -229,12 +229,12 @@ Add your own overrides:
 {
   "agents": {
     "Sisyphus": {
-      "model": "anthropic/claude-opus-4"
+      "model": "anthropic/claude-opus-5"
     }
   },
   "categories": {
     "visual-engineering": {
-      "model": "anthropic/claude-opus-4-6"
+      "model": "anthropic/claude-opus-5"
     }
   }
 }

--- a/registry/files/profiles/omo/oh-my-opencode.jsonc
+++ b/registry/files/profiles/omo/oh-my-opencode.jsonc
@@ -31,7 +31,7 @@
   "categories": {
     // Configure category models for domain-specific tasks
     "visual-engineering": {
-      "model": "google/gemini-3-pro-preview"
+      "model": "google/gemini-3.1-pro-preview"
     },
     "ultrabrain": {
       "model": "openai/gpt-5.3-codex",
@@ -41,10 +41,10 @@
       "model": "anthropic/claude-haiku-4-5"
     },
     "unspecified-low": {
-      "model": "anthropic/claude-sonnet-4-5"
+      "model": "anthropic/claude-sonnet-5"
     },
     "unspecified-high": {
-      "model": "anthropic/claude-opus-4-6",
+      "model": "anthropic/claude-opus-5",
       "variant": "max"
     }
   },

--- a/skills/agent-native-architecture/references/agent-execution-patterns.md
+++ b/skills/agent-native-architecture/references/agent-execution-patterns.md
@@ -234,9 +234,9 @@ enum ModelTier {
 
     var modelId: String {
         switch self {
-        case .fast: return "claude-3-haiku-20240307"
-        case .balanced: return "claude-sonnet-4-20250514"
-        case .powerful: return "claude-opus-4-20250514"
+        case .fast: return "claude-haiku-4-5"
+        case .balanced: return "claude-sonnet-5"
+        case .powerful: return "claude-opus-5"
         }
     }
 }

--- a/src/lib/config-schema.ts
+++ b/src/lib/config-schema.ts
@@ -39,13 +39,13 @@ const permissionSchema = z.record(z.string(), permissionRuleSchema).meta({
 })
 
 const MODEL_FORMAT_MESSAGE =
-  'must be in provider/model format (e.g., "anthropic/claude-sonnet-4")'
+  'must be in provider/model format (e.g., "anthropic/claude-sonnet-5")'
 
 /**
  * Pattern for provider/model format.
  * Provider: one or more non-whitespace, non-slash chars (e.g., "anthropic", "openai").
  * Model: one or more non-whitespace chars — may contain slashes for multi-segment
- *        paths such as "openrouter/anthropic/claude-sonnet-4".
+ *        paths such as "openrouter/anthropic/claude-sonnet-5".
  *
  * This is an exact regex translation of the original isValidModelFormat check:
  * "no whitespace anywhere, at least one char before the first slash, at least one
@@ -62,7 +62,7 @@ const modelSchema = z
   .meta({
     description:
       'Model identifier in provider/model format, or null to inherit parent model',
-    examples: ['anthropic/claude-sonnet-4', null],
+    examples: ['anthropic/claude-sonnet-5', null],
   })
 
 const variantSchema = z
@@ -213,7 +213,7 @@ const OpencodeHarnessBlockSchema = z
     description:
       'OpenCode-specific routing block. When present, model/variant here override the flat model/variant fields for OpenCode only; the flat fields remain the harness-neutral default and still apply to Pi. `variant` is bound to whichever layer supplies `model`: it is used only from that layer or a more specific one, and is dropped when a more specific layer sets (or nulls) `model` without repeating the variant. A `variant` with no `model` anywhere in the merged overlay is a config-load error raised by the routing resolver, not a parse-time error.',
     examples: [
-      { model: 'anthropic/claude-opus-4-7', variant: 'v2' },
+      { model: 'anthropic/claude-opus-5', variant: 'high' },
       { model: null },
     ],
   })
@@ -228,7 +228,7 @@ const PiHarnessBlockSchema = z
     description:
       "Pi-specific routing block. When present, model/thinking here override the flat model field and the legacy `pi_subagents.<name>.thinking` value for Pi only; the flat model field remains the harness-neutral default and still applies to OpenCode. Unlike OpenCode's `variant`, `thinking` is independent of `model`: it applies to whatever model the delegate ends up running, including one inherited from the parent session, so `thinking` with no `model` anywhere in the merged overlay is valid and never a config-load error.",
     examples: [
-      { model: 'anthropic/claude-opus-4-7', thinking: 'high' },
+      { model: 'anthropic/claude-opus-5', thinking: 'high' },
       { model: null },
     ],
   })
@@ -254,13 +254,13 @@ export const AgentOverlaySchema = z
     description: 'Per-agent configuration overlay',
     examples: [
       {
-        model: 'anthropic/claude-opus-4-7',
+        model: 'anthropic/claude-opus-5',
         temperature: 0.1,
         mode: 'subagent',
       },
       {
-        opencode: { model: 'anthropic/claude-opus-4-7', variant: 'v2' },
-        pi: { model: 'anthropic/claude-opus-4-7', thinking: 'high' },
+        opencode: { model: 'anthropic/claude-opus-5', variant: 'high' },
+        pi: { model: 'anthropic/claude-opus-5', thinking: 'high' },
       },
     ],
   })
@@ -285,8 +285,8 @@ export const CategoryOverlaySchema = z
     description:
       'Per-category configuration overlay (same fields as agent minus disable)',
     examples: [
-      { model: 'anthropic/claude-opus-4-7', temperature: 0.1 },
-      { opencode: { variant: 'v2' }, pi: { thinking: 'high' } },
+      { model: 'anthropic/claude-opus-5', temperature: 0.1 },
+      { opencode: { variant: 'high' }, pi: { thinking: 'high' } },
     ],
   })
 
@@ -314,8 +314,8 @@ export const ProfileOverlaySchema = z
     description:
       'Routing-only overlay fields permitted inside a named profile bundle entry: model, variant, temperature, top_p, and the opencode/pi harness blocks. Non-routing fields (permission, skills, mode, hidden, disable, steps, color) are rejected.',
     examples: [
-      { model: 'anthropic/claude-opus-4-7' },
-      { opencode: { variant: 'v2' }, pi: { thinking: 'high' } },
+      { model: 'anthropic/claude-opus-5' },
+      { opencode: { variant: 'high' }, pi: { thinking: 'high' } },
     ],
   })
 
@@ -352,7 +352,9 @@ function createProfileBundleSchema(
         .meta({
           description:
             'Per-agent routing overlays for this profile, keyed by bundled agent name (bare or qualified category/name), using the same routing-only field set as every profile entry. Unknown keys are rejected with a Zod parse error, exactly like the top-level `agents` field.',
-          examples: [{ 'correctness-reviewer': { model: 'openai/gpt-5' } }],
+          examples: [
+            { 'correctness-reviewer': { model: 'openai/gpt-6-astra' } },
+          ],
         }),
       categories: z
         .record(z.string(), ProfileOverlaySchema)
@@ -360,7 +362,7 @@ function createProfileBundleSchema(
         .meta({
           description:
             'Per-category routing overlays for this profile, keyed by category name, using the same routing-only field set as every profile entry.',
-          examples: [{ review: { model: 'anthropic/claude-opus-4-7' } }],
+          examples: [{ review: { model: 'anthropic/claude-opus-5' } }],
         }),
     })
     .strict()
@@ -369,7 +371,7 @@ function createProfileBundleSchema(
         'A named routing-only overlay bundle. Entries under agents/categories have the same shape as the top-level agents/categories overlays, restricted to routing fields.',
       examples: [
         {
-          agents: { fixer: { model: 'anthropic/claude-opus-4-7' } },
+          agents: { fixer: { model: 'anthropic/claude-opus-5' } },
           categories: { review: { pi: { thinking: 'high' } } },
         },
       ],
@@ -579,7 +581,7 @@ export function createSystematicConfigSchema(
         .meta({
           description:
             'Per-category configuration overlays keyed by category name',
-          examples: [{ review: { model: 'anthropic/claude-opus-4-7' } }, {}],
+          examples: [{ review: { model: 'anthropic/claude-opus-5' } }, {}],
         }),
       profiles: z
         .record(
@@ -593,7 +595,9 @@ export function createSystematicConfigSchema(
           examples: [
             {
               personal: {
-                agents: { 'correctness-reviewer': { model: 'openai/gpt-5' } },
+                agents: {
+                  'correctness-reviewer': { model: 'openai/gpt-6-astra' },
+                },
               },
             },
             {},

--- a/tests/fixtures/pi-subagents-personas/systematic-personas-manifest.json
+++ b/tests/fixtures/pi-subagents-personas/systematic-personas-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-24T19:13:37.092Z",
+  "generatedAt": "2026-09-05T15:34:47.264Z",
   "entries": [
     {
       "filename": "systematic-best-practices-researcher.md",

--- a/tests/fixtures/pi-subagents-personas/systematic-personas-manifest.json
+++ b/tests/fixtures/pi-subagents-personas/systematic-personas-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-09-05T15:34:47.264Z",
+  "generatedAt": "2026-08-24T19:13:37.092Z",
   "entries": [
     {
       "filename": "systematic-best-practices-researcher.md",

--- a/tests/unit/generate-config-schema.test.ts
+++ b/tests/unit/generate-config-schema.test.ts
@@ -827,7 +827,10 @@ describe('AJV parity: Zod runtime contract vs generated JSON Schema', () => {
       name: 'agent variant with explicit model accepted by both',
       value: {
         agents: {
-          'correctness-reviewer': { model: 'openai/gpt-5.5', variant: 'high' },
+          'correctness-reviewer': {
+            model: 'openai/gpt-6-astra',
+            variant: 'high',
+          },
         },
       },
       accepted: true,
@@ -855,7 +858,10 @@ describe('AJV parity: Zod runtime contract vs generated JSON Schema', () => {
       name: 'variant with explicit model accepted by both',
       value: {
         agents: {
-          'correctness-reviewer': { model: 'openai/gpt-5.5', variant: 'high' },
+          'correctness-reviewer': {
+            model: 'openai/gpt-6-astra',
+            variant: 'high',
+          },
         },
       },
       accepted: true,


### PR DESCRIPTION
## Summary

Example model identifiers across user-facing surfaces were several generations old. This refreshes them to current models.dev entries and updates the OMO routing profile's category models.

## Changes

- `src/lib/config-schema.ts` meta examples/descriptions → regenerated JSON Schema (`docs/public/schemas/v3`) and the generated reference region
- Hand-written `configuration.mdx` examples, `guides/pi-subagents.mdx`, one skill reference example
- OMO profile (`registry/files/profiles/omo/oh-my-opencode.jsonc` + its AGENTS.md): `gemini-3-pro-preview` → `gemini-3.1-pro-preview`, `claude-opus-4-6` → `claude-opus-5`, `claude-sonnet-4-5` → `claude-sonnet-5`; `gpt-5.3-codex` and `variant: max` unchanged
- Two schema-test fixture values that pinned the old example ids

Left alone on purpose: the deleted-defaults table in `model-defaults-migration.mdx` (historical record), the recorded with/without eval, plans, solutions, and the config corpus fixtures (arbitrary ids; rewriting them changes expected bytes for no behaviour gain).

All gates green: unit tests, typecheck, lint, schema/registry/persona drift, content-integrity, `docs:verify` (86 pages).

Also left alone: the `anthropic/claude-opus-4-7` / `variant: 'v2'` fixtures in `tests/unit/config-schema.test.ts` (arbitrary values in independent fixtures, not assertions against schema examples). `variant: "high"` in examples matches the profiles guide and is visually distinct from Pi's `thinking` by field name; both ids were confirmed against the models.dev registry (`openai/gpt-6-astra` released 2026-09-04, `gpt-5.6-luna` 2026-07-09); `claude-haiku-4-5` stays because no Haiku 5 exists.
