### PR TITLE
ci: add a required host-contract job that runs the integration suite against a real OpenCode host

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -184,6 +184,9 @@ jobs:
               - 'tests/**'
               - 'scripts/**'
               - 'evals/**'
+              - 'skills/**'
+              - 'agents/**'
+              - 'registry/**'
               - 'package.json'
               - 'bun.lock'
               - '.github/workflows/main.yaml'
@@ -194,11 +197,22 @@ jobs:
       # of repeating the push-vs-pull_request branch.
       - name: Determine whether to run the host contract suite
         id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          FILTER_RESULT: ${{ steps.filter.outputs.host-contract }}
         run: |
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$FILTER_RESULT" == "true" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$FILTER_RESULT" == "false" ]]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
           else
-            echo "run=${{ steps.filter.outputs.host-contract }}" >> "$GITHUB_OUTPUT"
+            # Fail closed: a malformed or empty paths-filter output must never
+            # be treated as "skip and report success", since that would
+            # silently satisfy release's needs on this job.
+            echo "::error::paths-filter returned an unexpected value: '$FILTER_RESULT' (expected 'true' or 'false')"
+            exit 1
           fi
 
       - name: Setup Node.js
@@ -225,7 +239,6 @@ jobs:
         run: bun run build
 
       - name: Run host contract suite
-        id: host-contract-run
         if: steps.gate.outputs.run == 'true'
         env:
           SYSTEMATIC_REQUIRE_OPENCODE: '1'
@@ -238,8 +251,11 @@ jobs:
       # The module-scope throw (SYSTEMATIC_REQUIRE_OPENCODE=1) already covers
       # a missing or mismatched host. This guard covers what it cannot: a
       # per-test gate such as test.skipIf(!DIST_LOCAL_AVAILABLE) skipping for
-      # an unexpected reason while the job stays green. The exempt set lives
-      # here, next to the guard, so adding an entry is a reviewed change.
+      # an unexpected reason while the job stays green, or a whole-file
+      # collapse (a crash or an early exit) that still leaves the console
+      # summary and pass floor looking plausible. The exempt set, the
+      # expected-file list, and the floor all live here, next to the guard,
+      # so widening any of them is a reviewed change.
       - name: Guard skipped tests and pass floor
         if: steps.gate.outputs.run == 'true'
         run: |
@@ -257,15 +273,38 @@ jobs:
             },
           ]
 
-          // Conservative placeholder floor. Re-tune upward from the actual
-          // pass count once this job has run against a live OpenCode host
-          // (see the plan's Unit 4 deferred item on the measured floor).
-          const PASS_FLOOR = 50
+          // Every test file under tests/integration/, enumerated by hand and
+          // verified against `ls tests/integration/*.test.ts`. A file
+          // producing zero JUnit testsuite entries means bun test never
+          // actually ran it -- the exact failure mode a mass-skip or an
+          // early crash would produce while the console summary and pass
+          // floor alone could still look plausible.
+          const EXPECTED_SUITE_FILES = [
+            'tests/integration/claude-code.test.ts',
+            'tests/integration/eval-artifact.test.ts',
+            'tests/integration/eval-fixture.test.ts',
+            'tests/integration/eval-runner.test.ts',
+            'tests/integration/opencode.test.ts',
+            'tests/integration/pi.test.ts',
+            'tests/integration/question-attestation-opencode.test.ts',
+            'tests/integration/receipt-workflow-dogfood.test.ts',
+            'tests/integration/receipt-workflow-guard-real-host.test.ts',
+            'tests/integration/receipt-workflow-recovery.test.ts',
+            'tests/integration/release-notes-ci.test.ts',
+          ]
+
+          // Measured: 138 test()/it() call sites exist across the eleven
+          // integration files as of this writing. The prior floor of 50
+          // exactly equalled the host-free test count (claude-code 18 +
+          // eval-artifact 7 + eval-fixture 5 + release-notes-ci 20 = 50), so
+          // a total collapse of every host-touching file could still clear
+          // it silently. Raise this floor as the suite grows; do not lower
+          // it without a documented reason.
+          const PASS_FLOOR = 120
 
           const [, , junitPath, logPath] = process.argv
           const xml = readFileSync(junitPath, 'utf8')
 
-          const testcaseRe = /<testcase\b([^>]*?)(\/>|>[\s\S]*?<\/testcase>)/g
           const attrRe = /(\w+)="([^"]*)"/g
 
           function parseAttrs(str) {
@@ -276,10 +315,30 @@ jobs:
             return attrs
           }
 
