### PR TITLE
refactor(evals): derive the OpenCode host pin from package.json

### DIFF
--- a/docs/plans/2026-09-04-001-refactor-ci-owned-host-contract-suite-plan.md
+++ b/docs/plans/2026-09-04-001-refactor-ci-owned-host-contract-suite-plan.md
@@ -155,7 +155,7 @@ Two adjacent facts shaped the design. `mise.toml` prepends `./node_modules/.bin`
 
 ## Implementation Units
 
-- [ ] **Unit 1: Derive the OpenCode pin from `package.json`**
+- [x] **Unit 1: Derive the OpenCode pin from `package.json`**
 
 **Goal:** One readable source of the pinned OpenCode version, with the two former constants and the lockstep test reduced to it.
 

--- a/docs/solutions/workflow-issues/version-pinned-evidence-must-be-reproven-2026-08-16.md
+++ b/docs/solutions/workflow-issues/version-pinned-evidence-must-be-reproven-2026-08-16.md
@@ -23,18 +23,16 @@ applies_when:
 
 Some claims in this repository are only true relative to a specific external runtime version. The clearest case is host skill discovery: Systematic can delete its own bootstrap skill catalog *because* OpenCode renders an equivalent catalog itself. That is not a property of Systematic's code — it is a property of the OpenCode build being run against. Change the build, and the evidence is no longer evidence.
 
-`tests/unit/eval-contract.test.ts` guards the pins:
+`scripts/lib/opencode-pin.ts` reads `@opencode-ai/sdk` out of `package.json` `devDependencies` at runtime; `EXPECTED_OPENCODE_VERSION` (`scripts/run-evals.ts`) and `EXACT_OPENCODE_VERSION` (`tests/integration/fixtures/receipt-workflow-host.ts`) are re-exports of that value, not hand-edited copies. `tests/unit/eval-contract.test.ts` keeps a single backstop assertion on top of that:
 
 ```ts
-// EXPECTED_OPENCODE_VERSION  (scripts/run-evals.ts)
-// EXACT_OPENCODE_VERSION     (tests/integration/fixtures/receipt-workflow-host.ts)
-// must both equal the @opencode-ai/sdk devDependency, and
-// @opencode-ai/sdk must equal @opencode-ai/plugin.
+// @opencode-ai/sdk must equal @opencode-ai/plugin in package.json devDependencies.
+// (@opencode-ai/plugin's peerDependencies range is a separate, unrelated field.)
 ```
 
 Its failure message is deliberately more than a diff report:
 
-> `OpenCode host pin drift: <name> is <pin>, but package.json devDependencies @opencode-ai/sdk and @opencode-ai/plugin are <version>. Change <name> to <version>, then re-run the host-coverage eval before relying on bootstrap catalog deletion evidence.`
+> `OpenCode devDependency versions disagree: @opencode-ai/sdk is <sdk version>, but @opencode-ai/plugin is <plugin version>. Align both dependencies before re-running the host-coverage eval.`
 
 ## Guidance
 
@@ -42,7 +40,7 @@ Its failure message is deliberately more than a diff report:
 
 The sequence when a pinned runtime moves:
 
