### PR TITLE
test(receipt-guard): make the receipt-guard test suites type-check

### DIFF
--- a/tests/integration/receipt-workflow-recovery.test.ts
+++ b/tests/integration/receipt-workflow-recovery.test.ts
@@ -78,6 +78,21 @@ function sseChunk(value: unknown): string {
   return `data: ${JSON.stringify(value)}\n\n`
 }
 
+/**
+ * The OpenCode SDK client types every response as `{ data?: T; error?:
+ * unknown }` to model transport failures. These recovery tests always run
+ * against a live host and expect success; this asserts that at the call
+ * site instead of accessing `.data` with `?.`/`!` at every downstream read.
+ */
+function unwrapData<T>(result: { data?: T; error?: unknown }): T {
+  if (result.data === undefined) {
+    throw new Error(
+      `opencode client call failed: ${JSON.stringify(result.error)}`,
+    )
+  }
+  return result.data
+}
+
 function buildToolCallChunks(
   response: ScriptedResponse,
   id: string,
@@ -530,12 +545,14 @@ async function createSession(
   title: string,
   permission = [{ permission: '*', pattern: '*', action: 'allow' as const }],
 ): Promise<string> {
-  const created = await client.session.create({
-    directory,
-    title,
-    permission,
-  })
-  return created.data.id
+  const created = unwrapData(
+    await client.session.create({
+      directory,
+      title,
+      permission,
+    }),
+  )
+  return created.id
 }
 
 function initializeIsolatedRepository(
@@ -614,12 +631,14 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
           baseUrl: firstHost.url,
           directory: fixture.projectDir,
         })
-        const created = await firstClient.session.create({
-          directory: fixture.projectDir,
-          title: 'receipt metadata probe',
-          permission: [{ permission: '*', pattern: '*', action: 'allow' }],
-        })
-        const sessionID = created.data.id
+        const created = unwrapData(
+          await firstClient.session.create({
+            directory: fixture.projectDir,
+            title: 'receipt metadata probe',
+            permission: [{ permission: '*', pattern: '*', action: 'allow' }],
+          }),
+        )
+        const sessionID = created.id
         await firstClient.session.prompt({
           sessionID,
           directory: fixture.projectDir,
@@ -627,11 +646,13 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
           parts: [{ type: 'text', text: 'Run the built-in bash tool once.' }],
         })
 
-        const firstMessages = await firstClient.session.messages({
-          sessionID,
-          directory: fixture.projectDir,
-        })
-        const firstBashParts = completedBashParts(firstMessages.data)
+        const firstMessages = unwrapData(
+          await firstClient.session.messages({
+            sessionID,
+            directory: fixture.projectDir,
+          }),
+        )
+        const firstBashParts = completedBashParts(firstMessages)
         expect(firstBashParts).toHaveLength(1)
         const firstState = firstBashParts[0]?.state as Record<string, unknown>
         const firstMetadata = firstState.metadata as Record<string, unknown>
@@ -665,11 +686,13 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             baseUrl: secondHost.url,
             directory: fixture.projectDir,
           })
-          const secondMessages = await secondClient.session.messages({
-            sessionID,
-            directory: fixture.projectDir,
-          })
-          const secondBashParts = completedBashParts(secondMessages.data)
+          const secondMessages = unwrapData(
+            await secondClient.session.messages({
+              sessionID,
+              directory: fixture.projectDir,
+            }),
+          )
+          const secondBashParts = completedBashParts(secondMessages)
           expect(secondBashParts).toHaveLength(1)
           const secondState = secondBashParts[0]?.state as Record<
             string,
@@ -721,50 +744,60 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             baseUrl: host.url,
             directory: localFixture.projectDir,
           })
-          const created = await client.session.create({
-            directory: localFixture.projectDir,
-            title: 'receipt fork probe',
-            permission: [{ permission: '*', pattern: '*', action: 'allow' }],
-          })
-          const sessionID = created.data.id
+          const created = unwrapData(
+            await client.session.create({
+              directory: localFixture.projectDir,
+              title: 'receipt fork probe',
+              permission: [{ permission: '*', pattern: '*', action: 'allow' }],
+            }),
+          )
+          const sessionID = created.id
           await client.session.prompt({
             sessionID,
             directory: localFixture.projectDir,
             model: { providerID: MOCK_PROVIDER_ID, modelID: MOCK_MODEL_ID },
             parts: [{ type: 'text', text: 'Run the built-in bash tool once.' }],
           })
-          const secondPrompt = await client.session.prompt({
-            sessionID,
-            directory: localFixture.projectDir,
-            model: { providerID: MOCK_PROVIDER_ID, modelID: MOCK_MODEL_ID },
-            parts: [{ type: 'text', text: 'Reply with one short sentence.' }],
-          })
+          const secondPrompt = unwrapData(
+            await client.session.prompt({
+              sessionID,
+              directory: localFixture.projectDir,
+              model: { providerID: MOCK_PROVIDER_ID, modelID: MOCK_MODEL_ID },
+              parts: [{ type: 'text', text: 'Reply with one short sentence.' }],
+            }),
+          )
 
-          const sourceMessages = await client.session.messages({
-            sessionID,
-            directory: localFixture.projectDir,
-          })
-          const sourcePart = completedBashParts(sourceMessages.data)[0]
+          const sourceMessages = unwrapData(
+            await client.session.messages({
+              sessionID,
+              directory: localFixture.projectDir,
+            }),
+          )
+          const sourcePart = completedBashParts(sourceMessages)[0]
           expect(sourcePart).toBeDefined()
           const sourceState = sourcePart?.state as Record<string, unknown>
           const sourceMetadata = sourceState.metadata as Record<string, unknown>
 
-          const forked = await client.session.fork({
-            sessionID,
-            directory: localFixture.projectDir,
-            messageID: secondPrompt.data.info.id,
-          })
-          expect(forked.data.id).not.toBe(sessionID)
+          const forked = unwrapData(
+            await client.session.fork({
+              sessionID,
+              directory: localFixture.projectDir,
+              messageID: secondPrompt.info.id,
+            }),
+          )
+          expect(forked.id).not.toBe(sessionID)
           expect({
-            parentIDPresent: typeof forked.data.parentID === 'string',
-            parentIDMatchesSource: forked.data.parentID === sessionID,
+            parentIDPresent: typeof forked.parentID === 'string',
+            parentIDMatchesSource: forked.parentID === sessionID,
           }).toEqual({ parentIDPresent: false, parentIDMatchesSource: false })
 
-          const childMessages = await client.session.messages({
-            sessionID: forked.data.id,
-            directory: localFixture.projectDir,
-          })
-          const childPart = completedBashParts(childMessages.data)[0]
+          const childMessages = unwrapData(
+            await client.session.messages({
+              sessionID: forked.id,
+              directory: localFixture.projectDir,
+            }),
+          )
+          const childPart = completedBashParts(childMessages)[0]
           expect(childPart).toBeDefined()
           const childState = childPart?.state as Record<string, unknown>
           const childMetadata = childState.metadata as Record<string, unknown>
@@ -788,13 +821,13 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             partIDReassigned: true,
           })
 
-          const children = await client.session.children({
-            sessionID,
-            directory: localFixture.projectDir,
-          })
-          expect(
-            children.data.some((child) => child.id === forked.data.id),
-          ).toBe(false)
+          const children = unwrapData(
+            await client.session.children({
+              sessionID,
+              directory: localFixture.projectDir,
+            }),
+          )
+          expect(children.some((child) => child.id === forked.id)).toBe(false)
         } finally {
           await host.stop()
           model.stop()
@@ -839,12 +872,14 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             baseUrl: host.url,
             directory: localFixture.projectDir,
           })
-          const created = await client.session.create({
-            directory: localFixture.projectDir,
-            title: 'receipt task lineage probe',
-            permission: [{ permission: '*', pattern: '*', action: 'allow' }],
-          })
-          const sessionID = created.data.id
+          const created = unwrapData(
+            await client.session.create({
+              directory: localFixture.projectDir,
+              title: 'receipt task lineage probe',
+              permission: [{ permission: '*', pattern: '*', action: 'allow' }],
+            }),
+          )
+          const sessionID = created.id
           await client.session.prompt({
             sessionID,
             directory: localFixture.projectDir,
@@ -878,22 +913,24 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             afterMetadataParentMatches: true,
           })
 