+          // Bun emits one outer <testsuite> per test file, plus one nested
+          // <testsuite> per describe block, all sharing that file's file=
+          // attribute -- so collecting every testsuite's file attribute and
+          // taking the unique set recovers exactly the set of files bun
+          // actually loaded and ran, regardless of describe nesting.
+          // <testsuite\b never matches the closing </testsuite> tag (a /
+          // immediately follows <, not t), and never matches the plural
+          // <testsuites container (no word boundary between testsuite and
+          // the trailing s).
+          const testsuiteRe = /<testsuite\b([^>]*)>/g
+          const producedFiles = new Set()
+          let suiteMatch
+          while ((suiteMatch = testsuiteRe.exec(xml))) {
+            const attrs = parseAttrs(suiteMatch[1])
+            if (attrs.file) producedFiles.add(attrs.file)
+          }
+
+          const missingFiles = EXPECTED_SUITE_FILES.filter((f) => !producedFiles.has(f))
+
+          const testcaseRe = /<testcase\b([^>]*?)(\/>|>[\s\S]*?<\/testcase>)/g
           const skipped = []
-          let match
-          while ((match = testcaseRe.exec(xml))) {
-            const [, attrStr, rest] = match
+          let caseMatch
+          while ((caseMatch = testcaseRe.exec(xml))) {
+            const [, attrStr, rest] = caseMatch
             const attrs = parseAttrs(attrStr)
             if (rest.includes('<skipped')) {
               skipped.push({ classname: attrs.classname ?? '', name: attrs.name ?? '' })
@@ -295,6 +354,12 @@ jobs:
 
           let failed = false
 
+          if (missingFiles.length > 0) {
+            console.error('Expected integration test file(s) produced no JUnit suite (bun test never ran them):')
+            for (const f of missingFiles) console.error(`  - ${f}`)
+            failed = true
+          }
+
           if (unexpected.length > 0) {
             console.error('Unexpected skipped test(s) (not in the known-exempt set):')
             for (const k of unexpected) console.error(`  - ${k}`)
@@ -308,12 +373,17 @@ jobs:
           }
 
           const log = readFileSync(logPath, 'utf8')
-          const passMatch = log.match(/^\s*(\d+)\s+pass\s*$/m)
-          if (!passMatch) {
+          // Bun's default reporter prints one "<N> pass" summary line per
+          // run; take the last match rather than the first so a captured
+          // log containing more than one summary is scored on the final,
+          // authoritative count.
+          const passMatches = [...log.matchAll(/^\s*(\d+)\s+pass\s*$/gm)]
+          const lastPassMatch = passMatches.at(-1)
+          if (!lastPassMatch) {
             console.error('Could not find a "<N> pass" summary line in the captured test output.')
             failed = true
           } else {
-            const passCount = Number(passMatch[1])
+            const passCount = Number(lastPassMatch[1])
             console.log(`Observed pass count: ${passCount} (floor: ${PASS_FLOOR})`)
             if (passCount < PASS_FLOOR) {
               console.error(`Pass count ${passCount} is below the floor of ${PASS_FLOOR}.`)

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -159,6 +159,183 @@ jobs:
       - name: Run tests
         run: bun test tests/unit
 
+  host-contract:
+    name: Host Contract
+    runs-on: ubuntu-latest
+    # Measured on the first real CI run; not summed from per-test ceilings
+    # (see the plan's Key Technical Decisions / Unit 4). Re-tune once this
+    # job has actually run against a live OpenCode host.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Path gating applies only to pull requests, and only at step level:
+      # this job has no top-level `if:`, so it always runs to completion and
+      # reports a status. A `needs` dependency that were skipped would skip
+      # `release` too, silently publishing nothing on a docs-only PR.
+      - name: Detect relevant path changes
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          filters: |
+            host-contract:
+              - 'src/**'
+              - 'tests/**'
+              - 'scripts/**'
+              - 'evals/**'
+              - 'package.json'
+              - 'bun.lock'
+              - '.github/workflows/main.yaml'
+
+      # On push to main the filter step above is bypassed entirely, so this
+      # always resolves to true there. On a pull request it mirrors the
+      # filter's verdict. Every later step reads this single output instead
+      # of repeating the push-vs-pull_request branch.
+      - name: Determine whether to run the host contract suite
+        id: gate
+        run: |
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=${{ steps.filter.outputs.host-contract }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Node.js
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Setup Bun
+        if: steps.gate.outputs.run == 'true'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Install dependencies
+        if: steps.gate.outputs.run == 'true'
+        run: bun install --frozen-lockfile
+
+      # Load-bearing: dist/ is gitignored, opencode.test.ts computes
+      # DIST_LOCAL_AVAILABLE from dist/index.js at module scope, and
+      # packTarballOnce() builds inside a beforeAll — too late for that gate.
+      # Building first makes the dist-local assertion run for real and turns
+      # the in-beforeAll build into a warm no-op.
+      - name: Build
+        if: steps.gate.outputs.run == 'true'
+        run: bun run build
+
+      - name: Run host contract suite
+        id: host-contract-run
+        if: steps.gate.outputs.run == 'true'
+        env:
+          SYSTEMATIC_REQUIRE_OPENCODE: '1'
+        run: |
+          set -o pipefail
+          bun test tests/integration \
+            --reporter=junit --reporter-outfile=host-contract-junit.xml \
+            2>&1 | tee host-contract-log.txt
+
+      # The module-scope throw (SYSTEMATIC_REQUIRE_OPENCODE=1) already covers
+      # a missing or mismatched host. This guard covers what it cannot: a
+      # per-test gate such as test.skipIf(!DIST_LOCAL_AVAILABLE) skipping for
+      # an unexpected reason while the job stays green. The exempt set lives
+      # here, next to the guard, so adding an entry is a reviewed change.
+      - name: Guard skipped tests and pass floor
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          cat <<'EOF' > host-contract-guard.mjs
+          import { readFileSync } from 'node:fs'
+
+          // The only test allowed to skip today: the mixed-version test stays
+          // opt-in because enabling it would put a fetch of a published
+          // @fro.bot/systematic release on the path that gates publishing the
+          // next one.
+          const EXEMPT_SKIPS = [
+            {
+              classname: 'opencode mixed-version integration',
+              name: 'pinned package plus local source keep systematic_skill deterministic and converge bootstrap',
+            },
+          ]
+
+          // Conservative placeholder floor. Re-tune upward from the actual
+          // pass count once this job has run against a live OpenCode host
+          // (see the plan's Unit 4 deferred item on the measured floor).
+          const PASS_FLOOR = 50
+
+          const [, , junitPath, logPath] = process.argv
+          const xml = readFileSync(junitPath, 'utf8')
+
+          const testcaseRe = /<testcase\b([^>]*?)(\/>|>[\s\S]*?<\/testcase>)/g
+          const attrRe = /(\w+)="([^"]*)"/g
+
+          function parseAttrs(str) {
+            const attrs = {}
+            let m
+            attrRe.lastIndex = 0
+            while ((m = attrRe.exec(str))) attrs[m[1]] = m[2]
+            return attrs
+          }
+
+          const skipped = []
+          let match
+          while ((match = testcaseRe.exec(xml))) {
+            const [, attrStr, rest] = match
+            const attrs = parseAttrs(attrStr)
+            if (rest.includes('<skipped')) {
+              skipped.push({ classname: attrs.classname ?? '', name: attrs.name ?? '' })
+            }
+          }
+
+          const key = (s) => `${s.classname}::${s.name}`
+          const exemptKeys = new Set(EXEMPT_SKIPS.map(key))
+          const actualKeys = skipped.map(key)
+
+          const unexpected = actualKeys.filter((k) => !exemptKeys.has(k))
+          const missingExempt = [...exemptKeys].filter((k) => !actualKeys.includes(k))
+
+          let failed = false
+
+          if (unexpected.length > 0) {
+            console.error('Unexpected skipped test(s) (not in the known-exempt set):')
+            for (const k of unexpected) console.error(`  - ${k}`)
+            failed = true
+          }
+
+          if (missingExempt.length > 0) {
+            console.error('Known-exempt skip(s) not found in this run (exempt set is stale):')
+            for (const k of missingExempt) console.error(`  - ${k}`)
+            failed = true
+          }
+
+          const log = readFileSync(logPath, 'utf8')
+          const passMatch = log.match(/^\s*(\d+)\s+pass\s*$/m)
+          if (!passMatch) {
+            console.error('Could not find a "<N> pass" summary line in the captured test output.')
+            failed = true
+          } else {
+            const passCount = Number(passMatch[1])
+            console.log(`Observed pass count: ${passCount} (floor: ${PASS_FLOOR})`)
+            if (passCount < PASS_FLOOR) {
+              console.error(`Pass count ${passCount} is below the floor of ${PASS_FLOOR}.`)
+              failed = true
+            }
+          }
+
+          if (failed) process.exit(1)
+          console.log('host-contract skip/pass guard passed.')
+          EOF
+          bun host-contract-guard.mjs host-contract-junit.xml host-contract-log.txt
+
+      - name: Upload test log on failure
+        if: failure() && steps.gate.outputs.run == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: host-contract-log
+          path: |
+            host-contract-log.txt
+            host-contract-junit.xml
+          if-no-files-found: ignore
+
   registry:
     name: Registry
     runs-on: ubuntu-latest
@@ -225,7 +402,7 @@ jobs:
       # override here silently turns a requested dry run into a real release.
       DRY_RUN: ${{ (github.event_name == 'pull_request' || github.event.inputs.dry-run == 'true') && 'true' || 'false' }}
     name: Release
-    needs: [build, typecheck, lint, test]
+    needs: [build, typecheck, lint, test, host-contract]
     outputs:
       new-release-published: ${{ steps.semantic-release.outputs.new-release-published }}
       new-release-version: ${{ steps.semantic-release.outputs.new-release-version }}

--- a/docs/plans/2026-09-04-001-refactor-ci-owned-host-contract-suite-plan.md
+++ b/docs/plans/2026-09-04-001-refactor-ci-owned-host-contract-suite-plan.md
@@ -262,7 +262,7 @@ Two adjacent facts shaped the design. `mise.toml` prepends `./node_modules/.bin`
 - Neither `OPENCODE_TEST_MODEL` nor `big-pickle` appears anywhere under `tests/integration/` (`tests/manual/` legitimately keeps its hosted-model scripts).
 - Under `SYSTEMATIC_REQUIRE_OPENCODE=1`, no test in `tests/integration/` has an assertion that admits every outcome. Locally, two eval-runner shapes stay tolerant by design — the gate test's `infra_failure` branch and the repeated-runs equality test (two `infra_failure` envelopes compare equal) — and both are unreachable offline once Unit 2 gates them. In CI the host is available (the module-scope throw guarantees it), so both tests run against a real host and their assertions are live.
 
-- [ ] **Unit 4: Add the `host-contract` CI job**
+- [x] **Unit 4: Add the `host-contract` CI job**
 
 **Goal:** Run the integration suite in CI on the PRs that can change its outcome, fail closed, and gate release on it.
 

--- a/scripts/lib/opencode-availability.ts
+++ b/scripts/lib/opencode-availability.ts
@@ -55,6 +55,13 @@ export interface ProbeOpencodeAvailabilityOptions {
    * `[opencode-ai@<pin>, --version]`. Production callers must not set this.
    */
   args?: readonly string[]
+  /**
+   * Suppresses the pre-probe diagnostic (see below). Set by callers whose
+   * output is itself asserted to be clean, such as `verifyExactOpencodeRuntime`'s
+   * per-case probe inside the eval runner CLI child — its stderr is asserted
+   * empty by `eval-runner.test.ts`'s direct-CLI tests. Defaults to `false`.
+   */
+  quiet?: boolean
 }
 
 const DEFAULT_PROBE_TIMEOUT_MS = 300_000
@@ -95,8 +102,10 @@ export function probeOpencodeAvailability(
   // own `command`, and this line would otherwise fire once per fake-launcher
   // case. A wedged package registry blocks synchronously for the full
   // timeout with no other output, so this line is what makes that stall
-  // attributable in CI logs rather than a silent multi-minute pause.
-  if (options.command === undefined) {
+  // attributable in CI logs rather than a silent multi-minute pause. Callers
+  // whose own output must stay clean (the eval runner CLI child) pass
+  // `quiet: true` to suppress it.
+  if (options.command === undefined && !options.quiet) {
     console.warn(
       `[opencode-availability] probing bunx opencode-ai@${options.pin} --version`,
     )

--- a/scripts/lib/opencode-availability.ts
+++ b/scripts/lib/opencode-availability.ts
@@ -85,6 +85,20 @@ function extractReportedVersion(output: string): string | undefined {
 }
 
 /**
+ * True only on the real launcher path: every unit test override supplies its
+ * own `command`, and logging would otherwise fire once per fake-launcher
+ * case. Callers whose own output must stay clean (the eval runner CLI
+ * child) pass `quiet: true` to suppress it. Split out from
+ * {@link probeOpencodeAvailability} to keep that function's cognitive
+ * complexity under the project's lint ceiling.
+ */
+function shouldLogProbeDiagnostic(
+  options: ProbeOpencodeAvailabilityOptions,
+): boolean {
+  return options.command === undefined && !options.quiet
+}
+
+/**
  * Runs `bunx opencode-ai@<pin> --version` (or the test-only override) under
  * the given environment and classifies the outcome. Never throws; never
  * memoizes. `available` requires exit 0 and the last stdout line to equal
@@ -98,14 +112,10 @@ export function probeOpencodeAvailability(
   const command = options.command ?? 'bunx'
   const args = options.args ?? [`opencode-ai@${options.pin}`, '--version']
 
-  // Only the real launcher path logs: every unit test override supplies its
-  // own `command`, and this line would otherwise fire once per fake-launcher
-  // case. A wedged package registry blocks synchronously for the full
-  // timeout with no other output, so this line is what makes that stall
-  // attributable in CI logs rather than a silent multi-minute pause. Callers
-  // whose own output must stay clean (the eval runner CLI child) pass
-  // `quiet: true` to suppress it.
-  if (options.command === undefined && !options.quiet) {
+  // A wedged package registry blocks synchronously for the full timeout
+  // with no other output, so this line is what makes that stall
+  // attributable in CI logs rather than a silent multi-minute pause.
+  if (shouldLogProbeDiagnostic(options)) {
     console.warn(
       `[opencode-availability] probing bunx opencode-ai@${options.pin} --version`,
     )

--- a/scripts/lib/opencode-availability.ts
+++ b/scripts/lib/opencode-availability.ts
@@ -91,6 +91,17 @@ export function probeOpencodeAvailability(
   const command = options.command ?? 'bunx'
   const args = options.args ?? [`opencode-ai@${options.pin}`, '--version']
 
+  // Only the real launcher path logs: every unit test override supplies its
+  // own `command`, and this line would otherwise fire once per fake-launcher
+  // case. A wedged package registry blocks synchronously for the full
+  // timeout with no other output, so this line is what makes that stall
+  // attributable in CI logs rather than a silent multi-minute pause.
+  if (options.command === undefined) {
+    console.warn(
+      `[opencode-availability] probing bunx opencode-ai@${options.pin} --version`,
+    )
+  }
+
   // spawnSync's own timeout sends SIGTERM (then SIGKILL) to the direct child
   // only, not its process group; this function is deliberately synchronous
   // (every caller computes availability once, inline, before deciding

--- a/scripts/run-evals.ts
+++ b/scripts/run-evals.ts
@@ -2970,6 +2970,10 @@ export function verifyExactOpencodeRuntime(options: {
     env,
     cwd: options.fixture.projectRoot,
     timeoutMs: options.timeoutMs ?? 300_000,
+    // The eval runner CLI's own stderr is asserted clean by
+    // eval-runner.test.ts's direct-CLI tests; the pre-probe diagnostic is
+    // for the module-scope gates that run inside the parent test process.
+    quiet: true,
   })
   if (classification.status === 'unavailable') {
     return {

--- a/tests/unit/opencode-availability.test.ts
+++ b/tests/unit/opencode-availability.test.ts
@@ -176,6 +176,49 @@ describe('probeOpencodeAvailability', () => {
   })
 })
 
+describe('probeOpencodeAvailability diagnostic logging', () => {
+  test('logs a diagnostic before the real bunx probe unless quiet is set', () => {
+    // Every other case in this suite passes a `command` override, which
+    // means `options.command === undefined` -- the branch that gates the
+    // diagnostic -- is never exercised. Aliasing a fake launcher as `bunx`
+    // on a PATH scoped to the child's env lets this test drive the real
+    // default-command path without touching the network-reaching real
+    // launcher.
+    const dir = tempDir()
+    try {
+      const bunxPath = path.join(dir, 'bunx')
+      fs.writeFileSync(bunxPath, '#!/usr/bin/env bash\necho "1.18.28"\n', {
+        mode: 0o755,
+      })
+      fs.chmodSync(bunxPath, 0o755)
+      const env = { PATH: `${dir}:${process.env.PATH ?? ''}` }
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const loud = probeOpencodeAvailability({ pin: '1.18.28', env })
+        expect(loud.status).toBe('available')
+        expect(warnSpy).toHaveBeenCalledTimes(1)
+        expect(warnSpy.mock.calls[0]?.[0]).toContain(
+          'probing bunx opencode-ai@1.18.28',
+        )
+
+        warnSpy.mockClear()
+
+        const quiet = probeOpencodeAvailability({
+          pin: '1.18.28',
+          env,
+          quiet: true,
+        })
+        expect(quiet.status).toBe('available')
+        expect(warnSpy).not.toHaveBeenCalled()
+      } finally {
+        warnSpy.mockRestore()
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
 describe('requireOpencodeAvailable', () => {
   test('an available classification never throws, flag set or not', () => {
     const available: OpencodeAvailabilityClassification = {

--- a/tests/unit/receipt-workflow-host-no-spawn.test.ts
+++ b/tests/unit/receipt-workflow-host-no-spawn.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const FIXTURE_PATH = path.resolve(
+  import.meta.dirname,
+  '../integration/fixtures/receipt-workflow-host.ts',
+)
+
+// Locks Unit 2's load-bearing invariant: importing this fixture must never
+// spawn bunx/opencode at module scope. `bun test tests/unit` (which the
+// required `test` job runs, with no network and no launcher on PATH)
+// imports this fixture indirectly through `receipt-workflow-host.test.ts`.
+// The availability probe only runs behind the memoizing `isOpencodeAvailable()`
+// function, called lazily by integration modules at their own scope — never
+// by the fixture module itself. Driven as a child process so a stray spawn
+// (which would need network or a real launcher and could hang or take
+// seconds) shows up as elapsed wall time rather than a mocked assertion.
+describe('receipt-workflow-host fixture import', () => {
+  test('importing the fixture module does not spawn bunx/opencode at module scope', () => {
+    const script = `
+      const start = Date.now()
+      await import(${JSON.stringify(pathToFileURL(FIXTURE_PATH).href)})
+      const elapsedMs = Date.now() - start
+      process.stdout.write('IMPORT_ELAPSED_MS:' + elapsedMs)
+    `
+
+    const result = spawnSync('bun', ['-e', script], {
+      cwd: process.cwd(),
+      env: { PATH: process.env.PATH ?? '' },
+      encoding: 'utf8',
+      timeout: 10_000,
+    })
+
+    expect(result.status).toBe(0)
+
+    const match = /IMPORT_ELAPSED_MS:(\d+)/.exec(result.stdout)
+    expect(match).not.toBeNull()
+
+    // A bunx probe (network fetch or launcher exec) takes hundreds of
+    // milliseconds to tens of seconds; a pure module import completes in
+    // low tens of milliseconds. 500ms leaves ample margin for CI jitter
+    // while still catching a probe call reintroduced at module scope.
+    const elapsedMs = Number(match?.[1])
+    expect(elapsedMs).toBeLessThan(500)
+  })
+})


### PR DESCRIPTION
## Summary

Implements Unit 4 of `docs/plans/2026-09-04-001-refactor-ci-owned-host-contract-suite-plan.md`: a new required `host-contract` CI job that runs `tests/integration` against a real, `bunx`-launched OpenCode host, fails closed on a missing/mismatched host, and gates `release`.

## Job design

- **New job**: `host-contract` in `.github/workflows/main.yaml`, `ubuntu-latest`, same Bun + Node 24 setup steps as the `test` job.
- **Build before test (load-bearing)**: `dist/` is gitignored. `opencode.test.ts` computes `DIST_LOCAL_AVAILABLE` from `dist/index.js` at *module scope*, and `packTarballOnce()` builds inside a `beforeAll` — too late to gate that assertion. Building first in the job makes the dist-local assertion exercise a real build and turns the in-`beforeAll` build into a warm no-op instead of the only build that ever ran.
- **Fail-closed**: `SYSTEMATIC_REQUIRE_OPENCODE=1` is set in the job's `env`. That flag lives in the workflow, which a PR (including a fork PR) cannot alter, and it makes every gated integration module throw at load time if the pinned host isn't `available` — so a green run can never be a run of zero tests.
- **No top-level `if:`**: the job always runs to completion and reports a status, which is required for it to be a valid required check and for `release`'s `needs` on it to mean anything. Path gating (PRs only) lives at *step* level: a `dorny/paths-filter` step (pinned `v4.0.3`) decides whether the PR touches `src/`, `tests/`, `scripts/`, `evals/`, `skills/`, `agents/`, `registry/`, `package.json`, `bun.lock`, or the workflow file itself; a "Determine whether to run" step folds that into one `gate.outputs.run` boolean so every later step reads one condition instead of repeating the push-vs-pull_request branch. On `push` to `main`, the filter step is skipped and `gate.outputs.run` is unconditionally `true`. That step fails closed: any `paths-filter` output other than the literal strings `'true'`/`'false'` fails the job rather than silently skipping-and-succeeding.
- **`release.needs`** now includes `host-contract`, so a skipped or missing result on this job blocks publish — a docs-only PR still gets a real (fast, path-gated) status rather than silently skipping the check.
- **Skip/pass guard**: the test step runs with `--reporter=junit --reporter-outfile=...` in addition to default console output. A guard step (an inline Node script written to a temp file at run time, not a new repo script — this unit's file scope is `.github/workflows/main.yaml` only) parses the JUnit file and the console summary, then fails unless:
  - every one of the eleven `tests/integration/*.test.ts` files produced at least one JUnit `<testsuite file="...">` entry (catches a whole-file collapse — a crash or early exit — that a plausible-looking pass count and skip set could otherwise hide),
  - the skipped set is *exactly* the known-exempt set (today: the `SYSTEMATIC_MIXED_VERSION_TEST`-gated mixed-version test, matched by `classname`+`name`), and
  - the pass count (taking the *last* `N pass` line in the captured log, in case more than one summary appears) is at or above a floor.

  The exempt set, the expected-file list, and the floor all live inline next to the guard so widening any of them is a reviewed diff, not a silent loosening.
- **No secrets, no elevated permissions**: the job inherits the workflow-level `contents: read`; the scripted provider (already in place from Unit 3) uses a local mock model server with dummy keys, never real credentials.
- **Artifact on failure**: the test log and JUnit file upload via `actions/upload-artifact` (pinned `v7.0.1`) with `if-no-files-found: ignore`, so a host that dies on startup is diagnosable without a re-run.
- **`timeout-minutes: 30`**: I cannot run the live 11-file integration suite locally (no real OpenCode host available in this sandbox), so this is a conservative placeholder, explicitly commented as needing re-tuning from a real run.

## Why build-first is load-bearing

Without it, `opencode.test.ts`'s `DIST_LOCAL_AVAILABLE` constant (computed once at import time from whether `dist/index.js` exists) would be `false` for the entire CI run — the dist-local test group would just skip, and the guard's exempt set would need to grow to cover it, silently weakening the suite. Building in its own step, before `bun test`, means the constant is `true` when the test file loads and the fixture's own `packTarballOnce()` build (which still runs inside `beforeAll` for the packaged-artifact tests) is a fast no-op against an already-built `dist/`.

## Folded-in follow-ups

Two tracked follow-ups from the same effort belong with this job because it's what depends on them:

1. **`tests/unit/receipt-workflow-host-no-spawn.test.ts`** — locks in Unit 2's load-bearing invariant that `bun test tests/unit` never spawns `bunx`/`opencode`. It drives a child `bun -e` process that imports `tests/integration/fixtures/receipt-workflow-host.ts` and measures wall-clock import time, asserting a fast (<500ms), clean, offline exit. This is exactly the invariant the *required* `test` job depends on: that job has no network and no launcher on `PATH`, so if the fixture ever regressed to probing availability at module scope instead of behind the memoizing `isOpencodeAvailable()` function, `test` would start hanging or failing offline.
2. **`scripts/lib/opencode-availability.ts`** — adds a single-line `console.warn` immediately before the real `bunx opencode-ai@<pin> --version` probe, gated off the test-only `command` override so it never fires per-case across the existing fake-launcher unit tests. A registry stall during this synchronous, timeout-bounded probe would otherwise block silently for the full timeout; this line makes that attributable in CI logs instead.

Deliberately **not** done here (separate, out of this unit's file scope): `spawnOpencodeChild` interrupt-reaping via `liveOpencodeHosts` registration, and the `setEncoding` change. Left for a later small PR.

## Guard hardening (review round 2)

Review (`@fro-bot`) found the skip/pass guard could not detect the failure it exists for, plus a path-gating gap and several smaller hygiene items. All addressed in this PR:

- **Fixed — floor could not fire**: `PASS_FLOOR` was `50`, exactly the count of tests that never touch a real host (`claude-code` 18 + `eval-artifact` 7 + `eval-fixture` 5 + `release-notes-ci` 20 = 50). A total collapse of every host-touching file would still clear that floor. The guard now also checks, per file, that every one of the eleven `tests/integration/*.test.ts` files produced at least one JUnit `<testsuite file="...">` entry, and the floor is raised to `120` (138 `test()`/`it()` call sites exist across those files today; the comment states it must rise as the suite grows).
- **Fixed — path filter omitted content dirs**: `tests/integration/claude-code.test.ts` reads `skills/` and `agents/` as its 1:1 generated-vs-source assertion. Added `skills/**`, `agents/**`, `registry/**` to the `paths-filter` glob list so a content-only PR can no longer skip the job green and then fail on the next push to `main`.
- **Fixed — fail-open on malformed filter output**: the "Determine whether to run" step now branches explicitly on `'true'`/`'false'` from the filter and fails the job on any other value, instead of treating anything-not-`'true'` as skip-and-succeed. Its `${{ }}` expressions now arrive through `env:` rather than being interpolated directly into the `run:` block.
- **Fixed — first-match pass-count regex**: now takes the *last* `N pass` line via `matchAll(...).at(-1)`, so a captured log with more than one summary is scored on the final count.
- **Fixed — lint complexity warning**: `probeOpencodeAvailability`'s `options.command === undefined && !options.quiet` condition pushed its cognitive complexity to 16 (ceiling 15). Extracted a `shouldLogProbeDiagnostic(options)` helper and added a unit test that aliases a fake launcher as `bunx` on a scoped `PATH` to exercise the real default-command branch — every existing case passed a `command` override, so that branch (and the `quiet` suppression) was previously untested.
- **Removed** the unused step id `host-contract-run`.
- **Checked — `paths-filter` permissions**: the job declares no permissions beyond the inherited workflow-level `contents: read`. I confirmed from the prior live run's log (before this PR's rebase) that the `Detect relevant path changes` step's `listFiles(pull_number: ...)` GitHub API call succeeded with no 403/permission error and correctly resolved the changed-file set — so no `pull-requests: read` addition is needed on current evidence.
- **Deferred to #935** (per review guidance, out of this PR's file scope): moving the guard into `scripts/` with its own tests, a workflow-structural-invariants test, and rewriting the `EXEMPT_SKIPS` anchor.

## Authoritative proof

I cannot run the live 11-file integration suite locally against a real OpenCode host, so this PR's own `host-contract` CI run is the authoritative proof of Units 1–3.

The most recent live run on this branch (prior to this hardening commit, after #932/#933's stdin/SIGINT fixes merged into `main`) got substantially further than the initial attempt — the suite now spawns real hosts, exchanges scripted-provider traffic, and most of `tests/integration` passes — but the job is still red on `receipt-workflow-recovery.test.ts`'s "persists built-in tool metadata across an isolated host restart" test: an off-by-one PID comparison (`[6419, 6447]` vs `[6420, 6448]`), unrelated to this PR's file scope (workflow, `opencode-availability.ts`, unit tests, plan doc). Because that step failed, the guard step itself was skipped by GitHub Actions' default step semantics (no `if: failure()`/`always()` on it) and never got to run — so this hardening pass has not yet been exercised end-to-end against a live red *or* green result. That remains open until a subsequent run gets a clean `tests/integration` pass.

## Verification

- `bun run typecheck:all` → 0 errors
- `bun run typecheck` → clean
- `bun run typecheck:scripts` → clean
- `bun test tests/unit` → 2244 pass, 0 fail (includes the no-spawn test and the two new `opencode-availability` diagnostic-logging assertions)
- `bun run lint` → 0 errors, 13 warnings (all pre-existing; the complexity warning this PR introduced and then fixed brought the count from 14 back to 13)
- `bun scripts/content-integrity.ts` → clean
- `bun run build` → OK
- Workflow YAML: `bunx --yes @action-validator/cli@latest .github/workflows/main.yaml` → exit 0; also parsed with `js-yaml` and asserted structurally: `host-contract` has no top-level `if:`, `release.needs` includes `host-contract`, `SYSTEMATIC_REQUIRE_OPENCODE: '1'` is in the job's `env`, the `paths-filter` glob list includes `skills/**`/`agents/**`/`registry/**`.
- Guard script logic (extracted byte-for-byte from the workflow's heredoc) validated locally against seven synthetic JUnit/log fixtures: all-files-present-with-exempt-skip-at-floor (pass), below-floor (fail), an unexpected skip (fail), a missing exempt skip (fail), one expected file entirely absent (fail — new), all files present with a higher count (pass — new), and a log with two summary lines scored on the last one only (pass — new).
- Rebased cleanly onto `main` (no conflicts) to pick up #932/#933.
- **Not run locally** (no real OpenCode host available in this sandbox): the live `tests/integration` suite. Authoritative proof is this PR's own `host-contract` job run.

Refs #909 #935