-1. Bump every pin in lockstep — `EXPECTED_OPENCODE_VERSION`, `EXACT_OPENCODE_VERSION`, and the `@opencode-ai/sdk` / `@opencode-ai/plugin` devDependencies must all agree.
+1. Bump `@opencode-ai/sdk` and `@opencode-ai/plugin` together in `package.json` `devDependencies` (Renovate's `OpenCode` group already does this in one PR). `EXPECTED_OPENCODE_VERSION` and `EXACT_OPENCODE_VERSION` derive from `@opencode-ai/sdk` automatically — there is no separate constant to edit or forget.
 2. Re-run the version-dependent suite against the real host:
 
    ```bash
@@ -76,25 +74,24 @@ The guard is worth having precisely because it is inconvenient at exactly the ri
 
 ## Examples
 
-### Wrong: satisfy the guard, keep the old result
+### Wrong: bump the pin, keep the old result
 
 ```diff
--export const EXPECTED_OPENCODE_VERSION = '1.18.17' as const
-+export const EXPECTED_OPENCODE_VERSION = '1.18.18' as const
+-    "@opencode-ai/plugin": "1.18.17",
+-    "@opencode-ai/sdk": "1.18.17",
++    "@opencode-ai/plugin": "1.18.18",
++    "@opencode-ai/sdk": "1.18.18",
 ```
 
-Tests pass. The host-coverage claim still rests on a 1.18.17 observation. The guard has been converted into a formality.
+`EXPECTED_OPENCODE_VERSION` and `EXACT_OPENCODE_VERSION` follow automatically (they derive from `@opencode-ai/sdk`), and the unit suite passes. The host-coverage claim still rests on a 1.18.17 observation. The pin moved; the evidence did not.
 
 ### Right: move the pin and re-collect the evidence
 
 ```diff
--export const EXPECTED_OPENCODE_VERSION = '1.18.17' as const
-+export const EXPECTED_OPENCODE_VERSION = '1.18.18' as const
-```
-
-```diff
--export const EXACT_OPENCODE_VERSION = '1.18.17'
-+export const EXACT_OPENCODE_VERSION = '1.18.18'
+-    "@opencode-ai/plugin": "1.18.17",
+-    "@opencode-ai/sdk": "1.18.17",
++    "@opencode-ai/plugin": "1.18.18",
++    "@opencode-ai/sdk": "1.18.18",
 ```
 
 ```bash
@@ -107,15 +104,16 @@ bun test tests/integration/eval-runner.test.ts \
 ### Write the follow-up into the guard itself
 
 ```ts
-throw new Error(
-  `OpenCode host pin drift: ${name} is ${pin}, but package.json devDependencies ` +
-  `@opencode-ai/sdk and @opencode-ai/plugin are ${sdkVersion}. Change ${name} to ` +
-  `${sdkVersion}, then re-run the host-coverage eval before relying on bootstrap ` +
-  `catalog deletion evidence.`,
-)
+if (sdkVersion !== pluginVersion) {
+  throw new Error(
+    `OpenCode devDependency versions disagree: @opencode-ai/sdk is ${sdkVersion}, ` +
+    `but @opencode-ai/plugin is ${pluginVersion}. Align both dependencies before ` +
+    `re-running the host-coverage eval.`,
+  )
+}
 ```
 
-The instruction is the load-bearing part. The comparison only detects drift; the message is what prevents the drift from being papered over.
+The instruction is the load-bearing part. The comparison only detects drift; the message is what prevents the drift from being papered over. The re-proof requirement in Guidance above is unchanged by where the pin lives — it is a property of the evidence, not of how the constant is written.
 
 ## Related
 

--- a/scripts/lib/opencode-pin.ts
+++ b/scripts/lib/opencode-pin.ts
@@ -27,14 +27,16 @@ interface PackageJsonShape {
   devDependencies?: Record<string, unknown>
 }
 
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
 function readPackageJson(packageJsonPath: string): PackageJsonShape {
   let raw: string
   try {
     raw = fs.readFileSync(packageJsonPath, 'utf8')
   } catch (err) {
-    throw new Error(
-      `Failed to read ${packageJsonPath}: ${(err as Error).message}`,
-    )
+    throw new Error(`Failed to read ${packageJsonPath}: ${errorMessage(err)}`)
   }
 
   let parsed: unknown
@@ -42,7 +44,7 @@ function readPackageJson(packageJsonPath: string): PackageJsonShape {
     parsed = JSON.parse(raw)
   } catch (err) {
     throw new Error(
-      `Failed to parse ${packageJsonPath} as JSON: ${(err as Error).message}`,
+      `Failed to parse ${packageJsonPath} as JSON: ${errorMessage(err)}`,
     )
   }
 
@@ -56,11 +58,18 @@ function readPackageJson(packageJsonPath: string): PackageJsonShape {
 /** Matches an exact semver version with no range specifier. */
 const EXACT_SEMVER_PATTERN = /^\d+\.\d+\.\d+(?:[-+].+)?$/
 
-function readExactDevDependency(
+/**
+ * Extracts and validates one exact-pinned devDependency field from an
+ * already-parsed `package.json` object. Kept separate from `readPackageJson`
+ * so a caller that needs multiple fields (`readOpencodeDevDependencyPins`)
+ * reads and parses the file once and extracts each field from that same
+ * parsed object, rather than re-reading the file per field.
+ */
+function extractExactDevDependency(
+  pkg: PackageJsonShape,
   fieldName: string,
   packageJsonPath: string,
 ): string {
-  const pkg = readPackageJson(packageJsonPath)
   const devDeps = pkg.devDependencies
   if (
     typeof devDeps !== 'object' ||
@@ -86,6 +95,17 @@ function readExactDevDependency(
   }
 
   return raw
+}
+
+function readExactDevDependency(
+  fieldName: string,
+  packageJsonPath: string,
+): string {
+  return extractExactDevDependency(
+    readPackageJson(packageJsonPath),
+    fieldName,
+    packageJsonPath,
+  )
 }
 
 /**
@@ -118,8 +138,9 @@ export function readOpencodeDevDependencyPins(packageJsonPath?: string): {
   plugin: string
 } {
   const resolvedPath = packageJsonPath ?? DEFAULT_PACKAGE_JSON_PATH
+  const pkg = readPackageJson(resolvedPath)
   return {
-    sdk: readExactDevDependency('@opencode-ai/sdk', resolvedPath),
-    plugin: readExactDevDependency('@opencode-ai/plugin', resolvedPath),
+    sdk: extractExactDevDependency(pkg, '@opencode-ai/sdk', resolvedPath),
+    plugin: extractExactDevDependency(pkg, '@opencode-ai/plugin', resolvedPath),
   }
 }

--- a/scripts/lib/opencode-pin.ts
+++ b/scripts/lib/opencode-pin.ts
@@ -1,0 +1,125 @@
+/**
+ * Single source of truth for the pinned OpenCode host version: the
+ * `@opencode-ai/sdk` devDependency in this repository's `package.json`.
+ *
+ * `@opencode-ai/plugin` also has a devDependency entry (the exact pin used
+ * for the equality backstop below) and a separate `peerDependencies` range
+ * entry (a consumer-facing compatibility range, not a pin). Only the
+ * devDependency entries participate in the pin.
+ *
+ * Renovate's `OpenCode` group bumps both `@opencode-ai/sdk` and
+ * `@opencode-ai/plugin` devDependencies together, so callers that need the
+ * exact pinned version should read it from here rather than hardcoding a
+ * literal, which would silently drift from `package.json` on the next bump.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const DEFAULT_PACKAGE_JSON_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'package.json',
+)
+
+interface PackageJsonShape {
+  devDependencies?: Record<string, unknown>
+}
+
+function readPackageJson(packageJsonPath: string): PackageJsonShape {
+  let raw: string
+  try {
+    raw = fs.readFileSync(packageJsonPath, 'utf8')
+  } catch (err) {
+    throw new Error(
+      `Failed to read ${packageJsonPath}: ${(err as Error).message}`,
+    )
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    throw new Error(
+      `Failed to parse ${packageJsonPath} as JSON: ${(err as Error).message}`,
+    )
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`${packageJsonPath} does not contain a JSON object.`)
+  }
+
+  return parsed as PackageJsonShape
+}
+
+/** Matches an exact semver version with no range specifier. */
+const EXACT_SEMVER_PATTERN = /^\d+\.\d+\.\d+(?:[-+].+)?$/
+
+function readExactDevDependency(
+  fieldName: string,
+  packageJsonPath: string,
+): string {
+  const pkg = readPackageJson(packageJsonPath)
+  const devDeps = pkg.devDependencies
+  if (
+    typeof devDeps !== 'object' ||
+    devDeps === null ||
+    Array.isArray(devDeps)
+  ) {
+    throw new Error(
+      `${packageJsonPath} is missing a devDependencies object. Add "${fieldName}": "<exact version>" to devDependencies.`,
+    )
+  }
+
+  const raw = devDeps[fieldName]
+  if (typeof raw !== 'string' || raw.length === 0) {
+    throw new Error(
+      `${fieldName} is not listed in ${packageJsonPath} devDependencies. Add it with an exact version pin (no ^ or ~).`,
+    )
+  }
+
+  if (!EXACT_SEMVER_PATTERN.test(raw)) {
+    throw new Error(
+      `${fieldName} in ${packageJsonPath} devDependencies must be an exact version, but found "${raw}". Remove any range specifier (^, ~, *, etc.) so the OpenCode host pin stays exact.`,
+    )
+  }
+
+  return raw
+}
+
+/**
+ * Returns the exact `@opencode-ai/sdk` devDependency version from
+ * `package.json`. Throws a clear error naming the field if it is missing or
+ * not an exact version.
+ *
+ * @param packageJsonPath - Optional override, primarily for tests that point
+ *   at a temporary copy of `package.json`. Defaults to the repository's own
+ *   `package.json`, resolved relative to this module rather than `cwd`.
+ */
+export function readOpencodeSdkPin(packageJsonPath?: string): string {
+  return readExactDevDependency(
+    '@opencode-ai/sdk',
+    packageJsonPath ?? DEFAULT_PACKAGE_JSON_PATH,
+  )
+}
+
+/**
+ * Returns both the `@opencode-ai/sdk` and `@opencode-ai/plugin` devDependency
+ * versions from `package.json`, for the equality backstop that guards against
+ * the two drifting apart on a manual edit (Renovate's `OpenCode` group bumps
+ * both together in one PR).
+ *
+ * @param packageJsonPath - Optional override, primarily for tests that point
+ *   at a temporary copy of `package.json`.
+ */
+export function readOpencodeDevDependencyPins(packageJsonPath?: string): {
+  sdk: string
+  plugin: string
+} {
+  const resolvedPath = packageJsonPath ?? DEFAULT_PACKAGE_JSON_PATH
+  return {
+    sdk: readExactDevDependency('@opencode-ai/sdk', resolvedPath),
+    plugin: readExactDevDependency('@opencode-ai/plugin', resolvedPath),
+  }
+}

--- a/scripts/run-evals.ts
+++ b/scripts/run-evals.ts
@@ -1888,6 +1888,7 @@ export function serializeRunManifest(input: unknown): string {
   return serialized
 }
 
+// `string`, read from package.json at import time; throws if the pin is missing or not exact.
 export const EXPECTED_OPENCODE_VERSION = readOpencodeSdkPin()
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '..')

--- a/scripts/run-evals.ts
+++ b/scripts/run-evals.ts
@@ -6,6 +6,8 @@ import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { gunzipSync } from 'node:zlib'
 
+import { readOpencodeSdkPin } from './lib/opencode-pin.js'
+
 const CASE_SCHEMA_VERSION = 1 as const
 const RESULT_SCHEMA_VERSION = 1 as const
 export const RUN_MANIFEST_SCHEMA_VERSION = 1 as const
@@ -1886,7 +1888,7 @@ export function serializeRunManifest(input: unknown): string {
   return serialized
 }
 
-export const EXPECTED_OPENCODE_VERSION = '1.18.21' as const
+export const EXPECTED_OPENCODE_VERSION = readOpencodeSdkPin()
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '..')
 const FIXTURE_CONTRACT_VERSION = 1 as const

--- a/tests/integration/fixtures/receipt-workflow-host.ts
+++ b/tests/integration/fixtures/receipt-workflow-host.ts
@@ -8,6 +8,7 @@ import { readOpencodeSdkPin } from '../../../scripts/lib/opencode-pin.js'
 import { stopProcessGroup } from '../../../scripts/lib/process-group.js'
 
 export const TIMEOUT_MS = 180_000
+// `string`, read from package.json at import time; throws if the pin is missing or not exact.
 export const EXACT_OPENCODE_VERSION = readOpencodeSdkPin()
 let exactNpmCacheDir: string | undefined
 export const MAX_RETRIES = 1

--- a/tests/integration/fixtures/receipt-workflow-host.ts
+++ b/tests/integration/fixtures/receipt-workflow-host.ts
@@ -4,10 +4,11 @@ import os from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
+import { readOpencodeSdkPin } from '../../../scripts/lib/opencode-pin.js'
 import { stopProcessGroup } from '../../../scripts/lib/process-group.js'
 
 export const TIMEOUT_MS = 180_000
-export const EXACT_OPENCODE_VERSION = '1.18.21'
+export const EXACT_OPENCODE_VERSION = readOpencodeSdkPin()
 let exactNpmCacheDir: string | undefined
 export const MAX_RETRIES = 1
 export const RETRY_DELAY_MS = 3_000

--- a/tests/unit/eval-contract.test.ts
+++ b/tests/unit/eval-contract.test.ts
@@ -3,11 +3,11 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { validateModelInheritanceManifest } from '../../scripts/eval-cases/opencode.ts'
+import { readOpencodeDevDependencyPins } from '../../scripts/lib/opencode-pin.ts'
 import {
   CASE_IDS,
   CASE_SCHEMA_VERSION,
   type EvalMode,
-  EXPECTED_OPENCODE_VERSION,
   normalizeResult,
   OUTCOMES,
   parseCaseManifest,
@@ -16,7 +16,6 @@ import {
 } from '../../scripts/run-evals.ts'
 import { buildBundledAgentInventory } from '../../src/lib/agent-overlays.js'
 import { buildCatalogEntries } from '../../src/lib/skill-catalog.js'
-import { EXACT_OPENCODE_VERSION } from '../integration/fixtures/receipt-workflow-host.js'
 
 const ROOT_DIR = path.resolve(import.meta.dirname, '../..')
 const MANIFEST_DIR = path.join(ROOT_DIR, 'evals/cases/opencode')
@@ -281,44 +280,17 @@ describe('local OpenCode eval contracts', () => {
     expect(staleManifestNames).toEqual([])
   })
 
-  test('keeps exact host-coverage pins aligned with OpenCode devDependencies', () => {
-    const packageJson = JSON.parse(
-      fs.readFileSync(path.join(ROOT_DIR, 'package.json'), 'utf8'),
-    ) as {
-      devDependencies?: Record<string, unknown>
-    }
-    const sdkVersion = packageJson.devDependencies?.['@opencode-ai/sdk']
-    const pluginVersion = packageJson.devDependencies?.['@opencode-ai/plugin']
+  test('keeps @opencode-ai/sdk and @opencode-ai/plugin devDependencies aligned', () => {
+    const { sdk: sdkVersion, plugin: pluginVersion } =
+      readOpencodeDevDependencyPins()
 
-    if (typeof sdkVersion !== 'string' || typeof pluginVersion !== 'string') {
-      throw new Error(
-        'OpenCode host pin check cannot read @opencode-ai/sdk and @opencode-ai/plugin from package.json devDependencies.',
-      )
-    }
     if (sdkVersion !== pluginVersion) {
       throw new Error(
         `OpenCode devDependency versions disagree: @opencode-ai/sdk is ${sdkVersion}, but @opencode-ai/plugin is ${pluginVersion}. Align both dependencies before re-running the host-coverage eval.`,
       )
     }
 
-    const pins = [
-      [
-        'scripts/run-evals.ts EXPECTED_OPENCODE_VERSION',
-        EXPECTED_OPENCODE_VERSION,
-      ],
-      [
-        'tests/integration/fixtures/receipt-workflow-host.ts EXACT_OPENCODE_VERSION',
-        EXACT_OPENCODE_VERSION,
-      ],
-    ] as const
-
-    for (const [name, pin] of pins) {
-      if (pin !== sdkVersion) {
-        throw new Error(
-          `OpenCode host pin drift: ${name} is ${pin}, but package.json devDependencies @opencode-ai/sdk and @opencode-ai/plugin are ${sdkVersion}. Change ${name} to ${sdkVersion}, then re-run the host-coverage eval before relying on bootstrap catalog deletion evidence.`,
-        )
-      }
-    }
+    expect(sdkVersion).toBe(pluginVersion)
   })
 
   test('rejects unknown, missing, unsupported, and wrong-version manifest fields', () => {

--- a/tests/unit/eval-contract.test.ts
+++ b/tests/unit/eval-contract.test.ts
@@ -289,8 +289,6 @@ describe('local OpenCode eval contracts', () => {
         `OpenCode devDependency versions disagree: @opencode-ai/sdk is ${sdkVersion}, but @opencode-ai/plugin is ${pluginVersion}. Align both dependencies before re-running the host-coverage eval.`,
       )
     }
-
-    expect(sdkVersion).toBe(pluginVersion)
   })
 
   test('rejects unknown, missing, unsupported, and wrong-version manifest fields', () => {

--- a/tests/unit/opencode-pin.test.ts
+++ b/tests/unit/opencode-pin.test.ts
@@ -167,10 +167,12 @@ describe('re-exports stay in sync with the helper', () => {
 })
 
 describe('R1: no hardcoded OpenCode pin literal', () => {
-  const EXCLUDED_DIR = path.join(REPO_ROOT, 'tests', 'fixtures')
-
   function isExcludedDir(dirPath: string): boolean {
-    return dirPath.includes('node_modules') || dirPath === EXCLUDED_DIR
+    return path.basename(dirPath) === 'node_modules'
+  }
+
+  function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   }
 
   function collectTsFiles(rootDir: string): string[] {
@@ -197,8 +199,11 @@ describe('R1: no hardcoded OpenCode pin literal', () => {
       ...collectTsFiles(path.join(REPO_ROOT, 'tests')),
     ]
 
+    expect(files.length).toBeGreaterThan(0)
+
+    const pinPattern = new RegExp(`(?<![\\d.])${escapeRegExp(pin)}(?![\\d.])`)
     const offenders = files.filter((file) =>
-      fs.readFileSync(file, 'utf8').includes(pin),
+      pinPattern.test(fs.readFileSync(file, 'utf8')),
     )
 
     if (offenders.length > 0) {

--- a/tests/unit/opencode-pin.test.ts
+++ b/tests/unit/opencode-pin.test.ts
@@ -24,19 +24,50 @@ function makeTempDir(): string {
   return tmp
 }
 
-function writePackageJson(
+function writePackageJson(dir: string, contents: unknown): string {
+  const full = path.join(dir, 'package.json')
+  fs.writeFileSync(full, JSON.stringify(contents), 'utf-8')
+  return full
+}
+
+function writeDevDependencies(
   dir: string,
   devDependencies: Record<string, unknown>,
 ): string {
-  const full = path.join(dir, 'package.json')
-  fs.writeFileSync(full, JSON.stringify({ devDependencies }), 'utf-8')
-  return full
+  return writePackageJson(dir, { devDependencies })
 }
 
 afterAll(() => {
   for (const root of TEMP_ROOTS) {
     fs.rmSync(root, { recursive: true, force: true })
   }
+})
+
+describe('readPackageJson error branches (via readOpencodeSdkPin)', () => {
+  test('throws when the package.json file does not exist', () => {
+    const dir = makeTempDir()
+    const missingPath = path.join(dir, 'package.json')
+
+    expect(() => readOpencodeSdkPin(missingPath)).toThrow(/Failed to read/)
+  })
+
+  test('throws when the package.json file is not valid JSON', () => {
+    const dir = makeTempDir()
+    const pkgPath = path.join(dir, 'package.json')
+    fs.writeFileSync(pkgPath, '{ not valid json', 'utf-8')
+
+    expect(() => readOpencodeSdkPin(pkgPath)).toThrow(/Failed to parse/)
+  })
+
+  test('throws when the parsed package.json is not a JSON object (an array)', () => {
+    const dir = makeTempDir()
+    const pkgPath = path.join(dir, 'package.json')
+    fs.writeFileSync(pkgPath, '[]', 'utf-8')
+
+    expect(() => readOpencodeSdkPin(pkgPath)).toThrow(
+      /does not contain a JSON object/,
+    )
+  })
 })
 
 describe('readOpencodeSdkPin', () => {
@@ -53,30 +84,50 @@ describe('readOpencodeSdkPin', () => {
     expect(readOpencodeSdkPin()).toBe(expected)
   })
 
-  test('throws naming the field when the sdk entry is a range', () => {
+  test('throws when devDependencies is missing entirely', () => {
     const dir = makeTempDir()
-    const pkgPath = writePackageJson(dir, {
+    const pkgPath = writePackageJson(dir, {})
+
+    expect(() => readOpencodeSdkPin(pkgPath)).toThrow(
+      /is missing a devDependencies object/,
+    )
+  })
+
+  test('throws when devDependencies is not an object', () => {
+    const dir = makeTempDir()
+    const pkgPath = writePackageJson(dir, { devDependencies: [] })
+
+    expect(() => readOpencodeSdkPin(pkgPath)).toThrow(
+      /is missing a devDependencies object/,
+    )
+  })
+
+  test('throws "not listed in" when the sdk entry is missing', () => {
+    const dir = makeTempDir()
+    const pkgPath = writeDevDependencies(dir, {
+      '@opencode-ai/plugin': '9.9.0',
+    })
+
+    expect(() => readOpencodeSdkPin(pkgPath)).toThrow(/not listed in/)
+  })
+
+  test('throws "must be an exact version" when the sdk entry is a range', () => {
+    const dir = makeTempDir()
+    const pkgPath = writeDevDependencies(dir, {
       '@opencode-ai/sdk': '^9.9.0',
       '@opencode-ai/plugin': '9.9.0',
     })
 
-    expect(() => readOpencodeSdkPin(pkgPath)).toThrow(/@opencode-ai\/sdk/)
-  })
-
-  test('throws naming the field when the sdk entry is missing', () => {
-    const dir = makeTempDir()
-    const pkgPath = writePackageJson(dir, {
-      '@opencode-ai/plugin': '9.9.0',
-    })
-
-    expect(() => readOpencodeSdkPin(pkgPath)).toThrow(/@opencode-ai\/sdk/)
+    expect(() => readOpencodeSdkPin(pkgPath)).toThrow(
+      /must be an exact version/,
+    )
   })
 })
 
 describe('readOpencodeDevDependencyPins', () => {
   test('returns matching sdk and plugin devDependency versions', () => {
     const dir = makeTempDir()
-    const pkgPath = writePackageJson(dir, {
+    const pkgPath = writeDevDependencies(dir, {
       '@opencode-ai/sdk': '9.9.1',
       '@opencode-ai/plugin': '9.9.1',
     })
@@ -89,7 +140,7 @@ describe('readOpencodeDevDependencyPins', () => {
 
   test('the equality check fails when sdk and plugin devDependencies disagree', () => {
     const dir = makeTempDir()
-    const pkgPath = writePackageJson(dir, {
+    const pkgPath = writeDevDependencies(dir, {
       '@opencode-ai/sdk': '9.9.1',
       '@opencode-ai/plugin': '9.9.0',
     })
@@ -112,5 +163,54 @@ describe('re-exports stay in sync with the helper', () => {
       '../integration/fixtures/receipt-workflow-host.ts'
     )
     expect(EXACT_OPENCODE_VERSION).toBe(readOpencodeSdkPin())
+  })
+})
+
+describe('R1: no hardcoded OpenCode pin literal', () => {
+  const EXCLUDED_DIR = path.join(REPO_ROOT, 'tests', 'fixtures')
+
+  function isExcludedDir(dirPath: string): boolean {
+    return dirPath.includes('node_modules') || dirPath === EXCLUDED_DIR
+  }
+
+  function collectTsFiles(rootDir: string): string[] {
+    const results: string[] = []
+
+    for (const entry of fs.readdirSync(rootDir, { withFileTypes: true })) {
+      const fullPath = path.join(rootDir, entry.name)
+      if (entry.isDirectory()) {
+        if (!isExcludedDir(fullPath)) {
+          results.push(...collectTsFiles(fullPath))
+        }
+      } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+        results.push(fullPath)
+      }
+    }
+
+    return results
+  }
+
+  test('the pinned version string appears nowhere under scripts/ or tests/', () => {
+    const pin = readOpencodeSdkPin()
+    const files = [
+      ...collectTsFiles(path.join(REPO_ROOT, 'scripts')),
+      ...collectTsFiles(path.join(REPO_ROOT, 'tests')),
+    ]
+
+    const offenders = files.filter((file) =>
+      fs.readFileSync(file, 'utf8').includes(pin),
+    )
+
+    if (offenders.length > 0) {
+      throw new Error(
+        `Found the hardcoded OpenCode pin "${pin}" in: ${offenders
+          .map((file) => path.relative(REPO_ROOT, file))
+          .join(
+            ', ',
+          )}. Read it via readOpencodeSdkPin() / readOpencodeDevDependencyPins() from scripts/lib/opencode-pin.ts instead.`,
+      )
+    }
+
+    expect(offenders).toEqual([])
   })
 })

--- a/tests/unit/opencode-pin.test.ts
+++ b/tests/unit/opencode-pin.test.ts
@@ -1,0 +1,116 @@
+import { afterAll, describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  readOpencodeDevDependencyPins,
+  readOpencodeSdkPin,
+} from '../../scripts/lib/opencode-pin.ts'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const REPO_ROOT = path.resolve(__dirname, '../..')
+
+// ---------------------------------------------------------------------------
+// Temp dir helpers
+// ---------------------------------------------------------------------------
+
+const TEMP_ROOTS: string[] = []
+
+function makeTempDir(): string {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-pin-'))
+  TEMP_ROOTS.push(tmp)
+  return tmp
+}
+
+function writePackageJson(
+  dir: string,
+  devDependencies: Record<string, unknown>,
+): string {
+  const full = path.join(dir, 'package.json')
+  fs.writeFileSync(full, JSON.stringify({ devDependencies }), 'utf-8')
+  return full
+}
+
+afterAll(() => {
+  for (const root of TEMP_ROOTS) {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('readOpencodeSdkPin', () => {
+  test('returns the exact @opencode-ai/sdk devDependency from the real package.json', () => {
+    const realPackageJson = JSON.parse(
+      fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'),
+    ) as { devDependencies?: Record<string, unknown> }
+    const expected = realPackageJson.devDependencies?.['@opencode-ai/sdk']
+    if (typeof expected !== 'string') {
+      throw new Error(
+        'expected package.json devDependencies["@opencode-ai/sdk"] to be a string',
+      )
+    }
+    expect(readOpencodeSdkPin()).toBe(expected)
+  })
+
+  test('throws naming the field when the sdk entry is a range', () => {
+    const dir = makeTempDir()
+    const pkgPath = writePackageJson(dir, {
+      '@opencode-ai/sdk': '^9.9.0',
+      '@opencode-ai/plugin': '9.9.0',
+    })
+
+    expect(() => readOpencodeSdkPin(pkgPath)).toThrow(/@opencode-ai\/sdk/)
+  })
+
+  test('throws naming the field when the sdk entry is missing', () => {
+    const dir = makeTempDir()
+    const pkgPath = writePackageJson(dir, {
+      '@opencode-ai/plugin': '9.9.0',
+    })
+
+    expect(() => readOpencodeSdkPin(pkgPath)).toThrow(/@opencode-ai\/sdk/)
+  })
+})
+
+describe('readOpencodeDevDependencyPins', () => {
+  test('returns matching sdk and plugin devDependency versions', () => {
+    const dir = makeTempDir()
+    const pkgPath = writePackageJson(dir, {
+      '@opencode-ai/sdk': '9.9.1',
+      '@opencode-ai/plugin': '9.9.1',
+    })
+
+    expect(readOpencodeDevDependencyPins(pkgPath)).toEqual({
+      sdk: '9.9.1',
+      plugin: '9.9.1',
+    })
+  })
+
+  test('the equality check fails when sdk and plugin devDependencies disagree', () => {
+    const dir = makeTempDir()
+    const pkgPath = writePackageJson(dir, {
+      '@opencode-ai/sdk': '9.9.1',
+      '@opencode-ai/plugin': '9.9.0',
+    })
+
+    const { sdk, plugin } = readOpencodeDevDependencyPins(pkgPath)
+    expect(sdk).not.toBe(plugin)
+  })
+})
+
+describe('re-exports stay in sync with the helper', () => {
+  test('scripts/run-evals.ts EXPECTED_OPENCODE_VERSION equals the helper value', async () => {
+    const { EXPECTED_OPENCODE_VERSION } = await import(
+      '../../scripts/run-evals.ts'
+    )
+    expect(EXPECTED_OPENCODE_VERSION).toBe(readOpencodeSdkPin())
+  })
+
+  test('tests/integration/fixtures/receipt-workflow-host.ts EXACT_OPENCODE_VERSION equals the helper value', async () => {
+    const { EXACT_OPENCODE_VERSION } = await import(
+      '../integration/fixtures/receipt-workflow-host.ts'
+    )
+    expect(EXACT_OPENCODE_VERSION).toBe(readOpencodeSdkPin())
+  })
+})


### PR DESCRIPTION
## Summary

Implements Unit 1 of `docs/plans/2026-09-04-001-refactor-ci-owned-host-contract-suite-plan.md`: one readable source of the pinned OpenCode host version, replacing the four-way lockstep (two hand-maintained constants + two devDependencies that all had to move together).

## What changed

- New `scripts/lib/opencode-pin.ts`:
  - `readOpencodeSdkPin(packageJsonPath?)` — reads `devDependencies['@opencode-ai/sdk']` from the repository's `package.json` (resolved relative to the module via `import.meta.url`, not `cwd`), returns it as an exact semver string, and throws a clear error naming the field if it is missing or not an exact version (a `^`/`~` range throws).
  - `readOpencodeDevDependencyPins(packageJsonPath?)` — returns both the `@opencode-ai/sdk` and `@opencode-ai/plugin` devDependency values for the equality backstop. `@opencode-ai/plugin` also appears under `peerDependencies` as a range; that field is deliberately not read here — it is not the pin.
  - Both accept an optional `package.json` path override so tests can point at a temp copy without touching the real file.
- `scripts/run-evals.ts` `EXPECTED_OPENCODE_VERSION` and `tests/integration/fixtures/receipt-workflow-host.ts` `EXACT_OPENCODE_VERSION` are now re-exports of `readOpencodeSdkPin()`. The literal `'1.18.21'` is gone from both files.
- `tests/unit/eval-contract.test.ts`'s host pin check keeps exactly one assertion: `@opencode-ai/sdk` devDependency equals `@opencode-ai/plugin` devDependency. The two constant-vs-package.json comparisons are dropped since both constants are now that same field. The failure message still names both fields and tells the reader what to do.
- New `tests/unit/opencode-pin.test.ts` covers: happy path (helper matches the real `package.json`), a range entry throwing and naming the field, a missing entry throwing and naming the field, both re-exports equaling the helper's value, and the equality check failing on a temp `package.json` fixture where sdk and plugin disagree (never by editing the real file).
- `docs/solutions/workflow-issues/version-pinned-evidence-must-be-reproven-2026-08-16.md` updated to describe the constants as derived re-exports rather than hand-edited copies that must be bumped in lockstep. The evidence-reproof lesson itself (a pin move invalidates prior real-host evidence until the suite is re-run) is unchanged — this plan only retires the *local* four-way-lockstep ritual; the CI-owned host-contract job that makes reproof itself CI-enforced lands in a later unit.
- Ticked Unit 1's checkbox in the plan.

## The two-step proof

Verified end-to-end in the worktree by editing `package.json` directly (never the test fixtures) and reverting after:

1. Set `@opencode-ai/sdk` to `1.18.27`, left `@opencode-ai/plugin` at `1.18.21`:
   ```
   error: OpenCode devDependency versions disagree: @opencode-ai/sdk is 1.18.27, but @opencode-ai/plugin is 1.18.21. Align both dependencies before re-running the host-coverage eval.
   17 pass / 1 fail
   ```
2. Also set `@opencode-ai/plugin` to `1.18.27`:
   ```
   18 pass / 0 fail
   ```
3. `git checkout package.json` restored the real pins with no diff.

## Verification

- `grep -rn "1\.18\.21" scripts tests --include=*.ts` → no matches.
- `bun test tests/unit` → 2207 pass, 0 fail.
- `bun run typecheck` → clean.
- `bun run typecheck:scripts` → clean.
- `bun run typecheck:all` → 343 errors (pre-existing baseline on `main`, confirmed via `git stash -u` before/after — this change does not add or remove any).
- `bun run lint` → 0 errors (13 pre-existing warnings, 2 infos, unrelated to this change).
- `bun scripts/content-integrity.ts` → clean.
- `scripts/lib/` has no README/module table and STRUCTURE.md's mention of `scripts/lib/` is prose, not a per-module list — no registration surface to update.

## Note

The evidence-reproof rule from `version-pinned-evidence-must-be-reproven-2026-08-16.md` is **not** retired by this change — it still applies exactly as before. This unit only moves where the pin constants come from; the CI job that makes the reproof unskippable on `main` lands in a later unit of the same plan.
