### PR TITLE
ci(fro-bot): request branch-pr delivery for autoheal runs and check all four drift gates

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -242,8 +242,9 @@ env:
           committed artifact).
         - Run `bun run review-schema:drift` and report drift (the review
           schema must stay aligned with its committed artifact).
-        - Run `bun run agent-browser:drift` and report drift (agent-browser
-          config must stay aligned with its committed artifact).
+        - Run `bun run agent-browser:drift` and report drift
+          (`skills/agent-browser/SKILL.md` and `ATTRIBUTIONS.md` must stay
+          aligned with the pinned `agent-browser` package generator).
         - Run `bun run docs:build` and report any docs build regressions
           (especially MDX parse errors, Starlight config-shape breaks).
         - Verify convention compliance:
@@ -713,9 +714,15 @@ jobs:
           model: ${{ vars.FRO_BOT_MODEL }}
           omo-providers: ${{ secrets.OMO_PROVIDERS }}
           opencode-config: ${{ secrets.OPENCODE_CONFIG }}
-          # branch-pr only for schedule/autoheal-dispatch runs, so the agent's
-          # file changes land on a branch instead of being discarded; PR-review
-          # and comment-triggered runs stay comment-only (empty = default).
-          output-mode: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'autoheal')) && 'branch-pr' || '' }}
+          # branch-pr only for the daily autoheal schedule and autoheal-mode
+          # dispatch runs, so the agent's file changes land on a branch instead
+          # of being discarded. Prompt-only dispatches (release-notes-narrative
+          # automation via scripts/dispatch-release-notes.sh) carry inputs.prompt
+          # and must stay comment-only, so this uses the same `inputs.prompt ==
+          # ''` guard and cron predicate as the PROMPT ladder above. PR-review
+          # and comment-triggered runs never match either branch, so the ''
+          # fallback there is defensive only: the action consults output-mode
+          # solely on schedule/workflow_dispatch runs.
+          output-mode: ${{ ((github.event_name == 'schedule' && github.event.schedule == '30 3 * * *') || (github.event_name == 'workflow_dispatch' && inputs.prompt == '' && inputs.mode == 'autoheal')) && 'branch-pr' || '' }}
           prompt: ${{ env.PROMPT }}
           timeout: 0

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -240,6 +240,10 @@ env:
         - Run `bun run schema:drift` and report drift (the JSON Schema
           emitted from the Zod source must stay aligned with the
           committed artifact).
+        - Run `bun run review-schema:drift` and report drift (the review
+          schema must stay aligned with its committed artifact).
+        - Run `bun run agent-browser:drift` and report drift (agent-browser
+          config must stay aligned with its committed artifact).
         - Run `bun run docs:build` and report any docs build regressions
           (especially MDX parse errors, Starlight config-shape breaks).
         - Verify convention compliance:
@@ -292,8 +296,10 @@ env:
        e. `bun scripts/content-integrity.ts` — 0 violations.
         f. `bun run registry:drift` — 0 drift.
         g. `bun run schema:drift` — 0 drift.
-        h. `bun run docs:verify` — completes without error.
-        i. Node ESM smoke test:
+        h. `bun run review-schema:drift` — 0 drift.
+        i. `bun run agent-browser:drift` — 0 drift.
+        j. `bun run docs:verify` — completes without error.
+        k. Node ESM smoke test:
            `node --input-type=module -e "import('./dist/index.js').then(m => console.log(Object.keys(m).sort()))"`
            — exports only `['default']` (regression contract from v2.5.2/v2.12.2;
            a named export of `SystematicPlugin` breaks OpenCode plugin loading).
@@ -707,5 +713,9 @@ jobs:
           model: ${{ vars.FRO_BOT_MODEL }}
           omo-providers: ${{ secrets.OMO_PROVIDERS }}
           opencode-config: ${{ secrets.OPENCODE_CONFIG }}
+          # branch-pr only for schedule/autoheal-dispatch runs, so the agent's
+          # file changes land on a branch instead of being discarded; PR-review
+          # and comment-triggered runs stay comment-only (empty = default).
+          output-mode: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'autoheal')) && 'branch-pr' || '' }}
           prompt: ${{ env.PROMPT }}
           timeout: 0

