### PR TITLE
test(evals): harden the OpenCode host fixture's spawn, stdio, and signal handling

### DIFF
--- a/tests/integration/eval-runner.test.ts
+++ b/tests/integration/eval-runner.test.ts
@@ -2341,17 +2341,25 @@ describe('local OpenCode eval runner', () => {
     // diff the listener list before/after installing this test's handler and
     // invoke only the listener `installEvalSignalHandlers` just registered,
     // so unrelated SIGINT listeners elsewhere in the worker are untouched.
-    const priorSigintListeners = new Set(process.listeners('SIGINT'))
-    const removeSignalHandlers = installEvalSignalHandlers()
-    const [installedSigintListener] = process
-      .listeners('SIGINT')
-      .filter((listener) => !priorSigintListeners.has(listener))
-    if (!installedSigintListener) {
-      throw new Error(
-        'installEvalSignalHandlers did not register a SIGINT listener',
-      )
-    }
+    //
+    // Both the install and the listener-capture live inside this `try` (not
+    // before it) so a throw from either still reaches `finally` and calls
+    // `removeSignalHandlers`, instead of leaking the listener for the rest
+    // of this worker's life.
+    let removeSignalHandlers: (() => void) | undefined
     try {
+      const priorSigintListeners = new Set(process.listeners('SIGINT'))
+      removeSignalHandlers = installEvalSignalHandlers()
+      const installedSigintListeners = process
+        .listeners('SIGINT')
+        .filter((listener) => !priorSigintListeners.has(listener))
+      if (installedSigintListeners.length !== 1) {
+        throw new Error(
+          `installEvalSignalHandlers registered ${installedSigintListeners.length} SIGINT listeners, expected exactly 1`,
+        )
+      }
+      const [installedSigintListener] = installedSigintListeners
+
       const result = normalizeResult(
         await runSourceEval({
           caseId: 'bootstrap-loading',
@@ -2386,7 +2394,7 @@ describe('local OpenCode eval runner', () => {
           .filter((entry) => entry.startsWith('systematic-eval-')),
       ).toHaveLength(1)
     } finally {
-      removeSignalHandlers()
+      removeSignalHandlers?.()
       process.exitCode = previousExitCode ?? 0
       fs.rmSync(parentDir, { recursive: true, force: true })
     }

--- a/tests/integration/eval-runner.test.ts
+++ b/tests/integration/eval-runner.test.ts
@@ -2328,6 +2328,18 @@ describe('local OpenCode eval runner', () => {
     }
   }, 360_000)
 
+  // Removes any listener on `signal` not present in `priorListeners` -- the
+  // fallback path used when installEvalSignalHandlers throws partway through
+  // registering its SIGINT/SIGTERM pair, before it can return a remover.
+  function removeListenersNotIn(
+    signal: 'SIGINT' | 'SIGTERM',
+    priorListeners: Set<unknown> | undefined,
+  ): void {
+    for (const listener of process.listeners(signal)) {
+      if (!priorListeners?.has(listener)) process.off(signal, listener)
+    }
+  }
+
   test('signal cleanup uses registered hooks and quarantines residue before returning', async () => {
     const parentDir = runParent()
     const events: string[] = []
@@ -2343,16 +2355,26 @@ describe('local OpenCode eval runner', () => {
     // so unrelated SIGINT listeners elsewhere in the worker are untouched.
     //
     // Both the install and the listener-capture live inside this `try` (not
-    // before it) so a throw from either still reaches `finally` and calls
-    // `removeSignalHandlers`, instead of leaking the listener for the rest
-    // of this worker's life.
+    // before it) so a throw from either still reaches `finally`, instead of
+    // leaking a listener for the rest of this worker's life. That covers a
+    // throw during capture, but `installEvalSignalHandlers` itself registers
+    // SIGINT then SIGTERM as two separate `process.on` calls before
+    // returning its remover -- a throw between those two registrations (or
+    // before the return) would leave whichever listener(s) it managed to
+    // attach with no remover reference left to remove them. Both signals'
+    // prior listeners are snapshotted before the call so `finally` can fall
+    // back to removing anything new, by name, when `removeSignalHandlers`
+    // itself was never assigned.
     let removeSignalHandlers: (() => void) | undefined
+    let priorSigintListeners: Set<unknown> | undefined
+    let priorSigtermListeners: Set<unknown> | undefined
     try {
-      const priorSigintListeners = new Set(process.listeners('SIGINT'))
+      priorSigintListeners = new Set(process.listeners('SIGINT'))
+      priorSigtermListeners = new Set(process.listeners('SIGTERM'))
       removeSignalHandlers = installEvalSignalHandlers()
       const installedSigintListeners = process
         .listeners('SIGINT')
-        .filter((listener) => !priorSigintListeners.has(listener))
+        .filter((listener) => !priorSigintListeners?.has(listener))
       if (installedSigintListeners.length !== 1) {
         throw new Error(
           `installEvalSignalHandlers registered ${installedSigintListeners.length} SIGINT listeners, expected exactly 1`,
@@ -2394,7 +2416,12 @@ describe('local OpenCode eval runner', () => {
           .filter((entry) => entry.startsWith('systematic-eval-')),
       ).toHaveLength(1)
     } finally {
-      removeSignalHandlers?.()
+      if (removeSignalHandlers) {
+        removeSignalHandlers()
+      } else {
+        removeListenersNotIn('SIGINT', priorSigintListeners)
+        removeListenersNotIn('SIGTERM', priorSigtermListeners)
+      }
       process.exitCode = previousExitCode ?? 0
       fs.rmSync(parentDir, { recursive: true, force: true })
     }

--- a/tests/integration/fixtures/receipt-workflow-host.ts
+++ b/tests/integration/fixtures/receipt-workflow-host.ts
@@ -517,6 +517,12 @@ export interface RunOpencodeOptions {
  * Ignoring stdin closes it from the start, matching how a real terminal
  * invocation's stdin behaves for a one-shot `run` command with the prompt
  * passed as an argument.
+ *
+ * The child's pid is registered in `liveRunOpencodeChildPids` for the
+ * lifetime of this call and evicted the moment it settles. That is what
+ * lets an *interactive* Ctrl-C during a live call reap the `bunx` group too
+ * (previously only a timeout or CI cancellation did): the terminal-signal
+ * handler below walks that same set.
  */
 export async function spawnOpencodeChild(
   argv: readonly string[],
@@ -532,6 +538,17 @@ export async function spawnOpencodeChild(
       detached: true,
       stdio: ['ignore', 'pipe', 'pipe'],
     })
+    // Multi-byte UTF-8 characters can split across chunk boundaries; letting
+    // the stream decode with an encoding set keeps partial sequences buffered
+    // internally instead of corrupting stdout/stderr text (and error tails).
+    child.stdout?.setEncoding('utf8')
+    child.stderr?.setEncoding('utf8')
+
+    const pid = child.pid
+    if (pid) {
+      liveRunOpencodeChildPids.add(pid)
+      installTerminalSignalHandlers()
+    }
 
     let stdout = ''
     let stderr = ''
@@ -541,6 +558,7 @@ export async function spawnOpencodeChild(
       if (settled) return
       settled = true
       clearTimeout(timeout)
+      if (pid) evictRunOpencodeChildPid(pid)
       resolve({ stdout, stderr, exitCode })
     }
 
@@ -548,11 +566,11 @@ export async function spawnOpencodeChild(
       void stopProcessGroup(child, 10_000).then(() => finish(-1))
     }, options.timeoutMs)
 
-    child.stdout?.on('data', (chunk: Buffer) => {
-      stdout += chunk.toString()
+    child.stdout?.on('data', (chunk: string) => {
+      stdout += chunk
     })
-    child.stderr?.on('data', (chunk: Buffer) => {
-      stderr += chunk.toString()
+    child.stderr?.on('data', (chunk: string) => {
+      stderr += chunk
     })
     child.once('error', (error) => {
       stderr += `\n${String(error)}`
@@ -879,10 +897,16 @@ async function startOpencodeProcess(
   env: Record<string, string>,
   timeoutMs = TIMEOUT_MS,
 ): Promise<OpencodeServer> {
+  // Matches spawnOpencodeChild's stdio: default node stdio leaves stdin an
+  // open pipe the parent never writes to or closes, which `opencode serve`
+  // does not appear to block on today, but keeping the two launchers'
+  // stdio identical means that stops being an assumption either call site
+  // could quietly violate later.
   const server = spawn(command, [...args], {
     env,
     cwd: fixture.projectDir,
     detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
   })
   const pid = server.pid
   if (!pid) throw new Error('opencode server did not expose a process id')
@@ -991,31 +1015,73 @@ export interface OpencodeServer {
 }
 
 const liveOpencodeHosts = new Set<OpencodeServer>()
+// Parallel to liveOpencodeHosts: pids of in-flight spawnOpencodeChild
+// children (runOpencode, runOpencodeDebugConfig). A startOpencodeServer host
+// outlives its call and is reaped through its own stop()/exit bookkeeping;
+// a spawnOpencodeChild child has no long-lived handle, so its pid lives here
+// instead, for the terminal-signal safety net below, and is evicted the
+// moment the child settles (see evictRunOpencodeChildPid).
+const liveRunOpencodeChildPids = new Set<number>()
 
 let terminalSignalHandlersInstalled = false
 
-function killLiveOpencodeHostsSync(): void {
-  for (const host of liveOpencodeHosts) {
-    try {
-      process.kill(-host.pid, 'SIGKILL')
-    } catch {
-      // Cleanup is best effort; the process may already be gone.
-    }
+function killProcessGroupSync(pid: number): void {
+  try {
+    process.kill(-pid, 'SIGKILL')
+  } catch {
+    // Cleanup is best effort; the process may already be gone.
   }
 }
 
+function killLiveOpencodeHostsSync(): void {
+  for (const host of liveOpencodeHosts) killProcessGroupSync(host.pid)
+  for (const pid of liveRunOpencodeChildPids) killProcessGroupSync(pid)
+}
+
+function evictRunOpencodeChildPid(pid: number): void {
+  // Mirrors startOpencodeProcess's own exit-handler eviction probe: a pgid
+  // cannot be recycled while its group still has members, so this pid is
+  // only forgotten once the group is provably empty. Otherwise a recycled
+  // pgid from some unrelated later process could be mistaken for still-live
+  // and wrongly signalled by killLiveOpencodeHostsSync.
+  try {
+    process.kill(-pid, 0)
+  } catch {
+    liveRunOpencodeChildPids.delete(pid)
+  }
+}
+
+function hasLiveOpencodeProcesses(): boolean {
+  return liveOpencodeHosts.size > 0 || liveRunOpencodeChildPids.size > 0
+}
+
+/**
+ * Terminal-signal safety net for every real `opencode` process this fixture
+ * spawns: long-lived hosts in `liveOpencodeHosts`, one-shot
+ * `spawnOpencodeChild` children in `liveRunOpencodeChildPids`. This is the
+ * root-cause fix for a full-suite exit 130: the handler used to reap and
+ * force-exit(130) unconditionally, even with nothing live, so a Ctrl-C
+ * during ANY part of the suite -- not just a live host run -- looked
+ * indistinguishable from an interrupted host and killed the whole runner.
+ * Now, when nothing is live it does nothing and returns, leaving other
+ * SIGINT/SIGTERM listeners (and Node's default terminating behaviour, if
+ * none remain) to run unobstructed. Only when something is actually live
+ * does it reap the group(s) and force-exit -- skipping remaining afterAll
+ * hooks (temp dirs may leak) is an acceptable tradeoff only when there is a
+ * real orphaned-host-process risk to avoid.
+ */
 function installTerminalSignalHandlers(): void {
   if (terminalSignalHandlersInstalled) return
   terminalSignalHandlersInstalled = true
 
   process.on('SIGINT', () => {
+    if (!hasLiveOpencodeProcesses()) return
     killLiveOpencodeHostsSync()
-    // Exiting here skips remaining afterAll hooks (temp dirs may leak); orphaned host processes cost more than temp dirs.
     process.exit(130)
   })
   process.on('SIGTERM', () => {
+    if (!hasLiveOpencodeProcesses()) return
     killLiveOpencodeHostsSync()
-    // Exiting here skips remaining afterAll hooks (temp dirs may leak); orphaned host processes cost more than temp dirs.
     process.exit(143)
   })
   process.on('exit', killLiveOpencodeHostsSync)

--- a/tests/integration/fixtures/receipt-workflow-host.ts
+++ b/tests/integration/fixtures/receipt-workflow-host.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, spawn } from 'node:child_process'
+import { type ChildProcess, type SpawnOptions, spawn } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -487,6 +487,23 @@ export interface RunOpencodeOptions {
 }
 
 /**
+ * Shared `spawn` options for every real `opencode`-launching child process in
+ * this module (`spawnOpencodeChild`, `startOpencodeProcess`): `detached: true`
+ * (its own process group, so the whole group can be reaped by pgid) and
+ * `stdio: ['ignore', 'pipe', 'pipe']` (stdin closed from the start, so
+ * `opencode run`'s stdin handling can't block on a pipe this fixture never
+ * writes to or closes -- see spawnOpencodeChild's doc comment below for the
+ * empirical evidence). Both call sites build their options through this one
+ * function so they cannot quietly diverge on either point.
+ */
+export function buildDetachedChildSpawnOptions(
+  cwd: string,
+  env: Record<string, string>,
+): SpawnOptions {
+  return { cwd, env, detached: true, stdio: ['ignore', 'pipe', 'pipe'] }
+}
+
+/**
  * Runs an argv async via node's `spawn`, never `Bun.spawnSync`. This function
  * (and every other real `opencode` child process in this module) shares the
  * event loop with `startScriptedSkillModelServer`'s `Bun.serve` instance: a
@@ -532,12 +549,11 @@ export async function spawnOpencodeChild(
   if (!command) throw new Error('spawnOpencodeChild requires a non-empty argv')
 
   return new Promise<OpencodeResult>((resolve) => {
-    const child = spawn(command, rest, {
-      cwd: options.cwd,
-      env: options.env,
-      detached: true,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
+    const child = spawn(
+      command,
+      rest,
+      buildDetachedChildSpawnOptions(options.cwd, options.env),
+    )
     // Multi-byte UTF-8 characters can split across chunk boundaries; letting
     // the stream decode with an encoding set keeps partial sequences buffered
     // internally instead of corrupting stdout/stderr text (and error tails).
@@ -897,17 +913,11 @@ async function startOpencodeProcess(
   env: Record<string, string>,
   timeoutMs = TIMEOUT_MS,
 ): Promise<OpencodeServer> {
-  // Matches spawnOpencodeChild's stdio: default node stdio leaves stdin an
-  // open pipe the parent never writes to or closes, which `opencode serve`
-  // does not appear to block on today, but keeping the two launchers'
-  // stdio identical means that stops being an assumption either call site
-  // could quietly violate later.
-  const server = spawn(command, [...args], {
-    env,
-    cwd: fixture.projectDir,
-    detached: true,
-    stdio: ['ignore', 'pipe', 'pipe'],
-  })
+  const server = spawn(
+    command,
+    [...args],
+    buildDetachedChildSpawnOptions(fixture.projectDir, env),
+  )
   const pid = server.pid
   if (!pid) throw new Error('opencode server did not expose a process id')
 
@@ -963,11 +973,10 @@ async function startOpencodeProcess(
     // ownership probe. Only evict once the group is actually empty; otherwise
     // the launcher exited but the opencode grandchild is still alive and
     // needs to stay reachable for stopAllOpencodeHosts/the terminal-signal guard.
-    try {
-      process.kill(-pid, 0)
-    } catch {
-      liveOpencodeHosts.delete(host)
-    }
+    // This is the fast path; pruneLiveOpencodeProcesses (see its doc comment)
+    // is the fallback for the case where the group was still non-empty at
+    // this exact instant.
+    if (!isProcessGroupAlive(pid)) liveOpencodeHosts.delete(host)
   })
   installTerminalSignalHandlers()
   return host
@@ -1033,7 +1042,42 @@ function killProcessGroupSync(pid: number): void {
   }
 }
 
+function isProcessGroupAlive(pid: number): boolean {
+  try {
+    process.kill(-pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Both `liveOpencodeHosts` (startOpencodeProcess's own `exit` handler) and
+ * `liveRunOpencodeChildPids` (evictRunOpencodeChildPid) are also evicted by
+ * a one-shot probe at the instant their launcher process exits, as a fast
+ * path. That probe only ever runs once: if the process group still has a
+ * member draining at that exact instant (e.g. a grandchild not yet reaped),
+ * the entry is never evicted by the fast path and would otherwise survive
+ * for the rest of the worker's life -- permanently pinning
+ * `hasLiveOpencodeProcesses()` to true (silently re-arming the
+ * force-exit-on-signal path forever, since it would then believe something
+ * is always live) and leaving a now-stale, recyclable pgid in
+ * `killLiveOpencodeHostsSync`'s SIGKILL sweep, which could wrongly signal
+ * an unrelated later process holding that recycled pgid. Both call sites
+ * below re-probe and prune stale entries before acting, so a late-draining
+ * group costs one extra `process.kill(pid, 0)` call, never a stuck entry.
+ */
+function pruneLiveOpencodeProcesses(): void {
+  for (const host of liveOpencodeHosts) {
+    if (!isProcessGroupAlive(host.pid)) liveOpencodeHosts.delete(host)
+  }
+  for (const pid of liveRunOpencodeChildPids) {
+    if (!isProcessGroupAlive(pid)) liveRunOpencodeChildPids.delete(pid)
+  }
+}
+
 function killLiveOpencodeHostsSync(): void {
+  pruneLiveOpencodeProcesses()
   for (const host of liveOpencodeHosts) killProcessGroupSync(host.pid)
   for (const pid of liveRunOpencodeChildPids) killProcessGroupSync(pid)
 }
@@ -1043,15 +1087,14 @@ function evictRunOpencodeChildPid(pid: number): void {
   // cannot be recycled while its group still has members, so this pid is
   // only forgotten once the group is provably empty. Otherwise a recycled
   // pgid from some unrelated later process could be mistaken for still-live
-  // and wrongly signalled by killLiveOpencodeHostsSync.
-  try {
-    process.kill(-pid, 0)
-  } catch {
-    liveRunOpencodeChildPids.delete(pid)
-  }
+  // and wrongly signalled by killLiveOpencodeHostsSync. This is the fast
+  // path; pruneLiveOpencodeProcesses is the fallback for the case where the
+  // group was still non-empty at this exact instant (see its doc comment).
+  if (!isProcessGroupAlive(pid)) liveRunOpencodeChildPids.delete(pid)
 }
 
-function hasLiveOpencodeProcesses(): boolean {
+export function hasLiveOpencodeProcesses(): boolean {
+  pruneLiveOpencodeProcesses()
   return liveOpencodeHosts.size > 0 || liveRunOpencodeChildPids.size > 0
 }
 
@@ -1063,9 +1106,8 @@ function hasLiveOpencodeProcesses(): boolean {
  * force-exit(130) unconditionally, even with nothing live, so a Ctrl-C
  * during ANY part of the suite -- not just a live host run -- looked
  * indistinguishable from an interrupted host and killed the whole runner.
- * Now, when nothing is live it does nothing and returns, leaving other
- * SIGINT/SIGTERM listeners (and Node's default terminating behaviour, if
- * none remain) to run unobstructed. Only when something is actually live
+ * Now, when nothing is live it returns without exiting, leaving other
+ * SIGINT/SIGTERM listeners to run. Only when something is actually live
  * does it reap the group(s) and force-exit -- skipping remaining afterAll
  * hooks (temp dirs may leak) is an acceptable tradeoff only when there is a
  * real orphaned-host-process risk to avoid.

--- a/tests/integration/opencode.test.ts
+++ b/tests/integration/opencode.test.ts
@@ -38,6 +38,7 @@ import {
   parseProbeEvent,
   REPO_ROOT,
   runOpencode,
+  spawnOpencodeChild,
   TIMEOUT_MS,
 } from './fixtures/receipt-workflow-host.js'
 
@@ -789,13 +790,19 @@ describe.skipIf(!isOpencodeAvailable())('opencode integration', () => {
   )
 })
 
-/** Model-free `opencode debug config` invocation, isolated the same way as `runOpencode`. */
-function runOpencodeDebugConfig(
+/**
+ * Model-free `opencode debug config` invocation, isolated the same way as
+ * `runOpencode`. Routed through `spawnOpencodeChild` (not `Bun.spawnSync`)
+ * for the same reason `runOpencode` is: `Bun.spawnSync` signals only the
+ * direct `bunx` process on timeout, leaving a `opencode-ai` grandchild
+ * orphaned; `spawnOpencodeChild` reaps the whole process group instead.
+ */
+async function runOpencodeDebugConfig(
   fixture: IsolatedFixture,
   configContent: string,
-): OpencodeResult {
+): Promise<OpencodeResult> {
   const childEnv = buildIsolatedOpencodeEnv(fixture, configContent)
-  const result = Bun.spawnSync(
+  return spawnOpencodeChild(
     [
       'bunx',
       `opencode-ai@${EXACT_OPENCODE_VERSION}`,
@@ -805,13 +812,8 @@ function runOpencodeDebugConfig(
       '--log-level',
       'ERROR',
     ],
-    { cwd: fixture.projectDir, env: childEnv, timeout: TIMEOUT_MS },
+    { cwd: fixture.projectDir, env: childEnv, timeoutMs: TIMEOUT_MS },
   )
-  return {
-    stdout: result.stdout.toString(),
-    stderr: result.stderr.toString(),
-    exitCode: result.exitCode ?? -1,
-  }
 }
 
 // Requires real `tar` and symlink semantics for artifact extraction; POSIX only.
@@ -886,7 +888,7 @@ describe.skipIf(!isOpencodeAvailable() || process.platform === 'win32')(
 
     test(
       'packaged plugin rejects an unrecognized disabled_skills name, model-free',
-      () => {
+      async () => {
         const { pluginUrl } = extractPackagedPlugin(fixture)
         fs.mkdirSync(path.join(fixture.projectDir, '.opencode'), {
           recursive: true,
@@ -897,7 +899,7 @@ describe.skipIf(!isOpencodeAvailable() || process.platform === 'win32')(
         )
         const configContent = JSON.stringify({ plugin: [pluginUrl] })
 
-        const result = runOpencodeDebugConfig(fixture, configContent)
+        const result = await runOpencodeDebugConfig(fixture, configContent)
 
         // OpenCode 1.17.18 host contract: plugin-factory rejections are
         // caught and logged, hooks omitted, host exits 0

--- a/tests/integration/receipt-workflow-recovery.test.ts
+++ b/tests/integration/receipt-workflow-recovery.test.ts
@@ -468,9 +468,26 @@ function readProbeEvents(capturePath: string): Array<Record<string, unknown>> {
  * either way, membership in *that* host's group is topology-independent
  * evidence that a given in-process pid came from that host generation.
  */
-function processGroupMemberPids(pgid: number): number[] {
-  const result = Bun.spawnSync(['ps', '-eo', 'pid,pgid'])
-  const lines = result.stdout.toString().trim().split('\n').slice(1)
+async function processGroupMemberPids(pgid: number): Promise<number[]> {
+  // Async, not Bun.spawnSync: this fixture documents a sync-spawn hazard
+  // (a synchronous spawn blocks the very thread the scripted model server
+  // needs to answer the child's own HTTP request on, see spawnOpencodeChild's
+  // doc comment). `ps` is not a client of that server so it cannot itself
+  // deadlock, but staying async keeps every spawn in this file consistent
+  // with the one rule that matters everywhere else in it.
+  const proc = Bun.spawn(['ps', '-eo', 'pid,pgid'], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  if (exitCode !== 0) {
+    throw new Error(`ps -eo pid,pgid exited with code ${exitCode}: ${stderr}`)
+  }
+  const lines = stdout.trim().split('\n').slice(1)
   const pids: number[] = []
   for (const line of lines) {
     const fields = line.trim().split(/\s+/)
@@ -721,7 +738,7 @@ describe.skipIf(!isOpencodeAvailable())(
         // id. This snapshot is every pid that belonged to host 1's group
         // while it was alive -- the only evidence available once host 1
         // stops that a given in-process pid actually came from it.
-        const firstHostGroup = processGroupMemberPids(firstPid)
+        const firstHostGroup = await processGroupMemberPids(firstPid)
         await firstHost.stop()
 
         const secondHost = await startOpencodeServer(fixture, configContent)
@@ -746,7 +763,7 @@ describe.skipIf(!isOpencodeAvailable())(
           const secondMetadata = secondState.metadata as Record<string, unknown>
           expect(secondMetadata[RECEIPT_MARKER_KEY]).toBe(RECEIPT_MARKER_VALUE)
           // Captured before stopping host 2, same reasoning as firstHostGroup.
-          const secondHostGroup = processGroupMemberPids(secondHost.pid)
+          const secondHostGroup = await processGroupMemberPids(secondHost.pid)
           const loadedPids = readProbeEvents(probe.capturePath)
             .filter((event) => event.type === 'loaded')
             .map((event) => Number(event.pid))

--- a/tests/unit/receipt-workflow-host.test.ts
+++ b/tests/unit/receipt-workflow-host.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from 'bun:test'
+import { spawn } from 'node:child_process'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 import {
   assertMixedVersionProbeEvents,
+  buildDetachedChildSpawnOptions,
   extractSkillNameFromPrompt,
   type ProbeEvent,
   scriptedResponseChunks,
@@ -502,11 +504,190 @@ describe('terminal-signal safety net (nothing-live vs something-live)', () => {
       timeout: 15_000,
     })
     const stdout = result.stdout.toString()
+    const stderr = result.stderr.toString()
 
-    expect(result.exitCode).toBe(0)
+    // Fails with the harness's own stderr attached: a failure here means the
+    // *harness script* threw or crashed, and without stderr that failure is
+    // otherwise undiagnosable (stdout alone would just show which of the
+    // later CASE_A/CASE_B markers never got written).
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `harness script exited with code ${result.exitCode}: ${stderr}`,
+      )
+    }
     expect(stdout).toContain('CASE_A_EXIT_CALLS=0')
     expect(stdout).toContain('CASE_A_THREW=false')
     expect(stdout).toContain('CASE_B_EXIT_CALLS=1')
     expect(stdout).toContain('CASE_B_THREW=true')
+  }, 20_000)
+})
+
+// Pin for item 2: multi-byte UTF-8 characters can split across chunk
+// boundaries. Without `setEncoding('utf8')`, each `Buffer` arriving on
+// `data` is decoded independently, so an incomplete lead byte in one chunk
+// becomes a replacement character (U+FFFD) instead of being buffered until
+// the rest of the sequence arrives in the next chunk.
+//
+// Bidirectional proof: temporarily removing spawnOpencodeChild's two
+// `setEncoding('utf8')` calls (and reverting its data handlers to
+// `chunk.toString()` on the raw `Buffer`) was confirmed to make this test
+// fail -- `result.stdout` then contains U+FFFD instead of '€' -- before
+// restoring the fix.
+describe('spawnOpencodeChild UTF-8 chunk reassembly (item 2 pin)', () => {
+  test('reassembles a multi-byte character split across two stdout chunks', async () => {
+    // '€' (U+20AC) is 0xE2 0x82 0xAC in UTF-8. Writing the lead byte, then
+    // sleeping, then the two continuation bytes forces two separate `data`
+    // events on the receiving end instead of one coalesced read.
+    const script = `
+      process.stdout.write(Buffer.from([0xe2]))
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      process.stdout.write(Buffer.from([0x82, 0xac]))
+    `
+    const result = await spawnOpencodeChild(['bun', '-e', script], {
+      cwd: process.cwd(),
+      env: TEST_CHILD_ENV,
+      timeoutMs: 5_000,
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toBe('\u20ac')
+  }, 10_000)
+})
+
+// Pin for item 5: startOpencodeProcess isn't directly testable host-free
+// (its promise only resolves once a real `opencode serve` prints a listen
+// URL), so this tests the shared `buildDetachedChildSpawnOptions` builder
+// both `spawnOpencodeChild` and `startOpencodeProcess` construct their
+// `spawn` options through -- proving the invariant for both call sites at
+// once, and guaranteeing they cannot diverge (they call the same function).
+describe('buildDetachedChildSpawnOptions (shared by spawnOpencodeChild and startOpencodeProcess, item 5 pin)', () => {
+  test('always closes stdin and always keeps stdout/stderr piped, detached into its own group', () => {
+    const options = buildDetachedChildSpawnOptions('/tmp/example', {
+      PATH: '/usr/bin',
+    })
+
+    expect(options.detached).toBe(true)
+    expect(options.stdio).toEqual(['ignore', 'pipe', 'pipe'])
+    expect(options.cwd).toBe('/tmp/example')
+    expect(options.env).toEqual({ PATH: '/usr/bin' })
+  })
+
+  // Mirrors the existing spawnOpencodeChild stdin-invariant test above
+  // (~line 339): a real child spawned with these exact options must see
+  // stdin EOF immediately, never node's default open pipe.
+  test('a real child spawned with these options sees stdin EOF immediately instead of hanging', async () => {
+    const script = `
+      process.stdin.resume()
+      process.stdin.on('end', () => {
+        process.stdout.write('stdin-eof\\n')
+        process.exit(0)
+      })
+    `
+
+    const start = Date.now()
+    const result = await new Promise<{ stdout: string; exitCode: number }>(
+      (resolve) => {
+        const child = spawn(
+          'bun',
+          ['-e', script],
+          buildDetachedChildSpawnOptions(process.cwd(), TEST_CHILD_ENV),
+        )
+        let stdout = ''
+        child.stdout?.setEncoding('utf8')
+        child.stdout?.on('data', (chunk: string) => {
+          stdout += chunk
+        })
+        child.once('close', (code) => resolve({ stdout, exitCode: code ?? -1 }))
+      },
+    )
+    const elapsedMs = Date.now() - start
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('stdin-eof')
+    expect(elapsedMs).toBeLessThan(3_000)
+  }, 10_000)
+})
+
+// Regression test for item 1's stale-pid bug: `finish()`'s at-settle
+// eviction (evictRunOpencodeChildPid) only re-probes once, at the instant
+// the direct child's stdio pipes close. If the child's own process group
+// still has a member (e.g. a detached grandchild it spawned and then
+// exited without waiting for) at that exact instant, the pid is retained
+// -- and without pruning, stays retained for the rest of the worker's life
+// even after that grandchild later exits on its own, permanently pinning
+// `hasLiveOpencodeProcesses()` to true.
+//
+// Runs entirely inside an isolated `bun -e` harness process (its own fresh
+// module graph, its own empty live-pid set) so this test's own real
+// grandchild process can't be confused with anything another test file in
+// this worker may have registered.
+//
+// Bidirectional proof: temporarily reverting `hasLiveOpencodeProcesses` (and
+// `killLiveOpencodeHostsSync`) to skip `pruneLiveOpencodeProcesses()` was
+// confirmed to make this test fail -- `HAS_LIVE_AFTER_KILL` stays `true`
+// instead of flipping to `false` -- before restoring the fix.
+describe('stale run-child pid pruning (item 1 regression: grandchild still draining at settle time)', () => {
+  test('hasLiveOpencodeProcesses re-probes and prunes a pid once its process group has since emptied', () => {
+    const script = `
+      const mod = await import(${JSON.stringify(FIXTURE_MODULE_URL)})
+
+      const childScript = \`
+        const { spawn } = require('node:child_process')
+        const grandchild = spawn('sleep', ['30'], { stdio: 'ignore' })
+        process.stdout.write('grandchild-pid:' + grandchild.pid + '\\\\n')
+        process.exit(0)
+      \`
+
+      let grandchildPid
+      try {
+        const result = await mod.spawnOpencodeChild(['bun', '-e', childScript], {
+          cwd: process.cwd(),
+          env: { PATH: process.env.PATH ?? '' },
+          timeoutMs: 5000,
+        })
+        const match = /grandchild-pid:(\\d+)/.exec(result.stdout)
+        if (!match) {
+          throw new Error('no grandchild pid in stdout: ' + JSON.stringify(result))
+        }
+        grandchildPid = Number(match[1])
+
+        // The direct child already exited (its stdio closed, so
+        // spawnOpencodeChild's promise above already resolved), but the
+        // grandchild -- still in the same process group -- is a 30s sleep,
+        // so the group is still non-empty right now.
+        process.stdout.write(
+          'HAS_LIVE_BEFORE_KILL=' + mod.hasLiveOpencodeProcesses() + '\\n',
+        )
+
+        process.kill(grandchildPid, 'SIGKILL')
+        // Give the OS a brief moment to finish reaping after the signal.
+        await new Promise((resolve) => setTimeout(resolve, 300))
+
+        process.stdout.write(
+          'HAS_LIVE_AFTER_KILL=' + mod.hasLiveOpencodeProcesses() + '\\n',
+        )
+      } finally {
+        if (grandchildPid) {
+          try {
+            process.kill(grandchildPid, 'SIGKILL')
+          } catch {}
+        }
+      }
+    `
+
+    const result = Bun.spawnSync(['bun', '-e', script], {
+      env: TEST_CHILD_ENV,
+      timeout: 15_000,
+    })
+    const stdout = result.stdout.toString()
+    const stderr = result.stderr.toString()
+
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `harness script exited with code ${result.exitCode}: ${stderr}`,
+      )
+    }
+    expect(stdout).toContain('HAS_LIVE_BEFORE_KILL=true')
+    expect(stdout).toContain('HAS_LIVE_AFTER_KILL=false')
   }, 20_000)
 })

--- a/tests/unit/receipt-workflow-host.test.ts
+++ b/tests/unit/receipt-workflow-host.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'bun:test'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import {
   assertMixedVersionProbeEvents,
@@ -9,6 +11,17 @@ import {
   startScriptedSkillModelServer,
   withScriptedProvider,
 } from '../integration/fixtures/receipt-workflow-host.js'
+
+// Absolute file:// URL to the real fixture source, resolved from THIS file
+// so the isolated child process spawned below (its own fresh module graph,
+// its own empty `process.listeners('SIGINT')`) can `import()` the exact
+// same module under test.
+const FIXTURE_MODULE_URL = pathToFileURL(
+  path.join(
+    import.meta.dirname,
+    '../integration/fixtures/receipt-workflow-host.ts',
+  ),
+).href
 
 const WORKFLOW_OPEN = '<SYSTEMATIC_WORKFLOWS>'
 const WORKFLOW_CLOSE = '</SYSTEMATIC_WORKFLOWS>'
@@ -397,4 +410,103 @@ describe('spawnOpencodeChild timeout path', () => {
     await Bun.sleep(300)
     expect(() => process.kill(grandchildPid, 0)).toThrow()
   }, 15_000)
+})
+
+// Item 6 pinning test: `installTerminalSignalHandlers`'s SIGINT listener
+// must NOT force-exit when nothing is live (this is the fix for the root
+// cause of a spurious full-suite exit 130 -- the handler used to reap and
+// `process.exit(130)` unconditionally, even with nothing to reap), but
+// must still reap-and-exit when something (a registered
+// `spawnOpencodeChild` child, per item 1) is live.
+//
+// Runs entirely inside an isolated `bun -e` child process: that process's
+// own `process.listeners('SIGINT')` starts empty, so the before/after diff
+// below cannot be confused by any other SIGINT listener already installed
+// elsewhere in this bun test worker, and the listener is captured and
+// invoked directly -- never via `process.emit` -- mirroring the technique
+// documented in eval-runner.test.ts's "signal cleanup" test.
+//
+// Bidirectional proof: reverting the `if (!hasLiveOpencodeProcesses())
+// return` early-return in `installTerminalSignalHandlers` makes case A
+// below also reap-and-exit, flipping `CASE_A_EXIT_CALLS` to `1` and
+// `CASE_A_THREW` to `true` -- this test then fails.
+describe('terminal-signal safety net (nothing-live vs something-live)', () => {
+  test('does not force-exit with an empty live set, but reaps and exits with a live child', () => {
+    const script = `
+      const priorSigintListeners = new Set(process.listeners('SIGINT'))
+      const mod = await import(${JSON.stringify(FIXTURE_MODULE_URL)})
+
+      const exitCalls = []
+      const originalExit = process.exit
+      process.exit = (code) => {
+        exitCalls.push(code ?? 0)
+        throw new Error('process.exit stub invoked')
+      }
+
+      // Triggers installTerminalSignalHandlers as a side effect and is
+      // fully awaited, so its pid is evicted before this resolves -- the
+      // live set is empty again by the time case A invokes the listener.
+      await mod.spawnOpencodeChild(['bun', '-e', 'process.exit(0)'], {
+        cwd: process.cwd(),
+        env: { PATH: process.env.PATH ?? '' },
+        timeoutMs: 5000,
+      })
+
+      const installed = process
+        .listeners('SIGINT')
+        .filter((listener) => !priorSigintListeners.has(listener))
+      if (installed.length !== 1) {
+        throw new Error(
+          'expected exactly 1 new SIGINT listener, got ' + installed.length,
+        )
+      }
+      const [listener] = installed
+
+      let threwA = false
+      try {
+        listener()
+      } catch {
+        threwA = true
+      }
+      process.stdout.write('CASE_A_EXIT_CALLS=' + exitCalls.length + '\\n')
+      process.stdout.write('CASE_A_THREW=' + threwA + '\\n')
+
+      // Case B: register one real live child (deliberately not awaited
+      // before invoking the listener), so the reap path has something to
+      // actually kill.
+      const longLived = mod.spawnOpencodeChild(
+        ['bun', '-e', 'setInterval(() => {}, 1000)'],
+        {
+          cwd: process.cwd(),
+          env: { PATH: process.env.PATH ?? '' },
+          timeoutMs: 60000,
+        },
+      )
+      await new Promise((resolve) => setTimeout(resolve, 300))
+
+      let threwB = false
+      try {
+        listener()
+      } catch {
+        threwB = true
+      }
+      process.stdout.write('CASE_B_EXIT_CALLS=' + exitCalls.length + '\\n')
+      process.stdout.write('CASE_B_THREW=' + threwB + '\\n')
+
+      await longLived
+      process.exit = originalExit
+    `
+
+    const result = Bun.spawnSync(['bun', '-e', script], {
+      env: TEST_CHILD_ENV,
+      timeout: 15_000,
+    })
+    const stdout = result.stdout.toString()
+
+    expect(result.exitCode).toBe(0)
+    expect(stdout).toContain('CASE_A_EXIT_CALLS=0')
+    expect(stdout).toContain('CASE_A_THREW=false')
+    expect(stdout).toContain('CASE_B_EXIT_CALLS=1')
+    expect(stdout).toContain('CASE_B_THREW=true')
+  }, 20_000)
 })


### PR DESCRIPTION
## Summary

Follow-up on review feedback: eight review-deferred hardening items on the OpenCode host fixture's spawn/stdio/signal theme, plus a real bug found in the first round's own new code (stale-pid retention) and two follow-up hardening items. No assertion changes anywhere except item 8's `length === 1` check and new pinning tests.

## Follow-up round (this push)

| # | What | Why |
|---|---|---|
| **1 (bug fix)** | `pruneLiveOpencodeProcesses()` re-probes every entry in `liveOpencodeHosts` and `liveRunOpencodeChildPids` with `process.kill(-pid, 0)` and deletes dead ones, called from both `hasLiveOpencodeProcesses()` and `killLiveOpencodeHostsSync()` before they act. The at-settle eviction (`evictRunOpencodeChildPid`, and `startOpencodeProcess`'s own exit handler) stays as a fast path. | The settle-time eviction only re-probed once, at the instant the launcher's stdio closed. A still-draining grandchild at that exact instant left the pid retained for the rest of the worker's life — permanently pinning `hasLiveOpencodeProcesses()` to true (silently reverting the item-6 no-live early-return) and leaving a stale, recyclable pgid in `killLiveOpencodeHostsSync`'s SIGKILL sweep. **`liveOpencodeHosts` had the identical one-shot weakness** and now shares the same pruning discipline. |
| 2 | Dropped the doc-comment claim that the SIGINT/SIGTERM handler falls back to Node's default terminating behaviour. | Unreachable — the fixture listener is never removed, and a registered no-op listener suppresses default termination regardless of what else is registered. |
| 3 | eval-runner.test.ts's "signal cleanup" test now snapshots both `SIGINT` and `SIGTERM` prior listeners before calling `installEvalSignalHandlers()`, and `finally` removes anything new by name when the remover was never assigned. | The previous fix covered a throw during listener *capture*, but not a throw inside `installEvalSignalHandlers()` itself — it registers SIGINT then SIGTERM as two separate `process.on` calls before returning its remover, so a throw between them (or before the return) left whichever listener(s) it managed to attach with no remover reference to clean them up. |
| 4 | The item-6 pinning test's harness-failure path now throws with the harness's own `stderr` attached. | It previously discarded `stderr` on a non-zero exit, making a harness crash undiagnosable from the assertion failure alone. |
| 5 (new pin) | `spawnOpencodeChild UTF-8 chunk reassembly` test: a child writes `'€'`'s lead byte, sleeps, then the two continuation bytes, forcing two separate `data` events; asserts the collected stdout equals `'€'`. | Item 2 (multi-byte UTF-8 `setEncoding`) shipped in the prior round with no test. |
| 6 (new pin) | `buildDetachedChildSpawnOptions` extracted as the shared `spawn`-options builder both `spawnOpencodeChild` and `startOpencodeProcess` now call through; tested directly (structural + a real child sees stdin EOF immediately). | `startOpencodeProcess` isn't testable host-free (its promise only resolves once a real `opencode serve` prints a listen URL). Testing the *shared builder* both sites call through covers both call sites at once and guarantees they cannot diverge on stdio, since there's only one implementation left to diverge from. |

## Bidirectional proof results (this round)

All reverted, confirmed failing, then restored and confirmed passing:

- **Item 1 (stale-pid pruning):** reverting `hasLiveOpencodeProcesses()` to skip `pruneLiveOpencodeProcesses()` → `HAS_LIVE_AFTER_KILL` stayed `true` instead of flipping to `false` (`Received: "HAS_LIVE_BEFORE_KILL=true\nHAS_LIVE_AFTER_KILL=true\n"`). Restored → passes.
- **Item 2 (UTF-8 pin):** removing `spawnOpencodeChild`'s two `setEncoding('utf8')` calls (reverting to raw `Buffer.toString()` per chunk) → `result.stdout` became `"���"` (U+FFFD) instead of `'€'`. Restored → passes.
- **Item 5/6 (shared builder pin):** reverting `buildDetachedChildSpawnOptions`'s `stdio` to `['pipe', 'pipe', 'pipe']` → the stdin-EOF test hung to its own 10s timeout (bun reported "killed 1 dangling process"). Restored → passes.
- **Item 6/prior-round early-return (re-verified still holds under the new pruning code):** reverting the `if (!hasLiveOpencodeProcesses()) return` early-return → `CASE_A_EXIT_CALLS` flipped from `0` to `1` and `CASE_A_THREW` from `false` to `true`. Restored → passes.

## Verification

- `bun test tests/unit` → **2260 pass, 0 fail** (2249 prior-round tests + #939's 11-test `spawn-and-signal-conventions.test.ts`, which merged to `main` in between rounds and rebases in clean — this fixture's own strings don't trip its bare-`opencode`-launch guard)
- `SYSTEMATIC_REQUIRE_OPENCODE=1 bun test tests/integration/opencode.test.ts` → **22 pass, 1 skip (Windows-only), 0 fail**
- `SYSTEMATIC_REQUIRE_OPENCODE=1 bun test tests/integration/receipt-workflow-recovery.test.ts` → **9 pass, 0 fail**
- `SYSTEMATIC_REQUIRE_OPENCODE=1 bun test tests/integration > /tmp/full.log 2>&1; echo exit=$?` → **exit=0**; summary: `137 pass, 1 skip, 0 fail — Ran 138 tests across 11 files`
- `pgrep -fl opencode-ai` and `pgrep -f 'sleep 30'` after every real-host run → **empty** every time (checked after each individual real-host run, not just at the end)
- `bun run typecheck:all` → 0 errors
- `bun run lint` → 0 errors, **13 warnings / 2 infos** (identical to `main` baseline, verified no new complexity warning was introduced by the eval-runner refactor — extracted a `removeListenersNotIn` helper to keep it under the cognitive-complexity cap)
- `bun scripts/content-integrity.ts` → clean
- `bun run build` → OK
- `git fetch origin && git rebase origin/main` → clean, no conflicts (branch was rebased onto `main` at the very start of this round, picking up #938 and #939)

Refs #932 #933 #936
