### PR TITLE
test(evals): stop asserting the host launcher pid equals the in-process pid

### DIFF
--- a/tests/integration/receipt-workflow-recovery.test.ts
+++ b/tests/integration/receipt-workflow-recovery.test.ts
@@ -454,6 +454,33 @@ function readProbeEvents(capturePath: string): Array<Record<string, unknown>> {
     .map((line) => JSON.parse(line) as Record<string, unknown>)
 }
 
+/**
+ * Returns every pid currently belonging to the process group led by `pgid`,
+ * via `ps -eo pid,pgid` -- the one column set both BSD `ps` (macOS) and GNU
+ * procps `ps` (Linux CI) agree on. `-g <pgid>` is NOT portable: on Linux it
+ * selects by session/group *name*, not process-group id, so it cannot be
+ * used here.
+ *
+ * The fixture spawns each host `detached: true`, making the launcher pid
+ * its own process-group leader (pgid == launcher pid). That group contains
+ * only the launcher itself when `bunx` execs the opencode binary in place,
+ * or the launcher plus its opencode child when `bunx` forks instead --
+ * either way, membership in *that* host's group is topology-independent
+ * evidence that a given in-process pid came from that host generation.
+ */
+function processGroupMemberPids(pgid: number): number[] {
+  const result = Bun.spawnSync(['ps', '-eo', 'pid,pgid'])
+  const lines = result.stdout.toString().trim().split('\n').slice(1)
+  const pids: number[] = []
+  for (const line of lines) {
+    const fields = line.trim().split(/\s+/)
+    const pid = Number(fields[0])
+    const groupId = Number(fields[1])
+    if (Number.isFinite(pid) && groupId === pgid) pids.push(pid)
+  }
+  return pids
+}
+
 function completedBashParts(
   messages: unknown[],
 ): Array<Record<string, unknown>> {
@@ -689,6 +716,12 @@ describe.skipIf(!isOpencodeAvailable())(
           },
         ])
         const firstPid = firstHost.pid
+        // Captured before stopping host 1: the fixture spawns each host
+        // `detached: true`, so `firstPid` is also that host's process-group
+        // id. This snapshot is every pid that belonged to host 1's group
+        // while it was alive -- the only evidence available once host 1
+        // stops that a given in-process pid actually came from it.
+        const firstHostGroup = processGroupMemberPids(firstPid)
         await firstHost.stop()
 
         const secondHost = await startOpencodeServer(fixture, configContent)
