### PR TITLE
test(evals): isolate the CLI-interruption test signal from the test runner

### DIFF
--- a/tests/integration/eval-runner.test.ts
+++ b/tests/integration/eval-runner.test.ts
@@ -2332,7 +2332,25 @@ describe('local OpenCode eval runner', () => {
     const parentDir = runParent()
     const events: string[] = []
     const previousExitCode = process.exitCode
+    // `process` is a single process-wide EventEmitter shared by every test
+    // file in this `bun test` worker. A real `process.emit('SIGINT')` would
+    // invoke every 'SIGINT' listener currently registered on it -- including
+    // the real-host fixture's terminal-signal safety net (installed once,
+    // for the life of the worker, by any earlier test file that started an
+    // opencode host) -- which force-exits the whole test runner. Instead,
+    // diff the listener list before/after installing this test's handler and
+    // invoke only the listener `installEvalSignalHandlers` just registered,
+    // so unrelated SIGINT listeners elsewhere in the worker are untouched.
+    const priorSigintListeners = new Set(process.listeners('SIGINT'))
     const removeSignalHandlers = installEvalSignalHandlers()
+    const [installedSigintListener] = process
+      .listeners('SIGINT')
+      .filter((listener) => !priorSigintListeners.has(listener))
+    if (!installedSigintListener) {
+      throw new Error(
+        'installEvalSignalHandlers did not register a SIGINT listener',
+      )
+    }
     try {
       const result = normalizeResult(
         await runSourceEval({
@@ -2342,7 +2360,7 @@ describe('local OpenCode eval runner', () => {
           parentDir,
           lifecycleHooks: {
             executeCase: async () => {
-              process.emit('SIGINT')
+              installedSigintListener('SIGINT')
               return syntheticExecution('success', 'none')
             },
             cleanupFixture: () => {


### PR DESCRIPTION
## Summary

`bun test tests/integration` exited **130 (SIGINT)** when run as a full suite with `SYSTEMATIC_REQUIRE_OPENCODE=1`, even though every individual test reported pass — the exact symptom blocking PR #931's required `host-contract` CI job. Fixed by isolating a synthetic in-process signal in one eval-runner test so it no longer collides with a shared, never-removed real-host SIGINT handler.

## Root cause (confirmed via reproduction, not hypothesis)

The full suite genuinely exits 130. Adding a temporary diagnostic to the real-host fixture's SIGINT handler and re-running the full suite captured the exact trigger:

```
DEBUG_SIGINT pid=98864 liveHosts=[]
Error: trace
    at <anonymous> (tests/integration/fixtures/receipt-workflow-host.ts:1013:117)
    at emit (unknown)
    at executeCase (tests/integration/eval-runner.test.ts:2345:23)
    at executeLifecycleCase (scripts/run-evals.ts:3208:18)
    ...
```

This is **not** the process-group-signal-propagation issue the original triage hypothesis suspected (`process.kill(-pid, ...)` hitting the runner's own group). The actual mechanism:

- `tests/integration/eval-runner.test.ts`'s `'signal cleanup uses registered hooks and quarantines residue before returning'` test calls `process.emit('SIGINT')` to simulate an interruption mid-`executeCase`, so it can assert `run-evals.ts`'s own `installEvalSignalHandlers()` cleanup path (`privacy_cleanup_failure` outcome, cleanup/quarantine ordering, quarantined residue).
- `process` is a single process-wide `EventEmitter` shared by **every** test file in the same `bun test` worker. `process.emit('SIGINT')` invokes **every** `'SIGINT'` listener currently registered on it, not just the one this test just installed.
- `tests/integration/fixtures/receipt-workflow-host.ts` installs its own SIGINT/SIGTERM safety net (`installTerminalSignalHandlers`) the first time any earlier test file starts a real opencode host (`startOpencodeServer`/`startExactOpencodeServer`, used by `receipt-workflow-dogfood.test.ts`, `receipt-workflow-guard-real-host.test.ts`, etc.). That install is guarded by a module-scope boolean and is **never removed** for the life of the worker.
- That handler unconditionally calls `process.exit(130)` on any SIGINT — even with `liveOpencodeHosts` empty (nothing to clean up) — which is exactly what fired here, killing the whole `bun test` process.
- It only reproduces running the **full** integration suite because it depends on an earlier test file (alphabetically before `eval-runner.test.ts`) having already installed that shared listener. Running `eval-runner.test.ts` alone never triggers it, which is why the prior fix lane never caught this.

## Fix

Entirely contained in the test: instead of broadcasting a real `SIGINT` on the shared `process` object, the test now diffs `process.listeners('SIGINT')` before and after `installEvalSignalHandlers()` to capture only the listener that call just registered, then invokes that listener directly. No production code changes. The test's assertion intent is unchanged — it still proves the CLI's own interruption-cleanup path runs correctly — it just no longer collaterally triggers unrelated SIGINT listeners installed by other test files in the same worker.

## Verification

**Money proof — full integration suite, before/after:**

- Before: `SYSTEMATIC_REQUIRE_OPENCODE=1 bun test tests/integration; echo exit=$?` → `exit=130` (reproduced twice)
- After: `SYSTEMATIC_REQUIRE_OPENCODE=1 bun test tests/integration; echo exit=$?` →
  ```
   137 pass
   1 skip
   0 fail
   1080 expect() calls
  Ran 138 tests across 11 files. [1663.31s]
  exit=0
  ```

Isolated suspect file also passes cleanly on its own (both before and after — confirming it only reproduces at full-suite scope):
```
SYSTEMATIC_REQUIRE_OPENCODE=1 bun test tests/integration/eval-runner.test.ts
 39 pass
 0 fail
 218 expect() calls
Ran 39 tests across 1 file.
exit=0
```

Standard gates, all green:
- `bun run typecheck:all` → 0 errors (`tsc -p tsconfig.tests.json` clean)
- `bun run typecheck` / `bun run typecheck:scripts` → clean
- `bun test tests/unit` → `2242 pass, 0 fail` (68 files)
- `bun run lint` → 0 errors (only 13 pre-existing complexity warnings + 2 infos, unrelated to this change)
- `bun scripts/content-integrity.ts` → clean
- `bun run build` → OK
- `pgrep -fl opencode-ai` → empty after the run (no leaked host processes)

This unblocks the PR #931 `host-contract` job rebase — the full real-host integration suite (`SYSTEMATIC_REQUIRE_OPENCODE=1 bun test tests/integration`) now exits 0.

Refs #909