-          const children = await client.session.children({
-            sessionID,
-            directory: localFixture.projectDir,
-          })
-          const child = children.data.find(
-            (entry) => entry.id === childSessionID,
+          const children = unwrapData(
+            await client.session.children({
+              sessionID,
+              directory: localFixture.projectDir,
+            }),
           )
+          const child = children.find((entry) => entry.id === childSessionID)
           expect(child).toBeDefined()
           expect(child?.parentID).toBe(sessionID)
 
-          const childMessages = await client.session.messages({
-            sessionID: childSessionID,
-            directory: localFixture.projectDir,
-          })
-          expect(childMessages.data.length).toBeGreaterThan(0)
-          const childTextPartCount = childMessages.data.reduce(
+          const childMessages = unwrapData(
+            await client.session.messages({
+              sessionID: childSessionID,
+              directory: localFixture.projectDir,
+            }),
+          )
+          expect(childMessages.length).toBeGreaterThan(0)
+          const childTextPartCount = childMessages.reduce(
             (count, message) =>
               count +
               message.parts.filter((part) => part.type === 'text').length,
@@ -901,14 +938,13 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
           )
           expect(childTextPartCount).toBeGreaterThan(0)
 
-          const parentMessages = await client.session.messages({
-            sessionID,
-            directory: localFixture.projectDir,
-          })
-          const parentTaskParts = completedToolParts(
-            parentMessages.data,
-            'task',
+          const parentMessages = unwrapData(
+            await client.session.messages({
+              sessionID,
+              directory: localFixture.projectDir,
+            }),
           )
+          const parentTaskParts = completedToolParts(parentMessages, 'task')
           expect(parentTaskParts).toHaveLength(1)
           const parentTaskState = parentTaskParts[0]?.state as Record<
             string,
@@ -961,13 +997,15 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             baseUrl: host.url,
             directory: localFixture.projectDir,
           })
-          const created = await client.session.create({
-            directory: localFixture.projectDir,
-            title: 'receipt privacy probe',
-            permission: [{ permission: '*', pattern: '*', action: 'allow' }],
-          })
+          const created = unwrapData(
+            await client.session.create({
+              directory: localFixture.projectDir,
+              title: 'receipt privacy probe',
+              permission: [{ permission: '*', pattern: '*', action: 'allow' }],
+            }),
+          )
           await client.session.prompt({
-            sessionID: created.data.id,
+            sessionID: created.id,
             directory: localFixture.projectDir,
             model: { providerID: MOCK_PROVIDER_ID, modelID: MOCK_MODEL_ID },
             parts: [{ type: 'text', text: 'Reply once.' }],
@@ -1085,12 +1123,14 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             'Run the guarded workflow and make one implementation change.',
           )
 
-          const beforeRestart = await firstClient.session.messages({
-            sessionID,
-            directory: localFixture.projectDir,
-          })
+          const beforeRestart = unwrapData(
+            await firstClient.session.messages({
+              sessionID,
+              directory: localFixture.projectDir,
+            }),
+          )
           const beforeSkillParts = completedToolParts(
-            beforeRestart.data,
+            beforeRestart,
             'systematic_skill',
           )
           expect(beforeSkillParts).toHaveLength(1)
@@ -1103,7 +1143,7 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
           expect(beforeSkillOutput).toContain('<skill_content name="ce:work">')
           expect(beforeSkillOutput).toContain('# Skill: ce:work')
           expect(beforeSkillOutput).toContain('Base directory for this skill:')
-          const beforeMarkers = systematicMarkers(beforeRestart.data)
+          const beforeMarkers = systematicMarkers(beforeRestart)
           expect(
             readProbeEvents(hookProbe.capturePath).filter(
               (event) => event.type === 'after-shape',
@@ -1187,7 +1227,7 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             },
           ])
           expect(beforeMarkers.length).toBeGreaterThan(0)
-          assertPrivacySafeMarkers(beforeRestart.data)
+          assertPrivacySafeMarkers(beforeRestart)
           const firstPID = firstHost.pid
           await firstHost.stop()
           firstHost = undefined
@@ -1198,25 +1238,27 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             baseUrl: secondHost.url,
             directory: localFixture.projectDir,
           })
-          const persisted = await secondClient.session.messages({
-            sessionID,
-            directory: localFixture.projectDir,
-          })
-          expect(systematicMarkers(persisted.data).length).toBe(
-            beforeMarkers.length,
+          const persisted = unwrapData(
+            await secondClient.session.messages({
+              sessionID,
+              directory: localFixture.projectDir,
+            }),
           )
+          expect(systematicMarkers(persisted).length).toBe(beforeMarkers.length)
           await promptSession(
             secondClient,
             sessionID,
             localFixture.projectDir,
             'Read the recovered workflow status, then complete the unit.',
           )
-          const afterRecovery = await secondClient.session.messages({
-            sessionID,
-            directory: localFixture.projectDir,
-          })
+          const afterRecovery = unwrapData(
+            await secondClient.session.messages({
+              sessionID,
+              directory: localFixture.projectDir,
+            }),
+          )
           const completionParts = completedToolParts(
-            afterRecovery.data,
+            afterRecovery,
             'systematic_workflow_complete',
           )
           expect(completionParts.length).toBeGreaterThan(0)
@@ -1227,7 +1269,7 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             return typeof output === 'string' && output.includes('completed')
           })
           expect(completionSucceeded).toBe(true)
-          assertPrivacySafeMarkers(afterRecovery.data)
+          assertPrivacySafeMarkers(afterRecovery)
         } finally {
           if (firstHost) await firstHost.stop()
           if (secondHost) await secondHost.stop()
@@ -1297,12 +1339,14 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             localFixture.projectDir,
             'Check workflow status only.',
           )
-          const messages = await secondClient.session.messages({
-            sessionID,
-            directory: localFixture.projectDir,
-          })
+          const messages = unwrapData(
+            await secondClient.session.messages({
+              sessionID,
+              directory: localFixture.projectDir,
+            }),
+          )
           const statusParts = completedToolParts(
-            messages.data,
+            messages,
             'systematic_workflow_status',
           )
           expect(statusParts.length).toBeGreaterThan(0)
@@ -1423,47 +1467,53 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             'Start a guarded unit and run one foreground child.',
           )
 
-          const parentMessages = await client.session.messages({
-            sessionID: parentSessionID,
-            directory: localFixture.projectDir,
-          })
-          const taskParts = completedToolParts(parentMessages.data, 'task')
+          const parentMessages = unwrapData(
+            await client.session.messages({
+              sessionID: parentSessionID,
+              directory: localFixture.projectDir,
+            }),
+          )
+          const taskParts = completedToolParts(parentMessages, 'task')
           expect(taskParts).toHaveLength(1)
           const taskState = taskParts[0]?.state as Record<string, unknown>
           const taskMetadata = taskState.metadata as Record<string, unknown>
           const childSessionID = taskMetadata.sessionId
           expect(typeof childSessionID).toBe('string')
 
-          const children = await client.session.children({
-            sessionID: parentSessionID,
-            directory: localFixture.projectDir,
-          })
-          const child = children.data.find(
-            (entry) => entry.id === childSessionID,
+          const children = unwrapData(
+            await client.session.children({
+              sessionID: parentSessionID,
+              directory: localFixture.projectDir,
+            }),
           )
+          const child = children.find((entry) => entry.id === childSessionID)
           expect(child).toBeDefined()
           expect(child?.parentID).toBe(parentSessionID)
 
-          const childMessages = await client.session.messages({
-            sessionID: childSessionID as string,
-            directory: localFixture.projectDir,
-          })
-          const childMarkers = systematicMarkers(childMessages.data)
+          const childMessages = unwrapData(
+            await client.session.messages({
+              sessionID: childSessionID as string,
+              directory: localFixture.projectDir,
+            }),
+          )
+          const childMarkers = systematicMarkers(childMessages)
           expect(childMarkers.length).toBeGreaterThan(0)
-          assertPrivacySafeMarkers(childMessages.data)
+          assertPrivacySafeMarkers(childMessages)
 
-          const parentMints = receiptMintSummaries(parentMessages.data)
+          const parentMints = receiptMintSummaries(parentMessages)
           expect(parentMints).toHaveLength(1)
           expect(parentMints[0]?.operation).toBe('implementation')
-          const repeatedParentMessages = await client.session.messages({
-            sessionID: parentSessionID,
-            directory: localFixture.projectDir,
-          })
+          const repeatedParentMessages = unwrapData(
+            await client.session.messages({
+              sessionID: parentSessionID,
+              directory: localFixture.projectDir,
+            }),
+          )
           const repeatedParentMints = receiptMintSummaries(
-            repeatedParentMessages.data,
+            repeatedParentMessages,
           )
           expect(repeatedParentMints).toEqual(parentMints)
-          assertPrivacySafeMarkers(parentMessages.data)
+          assertPrivacySafeMarkers(parentMessages)
         } finally {
           if (host) await host.stop()
           model.stop()
@@ -1612,35 +1662,39 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             'Start a guarded unit and run one foreground child that commits a change.',
           )
 
-          const parentMessages = await client.session.messages({
-            sessionID: parentSessionID,
-            directory: localFixture.projectDir,
-          })
-          const taskParts = completedToolParts(parentMessages.data, 'task')
+          const parentMessages = unwrapData(
+            await client.session.messages({
+              sessionID: parentSessionID,
+              directory: localFixture.projectDir,
+            }),
+          )
+          const taskParts = completedToolParts(parentMessages, 'task')
           expect(taskParts).toHaveLength(1)
           const taskState = taskParts[0]?.state as Record<string, unknown>
           const taskMetadata = taskState.metadata as Record<string, unknown>
           const childSessionID = taskMetadata.sessionId
           expect(typeof childSessionID).toBe('string')
 
-          const children = await client.session.children({
-            sessionID: parentSessionID,
-            directory: localFixture.projectDir,
-          })
-          const child = children.data.find(
-            (entry) => entry.id === childSessionID,
+          const children = unwrapData(
+            await client.session.children({
+              sessionID: parentSessionID,
+              directory: localFixture.projectDir,
+            }),
           )
+          const child = children.find((entry) => entry.id === childSessionID)
           expect(child).toBeDefined()
           expect(child?.parentID).toBe(parentSessionID)
 
-          const childMessages = await client.session.messages({
-            sessionID: childSessionID as string,
-            directory: localFixture.projectDir,
-          })
-          const childMarkers = systematicMarkers(childMessages.data)
+          const childMessages = unwrapData(
+            await client.session.messages({
+              sessionID: childSessionID as string,
+              directory: localFixture.projectDir,
+            }),
+          )
+          const childMarkers = systematicMarkers(childMessages)
           expect(childMarkers.length).toBeGreaterThan(0)
-          assertPrivacySafeMarkers(childMessages.data)
-          const childSessionSalts = receiptMintSessionSalts(childMessages.data)
+          assertPrivacySafeMarkers(childMessages)
+          const childSessionSalts = receiptMintSessionSalts(childMessages)
           expect(childSessionSalts.length).toBeGreaterThan(0)
           const childSessionSalt = childSessionSalts[0]
           if (childSessionSalt === undefined) {
@@ -1657,12 +1711,14 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             localFixture.projectDir,
             'Check workflow status only.',
           )
-          const afterStatusMessages = await client.session.messages({
-            sessionID: parentSessionID,
-            directory: localFixture.projectDir,
-          })
+          const afterStatusMessages = unwrapData(
+            await client.session.messages({
+              sessionID: parentSessionID,
+              directory: localFixture.projectDir,
+            }),
+          )
           const statusParts = completedToolParts(
-            afterStatusMessages.data,
+            afterStatusMessages,
             'systematic_workflow_status',
           )
           expect(statusParts.length).toBeGreaterThan(0)
@@ -1684,7 +1740,7 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
           expect(parsedStatus.state).not.toBe('unavailable')
           expect(parsedStatus.reasonCode).not.toBe('guard-unavailable')
           expect(parsedStatus.satisfiedOperations).toContain('commit')
-          assertPrivacySafeMarkers(afterStatusMessages.data)
+          assertPrivacySafeMarkers(afterStatusMessages)
         } finally {
           if (host) await host.stop()
           model.stop()
@@ -1931,11 +1987,13 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             'Start a guarded unit, write in the nested worktree, then commit it.',
           )
 
