### PR TITLE
test(evals): type the eval fixture factories and case unions

### DIFF
--- a/tests/integration/eval-runner.test.ts
+++ b/tests/integration/eval-runner.test.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
+
 import {
   type BoundedProbeEvent,
   createOpencodeProbe,
@@ -14,6 +15,7 @@ import {
   observePromptComposition,
 } from '../../scripts/eval-cases/opencode.ts'
 import {
+  type CaseId,
   capturePrimaryCheckout,
   cleanupEvalFixture,
   createEvalFixture,
@@ -79,18 +81,27 @@ function syntheticExecution(
   }
 }
 
+const SYNTHETIC_CASE_ASSERTIONS = {
+  'bootstrap-loading': ['bootstrap-observed'],
+  'fixture-local-write': ['fixture-file-content', 'fixture-file-created'],
+  'host-skill-coverage': ['host-catalog-covered'],
+  'model-inheritance': [
+    'agents-inherit-invoking-model',
+    'explicit-model-overlay-wins',
+    'model-null-restores-inheritance',
+    'project-model-trust-boundary',
+  ],
+} as const satisfies Record<CaseId, readonly string[]>
+
 function syntheticResult(options: {
-  caseId: 'bootstrap-loading' | 'fixture-local-write'
+  caseId: CaseId
   mode: 'source' | 'installed'
   runId: string
   outcome: 'success' | 'task_failure' | 'infra_failure'
   subcode: 'none' | 'write_mismatch' | 'identity_drift' | 'artifact_resolution'
 }): ReturnType<typeof normalizeResult> {
   const installed = options.mode === 'installed'
-  const assertionIds =
-    options.caseId === 'bootstrap-loading'
-      ? ['bootstrap-observed']
-      : ['fixture-file-content', 'fixture-file-created']
+  const assertionIds = SYNTHETIC_CASE_ASSERTIONS[options.caseId]
   return normalizeResult({
     resultSchemaVersion: 1,
     caseSchemaVersion: 1,
@@ -242,6 +253,13 @@ function normalizeRunIdentity<T>(value: T, runIds: readonly string[]): T {
   return value
 }
 
+function requireSubcode(subcode: string | undefined): string {
+  if (subcode === undefined) {
+    throw new Error('expected result.subcode to be defined')
+  }
+  return subcode
+}
+
 async function waitForMarker(
   markerPath: string,
   timeoutMs: number,
@@ -274,7 +292,7 @@ describe('local OpenCode eval runner', () => {
 
       if (normalized.outcome === 'infra_failure') {
         expect(['opencode_unavailable', 'identity_drift']).toContain(
-          normalized.subcode,
+          requireSubcode(normalized.subcode),
         )
       } else {
         expect(normalized.identity.opencodeVersion).toBe(
@@ -1009,7 +1027,7 @@ describe('local OpenCode eval runner', () => {
       )
       expect(result.outcome).toBe('infra_failure')
       expect(['opencode_unavailable', 'identity_drift']).toContain(
-        result.subcode,
+        requireSubcode(result.subcode),
       )
       expect(result.cleanup).toEqual({ status: 'clean', residue: 'none' })
       expect(fs.readdirSync(parentDir)).toEqual([])

--- a/tests/integration/eval-runner.test.ts
+++ b/tests/integration/eval-runner.test.ts
@@ -21,6 +21,7 @@ import {
   createEvalFixture,
   type EvalFixture,
   type EvalSelectionRunnerInput,
+  type EvalSubcode,
   EXPECTED_OPENCODE_VERSION,
   installEvalSignalHandlers,
   normalizeResult,
@@ -93,8 +94,17 @@ const SYNTHETIC_CASE_ASSERTIONS = {
   ],
 } as const satisfies Record<CaseId, readonly string[]>
 
+function requireSyntheticCaseId(
+  caseId: CaseId,
+): Exclude<CaseId, 'model-inheritance'> {
+  if (caseId === 'model-inheritance') {
+    throw new Error('syntheticResult cannot build a model-inheritance result')
+  }
+  return caseId
+}
+
 function syntheticResult(options: {
-  caseId: CaseId
+  caseId: Exclude<CaseId, 'model-inheritance'>
   mode: 'source' | 'installed'
   runId: string
   outcome: 'success' | 'task_failure' | 'infra_failure'
@@ -253,7 +263,7 @@ function normalizeRunIdentity<T>(value: T, runIds: readonly string[]): T {
   return value
 }
 
-function requireSubcode(subcode: string | undefined): string {
+function requireSubcode(subcode: EvalSubcode | undefined): EvalSubcode {
   if (subcode === undefined) {
     throw new Error('expected result.subcode to be defined')
   }
@@ -1481,7 +1491,7 @@ describe('local OpenCode eval runner', () => {
         sourceRunner: async (options) => {
           calls.push(`${options.caseId}/${options.mode}`)
           return syntheticResult({
-            caseId: options.caseId,
+            caseId: requireSyntheticCaseId(options.caseId),
             mode: 'source',
             runId: options.runId ?? 'run-missing',
             outcome: 'success',
@@ -1491,7 +1501,7 @@ describe('local OpenCode eval runner', () => {
         installedRunner: async (options) => {
           calls.push(`${options.caseId}/${options.mode}`)
           return syntheticResult({
-            caseId: options.caseId,
+            caseId: requireSyntheticCaseId(options.caseId),
             mode: 'installed',
             runId: options.runId ?? 'run-missing',
             outcome:
@@ -1532,7 +1542,7 @@ describe('local OpenCode eval runner', () => {
         sourceRunner: async (options) => {
           abortedCalls.push(options.caseId)
           return syntheticResult({
-            caseId: options.caseId,
+            caseId: requireSyntheticCaseId(options.caseId),
             mode: 'source',
             runId: options.runId ?? 'run-missing',
             outcome: 'infra_failure',
@@ -1570,7 +1580,7 @@ describe('local OpenCode eval runner', () => {
         sourceRunner: async (options) => {
           calls.push(`${options.caseId}/${options.mode}`)
           return syntheticResult({
-            caseId: options.caseId,
+            caseId: requireSyntheticCaseId(options.caseId),
             mode: 'source',
             runId: options.runId ?? 'run-missing',
             outcome: 'success',
@@ -1580,7 +1590,7 @@ describe('local OpenCode eval runner', () => {
         installedRunner: async (options) => {
           calls.push(`${options.caseId}/${options.mode}`)
           return syntheticResult({
-            caseId: options.caseId,
+            caseId: requireSyntheticCaseId(options.caseId),
             mode: 'installed',
             runId: options.runId ?? 'run-missing',
             outcome: 'success',
@@ -1625,7 +1635,7 @@ describe('local OpenCode eval runner', () => {
         },
         sourceRunner: async (input) =>
           syntheticResult({
-            caseId: input.caseId,
+            caseId: requireSyntheticCaseId(input.caseId),
             mode: 'source',
             runId: input.runId ?? 'run-missing',
             outcome: 'success',
@@ -1697,7 +1707,7 @@ describe('local OpenCode eval runner', () => {
       sourceRunner: async (input: EvalSelectionRunnerInput) => {
         cleanupCalls.push(`${input.caseId}/${input.mode}`)
         return syntheticResult({
-          caseId: input.caseId,
+          caseId: requireSyntheticCaseId(input.caseId),
           mode: 'source',
           runId: input.runId ?? 'run-missing',
           outcome: 'success',
@@ -1707,7 +1717,7 @@ describe('local OpenCode eval runner', () => {
       installedRunner: async (input: EvalSelectionRunnerInput) => {
         cleanupCalls.push(`${input.caseId}/${input.mode}`)
         return syntheticResult({
-          caseId: input.caseId,
+          caseId: requireSyntheticCaseId(input.caseId),
           mode: 'installed',
           runId: input.runId ?? 'run-missing',
           outcome: 'success',
@@ -1766,7 +1776,7 @@ describe('local OpenCode eval runner', () => {
       },
       sourceRunner: async (input: EvalSelectionRunnerInput) =>
         syntheticResult({
-          caseId: input.caseId,
+          caseId: requireSyntheticCaseId(input.caseId),
           mode: 'source',
           runId: input.runId ?? 'run-missing',
           outcome: 'success',
@@ -1774,7 +1784,7 @@ describe('local OpenCode eval runner', () => {
         }),
       installedRunner: async (input: EvalSelectionRunnerInput) =>
         syntheticResult({
-          caseId: input.caseId,
+          caseId: requireSyntheticCaseId(input.caseId),
           mode: 'installed',
           runId: input.runId ?? 'run-missing',
           outcome: 'success',
@@ -1852,7 +1862,7 @@ describe('local OpenCode eval runner', () => {
       sourceRunner: async (input: EvalSelectionRunnerInput) => {
         calls.push(`${input.caseId}/${input.mode}`)
         return syntheticResult({
-          caseId: input.caseId,
+          caseId: requireSyntheticCaseId(input.caseId),
           mode: 'source',
           runId: input.runId ?? 'run-missing',
           outcome: 'success',
@@ -1862,7 +1872,7 @@ describe('local OpenCode eval runner', () => {
       installedRunner: async (input: EvalSelectionRunnerInput) => {
         calls.push(`${input.caseId}/${input.mode}`)
         return syntheticResult({
-          caseId: input.caseId,
+          caseId: requireSyntheticCaseId(input.caseId),
           mode: 'installed',
           runId: input.runId ?? 'run-missing',
           outcome: 'success',
@@ -1974,7 +1984,7 @@ describe('local OpenCode eval runner', () => {
       }),
       sourceRunner: async (input: EvalSelectionRunnerInput) =>
         syntheticResult({
-          caseId: input.caseId,
+          caseId: requireSyntheticCaseId(input.caseId),
           mode: 'source',
           runId: input.runId ?? 'run-missing',
           outcome: 'success',
@@ -1982,7 +1992,7 @@ describe('local OpenCode eval runner', () => {
         }),
       installedRunner: async (input: EvalSelectionRunnerInput) =>
         syntheticResult({
-          caseId: input.caseId,
+          caseId: requireSyntheticCaseId(input.caseId),
           mode: 'installed',
           runId: input.runId ?? 'run-missing',
           outcome: 'success',
@@ -2043,7 +2053,7 @@ describe('local OpenCode eval runner', () => {
           runsRoot: path.join(parentDir, 'runs'),
           sourceRunner: async (options) =>
             syntheticResult({
-              caseId: options.caseId,
+              caseId: requireSyntheticCaseId(options.caseId),
               mode: 'source',
               runId: options.runId ?? 'run-missing',
               outcome: 'task_failure',

--- a/tests/integration/eval-runner.test.ts
+++ b/tests/integration/eval-runner.test.ts
@@ -94,17 +94,10 @@ const SYNTHETIC_CASE_ASSERTIONS = {
   ],
 } as const satisfies Record<CaseId, readonly string[]>
 
-function requireSyntheticCaseId(
-  caseId: CaseId,
-): Exclude<CaseId, 'model-inheritance'> {
-  if (caseId === 'model-inheritance') {
-    throw new Error('syntheticResult cannot build a model-inheritance result')
-  }
-  return caseId
-}
-
+// Does not build the 'model-inheritance' evidence branch; passing that
+// caseId throws in normalizeEvidence.
 function syntheticResult(options: {
-  caseId: Exclude<CaseId, 'model-inheritance'>
+  caseId: CaseId
   mode: 'source' | 'installed'
   runId: string
   outcome: 'success' | 'task_failure' | 'infra_failure'
@@ -1491,7 +1484,7 @@ describe('local OpenCode eval runner', () => {
         sourceRunner: async (options) => {
           calls.push(`${options.caseId}/${options.mode}`)
           return syntheticResult({
-            caseId: requireSyntheticCaseId(options.caseId),
+            caseId: options.caseId,
             mode: 'source',
             runId: options.runId ?? 'run-missing',
             outcome: 'success',
@@ -1501,7 +1494,7 @@ describe('local OpenCode eval runner', () => {
         installedRunner: async (options) => {
           calls.push(`${options.caseId}/${options.mode}`)
           return syntheticResult({
-            caseId: requireSyntheticCaseId(options.caseId),
+            caseId: options.caseId,
             mode: 'installed',
             runId: options.runId ?? 'run-missing',
             outcome:
@@ -1542,7 +1535,7 @@ describe('local OpenCode eval runner', () => {
         sourceRunner: async (options) => {
           abortedCalls.push(options.caseId)
           return syntheticResult({
-            caseId: requireSyntheticCaseId(options.caseId),
+            caseId: options.caseId,
             mode: 'source',
             runId: options.runId ?? 'run-missing',
             outcome: 'infra_failure',
@@ -1580,7 +1573,7 @@ describe('local OpenCode eval runner', () => {
         sourceRunner: async (options) => {
           calls.push(`${options.caseId}/${options.mode}`)
           return syntheticResult({
-            caseId: requireSyntheticCaseId(options.caseId),
+            caseId: options.caseId,
             mode: 'source',
             runId: options.runId ?? 'run-missing',
             outcome: 'success',
@@ -1590,7 +1583,7 @@ describe('local OpenCode eval runner', () => {
         installedRunner: async (options) => {
           calls.push(`${options.caseId}/${options.mode}`)
           return syntheticResult({
-            caseId: requireSyntheticCaseId(options.caseId),
+            caseId: options.caseId,
             mode: 'installed',
             runId: options.runId ?? 'run-missing',
             outcome: 'success',
@@ -1635,7 +1628,7 @@ describe('local OpenCode eval runner', () => {
         },
         sourceRunner: async (input) =>
           syntheticResult({
-            caseId: requireSyntheticCaseId(input.caseId),
+            caseId: input.caseId,
             mode: 'source',
             runId: input.runId ?? 'run-missing',
             outcome: 'success',
@@ -1707,7 +1700,7 @@ describe('local OpenCode eval runner', () => {
       sourceRunner: async (input: EvalSelectionRunnerInput) => {
         cleanupCalls.push(`${input.caseId}/${input.mode}`)
         return syntheticResult({
-          caseId: requireSyntheticCaseId(input.caseId),
+          caseId: input.caseId,
           mode: 'source',
           runId: input.runId ?? 'run-missing',
           outcome: 'success',
@@ -1717,7 +1710,7 @@ describe('local OpenCode eval runner', () => {
       installedRunner: async (input: EvalSelectionRunnerInput) => {
         cleanupCalls.push(`${input.caseId}/${input.mode}`)
         return syntheticResult({
-          caseId: requireSyntheticCaseId(input.caseId),
+          caseId: input.caseId,
           mode: 'installed',
           runId: input.runId ?? 'run-missing',
           outcome: 'success',
@@ -1776,7 +1769,7 @@ describe('local OpenCode eval runner', () => {
       },
       sourceRunner: async (input: EvalSelectionRunnerInput) =>
         syntheticResult({
-          caseId: requireSyntheticCaseId(input.caseId),
+          caseId: input.caseId,
           mode: 'source',
           runId: input.runId ?? 'run-missing',
           outcome: 'success',
@@ -1784,7 +1777,7 @@ describe('local OpenCode eval runner', () => {
         }),
       installedRunner: async (input: EvalSelectionRunnerInput) =>
         syntheticResult({
-          caseId: requireSyntheticCaseId(input.caseId),
+          caseId: input.caseId,
           mode: 'installed',
           runId: input.runId ?? 'run-missing',
           outcome: 'success',
@@ -1862,7 +1855,7 @@ describe('local OpenCode eval runner', () => {
       sourceRunner: async (input: EvalSelectionRunnerInput) => {
         calls.push(`${input.caseId}/${input.mode}`)
         return syntheticResult({
-          caseId: requireSyntheticCaseId(input.caseId),
+          caseId: input.caseId,
           mode: 'source',
           runId: input.runId ?? 'run-missing',
           outcome: 'success',
@@ -1872,7 +1865,7 @@ describe('local OpenCode eval runner', () => {
       installedRunner: async (input: EvalSelectionRunnerInput) => {
         calls.push(`${input.caseId}/${input.mode}`)
         return syntheticResult({
-          caseId: requireSyntheticCaseId(input.caseId),
+          caseId: input.caseId,
           mode: 'installed',
           runId: input.runId ?? 'run-missing',
           outcome: 'success',
@@ -1984,7 +1977,7 @@ describe('local OpenCode eval runner', () => {
       }),
       sourceRunner: async (input: EvalSelectionRunnerInput) =>
         syntheticResult({
-          caseId: requireSyntheticCaseId(input.caseId),
+          caseId: input.caseId,
           mode: 'source',
           runId: input.runId ?? 'run-missing',
           outcome: 'success',
@@ -1992,7 +1985,7 @@ describe('local OpenCode eval runner', () => {
         }),
       installedRunner: async (input: EvalSelectionRunnerInput) =>
         syntheticResult({
-          caseId: requireSyntheticCaseId(input.caseId),
+          caseId: input.caseId,
           mode: 'installed',
           runId: input.runId ?? 'run-missing',
           outcome: 'success',
@@ -2053,7 +2046,7 @@ describe('local OpenCode eval runner', () => {
           runsRoot: path.join(parentDir, 'runs'),
           sourceRunner: async (options) =>
             syntheticResult({
-              caseId: requireSyntheticCaseId(options.caseId),
+              caseId: options.caseId,
               mode: 'source',
               runId: options.runId ?? 'run-missing',
               outcome: 'task_failure',

--- a/tests/unit/eval-contract.test.ts
+++ b/tests/unit/eval-contract.test.ts
@@ -8,10 +8,15 @@ import {
   CASE_IDS,
   CASE_SCHEMA_VERSION,
   type EvalMode,
+  type EvalResult,
+  type HostCatalogCoverageObservation,
+  type InstalledProvenance,
   normalizeResult,
   OUTCOMES,
+  type PromptCompositionObservation,
   parseCaseManifest,
   RESULT_SCHEMA_VERSION,
+  type SourceProvenance,
   serializeResult,
 } from '../../scripts/run-evals.ts'
 import { buildBundledAgentInventory } from '../../src/lib/agent-overlays.js'
@@ -26,7 +31,7 @@ function readManifest(fileName: string): unknown {
   ) as unknown
 }
 
-function sourceProvenance(): Record<string, unknown> {
+function sourceProvenance(): SourceProvenance {
   return {
     kind: 'source',
     checkoutRelativeSource: 'src/index.ts',
@@ -37,7 +42,7 @@ function sourceProvenance(): Record<string, unknown> {
   }
 }
 
-function installedProvenance(): Record<string, unknown> {
+function installedProvenance(): InstalledProvenance {
   return {
     kind: 'installed',
     packageName: '@fro.bot/systematic',
@@ -49,7 +54,7 @@ function installedProvenance(): Record<string, unknown> {
   }
 }
 
-function validResult(mode: EvalMode = 'source'): Record<string, unknown> {
+function validResult(mode: EvalMode = 'source'): EvalResult {
   const fixtureAssertions = ['fixture-file-content', 'fixture-file-created']
   return {
     resultSchemaVersion: RESULT_SCHEMA_VERSION,
@@ -92,9 +97,7 @@ function validResult(mode: EvalMode = 'source'): Record<string, unknown> {
   }
 }
 
-function validModelInheritanceResult(
-  mode: EvalMode = 'source',
-): Record<string, unknown> {
+function validModelInheritanceResult(mode: EvalMode = 'source'): EvalResult {
   const assertionIds = [
     'agents-inherit-invoking-model',
     'explicit-model-overlay-wins',
@@ -106,7 +109,7 @@ function validModelInheritanceResult(
     caseId: 'model-inheritance',
     assertionIds,
     identity: {
-      ...(validResult(mode).identity as Record<string, unknown>),
+      ...validResult(mode).identity,
       artifactId: mode === 'source' ? 'source-entry' : 'installed-entry',
     },
     evidence: {
@@ -370,7 +373,7 @@ describe('local OpenCode eval contracts', () => {
       }),
     ).toThrow()
 
-    const incomplete = sourceProvenance()
+    const incomplete: Record<string, unknown> = { ...sourceProvenance() }
     delete incomplete.canonicalSourceEntryId
     expect(() =>
       normalizeResult({ ...validResult('source'), provenance: incomplete }),
@@ -405,7 +408,7 @@ describe('local OpenCode eval contracts', () => {
         entryCount: 0,
         skillNames: [],
       },
-    }
+    } satisfies PromptCompositionObservation
     const candidate = {
       ...validResult(),
       evidence: {
@@ -591,7 +594,7 @@ describe('local OpenCode eval contracts', () => {
       expectedSkillNames: ['agent-browser', 'ce:brainstorm'],
       observedSkillNames: ['agent-browser', 'ce:brainstorm', 'extra-skill'],
       missingSkillNames: [],
-    }
+    } satisfies HostCatalogCoverageObservation
     const candidate = {
       ...validResult(),
       evidence: {
@@ -626,7 +629,7 @@ describe('local OpenCode eval contracts', () => {
       expectedSkillNames: ['agent-browser', 'ce:brainstorm'],
       observedSkillNames: [],
       missingSkillNames: [],
-    }
+    } satisfies HostCatalogCoverageObservation
     expect(
       normalizeResult({
         ...validResult(),


### PR DESCRIPTION
## Summary

Part of the #897 typecheck burn-down: type-level-only fixes for `tests/integration/eval-runner.test.ts` (17 errors) and `tests/unit/eval-contract.test.ts` (8 errors). No test assertions changed, no `src/` files touched.

## Root causes

1. **Untyped shared fixture factories (`eval-contract.test.ts`)** — `validResult`, `validModelInheritanceResult`, `sourceProvenance`, and `installedProvenance` all returned `Record<string, unknown>`. Every place that spread their output (`...validResult()`) or read a nested property (`candidate.evidence.modelInheritance`) hit TS2698 ("Spread types may only be created from object types") or TS18046 ("is of type 'unknown'"). Typed them against the real `EvalResult`, `SourceProvenance`, and `InstalledProvenance` interfaces exported from `scripts/run-evals.ts`.
2. **`string | undefined` into `toContain()` (both files)** — `EvalResult['subcode']` is optional (`EvalSubcode | undefined`), but both files pass it straight into `expect([...]).toContain(result.subcode)`, which requires a `string` (TS2769). Added a `requireSubcode()` guard in `eval-runner.test.ts` that throws if the value is ever `undefined`, rather than silently widening or asserting with `!`.
3. **Stale/narrow literal unions:**
   - `eval-runner.test.ts`'s locally scoped `syntheticResult()` helper had a `caseId` parameter narrowed to only `'bootstrap-loading' | 'fixture-local-write'`, but callers pass the full `CaseId` from `EvalSelectionRunnerInput` (all four cases). Widened the parameter to the real exported `CaseId` type and extended the local assertion-ID lookup table to cover `host-skill-coverage` and `model-inheritance` (this union does **not** live in `scripts/run-evals.ts` — the real `CaseId` there was already correct and complete; the narrow union was purely local to the test file).
   - `eval-contract.test.ts` had three untyped object literals (`promptComposition`, `hostCatalogCoverage`, `impossibleCoverage`) whose `state` field widened to `string`, conflicting with the `PromptCatalogState` literal union expected by `toEqual()` (TS2769). Preserved the literal types with `satisfies PromptCompositionObservation` / `satisfies HostCatalogCoverageObservation` instead of widening the source.

No `src/` or `scripts/run-evals.ts` type gap was found — all four case IDs were already correctly declared in the shared `CaseId` export.

## Before / after

- `bun run typecheck:all` error count: **148 → 123** (-25)
- Target files: `eval-runner.test.ts` and `eval-contract.test.ts` now contribute **0** errors (verified via `bun run typecheck:all 2>&1 | grep -E 'eval-runner|eval-contract'` → empty)

## Verification

- `bun run typecheck` — clean
- `bun run typecheck:scripts` — clean
- `bun run typecheck:all` — 123 errors remaining (down from 148), none in the two target files
- `bun test tests/unit` — 2214 pass, 0 fail
- `bun run lint` — 0 errors (13 pre-existing warnings, unrelated)
- `bun scripts/content-integrity.ts` — clean

`eval-runner.test.ts` is a live-host integration test; it was type-fixed but not executed (per burn-down scope, `bun test:integration` was not run).

Refs #897, burn-down 2B