@@ -712,10 +745,33 @@ describe.skipIf(!isOpencodeAvailable())(
           >
           const secondMetadata = secondState.metadata as Record<string, unknown>
           expect(secondMetadata[RECEIPT_MARKER_KEY]).toBe(RECEIPT_MARKER_VALUE)
+          // Captured before stopping host 2, same reasoning as firstHostGroup.
+          const secondHostGroup = processGroupMemberPids(secondHost.pid)
           const loadedPids = readProbeEvents(probe.capturePath)
             .filter((event) => event.type === 'loaded')
-            .map((event) => event.pid)
-          expect(loadedPids).toEqual([firstPid, secondHost.pid])
+            .map((event) => Number(event.pid))
+
+          // `loadedPids` is `process.pid` read from INSIDE the running
+          // opencode process, not the fixture's launcher pid. The two are
+          // only the same pid when `bunx` execs the opencode binary in
+          // place of itself, which is what this repo's macOS runners do
+          // (measured directly: a single process, PPID 1, own PGID). On
+          // Linux CI, `bunx` instead forks opencode-ai as a child of the
+          // launcher, so the in-process pid is the launcher pid plus one
+          // (measured in CI: launcher/in-process pairs like [6419, 6420]
+          // and [6447, 6448]) -- asserting `loadedPids` equals the launcher
+          // pids only ever held by accident of the macOS exec-in-place
+          // behavior, never cross-platform. What this test actually needs
+          // to prove -- the probe fired exactly once per host generation,
+          // for two distinct generations, and each firing genuinely came
+          // from that generation's own host -- holds regardless of
+          // exec-vs-fork topology: two distinct in-process pids, each a
+          // member of its own host's process group captured while that
+          // host was still alive.
+          expect(loadedPids).toHaveLength(2)
+          expect(loadedPids[0]).not.toBe(loadedPids[1])
+          expect(firstHostGroup).toContain(loadedPids[0])
+          expect(secondHostGroup).toContain(loadedPids[1])
         } finally {
           await secondHost.stop()
           model.stop()


### PR DESCRIPTION
## Summary

PR #931's required `host-contract` CI job (ubuntu) surfaced a 4th real bug — the first that **passes locally on macOS and fails only in CI**. This fixes it by asserting what the test actually needs to prove (one probe load per host generation, in order) instead of an accidental launcher-pid identity that never held cross-platform.

## Root cause

`tests/integration/receipt-workflow-recovery.test.ts:718`, test `persists built-in tool metadata across an isolated host restart`:

```
expect(loadedPids).toEqual([firstPid, secondHost.pid])
```

`firstPid`/`secondHost.pid` are the fixture's `host.pid` — the pid of the **launcher** child the fixture spawns (`bunx opencode-ai@<pin> serve`, `startOpencodeProcess`). `loadedPids` are `process.pid` values the plugin's probe writes **from inside the opencode process itself** on `'loaded'`. The assertion claims launcher-pid == in-process-pid, which is only true when `bunx` execs the opencode binary in place of itself rather than forking it as a child.

**CI evidence:** `expected [6419, 6447], received [6420, 6448]` — both received values exactly `+1` over expected.

## Measured topology (both platforms)

- **macOS (this machine):** ran a real `bunx opencode-ai@1.18.27 serve` (fixture-matching env/args) and inspected the process tree directly:
  ```
    PID  PPID  PGID COMMAND
  44691     1 44691 /private/tmp/bunx-501-opencode-ai@1.18.27/node_modules/.bin/opencode serve --port 0 --print-logs
  ```
  A **single** process — `PPID 1`, `PGID` equal to its own pid — and that same pid is both the launcher pid `spawn` returns and the pid the running opencode process reports as `process.pid`. `bunx` execs in place; no fork. This is why the test passed locally.
- **Linux (CI):** the `+1` pairs above (`[6419, 6420]`, `[6447, 6448]`) show `bunx` instead forking `opencode-ai` as a child of the launcher, so the in-process pid is the launcher pid plus one.

## Fix

Replaced the launcher-pid-identity assertion with a process-group-membership check. The fixture spawns each host `detached: true`, so the launcher pid is also that host's process-group id. Added `processGroupMemberPids(pgid)` (via `ps -eo pid,pgid` — the one column set both BSD `ps` on macOS and GNU procps `ps` on Linux agree on; `-g <pgid>` is **not** portable, it means something else on Linux) to snapshot a host's live group members **before that host is stopped**.

New assertions:
- `loadedPids` has length 2
- the two in-process pids are distinct
- each in-process pid is a member of its own host generation's process group (captured while that host was still alive)

This proves the probe fired exactly once per host generation, for two distinct generations, and each firing genuinely came from that generation's own host — the actual intent of the original assertion — without depending on exec-vs-fork topology.

`host.pid` fixture semantics (the process-group leader used for reaping in `stopProcessGroup`) are unchanged. `secondHost.pid !== firstPid` (already asserted separately, line 696) is untouched.

## Topology-independence proof (bidirectional)

Verified the group-membership check discriminates correctly in both directions using a throwaway harness that simulates the Linux fork topology (a `bun -e` launcher that itself spawns a detached-group child):

```
launcherPid 55688 childPid 55689 group [ 55688, 55689 ]
childIsMember (expect true): true
foreignPid 55685 foreignIsMember (expect false): false
PASS: bidirectional group-membership check succeeded
```

- A detached-group child pid (simulating Linux's fork-instead-of-exec) **is** reported as a member of its launcher's group.
- An unrelated foreign pid (the shell's own parent) is **not**.

## Verification

- `SYSTEMATIC_REQUIRE_OPENCODE=1 bun test tests/integration/receipt-workflow-recovery.test.ts -t "persists built-in tool metadata"` → **1 pass**, 10 expect() calls, 28.51s
- `SYSTEMATIC_REQUIRE_OPENCODE=1 bun test tests/integration/receipt-workflow-recovery.test.ts` (full file) → 9 pass, 0 fail, 420 expect() calls, 259.91s
- `SYSTEMATIC_REQUIRE_OPENCODE=1 bun test tests/integration` (full suite) → **137 pass, 1 skip, 0 fail**, `exit=0`, 1083 expect() calls, 1280.36s
- `bun run typecheck:all` — 0 errors
- `bun run typecheck` / `typecheck:scripts` — clean
- `bun test tests/unit` — 2242 pass, 0 fail
- `bun run lint` — 0 errors (13 pre-existing warnings/2 infos in unrelated files, unchanged)
- `bun scripts/content-integrity.ts` — clean
- `bun run build` — OK
- `pgrep -fl opencode-ai` — empty after both the targeted and full integration runs (no leaked processes)

Diff is scoped to `tests/integration/receipt-workflow-recovery.test.ts` (+58/-2, one file).

This unblocks #931's `host-contract` job, which will be rebased on top of this fix alongside the two prior real-host fixes (#932, #933).

Refs #909