--- a/tests/unit/fro-bot-workflow.test.ts
+++ b/tests/unit/fro-bot-workflow.test.ts
@@ -237,6 +237,30 @@ describe('Fro Bot workflow contracts', () => {
     expect(outputMode).toContain('branch-pr')
     expect(outputMode).toContain("github.event_name == 'schedule'")
     expect(outputMode).toContain("inputs.mode == 'autoheal'")
+    expect(outputMode).toContain("|| ''")
+    expect(outputMode).toContain("inputs.prompt == ''")
+    expect(outputMode).toContain("github.event.schedule == '30 3 * * *'")
+  })
+
+  test('agrees with the PROMPT ladder that prompt-only dispatches stay comment-only', () => {
+    const { workflow } = readWorkflow()
+    const jobs = asRecord(workflow.jobs, 'jobs')
+    const froBot = asRecord(jobs['fro-bot'], 'fro-bot job')
+    const steps = asArray(froBot.steps, 'fro-bot steps')
+    const runFroBot = findStep(steps, 'Run Fro Bot')
+    const runFroBotEnv = asRecord(runFroBot.env, 'Run Fro Bot env')
+    const runFroBotWith = asRecord(runFroBot.with, 'Run Fro Bot with')
+    const promptExpression = asString(
+      runFroBotEnv.PROMPT,
+      'Run Fro Bot env.PROMPT',
+    )
+    const outputMode = asString(
+      runFroBotWith['output-mode'],
+      'Run Fro Bot with.output-mode',
+    )
+
+    expect(promptExpression).toContain("inputs.prompt != ''")
+    expect(outputMode).toContain("inputs.prompt == ''")
   })
 
   test('retains the exact issue_comment pull_request fork guard', () => {

--- a/tests/unit/fro-bot-workflow.test.ts
+++ b/tests/unit/fro-bot-workflow.test.ts
@@ -222,6 +222,23 @@ describe('Fro Bot workflow contracts', () => {
     )
   })
 
+  test('requests branch-pr output only for schedule and autoheal-mode dispatch runs', () => {
+    const { workflow } = readWorkflow()
+    const jobs = asRecord(workflow.jobs, 'jobs')
+    const froBot = asRecord(jobs['fro-bot'], 'fro-bot job')
+    const steps = asArray(froBot.steps, 'fro-bot steps')
+    const runFroBot = findStep(steps, 'Run Fro Bot')
+    const runFroBotWith = asRecord(runFroBot.with, 'Run Fro Bot with')
+    const outputMode = asString(
+      runFroBotWith['output-mode'],
+      'Run Fro Bot with.output-mode',
+    )
+
+    expect(outputMode).toContain('branch-pr')
+    expect(outputMode).toContain("github.event_name == 'schedule'")
+    expect(outputMode).toContain("inputs.mode == 'autoheal'")
+  })
+
   test('retains the exact issue_comment pull_request fork guard', () => {
     const { workflow } = readWorkflow()
     const jobs = asRecord(workflow.jobs, 'jobs')
@@ -286,6 +303,17 @@ describe('Fro Bot workflow contracts', () => {
       /(?:no|do not|never) named-agent follow-up tasks/i,
     )
     expect(autohealPrompt).not.toContain('### Tasks for Agents')
+  })
+
+  test('names all four drift-check commands in the autoheal prompt', () => {
+    const { workflow } = readWorkflow()
+    const env = asRecord(workflow.env, 'workflow env')
+    const autohealPrompt = asString(env.AUTOHEAL_PROMPT, 'AUTOHEAL_PROMPT')
+
+    expect(autohealPrompt).toContain('bun run registry:drift')
+    expect(autohealPrompt).toContain('bun run schema:drift')
+    expect(autohealPrompt).toContain('bun run review-schema:drift')
+    expect(autohealPrompt).toContain('bun run agent-browser:drift')
   })
 
   test('limits reactive healing and deferred notes to their safe execution model', () => {


### PR DESCRIPTION
- Gated `output-mode: branch-pr` on the `Run Fro Bot` step: `${{ ((github.event_name == 'schedule' && github.event.schedule == '30 3 * * *') || (github.event_name == 'workflow_dispatch' && inputs.prompt == '' && inputs.mode == 'autoheal')) && 'branch-pr' || '' }}` — so the daily autoheal cron and prompt-less autoheal dispatches land file changes on a branch instead of discarding them. `inputs.mode` defaults to `autoheal`, so the `inputs.prompt == ''` guard is what keeps prompt-only dispatches (the release-notes narrative automation in `scripts/dispatch-release-notes.sh`) comment-only; the guard and cron predicate mirror the PROMPT ladder directly above, and a test now pins that the two expressions agree. PR-review, comment, `workflow_call`, and review-mode runs resolve to the empty string, matching current behavior.
- Added `bun run review-schema:drift` and `bun run agent-browser:drift` to the autoheal prompt's code-quality list and quality-gates table, alongside the existing `registry:drift` and `schema:drift`, and covered both with new assertions in `tests/unit/fro-bot-workflow.test.ts`. The `agent-browser:drift` line names the artifacts it actually checks (`skills/agent-browser/SKILL.md`, `ATTRIBUTIONS.md`).
- Left the two "not reproduced" report items untouched: `IS_SUNDAY_UTC` propagation is already forwarded correctly by this workflow (issue points at the `fro-bot/agent` action's env handling, not here), and the described `--limit 400` workflow-census truncation isn't a command in this workflow — it's the agent's own runtime query.

After merge, the first scheduled run's `resolved-output-mode` output should be checked: delivery depends on `FRO_BOT_PAT` scopes, and an insufficient token fails closed to today's discard behavior.

Closes #910