-          const parentMessages = await client.session.messages({
-            sessionID: parentSessionID,
-            directory: localFixture.projectDir,
-          })
-          const taskParts = completedToolParts(parentMessages.data, 'task')
+          const parentMessages = unwrapData(
+            await client.session.messages({
+              sessionID: parentSessionID,
+              directory: localFixture.projectDir,
+            }),
+          )
+          const taskParts = completedToolParts(parentMessages, 'task')
           expect(taskParts).toHaveLength(2)
           const childSessionIDs = taskParts.map((part) => {
             const state = part.state as Record<string, unknown>
@@ -1945,35 +2003,35 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
             return childSessionID as string
           })
 
-          const children = await client.session.children({
-            sessionID: parentSessionID,
-            directory: localFixture.projectDir,
-          })
+          const children = unwrapData(
+            await client.session.children({
+              sessionID: parentSessionID,
+              directory: localFixture.projectDir,
+            }),
+          )
           for (const childSessionID of childSessionIDs) {
-            const child = children.data.find(
-              (entry) => entry.id === childSessionID,
-            )
+            const child = children.find((entry) => entry.id === childSessionID)
             expect(child).toBeDefined()
             expect(child?.parentID).toBe(parentSessionID)
-            const childMessages = await client.session.messages({
-              sessionID: childSessionID,
-              directory: localFixture.projectDir,
-            })
-            expect(
-              systematicMarkers(childMessages.data).length,
-            ).toBeGreaterThan(0)
-            assertPrivacySafeMarkers(childMessages.data)
+            const childMessages = unwrapData(
+              await client.session.messages({
+                sessionID: childSessionID,
+                directory: localFixture.projectDir,
+              }),
+            )
+            expect(systematicMarkers(childMessages).length).toBeGreaterThan(0)
+            assertPrivacySafeMarkers(childMessages)
           }
 
           expect(fs.existsSync(targetFile)).toBe(true)
-          const parentMints = receiptMintSummaries(parentMessages.data)
+          const parentMints = receiptMintSummaries(parentMessages)
           expect(parentMints.map(({ operation }) => operation)).toEqual([
             'implementation',
             'verification',
             'commit',
           ])
           const completionParts = completedToolParts(
-            parentMessages.data,
+            parentMessages,
             'systematic_workflow_complete',
           )
           expect(completionParts).toHaveLength(1)
