### PR TITLE
test(integration): narrow OpenCode client responses in host test suites

### DIFF
--- a/tests/integration/question-attestation-opencode.test.ts
+++ b/tests/integration/question-attestation-opencode.test.ts
@@ -43,7 +43,9 @@ interface MockModelServer {
  */
 function unwrapData<T>(result: { data?: T; error?: unknown }): T {
   if (result.data === undefined) {
-    throw new Error(`opencode client call failed: ${String(result.error)}`)
+    throw new Error(
+      `opencode client call failed: ${JSON.stringify(result.error)}`,
+    )
   }
   return result.data
 }
@@ -909,12 +911,12 @@ describe.skipIf(!OPENCODE_AVAILABLE)('OpenCode Question attestation', () => {
         const request = pending[0]
         expect(request).toBeDefined()
         if (!request) throw new Error('disablement question missing')
-        const beforeReply = (
+        const beforeReply = unwrapData(
           await client.session.messages({
             sessionID,
             directory: fixture.projectDir,
-          })
-        ).data
+          }),
+        )
         expect(JSON.stringify(beforeReply)).toContain('question-attestation')
         expect(JSON.stringify(beforeReply)).not.toContain('"state":"disabled"')
 

--- a/tests/integration/question-attestation-opencode.test.ts
+++ b/tests/integration/question-attestation-opencode.test.ts
@@ -35,6 +35,21 @@ interface MockModelServer {
   stop(): void
 }
 
+/**
+ * The OpenCode SDK client types every response as `{ data?: T; error?:
+ * unknown }` to model transport failures. These tests always run against a
+ * live host and expect success; this asserts that at the call site instead
+ * of accessing `.data` with `?.`/`!` at every downstream read.
+ */
+function unwrapData<T>(result: { data?: T; error?: unknown }): T {
+  if (result.data === undefined) {
+    throw new Error(
+      `opencode client call failed: ${JSON.stringify(result.error)}`,
+    )
+  }
+  return result.data
+}
+
 function sseChunk(value: unknown): string {
   return `data: ${JSON.stringify(value)}\n\n`
 }
@@ -396,7 +411,7 @@ async function createSession(
     title: 'U6 question attestation',
     permission: [{ permission: '*', pattern: '*', action: 'allow' }],
   })
