### PR TITLE
test(unit): complete SDK-shaped fixtures and narrow result unions

### DIFF
--- a/tests/unit/opencode-operation-observer.test.ts
+++ b/tests/unit/opencode-operation-observer.test.ts
@@ -6,10 +6,27 @@ import path from 'node:path'
 
 import {
   createOpencodeOperationObserver,
+  type OpencodeOperationObserver,
   type OperationObserverCommandResult,
   type OperationObserverLimits,
   type OperationObserverRemoteCommandResult,
+  type OperationObserverRemoteResult,
+  type RemoteOperation,
+  type RemoteReadbackPhase,
 } from '../../src/lib/opencode-operation-observer.js'
+
+/** `remoteSnapshot` is optional on the interface (implementations that never do readbacks may omit it), but every fixture observer here always implements it. */
+function callRemoteSnapshot(
+  observer: OpencodeOperationObserver,
+  operation: RemoteOperation,
+  phase: RemoteReadbackPhase,
+): Promise<OperationObserverRemoteResult> {
+  const { remoteSnapshot } = observer
+  if (!remoteSnapshot) {
+    throw new Error('Expected observer.remoteSnapshot to be defined')
+  }
+  return remoteSnapshot.call(observer, operation, phase)
+}
 
 interface GitFixture {
   root: string
@@ -891,7 +908,9 @@ describe('OpenCode operation observer', () => {
               timeout: timeoutMs,
             },
           )
-          const timedOut = child.error?.code === 'ETIMEDOUT'
+          const timedOut =
+            (child.error as NodeJS.ErrnoException | undefined)?.code ===
+            'ETIMEDOUT'
           return {
             status: child.status ?? -1,
             stdout: secret,
@@ -1002,7 +1021,7 @@ describe('OpenCode operation observer', () => {
         },
       })
       await expect(
-        remote.remoteSnapshot('pr-creation', 'after'),
+        callRemoteSnapshot(remote, 'pr-creation', 'after'),
       ).resolves.toMatchObject({ status: 'available' })
       expect(remoteTimeouts.length).toBeGreaterThan(0)
       expect(new Set(remoteTimeouts)).toEqual(new Set([1_000]))
@@ -1138,7 +1157,11 @@ describe('OpenCode operation observer', () => {
         targetDirectory: fixture.root,
         remoteCommandRunner,
       })
-      const result = await observer.remoteSnapshot('check-readback', 'after')
+      const result = await callRemoteSnapshot(
+        observer,
+        'check-readback',
+        'after',
+      )
       expect(result.status).toBe('available')
       if (result.status !== 'available') return
       expect(result.snapshot.resourceIdentity).toMatch(/^[0-9a-f]{64}$/)
@@ -1169,7 +1192,7 @@ describe('OpenCode operation observer', () => {
         limits: { maxCommandOutputBytes: 4096 },
       })
       await expect(
-        oversized.remoteSnapshot('review-readback', 'after'),
+        callRemoteSnapshot(oversized, 'review-readback', 'after'),
       ).resolves.toEqual({
         status: 'unavailable',
         reasonCode: 'remote-command-output-limit',
@@ -1184,7 +1207,8 @@ describe('OpenCode operation observer', () => {
           _maxOutputBytes: number,
         ) => ({ status: 0, stdout: '{bad', stderr: '' }),
       })
-      const malformedResult = await malformed.remoteSnapshot(
+      const malformedResult = await callRemoteSnapshot(
+        malformed,
         'pr-creation',
         'after',
       )

--- a/tests/unit/pi-delegate-session.test.ts
+++ b/tests/unit/pi-delegate-session.test.ts
@@ -23,6 +23,31 @@ afterAll(() => {
   }
 })
 
+type SessionModel = NonNullable<CreateAgentSessionOptions['model']>
+
+/**
+ * Builds a complete SDK-shaped `Model<any>` fixture (all required fields
+ * from `@earendil-works/pi-ai`'s `Model<TApi>` interface populated with
+ * inert defaults) so tests can override only the fields they assert on.
+ */
+function createModelFixture(
+  overrides: Partial<SessionModel> = {},
+): SessionModel {
+  return {
+    id: 'm',
+    name: 'm',
+    api: 'anthropic-messages',
+    provider: 'p',
+    baseUrl: 'https://example.invalid',
+    reasoning: false,
+    input: ['text'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1,
+    maxTokens: 1,
+    ...overrides,
+  }
+}
+
 function makeTempAgentsDir(files: Record<string, string>): string {
   const dir = fs.mkdtempSync(
     path.join(os.tmpdir(), 'pi-delegate-session-recursion-test-'),
@@ -61,14 +86,14 @@ describe('buildDelegateResourceLoaderOptions', () => {
 
 describe('buildDelegateAgentSessionOptions', () => {
   test('requests parent model/cwd, exact mapped tools, empty customTools, and the given loader/session manager', () => {
-    const model = { provider: 'anthropic', id: 'claude' }
+    const model = createModelFixture({ provider: 'anthropic', id: 'claude' })
     const resourceLoader = { marker: 'resource-loader' } as never
     const sessionManager = { marker: 'session-manager' } as never
 
     const options = buildDelegateAgentSessionOptions({
       cwd: '/parent/cwd',
       agentDir: '/agent/dir',
-      model: model as CreateAgentSessionOptions['model'],
+      model,
       allowedToolNames: ['read', 'grep'],
       resourceLoader,
       sessionManager,
@@ -87,7 +112,7 @@ describe('buildDelegateAgentSessionOptions', () => {
     const options = buildDelegateAgentSessionOptions({
       cwd: '/parent/cwd',
       agentDir: '/agent/dir',
-      model: { provider: 'p', id: 'm' } as CreateAgentSessionOptions['model'],
+      model: createModelFixture(),
       thinkingLevel: 'high',
       allowedToolNames: ['read'],
       resourceLoader: {} as never,
@@ -101,7 +126,7 @@ describe('buildDelegateAgentSessionOptions', () => {
     const options = buildDelegateAgentSessionOptions({
       cwd: '/parent/cwd',
       agentDir: '/agent/dir',
-      model: { provider: 'p', id: 'm' } as CreateAgentSessionOptions['model'],
+      model: createModelFixture(),
       allowedToolNames: ['read'],
       resourceLoader: {} as never,
       sessionManager: {} as never,
@@ -176,10 +201,10 @@ describe('createDelegateSessionWith: live adapter contract, no provider required
     const { runtime, calls } = createFakeRuntime()
     const createSession = createDelegateSessionWith(runtime)
 
-    const model = { provider: 'anthropic', id: 'claude' }
+    const model = createModelFixture({ provider: 'anthropic', id: 'claude' })
     const session = await createSession({
       agentName: 'git-analyzer',
-      model: model as CreateAgentSessionOptions['model'],
+      model,
       cwd: '/parent/cwd',
       systemPromptOverride: 'Persona body.',
       allowedToolNames: ['read', 'grep'],
@@ -230,7 +255,7 @@ describe('createDelegateSessionWith: live adapter contract, no provider required
 
     await createSession({
       agentName: 'git-analyzer',
-      model: { provider: 'p', id: 'm' } as CreateAgentSessionOptions['model'],
+      model: createModelFixture(),
       thinkingLevel: 'high',
       cwd: '/parent/cwd',
       systemPromptOverride: 'Persona body.',
@@ -245,7 +270,7 @@ describe('createDelegateSessionWith: live adapter contract, no provider required
     const createSession2 = createDelegateSessionWith(runtime2)
     await createSession2({
       agentName: 'git-analyzer',
-      model: { provider: 'p', id: 'm' } as CreateAgentSessionOptions['model'],
+      model: createModelFixture(),
       cwd: '/parent/cwd',
       systemPromptOverride: 'Persona body.',
       allowedToolNames: ['read'],
@@ -263,7 +288,7 @@ describe('createDelegateSessionWith: live adapter contract, no provider required
     await expect(
       createSession({
         agentName: 'malicious',
-        model: { provider: 'p', id: 'm' } as CreateAgentSessionOptions['model'],
+        model: createModelFixture(),
         cwd: '/cwd',
         systemPromptOverride: 'x',
         allowedToolNames: ['read', DELEGATE_TOOL_NAME],
@@ -337,10 +362,7 @@ describe('systematic_delegate child-session boundary: noExtensions + re-entry gu
 
     await createSession({
       agentName: 'any-persona',
-      model: {
-        provider: 'anthropic',
-        id: 'claude',
-      } as CreateAgentSessionOptions['model'],
+      model: createModelFixture({ provider: 'anthropic', id: 'claude' }),
       cwd: '/parent/cwd',
       systemPromptOverride: 'Persona body.',
       allowedToolNames: ['read'],
@@ -394,10 +416,7 @@ describe('systematic_delegate child-session boundary: noExtensions + re-entry gu
     await expect(
       createSession({
         agentName: 'any-persona',
-        model: {
-          provider: 'p',
-          id: 'm',
-        } as CreateAgentSessionOptions['model'],
+        model: createModelFixture(),
         cwd: '/cwd',
         systemPromptOverride: 'body',
         // Including DELEGATE_TOOL_NAME triggers the fail-closed guard.

--- a/tests/unit/pi.test.ts
+++ b/tests/unit/pi.test.ts
@@ -297,16 +297,25 @@ describe('src/pi.ts before_agent_start bootstrap injection', () => {
     )
     const originalReadFileSync = fs.readFileSync
     const readFileSyncSpy = spyOn(fs, 'readFileSync').mockImplementation(
-      // Cast to the overloaded `readFileSync` type: every production call site
-      // in this repo passes an explicit 'utf8' encoding (see grep across
-      // src/lib/*.ts), so this fixture only needs to honor the string-returning
-      // overload; the cast avoids re-declaring all native fs overloads here.
-      ((path: fs.PathOrFileDescriptor): string => {
+      // Cast to the overloaded `readFileSync` type: every readFileSync call
+      // reachable from piExtension()'s bootstrap computation (src/lib/bootstrap.ts,
+      // agent-resolver.ts, config-handler.ts, config.ts) passes an explicit
+      // 'utf8'/'utf-8' encoding, so this fixture only needs to honor the
+      // string-returning overload; the cast avoids re-declaring all native fs
+      // overloads here. (src/lib/setup.ts reads a Buffer via a bare fd with no
+      // encoding, but that path is not exercised by piExtension().)
+      ((
+        path: fs.PathOrFileDescriptor,
+        options?: Parameters<typeof fs.readFileSync>[1],
+      ): string => {
         const filePath = String(path)
         if (filePath.endsWith('using-systematic/SKILL.md')) {
           throw new Error('bootstrap failure')
         }
-        return originalReadFileSync(path, 'utf8')
+        return originalReadFileSync(
+          path,
+          options as unknown as BufferEncoding,
+        ) as string
       }) as unknown as typeof fs.readFileSync,
     )
 

--- a/tests/unit/pi.test.ts
+++ b/tests/unit/pi.test.ts
@@ -12,6 +12,7 @@ import type {
   ExtensionHandler,
   ToolDefinition,
 } from '@earendil-works/pi-coding-agent'
+import type { ToolResult } from '@opencode-ai/plugin'
 import type { Config } from '@opencode-ai/sdk'
 import { createConfigHandler } from '../../src/lib/config-handler.ts'
 import { formatSkillCommandName } from '../../src/lib/skill-loader.ts'
@@ -27,6 +28,16 @@ import piExtension from '../../src/pi.ts'
 
 const bundledSkillsDir = fileURLToPath(new URL('../../skills', import.meta.url))
 const resolverOptions = { bundledSkillsDir, disabledSkills: [] }
+
+/** `ToolDefinition['execute']` returns the SDK's `ToolResult` union; the skill tool always resolves the string branch. */
+function expectStringToolResult(result: ToolResult): string {
+  if (typeof result !== 'string') {
+    throw new Error(
+      'Expected the skill tool to return a string ToolResult, got a structured result instead.',
+    )
+  }
+  return result
+}
 
 interface RegisterToolSpy {
   registeredTools: ToolDefinition[]
@@ -230,7 +241,9 @@ describe('src/pi.ts systematic_skill tool registration', () => {
       {} as unknown as Parameters<ToolDefinition['execute']>[4],
     )) as AgentToolResult<{ skillDir: string }>
 
-    expect(piResult.content).toEqual([{ type: 'text', text: openCodeResult }])
+    expect(piResult.content).toEqual([
+      { type: 'text', text: expectStringToolResult(openCodeResult) },
+    ])
     expect(metadataCalls).toEqual([
       {
         title: 'Loaded skill: ce:plan',
@@ -284,13 +297,17 @@ describe('src/pi.ts before_agent_start bootstrap injection', () => {
     )
     const originalReadFileSync = fs.readFileSync
     const readFileSyncSpy = spyOn(fs, 'readFileSync').mockImplementation(
-      (...args) => {
-        const filePath = String(args[0])
+      // Cast to the overloaded `readFileSync` type: every production call site
+      // in this repo passes an explicit 'utf8' encoding (see grep across
+      // src/lib/*.ts), so this fixture only needs to honor the string-returning
+      // overload; the cast avoids re-declaring all native fs overloads here.
+      ((path: fs.PathOrFileDescriptor): string => {
+        const filePath = String(path)
         if (filePath.endsWith('using-systematic/SKILL.md')) {
           throw new Error('bootstrap failure')
         }
-        return originalReadFileSync(...args)
-      },
+        return originalReadFileSync(path, 'utf8')
+      }) as unknown as typeof fs.readFileSync,
     )
 
     await expect(piExtension(api)).resolves.toBeUndefined()

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -375,7 +375,12 @@ describe('per-invocation plugin registration', () => {
       const pluginModule = (await import(pathToFileURL(pluginPath).href)) as {
         default: (args: ReturnType<typeof makeInput>) => Promise<{
           config: unknown
-          tool: { systematic_skill: unknown }
+          tool: {
+            systematic_skill: unknown
+            systematic_workflow_start: unknown
+          }
+          'tool.execute.before': unknown
+          'tool.execute.after': unknown
           'experimental.chat.system.transform': unknown
         }>
       }

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -8,6 +8,14 @@ import { applyBootstrapContent } from '../../src/lib/bootstrap.js'
 const SRC_DIR = path.resolve(import.meta.dirname, '../../src')
 const ROOT_DIR = path.resolve(import.meta.dirname, '../..')
 
+/** Narrows an optional `Hooks` member (e.g. `tool`) that the plugin always registers. */
+function expectDefined<T>(value: T | undefined, message: string): T {
+  if (value === undefined) {
+    throw new Error(message)
+  }
+  return value
+}
+
 describe('plugin loading', () => {
   test('plugin file exists at src/index.ts', () => {
     const pluginPath = path.join(SRC_DIR, 'index.ts')
@@ -373,32 +381,33 @@ describe('per-invocation plugin registration', () => {
     try {
       const pluginPath = path.join(SRC_DIR, 'index.ts')
       const pluginModule = (await import(pathToFileURL(pluginPath).href)) as {
-        default: (args: ReturnType<typeof makeInput>) => Promise<{
-          config: unknown
-          tool: {
-            systematic_skill: unknown
-            systematic_workflow_start: unknown
-          }
-          'tool.execute.before': unknown
-          'tool.execute.after': unknown
-          'experimental.chat.system.transform': unknown
-        }>
+        default: (
+          args: ReturnType<typeof makeInput>,
+        ) => Promise<
+          Awaited<ReturnType<typeof import('../../src/index.js').default>>
+        >
       }
       const input = makeInput(tempDir)
       const result1 = await pluginModule.default(input)
       const result2 = await pluginModule.default(input)
-      expect(result1.tool.systematic_skill).not.toBe(
-        result2.tool.systematic_skill,
+      const tool1 = expectDefined(
+        result1.tool,
+        'Expected result1.tool to be defined',
       )
-      expect(Object.keys(result1.tool).sort()).toEqual([
+      const tool2 = expectDefined(
+        result2.tool,
+        'Expected result2.tool to be defined',
+      )
+      expect(tool1.systematic_skill).not.toBe(tool2.systematic_skill)
+      expect(Object.keys(tool1).sort()).toEqual([
         'systematic_skill',
         'systematic_workflow_complete',
         'systematic_workflow_control',
         'systematic_workflow_start',
         'systematic_workflow_status',
       ])
-      expect(result1.tool.systematic_workflow_start).not.toBe(
-        result2.tool.systematic_workflow_start,
+      expect(tool1.systematic_workflow_start).not.toBe(
+        tool2.systematic_workflow_start,
       )
       expect(result1['tool.execute.before']).not.toBe(
         result2['tool.execute.before'],

--- a/tests/unit/receipt-classifier.test.ts
+++ b/tests/unit/receipt-classifier.test.ts
@@ -3,9 +3,37 @@ import { fileURLToPath } from 'node:url'
 
 import {
   createReceiptClassifier,
+  type ReceiptClassifier,
   type ReceiptOperation,
 } from '../../src/lib/receipt-classifier.js'
-import { createReceiptLedger } from '../../src/lib/receipt-ledger.js'
+import {
+  createReceiptLedger,
+  type FinalizeObservationResult,
+  type ReceiptClassification,
+} from '../../src/lib/receipt-ledger.js'
+
+/** `classifyOperation` is optional on the interface (some classifiers only support `classify`), but `createReceiptClassifier` always implements it. */
+function callClassifyOperation(
+  classifier: ReceiptClassifier,
+  input: unknown,
+): Promise<ReceiptClassification> {
+  const { classifyOperation } = classifier
+  if (!classifyOperation) {
+    throw new Error('Expected classifier.classifyOperation to be defined')
+  }
+  return classifyOperation.call(classifier, input)
+}
+
+function assertFinalized(
+  result: FinalizeObservationResult,
+): asserts result is Extract<
+  FinalizeObservationResult,
+  { status: 'finalized' }
+> {
+  if (result.status !== 'finalized') {
+    throw new Error(`Expected a finalized result, got status: ${result.status}`)
+  }
+}
 
 const successfulTerminal = {
   status: 'success' as const,
@@ -228,7 +256,7 @@ describe('receipt classifier', () => {
       },
       terminal: successfulTerminal,
     }
-    const open = await classifier.classifyOperation({
+    const open = await callClassifyOperation(classifier, {
       ...base,
       after: {
         workspaceIdentity: identity,
@@ -243,7 +271,7 @@ describe('receipt classifier', () => {
       reasonCode: 'no-op-resource',
     })
 
-    const closed = await classifier.classifyOperation({
+    const closed = await callClassifyOperation(classifier, {
       ...base,
       after: {
         workspaceIdentity: identity,
@@ -262,7 +290,7 @@ describe('receipt classifier', () => {
   test('accepts implementation observations with the optional closure field', async () => {
     const classifier = createReceiptClassifier()
     const identity = 'a'.repeat(64)
-    const result = await classifier.classifyOperation({
+    const result = await callClassifyOperation(classifier, {
       callId: 'implementation-closure-field',
       operation: 'implementation',
       tool: 'write',
@@ -291,7 +319,7 @@ describe('receipt classifier', () => {
   test('does not let a non-shell write claim a commit operation', async () => {
     const classifier = createReceiptClassifier()
     const identity = 'a'.repeat(64)
-    const result = await classifier.classifyOperation({
+    const result = await callClassifyOperation(classifier, {
       callId: 'non-shell-commit-claim',
       operation: 'commit',
       tool: 'write',
@@ -443,8 +471,10 @@ describe('receipt classifier', () => {
     const secondReceipt = second.finalizeObservation(finalizeInput)
     expect(firstReceipt.status).toBe('finalized')
     expect(secondReceipt.status).toBe('finalized')
-    expect(firstReceipt.receipt?.canonical.registrationDigest).not.toBe(
-      secondReceipt.receipt?.canonical.registrationDigest,
+    assertFinalized(firstReceipt)
+    assertFinalized(secondReceipt)
+    expect(firstReceipt.receipt.canonical.registrationDigest).not.toBe(
+      secondReceipt.receipt.canonical.registrationDigest,
     )
 
     const rejectedLedger = createReceiptLedger({

--- a/tests/unit/skill-tool.test.ts
+++ b/tests/unit/skill-tool.test.ts
@@ -2,12 +2,23 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import type { ToolResult } from '@opencode-ai/plugin'
 import { createSkillTool } from '../../src/lib/skill-tool.ts'
 
 const mockContext = {
   ask: async () => {},
   metadata: () => {},
 } as never
+
+/** `ToolDefinition['execute']` returns the SDK's `ToolResult` union; the skill tool always resolves the string branch. */
+function expectStringToolResult(result: ToolResult): string {
+  if (typeof result !== 'string') {
+    throw new Error(
+      'Expected the skill tool to return a string ToolResult, got a structured result instead.',
+    )
+  }
+  return result
+}
 
 describe('skill-tool', () => {
   let testDir: string
@@ -480,9 +491,8 @@ description: Test file limit
         disabledSkills: [],
       })
 
-      const result = await tool.execute(
-        { name: 'file-limit-test' },
-        mockContext,
+      const result = expectStringToolResult(
+        await tool.execute({ name: 'file-limit-test' }, mockContext),
       )
 
       // Count the number of <file> tags


### PR DESCRIPTION
## Summary

Part of the #897 typecheck burn-down (batch 2C): fixes ~37 type-level errors across six `tests/unit/*` files by completing SDK-shaped fixtures and narrowing optional-member / discriminated-union result types. **No assertions changed, no `src/` files touched.**

## Root causes

1. **Incomplete SDK `Model` fixtures** — `CreateAgentSessionOptions['model']` is `Model<any> | undefined`. Ad hoc `{ provider, id }` literals cast through that type produced `Model<any> | undefined`, which doesn't satisfy callers requiring a non-optional `Model<any>` (e.g. `DelegateParentModel`).
2. **`ToolResult` union narrowing** — `createSkillTool()`'s declared `ToolDefinition` return type widens `execute()` to the SDK's `ToolResult` union (`string | { title?, output, metadata?, attachments? }`), so results need narrowing before string-only use.
3. **Optional interface members always implemented by fixtures** — `ReceiptClassifier.classifyOperation` and `OpencodeOperationObserver.remoteSnapshot` are both optional on their interfaces (for implementations that don't support those operations), but every fixture in these tests always implements them.
4. **Discriminated-union access without a type guard** — `FinalizeObservationResult` (`{status:'finalized', receipt} | {status:'rejected', reasonCode}`) was accessed via `.receipt` after an `expect(...).toBe('finalized')` runtime assertion, which doesn't narrow the type for TS.
5. **Stale hand-written type shapes / overloaded native APIs** — an inline type for the plugin's `default()` return value was missing keys the test already asserted on; `fs.readFileSync`'s heavily overloaded native signature broke a loose `(...args) => ...` passthrough mock.

## Before/after per file

| File | Errors before | Fix |
|---|---|---|
| `tests/unit/pi-delegate-session.test.ts` | 8 | `createModelFixture()` factory returning a complete `Model<any>` |
| `tests/unit/pi.test.ts` | 4 | `expectStringToolResult()` narrowing helper + explicitly typed `readFileSync` mock (single cast) |
| `tests/unit/plugin.test.ts` | 6 | Extended stale inline type shape to include `systematic_workflow_start`, `tool.execute.before`, `tool.execute.after` |
| `tests/unit/skill-tool.test.ts` | 2 | Same `ToolResult` narrowing helper as `pi.test.ts` |
| `tests/unit/opencode-operation-observer.test.ts` | 7 | `NodeJS.ErrnoException` cast (existing codebase pattern) for `child.error.code`; `callRemoteSnapshot()` present-assert-and-forward helper |
| `tests/unit/receipt-classifier.test.ts` | 10 | `callClassifyOperation()` present-assert-and-forward helper; `assertFinalized()` type-predicate narrowing `FinalizeObservationResult` |

## Verification

- `bun run typecheck:all` — total error count **148 → 111** (−37); `grep` for the six target files returns empty
- `bun run typecheck` — clean
- `bun run typecheck:scripts` — clean
- `bun test tests/unit` — **2214 pass, 0 fail**
- Six target suites run individually and combined — **133 pass, 0 fail**
- `bun run lint` — 0 errors (13 pre-existing warnings unrelated to this change, in `generate-config-reference.test.ts`)
- `bun scripts/content-integrity.ts` — clean

No `!`, `any`, or `@ts-ignore` introduced. No `src/` type was found to be genuinely too narrow — every optional member encountered here is legitimately optional in production (consumed via `?.` or explicit checks elsewhere in `src/`), so all fixes are test-side typed helpers or complete fixtures.

Refs #897, burn-down 2C