@@ -1984,8 +2042,8 @@ describe.skipIf(!OPENCODE_AVAILABLE)(
           expect(completionState.output).toContain(
             'workflow guard completed unit',
           )
-          expect(receiptMintSummaries(parentMessages.data)).toEqual(parentMints)
-          assertPrivacySafeMarkers(parentMessages.data)
+          expect(receiptMintSummaries(parentMessages)).toEqual(parentMints)
+          assertPrivacySafeMarkers(parentMessages)
         } finally {
           if (host) await host.stop()
           model.stop()

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -62,7 +62,7 @@ function ledger(
  * read `metadata` back by bracket key after the hook mutates it in place, so
  * the field is typed as a real record instead of an inferred empty object.
  */
-interface RecordedToolOutput {
+type RecordedToolOutput = {
   title?: string
   output: string
   metadata: Record<string, unknown>
@@ -306,7 +306,7 @@ async function observeOperationTool(
   adapter: OpencodeWorkflowGuard,
   tool: 'write' | 'edit' | 'apply_patch' | 'bash',
   args: Record<string, unknown>,
-  output: unknown,
+  output: Record<string, unknown>,
   callID = `${tool}-operation`,
   sessionID = SESSION_A,
 ): Promise<void> {
@@ -324,7 +324,7 @@ async function observeOperationToolWithArgs(
   adapter: OpencodeWorkflowGuard,
   beforeArgs: Record<string, unknown>,
   afterArgs: Record<string, unknown>,
-  output: unknown,
+  output: Record<string, unknown>,
   callID = 'apply_patch-operation',
   sessionID = SESSION_A,
 ): Promise<void> {
@@ -1278,6 +1278,11 @@ describe('OpenCode workflow guard adapter', () => {
   })
 
   test('replays an expanded parent declaration without becoming unavailable', async () => {
+    // `repositoryRevisionDigest`/`worktreeRevisionDigest` are required by
+    // `OperationObserverSnapshot`; the fixture previously omitted them,
+    // which typed at runtime as `undefined` rather than a real digest. They
+    // are filled in here with matching placeholder hex strings so the
+    // snapshot shape is honest instead of relying on optional fields.
     const source = createAdapter(
       'observe',
       false,
@@ -1348,6 +1353,8 @@ describe('OpenCode workflow guard adapter', () => {
         ],
       },
     ]
+    // Same fixture-typing fix as above: real (placeholder) revision digests
+    // instead of the previously-omitted, effectively-undefined fields.
     const restored = createAdapter(
       'observe',
       false,
@@ -2064,6 +2071,68 @@ describe('OpenCode workflow guard adapter', () => {
     )
     expect(status(complete).state).toBe('unavailable')
     expect(status(complete).unit?.status).toBe('active')
+  })
+
+  test('tool.execute.before reads args from its second (output) argument, not the first', async () => {
+    // The real `ToolContext.execute()` hook signature is
+    // `(args, context)`, and the plugin's `tool.execute.before` hook
+    // forwards them as `(input, output)` where `output.args` carries the
+    // tool arguments; `input` only carries call identity (tool/session/call
+    // ID). Args placed on `input` instead are never read.
+    const misplaced = createAdapter('observe')
+    await observeSkill(misplaced, 'systematic_skill', 'ce:work')
+    await misplaced.hooks['tool.execute.before'](
+      {
+        tool: 'systematic_workflow_start',
+        sessionID: SESSION_A,
+        callID: 'arg-contract-misplaced',
+        args: { expected_operations: ['commit'] },
+      },
+      {},
+    )
+    await misplaced.hooks['tool.execute.after'](
+      {
+        tool: 'systematic_workflow_start',
+        sessionID: SESSION_A,
+        callID: 'arg-contract-misplaced',
+        args: { expected_operations: ['commit'] },
+      },
+      { title: 'started', output: 'ok', metadata: {} },
+    )
+    // No pending start was ever registered, so the paired after call finds
+    // nothing to complete and fails closed, leaving the skill-activated
+    // unit's default required operations un-expanded by `['commit']`.
+    expect(status(misplaced).state).toBe('unavailable')
+    expect(status(misplaced).unit?.requiredOperations).toEqual([
+      'implementation',
+      'verification',
+    ])
+
+    const correct = createAdapter('observe')
+    await observeSkill(correct, 'systematic_skill', 'ce:work')
+    await correct.hooks['tool.execute.before'](
+      {
+        tool: 'systematic_workflow_start',
+        sessionID: SESSION_A,
+        callID: 'arg-contract-correct',
+      },
+      { args: { expected_operations: ['commit'] } },
+    )
+    await correct.hooks['tool.execute.after'](
+      {
+        tool: 'systematic_workflow_start',
+        sessionID: SESSION_A,
+        callID: 'arg-contract-correct',
+        args: { expected_operations: ['commit'] },
+      },
+      { title: 'started', output: 'ok', metadata: {} },
+    )
+    expect(status(correct).state).not.toBe('unavailable')
+    expect(status(correct).unit?.requiredOperations).toEqual([
+      'implementation',
+      'verification',
+      'commit',
+    ])
   })
 
   test('protected same-call target conflicts veto execution and mark unavailable', async () => {
@@ -4976,6 +5045,13 @@ describe('OpenCode workflow guard adapter', () => {
         sessionSalt: ownSalt,
         observer: {
           targetDigest: OPERATION_SCOPE.workspaceIdentity,
+          // Required by `OpencodeOperationObserver`; this fixture previously
+          // omitted it, which only compiled because Bun strips types at
+          // runtime. Verified this does not change this test's own
+          // behaviour: the task-lineage rollup path exercised below never
+          // calls `validateRegisteredWorktree` (that seam is only reached by
+          // file/command target derivation for write/edit/bash operations),
+          // so `snapshotCalled` reaches the same value with or without it.
           validateRegisteredWorktree(candidateDirectory) {
             return {
               status: 'ok',

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -5047,11 +5047,13 @@ describe('OpenCode workflow guard adapter', () => {
           targetDigest: OPERATION_SCOPE.workspaceIdentity,
           // Required by `OpencodeOperationObserver`; this fixture previously
           // omitted it, which only compiled because Bun strips types at
-          // runtime. Verified this does not change this test's own
-          // behaviour: the task-lineage rollup path exercised below never
-          // calls `validateRegisteredWorktree` (that seam is only reached by
-          // file/command target derivation for write/edit/bash operations),
-          // so `snapshotCalled` reaches the same value with or without it.
+          // runtime. It IS exercised here: rollupForegroundTask calls it
+          // (opencode-workflow-guard.ts:2145). The `snapshotCalled` assertion
+          // is unaffected because `options.observer?.snapshot()` (line 2100)
+          // runs first; previously the missing member threw a swallowed
+          // TypeError that aborted the rollup, so the rollup now runs to
+          // completion (end state rejected/rejected-operation rather than
+          // unavailable/guard-unavailable).
           validateRegisteredWorktree(candidateDirectory) {
             return {
               status: 'ok',
@@ -5101,7 +5103,8 @@ describe('OpenCode workflow guard adapter', () => {
       // Fire task after hook → triggers rollupForegroundTask
       // BEFORE FIX: extractReceiptReadbackSeed sees two differing seeds → conflicting-seed → markUnavailable
       //   before snapshot is ever called → snapshotCalled stays false.
-      // AFTER FIX: foreign markers filtered out → own markers only → seed ready → snapshot called.
+      // AFTER FIX: foreign markers filtered out → own markers only → seed ready → snapshot called,
+      //   then worktree validation runs and the rollup completes (see the observer fixture above).
       await fireTaskAfter(ownAdapter, childSessionID, parentSessionID)
 
       // Key assertion: snapshot must have been called, proving rollup got past the conflicting-seed gate.

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, test } from 'bun:test'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import type { ToolContext, ToolResult } from '@opencode-ai/plugin'
 import { z } from 'zod'
 
 import type {
   OpencodeOperationObserver,
-  OpencodeWorkflowHostReadback,
   OperationObserverRemoteResult,
   OperationObserverSnapshot,
 } from '../../src/lib/opencode-operation-observer.js'
@@ -17,6 +17,7 @@ import {
   deriveOpencodeOperationTarget,
   isWorkflowGuardBlockedError,
   type OpencodeWorkflowGuard,
+  type OpencodeWorkflowHostReadback,
   SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY,
 } from '../../src/lib/opencode-workflow-guard.js'
 import {
@@ -54,11 +55,43 @@ function ledger(
   return value
 }
 
-function toolContext(sessionID = SESSION_A): {
-  sessionID: string
-  metadata: () => void
-} {
-  return { sessionID, metadata: () => {} }
+/**
+ * Local shape for a mutable `tool.execute.after` output fixture. The real
+ * `ToolResult` from `@opencode-ai/plugin` is `string | {..., metadata?: {
+ * [key: string]: any }}`; these fixtures always use the object variant and
+ * read `metadata` back by bracket key after the hook mutates it in place, so
+ * the field is typed as a real record instead of an inferred empty object.
+ */
+interface RecordedToolOutput {
+  title?: string
+  output: string
+  metadata: Record<string, unknown>
+}
+
+/**
+ * `ToolContext.execute()` returns `ToolResult`, a `string |
+ * {output, metadata?, ...}` union. Every tool under test here always
+ * returns the structured object variant; this narrows for `.output`/
+ * `.metadata` access instead of casting.
+ */
+function expectToolOutput(result: ToolResult): Exclude<ToolResult, string> {
+  if (typeof result === 'string') {
+    throw new Error('expected a structured tool result, got a bare string')
+  }
+  return result
+}
+
+function toolContext(sessionID = SESSION_A): ToolContext {
+  return {
+    sessionID,
+    messageID: `message-${sessionID}`,
+    agent: 'systematic',
+    directory: process.cwd(),
+    worktree: process.cwd(),
+    abort: new AbortController().signal,
+    metadata: () => {},
+    ask: async () => {},
+  }
 }
 
 const SCOPE = {
@@ -216,7 +249,7 @@ function createAdapter(
   mode: 'observe' | 'protected' | 'disabled' = 'protected',
   debug = false,
   observer?: OpencodeOperationObserver,
-  runtimeRequiredOperations: readonly string[] = [],
+  runtimeRequiredOperations: readonly ReceiptOperation[] = [],
   observations?: ReceiptOperationObservation[],
   hostReadback?: OpencodeWorkflowHostReadback,
   sharedRecovery = false,
@@ -239,7 +272,13 @@ function createAdapter(
                 ...classifier,
                 classifyOperation: async (input: unknown) => {
                   observations.push(input as ReceiptOperationObservation)
-                  return classifier.classifyOperation?.(input)
+                  const classify = classifier.classifyOperation
+                  if (!classify) {
+                    throw new Error(
+                      'expected classifier to implement classifyOperation',
+                    )
+                  }
+                  return classify(input)
                 },
               }
             : classifier,
@@ -267,7 +306,7 @@ async function observeOperationTool(
   adapter: OpencodeWorkflowGuard,
   tool: 'write' | 'edit' | 'apply_patch' | 'bash',
   args: Record<string, unknown>,
-  output: Record<string, unknown>,
+  output: unknown,
   callID = `${tool}-operation`,
   sessionID = SESSION_A,
 ): Promise<void> {
@@ -285,7 +324,7 @@ async function observeOperationToolWithArgs(
   adapter: OpencodeWorkflowGuard,
   beforeArgs: Record<string, unknown>,
   afterArgs: Record<string, unknown>,
-  output: Record<string, unknown>,
+  output: unknown,
   callID = 'apply_patch-operation',
   sessionID = SESSION_A,
 ): Promise<void> {
@@ -525,7 +564,7 @@ async function createPinnedRecoveryAdapter(): Promise<{
   const sessionSalt = new Uint8Array(32).fill(137)
   let parentMarkers: readonly unknown[] = []
   const adapter = createOpencodeWorkflowGuard({
-    config: { mode: 'observe' },
+    config: { mode: 'observe', debug: false },
     workspaceIdentity: initial.snapshot.targetDigest,
     repositoryIdentity: targetInitial.snapshot.repositoryRevisionDigest,
     worktreeIdentity: targetInitial.snapshot.worktreeRevisionDigest,
@@ -577,7 +616,7 @@ async function createPinnedRecoveryAdapter(): Promise<{
   )
   await adapter.tools.systematic_workflow_status.execute(
     {},
-    { sessionID: SESSION_A, metadata: () => {} },
+    toolContext(SESSION_A),
   )
 
   return {
@@ -617,7 +656,7 @@ async function createFreshPinnedAdapter(
     throw new Error('parent unavailable')
   }
   const adapter = createOpencodeWorkflowGuard({
-    config: { mode: 'observe' },
+    config: { mode: 'observe', debug: false },
     workspaceIdentity: initial.snapshot.targetDigest,
     repositoryIdentity: initial.snapshot.repositoryRevisionDigest,
     worktreeIdentity: initial.snapshot.worktreeRevisionDigest,
@@ -1126,7 +1165,7 @@ describe('OpenCode workflow guard adapter', () => {
   test('projects the upgraded declaration with its actual operations and resource scopes', async () => {
     const adapter = createAdapter('observe')
     await observeSkill(adapter, 'systematic_skill', 'ce:work')
-    const output = {
+    const output: RecordedToolOutput = {
       title: 'pending',
       output: 'start complete',
       metadata: {},
@@ -1208,7 +1247,7 @@ describe('OpenCode workflow guard adapter', () => {
   test('does not emit a second progression marker for a no-growth start', async () => {
     const adapter = createAdapter('observe')
     await observeSkill(adapter, 'systematic_skill', 'ce:work')
-    const output = {
+    const output: RecordedToolOutput = {
       title: 'pending',
       output: 'start complete',
       metadata: {},
@@ -1242,13 +1281,23 @@ describe('OpenCode workflow guard adapter', () => {
     const source = createAdapter(
       'observe',
       false,
-      sequenceObserver([{ targetDigest: 'a'.repeat(64) }]),
+      sequenceObserver([
+        {
+          targetDigest: 'a'.repeat(64),
+          repositoryRevisionDigest: 'a'.repeat(64),
+          worktreeRevisionDigest: 'a'.repeat(64),
+        },
+      ]),
       [],
       undefined,
       undefined,
       true,
     )
-    const skillOutput = { title: 'skill', output: 'loaded', metadata: {} }
+    const skillOutput: RecordedToolOutput = {
+      title: 'skill',
+      output: 'loaded',
+      metadata: {},
+    }
     await observeSkill(
       source,
       'systematic_skill',
@@ -1257,7 +1306,7 @@ describe('OpenCode workflow guard adapter', () => {
       SESSION_A,
       skillOutput,
     )
-    const startOutput = {
+    const startOutput: RecordedToolOutput = {
       title: 'start',
       output: 'started',
       metadata: {},
@@ -1302,7 +1351,13 @@ describe('OpenCode workflow guard adapter', () => {
     const restored = createAdapter(
       'observe',
       false,
-      sequenceObserver([{ targetDigest: 'a'.repeat(64) }]),
+      sequenceObserver([
+        {
+          targetDigest: 'a'.repeat(64),
+          repositoryRevisionDigest: 'a'.repeat(64),
+          worktreeRevisionDigest: 'a'.repeat(64),
+        },
+      ]),
       [],
       undefined,
       {
@@ -1479,9 +1534,9 @@ describe('OpenCode workflow guard adapter', () => {
       toolContext(),
     )
 
-    expect(start.output).toContain('pending')
-    expect(statusOutput.output).toContain(statusBefore.state)
-    expect(control.output).toContain('question-attestation')
+    expect(expectToolOutput(start).output).toContain('pending')
+    expect(expectToolOutput(statusOutput).output).toContain(statusBefore.state)
+    expect(expectToolOutput(control).output).toContain('question-attestation')
     expect(status(adapter).epoch).toBeNull()
   })
 
@@ -1631,7 +1686,7 @@ describe('OpenCode workflow guard adapter', () => {
       {},
       toolContext(),
     )
-    expect(status.metadata).toMatchObject({
+    expect(expectToolOutput(status).metadata).toMatchObject({
       questionAttestation: { status: 'attested', requestId: 'request-1' },
     })
   })
@@ -1671,7 +1726,7 @@ describe('OpenCode workflow guard adapter', () => {
       { mode: 'disabled' },
       toolContext(),
     )
-    expect(first.output).toContain('question-attestation')
+    expect(expectToolOutput(first).output).toContain('question-attestation')
     expect(adapter.status(SESSION_A).state).not.toBe('disabled')
 
     const questionOutput = { args: {} as Record<string, unknown> }
@@ -1694,7 +1749,7 @@ describe('OpenCode workflow guard adapter', () => {
       { mode: 'disabled' },
       toolContext(),
     )
-    expect(second.output).toContain('disabled')
+    expect(expectToolOutput(second).output).toContain('disabled')
     expect(adapter.status(SESSION_A).state).toBe('disabled')
   })
 
@@ -2339,8 +2394,9 @@ describe('OpenCode workflow guard adapter', () => {
     const worst = document.sources.find(
       (source) => source.state === 'unavailable',
     )
+    if (!worst) throw new Error('expected an unavailable source')
     expect(document.aggregate.state).toBe('unavailable')
-    expect(document.aggregate.statusDigest).toBe(worst?.statusDigest)
+    expect(document.aggregate.statusDigest).toBe(worst.statusDigest)
   })
 
   test('fails closed on bounded marker overflow while retaining the current source', async () => {
@@ -2403,7 +2459,7 @@ describe('OpenCode workflow guard adapter', () => {
         observations,
       )
       await observeSkill(adapter, 'systematic_skill', 'ce:work')
-      const output = {
+      const output: RecordedToolOutput = {
         title: `${tool} complete`,
         output: 'local result',
         metadata: { hostMetadata: 'preserved' },
@@ -2462,7 +2518,7 @@ describe('OpenCode workflow guard adapter', () => {
 
     test('appends progression markers in order while preserving unrelated metadata', async () => {
       const adapter = createAdapter('observe')
-      const output = {
+      const output: RecordedToolOutput = {
         title: 'Loaded skill',
         output: 'skill result',
         metadata: { hostMetadata: 'preserved' },
@@ -2754,7 +2810,7 @@ describe('OpenCode workflow guard adapter', () => {
       const observations: ReceiptOperationObservation[] = []
       const classifier = createReceiptClassifier()
       const adapter = createOpencodeWorkflowGuard({
-        config: { mode: 'observe' },
+        config: { mode: 'observe', debug: false },
         workspaceIdentity: initial.snapshot.targetDigest,
         repositoryIdentity: initial.snapshot.repositoryRevisionDigest,
         worktreeIdentity: initial.snapshot.worktreeRevisionDigest,
@@ -2764,7 +2820,13 @@ describe('OpenCode workflow guard adapter', () => {
           ...classifier,
           classifyOperation: async (input: unknown) => {
             observations.push(input as ReceiptOperationObservation)
-            return classifier.classifyOperation?.(input)
+            const classify = classifier.classifyOperation
+            if (!classify) {
+              throw new Error(
+                'expected classifier to implement classifyOperation',
+              )
+            }
+            return classify(input)
           },
         },
       })
@@ -2817,7 +2879,7 @@ describe('OpenCode workflow guard adapter', () => {
       const initial = await parentObserver.snapshot()
       if (initial.status !== 'available') throw new Error('parent unavailable')
       const adapter = createOpencodeWorkflowGuard({
-        config: { mode: 'observe' },
+        config: { mode: 'observe', debug: false },
         workspaceIdentity: initial.snapshot.targetDigest,
         repositoryIdentity: initial.snapshot.repositoryRevisionDigest,
         worktreeIdentity: initial.snapshot.worktreeRevisionDigest,
@@ -2873,7 +2935,7 @@ describe('OpenCode workflow guard adapter', () => {
       const initial = await parentObserver.snapshot()
       if (initial.status !== 'available') throw new Error('parent unavailable')
       const adapter = createOpencodeWorkflowGuard({
-        config: { mode: 'observe' },
+        config: { mode: 'observe', debug: false },
         workspaceIdentity: initial.snapshot.targetDigest,
         repositoryIdentity: initial.snapshot.repositoryRevisionDigest,
         worktreeIdentity: initial.snapshot.worktreeRevisionDigest,
@@ -2919,7 +2981,7 @@ describe('OpenCode workflow guard adapter', () => {
       const initial = await parentObserver.snapshot()
       if (initial.status !== 'available') throw new Error('parent unavailable')
       const adapter = createOpencodeWorkflowGuard({
-        config: { mode: 'observe' },
+        config: { mode: 'observe', debug: false },
         workspaceIdentity: initial.snapshot.targetDigest,
         repositoryIdentity: initial.snapshot.repositoryRevisionDigest,
         worktreeIdentity: initial.snapshot.worktreeRevisionDigest,
@@ -3264,7 +3326,7 @@ describe('OpenCode workflow guard adapter', () => {
       observations,
     )
     await observeSkill(adapter, 'systematic_skill', 'ce:work')
-    const output = {
+    const output: RecordedToolOutput = {
       title: 'push',
       output: 'pushed',
       metadata: { hostMetadata: 'preserved', exit: 0 },
@@ -3800,7 +3862,7 @@ describe('OpenCode workflow guard adapter', () => {
         },
       }
       const adapter = createOpencodeWorkflowGuard({
-        config: { mode: 'observe' },
+        config: { mode: 'observe', debug: false },
         workspaceIdentity: initial.snapshot.targetDigest,
         repositoryIdentity: initial.snapshot.repositoryRevisionDigest,
         worktreeIdentity: initial.snapshot.worktreeRevisionDigest,
@@ -3864,7 +3926,7 @@ describe('OpenCode workflow guard adapter', () => {
         },
       }
       const adapter = createOpencodeWorkflowGuard({
-        config: { mode: 'observe' },
+        config: { mode: 'observe', debug: false },
         workspaceIdentity: initial.snapshot.targetDigest,
         repositoryIdentity: initial.snapshot.repositoryRevisionDigest,
         worktreeIdentity: initial.snapshot.worktreeRevisionDigest,
@@ -3986,7 +4048,11 @@ describe('OpenCode workflow guard adapter', () => {
       undefined,
       true,
     )
-    const skillOutput = { title: 'skill', output: 'loaded', metadata: {} }
+    const skillOutput: RecordedToolOutput = {
+      title: 'skill',
+      output: 'loaded',
+      metadata: {},
+    }
     await observeSkill(
       source,
       'systematic_skill',
@@ -3995,7 +4061,7 @@ describe('OpenCode workflow guard adapter', () => {
       SESSION_A,
       skillOutput,
     )
-    const output = {
+    const output: RecordedToolOutput = {
       title: 'write',
       output: 'changed',
       metadata: {},
@@ -4173,7 +4239,7 @@ describe('OpenCode workflow guard adapter', () => {
 
       await restored.tools.systematic_workflow_status.execute(
         {},
-        { sessionID: SESSION_A, metadata: () => {} },
+        toolContext(SESSION_A),
       )
 
       // BEFORE FIX: guard would be 'unavailable' due to conflicting-seed
@@ -4282,7 +4348,7 @@ describe('OpenCode workflow guard adapter', () => {
 
       await restored.tools.systematic_workflow_status.execute(
         {},
-        { sessionID: SESSION_A, metadata: () => {} },
+        toolContext(SESSION_A),
       )
 
       const s = restored.status(SESSION_A)
@@ -4333,7 +4399,7 @@ describe('OpenCode workflow guard adapter', () => {
 
       await restored.tools.systematic_workflow_status.execute(
         {},
-        { sessionID: SESSION_A, metadata: () => {} },
+        toolContext(SESSION_A),
       )
 
       const s = restored.status(SESSION_A)
@@ -4384,7 +4450,7 @@ describe('OpenCode workflow guard adapter', () => {
 
       await restored.tools.systematic_workflow_status.execute(
         {},
-        { sessionID: SESSION_A, metadata: () => {} },
+        toolContext(SESSION_A),
       )
 
       // A fresh guard (no epoch activated yet) has state 'unavailable' / 'no-active-epoch'.
@@ -4468,7 +4534,7 @@ describe('OpenCode workflow guard adapter', () => {
 
       await adapter.tools.systematic_workflow_status.execute(
         {},
-        { sessionID: SESSION_A, metadata: () => {} },
+        toolContext(SESSION_A),
       )
 
       const s = adapter.status(SESSION_A)
@@ -4548,7 +4614,7 @@ describe('OpenCode workflow guard adapter', () => {
 
       await adapter.tools.systematic_workflow_status.execute(
         {},
-        { sessionID: SESSION_A, metadata: () => {} },
+        toolContext(SESSION_A),
       )
 
       const s = adapter.status(SESSION_A)
@@ -4590,7 +4656,7 @@ describe('OpenCode workflow guard adapter', () => {
 
       await adapter.tools.systematic_workflow_status.execute(
         {},
-        { sessionID: SESSION_A, metadata: () => {} },
+        toolContext(SESSION_A),
       )
 
       const s = adapter.status(SESSION_A)
@@ -4627,7 +4693,7 @@ describe('OpenCode workflow guard adapter', () => {
 
       await adapter.tools.systematic_workflow_status.execute(
         {},
-        { sessionID: SESSION_A, metadata: () => {} },
+        toolContext(SESSION_A),
       )
 
       const s = adapter.status(SESSION_A)
@@ -4837,12 +4903,14 @@ describe('OpenCode workflow guard adapter', () => {
         output: 'done',
         metadata: { sessionId: childSessionID },
       }
-      await adapter.hooks['tool.execute.before']({
-        tool: 'task',
-        sessionID,
-        callID: 'task-call-1',
-        args: {},
-      })
+      await adapter.hooks['tool.execute.before'](
+        {
+          tool: 'task',
+          sessionID,
+          callID: 'task-call-1',
+        },
+        { args: {} },
+      )
       await adapter.hooks['tool.execute.after'](
         {
           tool: 'task',
@@ -4908,6 +4976,14 @@ describe('OpenCode workflow guard adapter', () => {
         sessionSalt: ownSalt,
         observer: {
           targetDigest: OPERATION_SCOPE.workspaceIdentity,
+          validateRegisteredWorktree(candidateDirectory) {
+            return {
+              status: 'ok',
+              targetRoot: candidateDirectory,
+              gitDir: path.join(candidateDirectory, '.git'),
+              commonDir: path.join(candidateDirectory, '.git'),
+            }
+          },
           async snapshot() {
             snapshotCalled = true
             return {
@@ -5877,7 +5953,7 @@ describe('OpenCode workflow guard adapter', () => {
           parentSessionID,
         )
 
-        const childSkillOutput = {
+        const childSkillOutput: RecordedToolOutput = {
           title: 'Loaded skill',
           output: 'child skill result',
           metadata: {},
@@ -5898,7 +5974,7 @@ describe('OpenCode workflow guard adapter', () => {
           callID: 'registered-worktree-child-write',
           args: { filePath, content: 'changed' },
         }
-        const childWriteOutput = {
+        const childWriteOutput: RecordedToolOutput = {
           title: 'write complete',
           output: 'changed',
           metadata: {},

--- a/tests/unit/receipt-ledger.test.ts
+++ b/tests/unit/receipt-ledger.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from 'bun:test'
 
 import {
   createReceiptLedger,
+  type FinalizeObservationResult,
+  type PrepareObservationResult,
   type ReceiptClassification,
   type ReceiptContext,
   type ReceiptOperation,
@@ -108,6 +110,37 @@ function finalizeLedgerObservation(
   })
 }
 
+/**
+ * Narrows a `FinalizeObservationResult` to its `finalized` branch, throwing
+ * with a descriptive message when the result was rejected instead. Tests use
+ * this to access `.receipt` without a non-null assertion.
+ */
+function expectFinalized(
+  result: FinalizeObservationResult,
+): Extract<FinalizeObservationResult, { status: 'finalized' }> {
+  if (result.status !== 'finalized') {
+    throw new Error(
+      `expected a finalized observation result, got status: ${result.status}`,
+    )
+  }
+  return result
+}
+
+/**
+ * Narrows a `PrepareObservationResult` to its `prepared` branch, throwing
+ * with a descriptive message when the result was duplicate/rejected instead.
+ */
+function expectPrepared(
+  result: PrepareObservationResult,
+): Extract<PrepareObservationResult, { status: 'prepared' }> {
+  if (result.status !== 'prepared') {
+    throw new Error(
+      `expected a prepared observation result, got status: ${result.status}`,
+    )
+  }
+  return result
+}
+
 describe('receipt ledger', () => {
   test('mints a v2 receipt with its operation target identity', () => {
     const ledger = createReceiptLedger({
@@ -118,10 +151,10 @@ describe('receipt ledger', () => {
 
     const result = finalizeLedgerObservation(ledger)
 
-    expect(result).toMatchObject({ status: 'finalized' })
-    expect(result.receipt?.schemaVersion).toBe(2)
-    expect(result.receipt?.protocolVersion).toBe(2)
-    expect(result.receipt?.canonical.operationTargetIdentity).toBe(
+    const finalized = expectFinalized(result)
+    expect(finalized.receipt.schemaVersion).toBe(2)
+    expect(finalized.receipt.protocolVersion).toBe(2)
+    expect(finalized.receipt.canonical.operationTargetIdentity).toBe(
       OPERATION_TARGET_IDENTITY,
     )
   })
@@ -179,8 +212,8 @@ describe('receipt ledger', () => {
 
     const result = finalizeLedgerObservation(ledger)
 
-    expect(result.status).toBe('finalized')
-    expect(result.receipt).toMatchObject({
+    const finalized = expectFinalized(result)
+    expect(finalized.receipt).toMatchObject({
       compatibility: 'compatible',
       canonical: {
         operation: 'implementation',
@@ -189,11 +222,11 @@ describe('receipt ledger', () => {
         source: 'runtime-verified',
       },
     })
-    expect(result.receipt?.canonical.receiptId).toBeString()
-    expect(JSON.stringify(result.receipt)).not.toContain(RAW_REPOSITORY)
-    expect(JSON.stringify(result.receipt)).not.toContain(RAW_WORKTREE)
-    expect(JSON.stringify(result.receipt)).not.toContain(RAW_COMMAND)
-    expect(JSON.stringify(result.receipt)).not.toContain(RAW_OUTPUT)
+    expect(finalized.receipt.canonical.receiptId).toBeString()
+    expect(JSON.stringify(finalized.receipt)).not.toContain(RAW_REPOSITORY)
+    expect(JSON.stringify(finalized.receipt)).not.toContain(RAW_WORKTREE)
+    expect(JSON.stringify(finalized.receipt)).not.toContain(RAW_COMMAND)
+    expect(JSON.stringify(finalized.receipt)).not.toContain(RAW_OUTPUT)
   })
 
   test('deduplicates a call and consumes its receipt exactly once', () => {
@@ -204,14 +237,17 @@ describe('receipt ledger', () => {
     expect(prepareLedgerObservation(ledger).status).toBe('prepared')
     expect(prepareLedgerObservation(ledger).status).toBe('duplicate')
 
-    const finalized = finalizeLedgerObservation(ledger)
-    expect(finalized.status).toBe('finalized')
+    const finalizedResult = finalizeLedgerObservation(ledger)
+    const finalized = expectFinalized(finalizedResult)
 
-    const replay = finalizeLedgerObservation(ledger)
-    expect(replay.status).toBe('rejected')
-    expect(replay.reasonCode).toBe('duplicate-finalization')
+    const replayResult = finalizeLedgerObservation(ledger)
+    expect(replayResult.status).toBe('rejected')
+    if (replayResult.status !== 'rejected') {
+      throw new Error('expected a rejected replay result')
+    }
+    expect(replayResult.reasonCode).toBe('duplicate-finalization')
 
-    const receiptId = finalized.receipt?.canonical.receiptId
+    const receiptId = finalized.receipt.canonical.receiptId
     expect(receiptId).toBeString()
     expect(
       ledger.consumeReceipt(receiptId ?? '', {
@@ -355,11 +391,11 @@ describe('receipt ledger', () => {
       classification: classification(),
       terminal: { status: 'success', output: 'non-empty', noOp: false },
     })
-    expect(result).toMatchObject({ status: 'finalized' })
-    expect(result.receipt?.canonical.workspaceDigest).toBe(
+    const finalized = expectFinalized(result)
+    expect(finalized.receipt.canonical.workspaceDigest).toBe(
       ledger.digestIdentity('workspace', RAW_WORKSPACE_BEFORE),
     )
-    expect(result.receipt?.canonical.worktreeDigest).toBe(
+    expect(finalized.receipt.canonical.worktreeDigest).toBe(
       ledger.digestIdentity('worktree', 'worktree-after'),
     )
   })
@@ -668,8 +704,8 @@ describe('receipt ledger', () => {
       registrationIdentity: 'registration-a',
     })
     prepareLedgerObservation(ledger)
-    const finalized = finalizeLedgerObservation(ledger)
-    const receiptId = finalized.receipt?.canonical.receiptId ?? ''
+    const finalized = expectFinalized(finalizeLedgerObservation(ledger))
+    const receiptId = finalized.receipt.canonical.receiptId
 
     expect(
       ledger.consumeReceipt(receiptId, {
@@ -727,7 +763,7 @@ describe('receipt ledger', () => {
       registrationIdentity: 'registration-a',
     })
     prepareLedgerObservation(first)
-    const finalized = finalizeLedgerObservation(first)
+    const finalized = expectFinalized(finalizeLedgerObservation(first))
     const envelope = finalized.receipt
     expect(envelope).toBeDefined()
     expect(first.validateEnvelope(envelope)).toMatchObject({
@@ -772,7 +808,7 @@ describe('receipt ledger', () => {
       capabilityFlags: ['zeta', 'alpha', 'zeta'],
     })
     prepareLedgerObservation(ledger)
-    const finalized = finalizeLedgerObservation(ledger)
+    const finalized = expectFinalized(finalizeLedgerObservation(ledger))
     const envelope = finalized.receipt
 
     expect(ledger.metadata.capabilityFlags).toEqual(['alpha', 'zeta'])
@@ -886,7 +922,7 @@ describe('receipt ledger', () => {
     expect(first.digestIdentity('repository', RAW_REPOSITORY)).toBe(firstDigest)
 
     prepareLedgerObservation(first)
-    const finalized = finalizeLedgerObservation(first)
+    const finalized = expectFinalized(finalizeLedgerObservation(first))
     const saltHex = Buffer.from(SUPPLIED_SALT).toString('hex')
     expect(JSON.stringify(finalized.receipt)).not.toContain(saltHex)
     expect(JSON.stringify(first.listReceipts())).not.toContain(saltHex)
@@ -904,11 +940,10 @@ describe('receipt ledger', () => {
     const ledger = createReceiptLedger({
       registrationIdentity: 'registration-a',
     })
-    const prepared = prepareLedgerObservation(ledger)
-    expect(prepared.status).toBe('prepared')
+    const prepared = expectPrepared(prepareLedgerObservation(ledger))
     expect(ledger.listReceipts()).toHaveLength(0)
     expect(
-      ledger.consumeReceipt(prepared.preparationId ?? '', {
+      ledger.consumeReceipt(prepared.preparationId, {
         epochId: 'epoch-1',
         unitId: 'unit-1',
         workspaceIdentity: RAW_WORKSPACE_BEFORE,
@@ -939,24 +974,18 @@ describe('receipt ledger', () => {
     prepareLedgerObservation(ledger, 'call-epoch-1', context('epoch-1'))
     prepareLedgerObservation(ledger, 'call-epoch-2', context('epoch-2'))
 
-    const first = finalizeLedgerObservation(
-      ledger,
-      'call-epoch-1',
-      context('epoch-1'),
+    const first = expectFinalized(
+      finalizeLedgerObservation(ledger, 'call-epoch-1', context('epoch-1')),
     )
-    const second = finalizeLedgerObservation(
-      ledger,
-      'call-epoch-2',
-      context('epoch-2'),
+    const second = expectFinalized(
+      finalizeLedgerObservation(ledger, 'call-epoch-2', context('epoch-2')),
     )
 
-    expect(first.status).toBe('finalized')
-    expect(second.status).toBe('finalized')
-    expect(first.receipt?.canonical.epochDigest).not.toBe(
-      second.receipt?.canonical.epochDigest,
+    expect(first.receipt.canonical.epochDigest).not.toBe(
+      second.receipt.canonical.epochDigest,
     )
     expect(
-      ledger.consumeReceipt(first.receipt?.canonical.receiptId ?? '', {
+      ledger.consumeReceipt(first.receipt.canonical.receiptId, {
         epochId: 'epoch-1',
         unitId: 'unit-1',
         workspaceIdentity: RAW_WORKSPACE_BEFORE,
@@ -967,7 +996,7 @@ describe('receipt ledger', () => {
       }).status,
     ).toBe('consumed')
     expect(
-      ledger.consumeReceipt(second.receipt?.canonical.receiptId ?? '', {
+      ledger.consumeReceipt(second.receipt.canonical.receiptId, {
         epochId: 'epoch-2',
         unitId: 'unit-1',
         workspaceIdentity: RAW_WORKSPACE_BEFORE,

--- a/tests/unit/receipt-ledger.test.ts
+++ b/tests/unit/receipt-ledger.test.ts
@@ -141,6 +141,21 @@ function expectPrepared(
   return result
 }
 
+/**
+ * Narrows a `FinalizeObservationResult` to its `rejected` branch, throwing
+ * with a descriptive message when the result unexpectedly finalized instead.
+ */
+function expectRejected(
+  result: FinalizeObservationResult,
+): Extract<FinalizeObservationResult, { status: 'rejected' }> {
+  if (result.status !== 'rejected') {
+    throw new Error(
+      `expected a rejected observation result, got status: ${result.status}`,
+    )
+  }
+  return result
+}
+
 describe('receipt ledger', () => {
   test('mints a v2 receipt with its operation target identity', () => {
     const ledger = createReceiptLedger({
@@ -240,11 +255,7 @@ describe('receipt ledger', () => {
     const finalizedResult = finalizeLedgerObservation(ledger)
     const finalized = expectFinalized(finalizedResult)
 
-    const replayResult = finalizeLedgerObservation(ledger)
-    expect(replayResult.status).toBe('rejected')
-    if (replayResult.status !== 'rejected') {
-      throw new Error('expected a rejected replay result')
-    }
+    const replayResult = expectRejected(finalizeLedgerObservation(ledger))
     expect(replayResult.reasonCode).toBe('duplicate-finalization')
 
     const receiptId = finalized.receipt.canonical.receiptId
@@ -765,7 +776,6 @@ describe('receipt ledger', () => {
     prepareLedgerObservation(first)
     const finalized = expectFinalized(finalizeLedgerObservation(first))
     const envelope = finalized.receipt
-    expect(envelope).toBeDefined()
     expect(first.validateEnvelope(envelope)).toMatchObject({
       compatibility: 'compatible',
     })
@@ -776,7 +786,7 @@ describe('receipt ledger', () => {
     })
     expect(
       first.validateEnvelope({
-        ...(envelope ?? {}),
+        ...envelope,
         schemaVersion: 999,
       }),
     ).toMatchObject({
@@ -785,7 +795,7 @@ describe('receipt ledger', () => {
     })
     expect(
       first.validateEnvelope({
-        ...(envelope ?? {}),
+        ...envelope,
         capabilityFlags: undefined,
       }),
     ).toMatchObject({
@@ -835,7 +845,7 @@ describe('receipt ledger', () => {
     for (const capabilityFlags of mismatches) {
       expect(
         ledger.validateEnvelope({
-          ...(envelope ?? {}),
+          ...envelope,
           capabilityFlags,
         }),
       ).toMatchObject({

--- a/tests/unit/receipt-operations.test.ts
+++ b/tests/unit/receipt-operations.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import {
   createReceiptClassifier,
+  type ReceiptClassifier,
   type ReceiptOperation,
 } from '../../src/lib/receipt-classifier.js'
 import {
@@ -22,6 +23,52 @@ const successTerminal = {
   status: 'success' as const,
   output: 'non-empty' as const,
   noOp: false,
+}
+
+/**
+ * Identity, resource, and PR-shaped fields shared by the `context` and
+ * `after` payloads built by `operationInput`. Carries an index signature so
+ * fixtures can re-shape one payload from another (e.g. seeding `after` from
+ * `context`, or a case-table injecting an arbitrary field name) without
+ * excess-property errors, while still typing the field as a real object so
+ * it can be spread instead of tripping TS2698.
+ */
+interface OperationFields {
+  workspaceIdentity?: string
+  repositoryIdentity?: string
+  worktreeIdentity?: string
+  operationTargetIdentity?: string
+  resourceIdentity?: string
+  resourceRevisionIdentity?: string
+  commitClosure?: boolean
+  pullRequest?: { identity: string; state: string }
+  checkState?: string
+  reviewDecision?: string
+  epochId?: string
+  unitId?: string
+  [key: string]: unknown
+}
+
+interface OperationTerminal {
+  status: string
+  output: string
+  noOp: boolean
+}
+
+/**
+ * Shape returned by `operationInput`/`operationWithRevision`. Carries an
+ * index signature so deliberately malformed overrides (extra/omitted fields
+ * exercised by negative tests below) stay assignable without `any`.
+ */
+interface OperationInput {
+  callId: string
+  operation: ReceiptOperation
+  tool: string
+  command?: string
+  context: OperationFields
+  after: OperationFields
+  terminal: OperationTerminal
+  [key: string]: unknown
 }
 
 const REVISION_A =
@@ -88,24 +135,33 @@ interface OperationClassifier {
   classifyOperation(input: unknown): Promise<ReceiptClassification>
 }
 
-interface ReadbackResult {
-  status: 'accepted' | 'rejected'
-  changed?: boolean
-  reasonCode?: string
+/**
+ * `ReceiptClassifier.classifyOperation` is declared optional in the source
+ * interface because some classifier implementations only support
+ * `classify`. The classifier this suite constructs via
+ * `createReceiptClassifier()` always implements it; this asserts that
+ * runtime guarantee for the type checker instead of using `!`.
+ */
+function requireClassifyOperation(
+  classifier: ReceiptClassifier,
+): NonNullable<ReceiptClassifier['classifyOperation']> {
+  const { classifyOperation } = classifier
+  if (!classifyOperation) {
+    throw new Error('expected classifier to implement classifyOperation')
+  }
+  return classifyOperation.bind(classifier)
 }
 
-interface OperationWorkflowGuard extends WorkflowGuard {
-  observeOperation(input: unknown): Promise<EvidenceObservationResult>
-  observeTrustedRecoveredOperation(
-    input: unknown,
-  ): Promise<EvidenceObservationResult>
-  observeReadback(input: unknown): ReadbackResult
-}
+// `WorkflowGuard` already declares `observeOperation`,
+// `observeTrustedRecoveredOperation`, and `observeReadback` with the exact
+// shapes exercised by these tests; this alias just names the narrowed cast
+// target used at call sites below.
+type OperationWorkflowGuard = WorkflowGuard
 
 function operationInput(
   operation: ReceiptOperation,
-  overrides: Record<string, unknown> = {},
-): Record<string, unknown> {
+  overrides: Partial<OperationInput> = {},
+): OperationInput {
   const commands: Partial<Record<ReceiptOperation, string>> = {
     implementation: undefined,
     verification: 'bun test tests/unit/receipt-operations.test.ts',
@@ -124,7 +180,7 @@ function operationInput(
     'check-readback': 'gh',
     'review-readback': 'gh',
   }
-  const after = {
+  const after: OperationFields = {
     workspaceIdentity: WORKSPACE_CURRENT,
     repositoryIdentity: REPOSITORY_CURRENT,
     worktreeIdentity:
@@ -163,7 +219,7 @@ function operationInput(
         }
       : {}),
   }
-  const context = {
+  const context: OperationFields = {
     ...baseContext,
     ...(operation === 'push'
       ? {
@@ -330,18 +386,18 @@ function operationWithRevision(
   resourceIdentity: string,
   beforeRevision: string | undefined,
   afterRevision: string | undefined,
-  overrides: Record<string, unknown> = {},
-): Record<string, unknown> {
+  overrides: Partial<OperationInput> = {},
+): OperationInput {
   const input = operationInput(operation, overrides)
   return {
     ...input,
     context: {
-      ...(input.context as Record<string, unknown>),
+      ...input.context,
       resourceIdentity,
       ...(beforeRevision ? { resourceRevisionIdentity: beforeRevision } : {}),
     },
     after: {
-      ...(input.after as Record<string, unknown>),
+      ...input.after,
       resourceIdentity,
       ...(afterRevision ? { resourceRevisionIdentity: afterRevision } : {}),
     },
@@ -837,10 +893,12 @@ describe('receipt operation adapters', () => {
         resourceIdentity: RESOURCE_WRONG,
       },
     })
-    expect(await classifier.classifyOperation(unrelated)).toMatchObject({
-      outcome: 'rejected',
-      category: 'push',
-    })
+    expect(await requireClassifyOperation(classifier)(unrelated)).toMatchObject(
+      {
+        outcome: 'rejected',
+        category: 'push',
+      },
+    )
 
     const { guard, ledger } = createScenario(classifier, ['push'])
     expect(
@@ -945,7 +1003,7 @@ describe('receipt operation adapters', () => {
       REVISION_A,
       REVISION_B,
     )
-    expect(await classifier.classifyOperation(valid)).toMatchObject({
+    expect(await requireClassifyOperation(classifier)(valid)).toMatchObject({
       outcome: 'accepted',
       category: 'push',
     })
@@ -955,7 +1013,7 @@ describe('receipt operation adapters', () => {
       'https://example.test/repo',
       'main',
     ]) {
-      const result = await classifier.classifyOperation(
+      const result = await requireClassifyOperation(classifier)(
         operationWithRevision('push', identity, identity, REVISION_B),
       )
       expect(result).toMatchObject({ outcome: 'rejected' })
@@ -996,12 +1054,14 @@ describe('receipt operation adapters', () => {
           [field]: raw,
         },
       })
-      const result = await classifier.classifyOperation(input)
+      const result = await requireClassifyOperation(classifier)(input)
       expect(result).toMatchObject({ outcome: 'rejected' })
       expect(JSON.stringify(result)).not.toContain(raw)
     }
     expect(
-      await classifier.classifyOperation(operationInput('verification')),
+      await requireClassifyOperation(classifier)(
+        operationInput('verification'),
+      ),
     ).toMatchObject({ outcome: 'accepted' })
     await classifier.close()
   })

--- a/tests/unit/receipt-operations.test.ts
+++ b/tests/unit/receipt-operations.test.ts
@@ -279,20 +279,19 @@ function createScenario(
     runtimeRequiredOperations: requiredOperations,
     runtimeResourceScopes: resourceScopes,
   } as WorkflowGuardOptions)
-  const operationGuard = guard
   expect(
-    operationGuard.activate({
+    guard.activate({
       event: 'guarded-skill',
       skill: 'ce-work',
       outcome: 'success',
     }),
   ).toMatchObject({ status: 'activated' })
   expect(
-    operationGuard.startUnit({ expectedOperations: requiredOperations }),
+    guard.startUnit({ expectedOperations: requiredOperations }),
   ).toMatchObject({
     status: 'started',
   })
-  return { guard: operationGuard, ledger }
+  return { guard, ledger }
 }
 
 function bindOperation(

--- a/tests/unit/receipt-operations.test.ts
+++ b/tests/unit/receipt-operations.test.ts
@@ -152,12 +152,6 @@ function requireClassifyOperation(
   return classifyOperation.bind(classifier)
 }
 
-// `WorkflowGuard` already declares `observeOperation`,
-// `observeTrustedRecoveredOperation`, and `observeReadback` with the exact
-// shapes exercised by these tests; this alias just names the narrowed cast
-// target used at call sites below.
-type OperationWorkflowGuard = WorkflowGuard
-
 function operationInput(
   operation: ReceiptOperation,
   overrides: Partial<OperationInput> = {},
@@ -260,7 +254,7 @@ function createScenario(
   classifier: unknown,
   requiredOperations: readonly ReceiptOperation[] = [],
 ): {
-  guard: OperationWorkflowGuard
+  guard: WorkflowGuard
   ledger: ReturnType<typeof createReceiptLedger>
 } {
   const ledger = createReceiptLedger({
@@ -285,7 +279,7 @@ function createScenario(
     runtimeRequiredOperations: requiredOperations,
     runtimeResourceScopes: resourceScopes,
   } as WorkflowGuardOptions)
-  const operationGuard = guard as OperationWorkflowGuard
+  const operationGuard = guard
   expect(
     operationGuard.activate({
       event: 'guarded-skill',
@@ -302,7 +296,7 @@ function createScenario(
 }
 
 function bindOperation(
-  guard: OperationWorkflowGuard,
+  guard: WorkflowGuard,
   input: Record<string, unknown>,
 ): Record<string, unknown> {
   const status = guard.status()
@@ -329,7 +323,7 @@ function bindOperation(
 }
 
 async function observeTrustedRecoveredOperation(
-  guard: OperationWorkflowGuard,
+  guard: WorkflowGuard,
   input: Record<string, unknown>,
 ): Promise<EvidenceObservationResult> {
   if (typeof guard.observeTrustedRecoveredOperation !== 'function') {
@@ -339,7 +333,7 @@ async function observeTrustedRecoveredOperation(
 }
 
 function mintSyntheticReceipt(
-  guard: OperationWorkflowGuard,
+  guard: WorkflowGuard,
   ledger: ReturnType<typeof createReceiptLedger>,
   operation: ReceiptOperation,
 ): ReceiptEnvelope {
@@ -459,7 +453,7 @@ function coherentFinalReadbacks(
 
 async function buildFullOperationScenario(): Promise<{
   classifier: ReturnType<typeof createReceiptClassifier>
-  guard: OperationWorkflowGuard
+  guard: WorkflowGuard
   ledger: ReturnType<typeof createReceiptLedger>
 }> {
   const classifier = createReceiptClassifier()
@@ -1289,7 +1283,7 @@ describe('receipt operation adapters', () => {
         'check-readback': RESOURCE_PR,
         'review-readback': RESOURCE_PR,
       },
-    } as WorkflowGuardOptions) as OperationWorkflowGuard
+    } as WorkflowGuardOptions)
     expect(
       guard.activate({
         event: 'guarded-skill',


### PR DESCRIPTION
## Summary

Burn-down 1 of N against #897. Fixes the four highest-error test files under `bun run typecheck:all` (tsconfig.tests.json, advisory in CI) — together they held 195 of the 343 baseline errors. Type-level fixes only; no assertion behaviour changed and no `src/` files touched.

## Root causes

- **`tests/unit/receipt-ledger.test.ts`** — tests accessed `.receipt` / `.reasonCode` / `.preparationId` on discriminated-union results (`FinalizeObservationResult`, `PrepareObservationResult`) without narrowing on `status` first. Added local `expectFinalized()` / `expectPrepared()` helpers that throw with a descriptive message and return the narrowed branch, replacing bare `.receipt?` chains.
- **`tests/unit/receipt-operations.test.ts`** — the `operationInput()` fixture builder returned a bare `Record<string, unknown>`, so its `.context` / `.after` fields were typed `unknown` and every `...operationInput(op).after` spread failed with TS2698 (the dominant error code, 59 across the whole suite). Gave it a real `OperationInput` / `OperationFields` return type (with an index signature to keep deliberately loose overrides assignable), which fixed the large majority of errors in one change. Also fixed a local `OperationWorkflowGuard` interface that re-declared `observeReadback` with an incompatible narrower return type (TS2430 — replaced with a type alias onto the real `WorkflowGuard` interface), and added a `requireClassifyOperation()` helper to narrow `ReceiptClassifier`'s optional `classifyOperation` instead of invoking a possibly-undefined method.
- **`tests/unit/opencode-workflow-guard.test.ts`** — `OpencodeWorkflowHostReadback` was imported from the wrong module (`opencode-operation-observer.js` instead of `opencode-workflow-guard.js`, per the #897 triage); mock `ToolContext` objects (`{sessionID, metadata}`) were missing `messageID`/`agent`/`directory`/`worktree`/`abort`/`ask` required by the real `@opencode-ai/plugin` type; `ToolResult` reads needed narrowing off its `string | {...}` union; several fixture observers/configs were missing required fields (`debug`, revision digests, `validateRegisteredWorktree`); and the same classifyOperation-optionality issue as above appeared in two adapter factories.
- **`tests/integration/receipt-workflow-recovery.test.ts`** — every OpenCode SDK client response (`session.create`/`messages`/`children`/`fork`/`prompt`) was read via `.data` without narrowing the `{data?, error?}` response wrapper. Added a single `unwrapData()` helper applied at each call site instead of `.data`/`?.` chains scattered through downstream reads.

## Before / after (error counts)

| File | Before | After |
|---|---:|---:|
| `tests/unit/receipt-ledger.test.ts` | 22 | 0 |
| `tests/unit/receipt-operations.test.ts` | 64 | 0 |
| `tests/unit/opencode-workflow-guard.test.ts` | 60 | 0 |
| `tests/integration/receipt-workflow-recovery.test.ts` | 49 | 0 |
| **`bun run typecheck:all` total** | **343** | **148** |

148 = 343 − 195, exact match (no other file's error count changed).

## Verification

- `bun run typecheck` — clean
- `bun run typecheck:scripts` — clean
- `bun run typecheck:all` — 343 → 148 (the four target files report 0; remaining 148 are pre-existing, out of scope)
- `bun test tests/unit` — 2213/2213 pass
- `bun test tests/unit/receipt-operations.test.ts tests/unit/opencode-workflow-guard.test.ts tests/unit/receipt-ledger.test.ts` — 171/171 pass
- `bun test tests/integration/receipt-workflow-recovery.test.ts` — skips cleanly (opencode availability probe failed in this sandbox: mise config trust), `pgrep -fl opencode` shows no leftover host processes from the run
- `bun run lint` — 0 errors
- `bun scripts/content-integrity.ts` — clean

## Notes for reviewers

- No `src/` types were found to be wrong during this pass — every error traced to test-fixture typing, an incorrect import, or a genuine call-site bug (a malformed `tool.execute.before` call in `opencode-workflow-guard.test.ts` that was missing its second argument).
- Scope was held strictly to the four listed files; `allowImportingTsExtensions` was not touched.

Refs #897, burn-down 1