-  return created.data.id
+  return unwrapData(created).id
 }
 
 async function promptSession(
@@ -519,7 +534,7 @@ describe.skipIf(!OPENCODE_AVAILABLE)('OpenCode Question attestation', () => {
               const response = await client.question.list({
                 directory: fixture.projectDir,
               })
-              return response.data.filter(
+              return unwrapData(response).filter(
                 (request) => request.sessionID === sessionID,
               )
             },
@@ -536,8 +551,8 @@ describe.skipIf(!OPENCODE_AVAILABLE)('OpenCode Question attestation', () => {
           throw new Error(
             `U6_PENDING ${JSON.stringify({
               events: readEvents(probe.capturePath),
-              globalQuestionCount: globalQuestions.data.length,
-              parts: summarizeParts(messages.data),
+              globalQuestionCount: unwrapData(globalQuestions).length,
+              parts: summarizeParts(unwrapData(messages)),
             })}`,
           )
         }
@@ -604,12 +619,12 @@ describe.skipIf(!OPENCODE_AVAILABLE)('OpenCode Question attestation', () => {
         expect(repliedIndex).toBeGreaterThan(askedIndex)
 
         await prompt
-        const messages = (
+        const messages = unwrapData(
           await client.session.messages({
             sessionID,
             directory: fixture.projectDir,
-          })
-        ).data
+          }),
+        )
         const markers = systemMarkers(messages)
         expect(markers.length).toBeGreaterThan(0)
         expect(JSON.stringify(markers)).not.toContain('wrong')
@@ -714,7 +729,7 @@ describe.skipIf(!OPENCODE_AVAILABLE)('OpenCode Question attestation', () => {
             const response = await client.question.list({
               directory: fixture.projectDir,
             })
-            return response.data.filter(
+            return unwrapData(response).filter(
               (request) => request.sessionID === sessionID,
             )
           },
@@ -737,12 +752,12 @@ describe.skipIf(!OPENCODE_AVAILABLE)('OpenCode Question attestation', () => {
           requestIDType: 'string',
           sessionIDType: 'string',
         })
-        const messages = (
+        const messages = unwrapData(
           await client.session.messages({
             sessionID,
             directory: fixture.projectDir,
-          })
-        ).data
+          }),
+        )
         const serializedMarkers = JSON.stringify(systemMarkers(messages))
         expect(serializedMarkers).not.toContain('attested')
         expect(serializedMarkers).not.toContain('declined')
@@ -887,7 +902,7 @@ describe.skipIf(!OPENCODE_AVAILABLE)('OpenCode Question attestation', () => {
             const response = await client.question.list({
               directory: fixture.projectDir,
             })
-            return response.data.filter(
+            return unwrapData(response).filter(
               (request) => request.sessionID === sessionID,
             )
           },
@@ -911,12 +926,12 @@ describe.skipIf(!OPENCODE_AVAILABLE)('OpenCode Question attestation', () => {
           answers: [['confirm']],
         })
         await prompt
-        const afterReply = (
+        const afterReply = unwrapData(
           await client.session.messages({
             sessionID,
             directory: fixture.projectDir,
-          })
-        ).data
+          }),
+        )
         const controlParts = workflowParts(afterReply).filter(
           (part) => part.tool === 'systematic_workflow_control',
         )

--- a/tests/integration/question-attestation-opencode.test.ts
+++ b/tests/integration/question-attestation-opencode.test.ts
@@ -43,9 +43,7 @@ interface MockModelServer {
  */
 function unwrapData<T>(result: { data?: T; error?: unknown }): T {
   if (result.data === undefined) {
-    throw new Error(
-      `opencode client call failed: ${JSON.stringify(result.error)}`,
-    )
+    throw new Error(`opencode client call failed: ${String(result.error)}`)
   }
   return result.data
 }
@@ -808,12 +806,12 @@ describe.skipIf(!OPENCODE_AVAILABLE)('OpenCode Question attestation', () => {
         })
         const sessionID = await createSession(client, fixture.projectDir)
         await promptSession(client, sessionID, fixture.projectDir, 'yes')
-        const messages = (
+        const messages = unwrapData(
           await client.session.messages({
             sessionID,
             directory: fixture.projectDir,
-          })
-        ).data
+          }),
+        )
         const serialized = JSON.stringify(messages)
         expect(serialized).not.toContain('questionAttestation')
         expect(

--- a/tests/integration/receipt-workflow-dogfood.test.ts
+++ b/tests/integration/receipt-workflow-dogfood.test.ts
@@ -36,9 +36,7 @@ type ModelResponse = { text?: string; toolCalls?: ToolCall[] }
  */
 function unwrapData<T>(result: { data?: T; error?: unknown }): T {
   if (result.data === undefined) {
-    throw new Error(
-      `opencode client call failed: ${JSON.stringify(result.error)}`,
-    )
+    throw new Error(`opencode client call failed: ${String(result.error)}`)
   }
   return result.data
 }
@@ -458,17 +456,16 @@ async function runScenario(
       title: `focused-${name}`,
       permission: [{ permission: '*', pattern: '*', action: 'allow' }],
     })
-    if (!session.data)
-      throw new Error(`session-create ${JSON.stringify(session)}`)
+    const sessionData = unwrapData(session)
     await client.session.prompt({
-      sessionID: session.data.id,
+      sessionID: sessionData.id,
       directory: fixture.projectDir,
       model: { providerID: PROVIDER, modelID: MODEL },
       parts: [{ type: 'text', text: `Run focused ${name}.` }],
     })
     const messages = unwrapData(
       await client.session.messages({
-        sessionID: session.data.id,
+        sessionID: sessionData.id,
         directory: fixture.projectDir,
       }),
     )
@@ -560,10 +557,10 @@ describe.skipIf(!OPENCODE_AVAILABLE)('focused real-host dogfood', () => {
       // The push unit ends at push — pr-creation/check/review require real GitHub.
       // The guard status after push is 'waiting'/'missing-evidence' (pending remote ops).
       // Verify via the systematic_workflow_status result directly.
-      const pushStatusResult = push?.results?.find(
-        (r: Record<string, unknown>) =>
+      const pushStatusResult = push?.results.find(
+        (r) =>
           r.callID === 'push-status' && r.tool === 'systematic_workflow_status',
-      ) as Record<string, unknown> | undefined
+      )
       expect(pushStatusResult).toBeDefined()
       expect(pushStatusResult?.state).toBe('waiting')
       expect(pushStatusResult?.reasonCode).toBe('missing-evidence')

--- a/tests/integration/receipt-workflow-dogfood.test.ts
+++ b/tests/integration/receipt-workflow-dogfood.test.ts
@@ -28,6 +28,21 @@ type ToolCall = {
 }
 type ModelResponse = { text?: string; toolCalls?: ToolCall[] }
 
+/**
+ * The OpenCode SDK client types every response as `{ data?: T; error?:
+ * unknown }` to model transport failures. These tests always run against a
+ * live host and expect success; this asserts that at the call site instead
+ * of accessing `.data` with `?.`/`!` at every downstream read.
+ */
+function unwrapData<T>(result: { data?: T; error?: unknown }): T {
+  if (result.data === undefined) {
+    throw new Error(
+      `opencode client call failed: ${JSON.stringify(result.error)}`,
+    )
+  }
+  return result.data
+}
+
 function sse(value: unknown): string {
   return `data: ${JSON.stringify(value)}\n\n`
 }
@@ -381,11 +396,23 @@ function callsFor(name: string, index: number): ToolCall[] {
   ]
 }
 
+interface ScenarioResult {
+  mode: Mode
+  scenario: string
+  workflow: Record<string, unknown>
+  markerKinds: string[]
+  results: Array<Record<string, unknown>>
+  pid: number
+  upstreamBefore?: string
+  upstreamAfter?: string
+  localHead?: string
+}
+
 async function runScenario(
   mode: Mode,
   name: string,
   index: number,
-): Promise<Record<string, unknown>> {
+): Promise<ScenarioResult> {
   const fixture = createIsolatedFixture()
   const file = `dogfood-${index}.txt`
   const remoteDir =
@@ -439,12 +466,12 @@ async function runScenario(
       model: { providerID: PROVIDER, modelID: MODEL },
       parts: [{ type: 'text', text: `Run focused ${name}.` }],
     })
-    const messages = (
+    const messages = unwrapData(
       await client.session.messages({
         sessionID: session.data.id,
         directory: fixture.projectDir,
-      })
-    ).data
+      }),
+    )
     const upstreamAfter =
       name === 'push'
         ? gitOutput(fixture.projectDir, [

--- a/tests/integration/receipt-workflow-dogfood.test.ts
+++ b/tests/integration/receipt-workflow-dogfood.test.ts
@@ -36,7 +36,9 @@ type ModelResponse = { text?: string; toolCalls?: ToolCall[] }
  */
 function unwrapData<T>(result: { data?: T; error?: unknown }): T {
   if (result.data === undefined) {
-    throw new Error(`opencode client call failed: ${String(result.error)}`)
+    throw new Error(
+      `opencode client call failed: ${JSON.stringify(result.error)}`,
+    )
   }
   return result.data
 }

--- a/tests/integration/receipt-workflow-guard-real-host.test.ts
+++ b/tests/integration/receipt-workflow-guard-real-host.test.ts
@@ -70,7 +70,9 @@ type HostCell =
  */
 function unwrapData<T>(result: { data?: T; error?: unknown }): T {
   if (result.data === undefined) {
-    throw new Error(`opencode client call failed: ${String(result.error)}`)
+    throw new Error(
+      `opencode client call failed: ${JSON.stringify(result.error)}`,
+    )
   }
   return result.data
 }

--- a/tests/integration/receipt-workflow-guard-real-host.test.ts
+++ b/tests/integration/receipt-workflow-guard-real-host.test.ts
@@ -58,6 +58,21 @@ interface MintMarkerEvidence {
   receiptId: string
 }
 
+/**
+ * The OpenCode SDK client types every response as `{ data?: T; error?:
+ * unknown }` to model transport failures. These tests always run against a
+ * live host and expect success; this asserts that at the call site instead
+ * of accessing `.data` with `?.`/`!` at every downstream read.
+ */
+function unwrapData<T>(result: { data?: T; error?: unknown }): T {
+  if (result.data === undefined) {
+    throw new Error(
+      `opencode client call failed: ${JSON.stringify(result.error)}`,
+    )
+  }
+  return result.data
+}
+
 function sseChunk(value: unknown): string {
   return `data: ${JSON.stringify(value)}\n\n`
 }
@@ -229,7 +244,7 @@ async function createSession(
     title: 'U7 real host',
     permission: [{ permission: '*', pattern: '*', action: 'allow' }],
   })
-  return session.data.id
+  return unwrapData(session).id
 }
 
 async function promptSession(
@@ -483,12 +498,12 @@ async function runObserveCell(
       fixture.projectDir,
       'Run the guarded workflow and ship the local change.',
     )
-    const messages = (
+    const messages = unwrapData(
       await client.session.messages({
         sessionID,
         directory: fixture.projectDir,
-      })
-    ).data
+      }),
+    )
     const markers = markerKinds(messages)
     console.log(
       `U7_CELL_EVIDENCE ${JSON.stringify({
@@ -587,7 +602,7 @@ describe.skipIf(!OPENCODE_AVAILABLE)('U7a real host', () => {
       console.log(`U7_HOST_MATRIX ${JSON.stringify(cells)}`)
       expect(cells).toHaveLength(HOST_VERSIONS.length)
       for (const cell of cells) {
-        expect(['pass', 'blocked']).toContain(cell.status)
+        expect(['pass', 'blocked'] as unknown[]).toContain(cell.status)
       }
     },
     TIMEOUT_MS * 12,

--- a/tests/integration/receipt-workflow-guard-real-host.test.ts
+++ b/tests/integration/receipt-workflow-guard-real-host.test.ts
@@ -58,6 +58,10 @@ interface MintMarkerEvidence {
   receiptId: string
 }
 
+type HostCell =
+  | ({ status: 'pass'; elapsedMs: number } & HostEvidence)
+  | { status: 'blocked'; version: string; reason: string }
+
 /**
  * The OpenCode SDK client types every response as `{ data?: T; error?:
  * unknown }` to model transport failures. These tests always run against a
@@ -66,9 +70,7 @@ interface MintMarkerEvidence {
  */
 function unwrapData<T>(result: { data?: T; error?: unknown }): T {
   if (result.data === undefined) {
-    throw new Error(
-      `opencode client call failed: ${JSON.stringify(result.error)}`,
-    )
+    throw new Error(`opencode client call failed: ${String(result.error)}`)
   }
   return result.data
 }
@@ -581,7 +583,7 @@ describe.skipIf(!OPENCODE_AVAILABLE)('U7a real host', () => {
   test(
     'reports each exact host version cell independently',
     async () => {
-      const cells: Array<Record<string, unknown>> = []
+      const cells: HostCell[] = []
       for (const version of HOST_VERSIONS) {
         const fixture = createIsolatedFixture()
         const packed = extractPackagedPlugin(fixture).pluginUrl
@@ -602,7 +604,7 @@ describe.skipIf(!OPENCODE_AVAILABLE)('U7a real host', () => {
       console.log(`U7_HOST_MATRIX ${JSON.stringify(cells)}`)
       expect(cells).toHaveLength(HOST_VERSIONS.length)
       for (const cell of cells) {
-        expect(['pass', 'blocked'] as unknown[]).toContain(cell.status)
+        expect(['pass', 'blocked']).toContain(cell.status)
       }
     },
     TIMEOUT_MS * 12,


### PR DESCRIPTION
## Summary

Part of the #897 typecheck burn-down. Fixes ~31 `bun run typecheck:all` errors across three real-host integration test files by narrowing OpenCode SDK client responses at the call site instead of accessing `.data` unguarded. Type-level only; no assertions changed; no `src/` edits.

## Root cause

The OpenCode SDK client (`@opencode-ai/sdk/v2`) types every response as `{ data?: T; error?: unknown }` to model transport failures. These three files read `session.data`, `.data.id`, and `session.messages(...).data` directly, which TypeScript correctly flags as possibly `undefined` (TS18048) and then propagates as `unknown`/mistyped downstream into helper functions expecting `unknown[]` (TS2345) or into `expect(...).toContain(...)` overloads (TS2769).

Fix: each file gets its own private `unwrapData<T>(result: { data?: T; error?: unknown }): T` helper — matching the pattern already established in `tests/integration/receipt-workflow-recovery.test.ts` (#919) — that throws a clear error if `data` is `undefined`, otherwise returns the narrowed value. A missing `data` at these call sites is already an unrecoverable test failure, so throwing there does not weaken any assertion.

`receipt-workflow-dogfood.test.ts` additionally needed a proper `ScenarioResult` interface on its local `runScenario` helper — it was annotated `Promise<Record<string, unknown>>`, which erased the `markerKinds`/`results` field types once those depended on the now-narrowed `messages` array, leaving downstream `.filter()`/`.find()` calls on `unknown`/`{}`.

## Before / after per file

| File | Errors before | Errors after |
|---|---|---|
| `tests/integration/question-attestation-opencode.test.ts` | 11 | 0 |
| `tests/integration/receipt-workflow-guard-real-host.test.ts` | 13 | 0 |
| `tests/integration/receipt-workflow-dogfood.test.ts` | 7 | 0 |

## Verification

- `bun run typecheck:all` — target three files: 0 matching errors (confirmed via grep)
- `bun run typecheck:all` total: 148 -> 117 (-31)
- `bun run typecheck` — clean
- `bun run typecheck:scripts` — clean
- `bun test tests/unit` — 2214 pass, 0 fail
- `bun run lint` — 0 errors (13 pre-existing complexity warnings in unrelated files, unchanged)
- `bun scripts/content-integrity.ts` — clean
- Did not run the real-host integration suites (`question-attestation-opencode`, `receipt-workflow-guard-real-host`, `receipt-workflow-dogfood`) — they require a live OpenCode host; only type-checked.
- No `opencode` host processes were spawned by this change.

No `src/` type was found to be too narrow; all three files' errors were entirely local test-file narrowing gaps.

Refs #897, burn-down 2A
