### PR TITLE
fix(workflow-guard): record a failed completion instead of leaving ready metadata

### DIFF
--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -2480,7 +2480,11 @@ function createSessionRuntime(
       result.satisfiedCount = source.debug.satisfiedCount
       result.missingCount = source.debug.missingCount
       result.family = source.debug.family
-      result.status = source.debug.status
+      // Guard-owned name, not a bare `status`: a bare key here would
+      // collide with (and in debug mode silently overwrite) a host tool's
+      // own `status` field — the exact field `isSuccessfulAfter()` reads
+      // to detect a failed host result (see parseHostOutput()).
+      result.debugEpochStatus = source.debug.status
     }
     return result
   }

--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -2535,10 +2535,12 @@ function createSessionRuntime(
     target: TransitionTarget,
   ): void {
     if (!isRecord(output)) return
+    const existingMetadata = isRecord(output.metadata) ? output.metadata : {}
     if (result.status === 'completed' || result.status === 'duplicate') {
       output.title = 'Workflow transition completed'
       output.output = `workflow guard completed ${target}`
       output.metadata = {
+        ...existingMetadata,
         ...metadata(),
         workflowGuard: { status: 'completed', target },
       }
@@ -2554,6 +2556,7 @@ function createSessionRuntime(
       reasonCode,
     })
     output.metadata = {
+      ...existingMetadata,
       ...metadata(),
       workflowGuard: {
         status: resultStatus,
@@ -2586,13 +2589,24 @@ function createSessionRuntime(
   // error title/text, which is evidence and must not be destroyed. Only the
   // metadata is corrected, using a fresh metadata() read taken after
   // guard.abandonTransition() so it reflects the corrected guard state.
+  //
+  // The host's existing metadata is preserved (spread first, lowest
+  // precedence) rather than replaced outright: on this path the host's own
+  // metadata carries the failure sentinel (`status: 'error' | 'failure' |
+  // 'cancelled'`) that `isSuccessfulAfter()` reads. Guard instances share
+  // the `output` reference across `tool.execute.after` calls, so replacing
+  // the metadata wholesale would erase that sentinel for any later
+  // instance and make it misclassify the call as successful — the exact
+  // fail-open inversion this fix exists to prevent.
   function writeAbandonedCompletionMetadata(
     output: unknown,
     target: TransitionTarget,
     reasonCode: WorkflowReasonCode,
   ): void {
     if (!isRecord(output)) return
+    const existingMetadata = isRecord(output.metadata) ? output.metadata : {}
     output.metadata = {
+      ...existingMetadata,
       ...metadata(),
       workflowGuard: { status: 'unavailable', target, reasonCode },
     }
@@ -3153,7 +3167,7 @@ function createSessionRuntime(
       writeAbandonedCompletionMetadata(
         output,
         pending.target,
-        'abandoned-transition',
+        'failed-operation',
       )
       return
     }
@@ -3370,11 +3384,7 @@ function createSessionRuntime(
   ): void {
     abandonComplete(callDigest, pending, false)
     markUnavailable()
-    writeAbandonedCompletionResult(
-      output,
-      pending.target,
-      'abandoned-transition',
-    )
+    writeAbandonedCompletionResult(output, pending.target, 'invalid-transition')
   }
 
   function finishUnreplayableComplete(
@@ -3385,7 +3395,11 @@ function createSessionRuntime(
     // No pending transition and nothing replayable: the target is unknown,
     // so 'unit' is used as the required TransitionTarget field on this
     // synthetic terminal result — display-only in this branch.
-    writeAbandonedCompletionResult(output, finalTarget ?? 'unit', 'guard-unavailable')
+    writeAbandonedCompletionResult(
+      output,
+      finalTarget ?? 'unit',
+      'guard-unavailable',
+    )
   }
 
   function finishUnavailableReadback(

--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -2563,6 +2563,41 @@ function createSessionRuntime(
     }
   }
 
+  // A completion that never reached `guard.finalizeTransition` (mismatched
+  // target, no replayable transition, or a failed readback bundle) must not
+  // leave the tool result carrying whatever pre-finalization metadata was
+  // written earlier in the request. Writes a full terminal result through
+  // `writeCompletionResult()` so the shape and reason-code vocabulary match
+  // every other non-success completion outcome.
+  function writeAbandonedCompletionResult(
+    output: unknown,
+    target: TransitionTarget,
+    reasonCode: WorkflowReasonCode,
+  ): void {
+    writeCompletionResult(
+      output,
+      { target, status: 'unavailable', reasonCode },
+      target,
+    )
+  }
+
+  // Companion to writeAbandonedCompletionResult() for the case where the
+  // HOST tool itself failed: the output already carries the host's own
+  // error title/text, which is evidence and must not be destroyed. Only the
+  // metadata is corrected, using a fresh metadata() read taken after
+  // guard.abandonTransition() so it reflects the corrected guard state.
+  function writeAbandonedCompletionMetadata(
+    output: unknown,
+    target: TransitionTarget,
+    reasonCode: WorkflowReasonCode,
+  ): void {
+    if (!isRecord(output)) return
+    output.metadata = {
+      ...metadata(),
+      workflowGuard: { status: 'unavailable', target, reasonCode },
+    }
+  }
+
   function prepareSkill(host: HostToolBefore, args: unknown): void {
     const skill = normalizeSkill(host.tool, args)
     if (!skill) return
@@ -3115,6 +3150,11 @@ function createSessionRuntime(
         callId: pending.callID,
         transitionId: pending.transitionId,
       })
+      writeAbandonedCompletionMetadata(
+        output,
+        pending.target,
+        'abandoned-transition',
+      )
       return
     }
     const result = guard.finalizeTransition({
@@ -3323,6 +3363,45 @@ function createSessionRuntime(
     return readbacks
   }
 
+  function finishMismatchedTarget(
+    callDigest: string,
+    pending: PendingComplete,
+    output: unknown,
+  ): void {
+    abandonComplete(callDigest, pending, false)
+    markUnavailable()
+    writeAbandonedCompletionResult(
+      output,
+      pending.target,
+      'abandoned-transition',
+    )
+  }
+
+  function finishUnreplayableComplete(
+    finalTarget: TransitionTarget | undefined,
+    output: unknown,
+  ): void {
+    markUnavailable()
+    // No pending transition and nothing replayable: the target is unknown,
+    // so 'unit' is used as the required TransitionTarget field on this
+    // synthetic terminal result — display-only in this branch.
+    writeAbandonedCompletionResult(output, finalTarget ?? 'unit', 'guard-unavailable')
+  }
+
+  function finishUnavailableReadback(
+    callDigest: string,
+    pending: PendingComplete,
+    output: unknown,
+  ): void {
+    abandonComplete(callDigest, pending, true)
+    markUnavailable()
+    writeAbandonedCompletionResult(
+      output,
+      pending.target,
+      'finalization-failed',
+    )
+  }
+
   async function finishComplete(
     host: HostToolAfter,
     output: unknown,
@@ -3331,13 +3410,12 @@ function createSessionRuntime(
     const pending = pendingCompletes.get(callDigest)
     const finalTarget = normalizeTarget(host.args)
     if (pending && (!finalTarget || finalTarget !== pending.target)) {
-      abandonComplete(callDigest, pending, false)
-      markUnavailable()
+      finishMismatchedTarget(callDigest, pending, output)
       return
     }
     if (!pending) {
       if (replayTerminalComplete(callDigest, finalTarget, output)) return
-      markUnavailable()
+      finishUnreplayableComplete(finalTarget, output)
       return
     }
     if (!options.observer) {
@@ -3346,8 +3424,7 @@ function createSessionRuntime(
     }
     const readbacks = await completionReadbacks()
     if (readbacks.status === 'unavailable') {
-      abandonComplete(callDigest, pending, true)
-      markUnavailable()
+      finishUnavailableReadback(callDigest, pending, output)
       return
     }
     finalizeComplete(

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -2455,6 +2455,60 @@ describe('OpenCode workflow guard adapter', () => {
     expect(sharedOutput.metadata.status).toBe('error')
   })
 
+  test('a shared output across two DEBUG-mode guard instances keeps the host failure sentinel visible to the second instance', async () => {
+    // Debug mode flattens the guard's own epoch status onto `metadata` too
+    // (alongside operations/satisfiedCount/missingCount/family). Before the
+    // fix this used a bare `status` key that collided with — and in debug
+    // mode silently overwrote — the host's own `status: 'error'` failure
+    // sentinel, letting a second guard instance finalize a unit off a
+    // failed host result.
+    const first = createAdapter('protected', true)
+    const second = createAdapter('protected', true)
+    await observeSkill(first, 'systematic_skill', 'ce:work')
+    await observeSkill(second, 'systematic_skill', 'ce:work')
+    mintReceipt(first, 'implementation')
+    mintReceipt(first, 'verification')
+    mintReceipt(second, 'implementation')
+    mintReceipt(second, 'verification')
+
+    const input = {
+      tool: 'systematic_workflow_complete',
+      sessionID: SESSION_A,
+      callID: 'shared-host-failure-complete-debug',
+    }
+    await first.hooks['tool.execute.before'](input, {
+      args: { target: 'unit' },
+    })
+    await second.hooks['tool.execute.before'](input, {
+      args: { target: 'unit' },
+    })
+
+    const sharedOutput: RecordedToolOutput = {
+      title: 'Bash command failed',
+      output: 'permission denied: /var/run/lock',
+      metadata: { status: 'error' },
+    }
+    await first.hooks['tool.execute.after'](
+      { ...input, args: { target: 'unit' } },
+      sharedOutput,
+    )
+    // (a) the host's failure sentinel survives in the shared metadata, even
+    // though debug mode is on and writes its own epoch status field.
+    expect(sharedOutput.metadata.status).toBe('error')
+    expect(sharedOutput.metadata.debugEpochStatus).not.toBe('error')
+
+    await second.hooks['tool.execute.after'](
+      { ...input, args: { target: 'unit' } },
+      sharedOutput,
+    )
+    // (b) the second instance does not finalize a unit off a failed host
+    // result, and (c) the title/output are not rewritten to success wording.
+    expect(status(second).unit?.status).not.toBe('completed')
+    expect(sharedOutput.title).not.toBe('Workflow transition completed')
+    expect(sharedOutput.output).not.toContain('workflow guard completed')
+    expect(sharedOutput.metadata.status).toBe('error')
+  })
+
   test('markers upsert one source entry and aggregate worst precedence', async () => {
     const first = createAdapter('protected')
     const second = createAdapter('protected')

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -2309,6 +2309,97 @@ describe('OpenCode workflow guard adapter', () => {
     ).toEqual(consumption)
   })
 
+  const staleReadyOutput = (): RecordedToolOutput => ({
+    title: 'Workflow unit ready',
+    output: JSON.stringify({ status: 'ready' }),
+    metadata: {
+      protocolVersion: 2,
+      state: 'protected',
+      reasonCode: 'unit-ready',
+      enforcement: 'protected',
+    },
+  })
+
+  test('a mismatched completion target writes an abandoned terminal result instead of stale ready metadata', async () => {
+    const adapter = createAdapter('protected')
+    await observeSkill(adapter, 'systematic_skill', 'ce:work')
+    mintReceipt(adapter, 'implementation')
+    mintReceipt(adapter, 'verification')
+    const input = {
+      tool: 'systematic_workflow_complete',
+      sessionID: SESSION_A,
+      callID: 'mismatched-target-complete',
+    }
+    await adapter.hooks['tool.execute.before'](input, {
+      args: { target: 'unit' },
+    })
+    const output = staleReadyOutput()
+    await adapter.hooks['tool.execute.after'](
+      { ...input, args: { target: 'epoch' } },
+      output,
+    )
+    expect(output.metadata).not.toMatchObject({ reasonCode: 'unit-ready' })
+    expect(output.metadata.workflowGuard).toMatchObject({
+      status: 'unavailable',
+      reasonCode: 'abandoned-transition',
+      target: 'unit',
+    })
+  })
+
+  test('a completion call with no pending transition and no replayable outcome writes an unavailable terminal result', async () => {
+    const adapter = createAdapter('protected')
+    const input = {
+      tool: 'systematic_workflow_complete',
+      sessionID: SESSION_A,
+      callID: 'no-pending-complete',
+    }
+    const output = staleReadyOutput()
+    await adapter.hooks['tool.execute.after'](
+      { ...input, args: { target: 'unit' } },
+      output,
+    )
+    expect(output.metadata).not.toMatchObject({ reasonCode: 'unit-ready' })
+    expect(output.metadata.workflowGuard).toMatchObject({
+      status: 'unavailable',
+      reasonCode: 'guard-unavailable',
+      target: 'unit',
+    })
+  })
+
+  test('a failed host completion tool preserves the host error text and only corrects the metadata', async () => {
+    const adapter = createAdapter('protected')
+    await observeSkill(adapter, 'systematic_skill', 'ce:work')
+    mintReceipt(adapter, 'implementation')
+    mintReceipt(adapter, 'verification')
+    const input = {
+      tool: 'systematic_workflow_complete',
+      sessionID: SESSION_A,
+      callID: 'host-failure-complete',
+    }
+    await adapter.hooks['tool.execute.before'](input, {
+      args: { target: 'unit' },
+    })
+    const hostErrorTitle = 'Bash command failed'
+    const hostErrorText = 'permission denied: /var/run/lock'
+    const output: RecordedToolOutput = {
+      title: hostErrorTitle,
+      output: hostErrorText,
+      metadata: { status: 'error' },
+    }
+    await adapter.hooks['tool.execute.after'](
+      { ...input, args: { target: 'unit' } },
+      output,
+    )
+    expect(output.title).toBe(hostErrorTitle)
+    expect(output.output).toBe(hostErrorText)
+    expect(output.metadata).not.toEqual({ status: 'error' })
+    expect(output.metadata.workflowGuard).toMatchObject({
+      status: 'unavailable',
+      reasonCode: 'abandoned-transition',
+      target: 'unit',
+    })
+  })
+
   test('markers upsert one source entry and aggregate worst precedence', async () => {
     const first = createAdapter('protected')
     const second = createAdapter('protected')
@@ -3744,6 +3835,56 @@ describe('OpenCode workflow guard adapter', () => {
         .listReceipts()
         .some((receipt) => receipt.canonical.consumption === 'consumed'),
     ).toBe(false)
+  })
+
+  test('an interleaved-digest completion readback writes an unavailable terminal result instead of stale ready metadata', async () => {
+    const adapter = createAdapter(
+      'observe',
+      false,
+      sequenceObserver([
+        operationSnapshot(),
+        operationSnapshot('b'.repeat(64), 'd'.repeat(64)),
+        operationSnapshot('b'.repeat(64), 'd'.repeat(64)),
+        operationSnapshot('b'.repeat(64), 'd'.repeat(64)),
+        operationSnapshot('b'.repeat(64), 'f'.repeat(64)),
+        operationSnapshot('b'.repeat(64), 'g'.repeat(64)),
+      ]),
+    )
+    await observeSkill(adapter, 'systematic_skill', 'ce:work')
+    await observeOperationTool(
+      adapter,
+      'write',
+      { filePath: 'a.ts', content: 'a' },
+      { title: 'write', output: 'changed', metadata: {} },
+      'readback-unavailable-implementation',
+    )
+    await observeOperationTool(
+      adapter,
+      'bash',
+      { command: 'bun test tests/unit/example.test.ts' },
+      { title: 'tests', output: 'pass', metadata: { exit: 0 } },
+      'readback-unavailable-verification',
+    )
+    const input = {
+      tool: 'systematic_workflow_complete',
+      sessionID: SESSION_A,
+      callID: 'readback-unavailable-completion',
+    }
+    await adapter.hooks['tool.execute.before'](input, {
+      args: { target: 'unit' },
+    })
+    const output = staleReadyOutput()
+    await adapter.hooks['tool.execute.after'](
+      { ...input, args: { target: 'unit' } },
+      output,
+    )
+    expect(status(adapter).unit?.status).toBe('active')
+    expect(output.metadata).not.toMatchObject({ reasonCode: 'unit-ready' })
+    expect(output.metadata.workflowGuard).toMatchObject({
+      status: 'unavailable',
+      reasonCode: 'finalization-failed',
+      target: 'unit',
+    })
   })
 
   test('requalifies a pinned worktree target during completion readback', async () => {

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -2341,7 +2341,7 @@ describe('OpenCode workflow guard adapter', () => {
     expect(output.metadata).not.toMatchObject({ reasonCode: 'unit-ready' })
     expect(output.metadata.workflowGuard).toMatchObject({
       status: 'unavailable',
-      reasonCode: 'abandoned-transition',
+      reasonCode: 'invalid-transition',
       target: 'unit',
     })
   })
@@ -2393,11 +2393,66 @@ describe('OpenCode workflow guard adapter', () => {
     expect(output.title).toBe(hostErrorTitle)
     expect(output.output).toBe(hostErrorText)
     expect(output.metadata).not.toEqual({ status: 'error' })
+    // The host's own failure sentinel must survive alongside the guard's
+    // corrected metadata — it is what a second shared-output instance
+    // relies on via isSuccessfulAfter() to avoid taking the success path.
+    expect(output.metadata.status).toBe('error')
     expect(output.metadata.workflowGuard).toMatchObject({
       status: 'unavailable',
-      reasonCode: 'abandoned-transition',
+      reasonCode: 'failed-operation',
       target: 'unit',
     })
+  })
+
+  test('a shared output across two guard instances keeps the host failure sentinel visible to the second instance', async () => {
+    const first = createAdapter('protected')
+    const second = createAdapter('protected')
+    await observeSkill(first, 'systematic_skill', 'ce:work')
+    await observeSkill(second, 'systematic_skill', 'ce:work')
+    mintReceipt(first, 'implementation')
+    mintReceipt(first, 'verification')
+    mintReceipt(second, 'implementation')
+    mintReceipt(second, 'verification')
+
+    const input = {
+      tool: 'systematic_workflow_complete',
+      sessionID: SESSION_A,
+      callID: 'shared-host-failure-complete',
+    }
+    await first.hooks['tool.execute.before'](input, {
+      args: { target: 'unit' },
+    })
+    await second.hooks['tool.execute.before'](input, {
+      args: { target: 'unit' },
+    })
+
+    // One host output object shared by both guard instances — mirrors how
+    // OpenCode invokes every registered plugin's `tool.execute.after` hook
+    // against the same result reference (see the `partial registration
+    // finalization…` test above for the established sharing pattern).
+    const sharedOutput: RecordedToolOutput = {
+      title: 'Bash command failed',
+      output: 'permission denied: /var/run/lock',
+      metadata: { status: 'error' },
+    }
+    await first.hooks['tool.execute.after'](
+      { ...input, args: { target: 'unit' } },
+      sharedOutput,
+    )
+    // (a) the host's failure sentinel survives in the shared metadata.
+    expect(sharedOutput.metadata.status).toBe('error')
+
+    await second.hooks['tool.execute.after'](
+      { ...input, args: { target: 'unit' } },
+      sharedOutput,
+    )
+    // (b) the second instance still reads the host failure via
+    // isSuccessfulAfter() and does not take the success path — it must not
+    // report a completed unit, and must not overwrite the terminal title
+    // with a completion title.
+    expect(status(second).unit?.status).not.toBe('completed')
+    expect(sharedOutput.title).not.toBe('Workflow transition completed')
+    expect(sharedOutput.metadata.status).toBe('error')
   })
 
   test('markers upsert one source entry and aggregate worst precedence', async () => {


### PR DESCRIPTION
## Summary

`systematic_workflow_complete` first returns `runtime.metadata()`, which can describe a ready-but-not-finalized unit (`reasonCode: 'unit-ready'`, no `workflowGuard` block). Four branches in `finishComplete()`/`finalizeComplete()` returned without ever rewriting that output through `writeCompletionResult()`, so a tool the host reported `completed` could still carry stale pre-finalization metadata — indistinguishable from a real success.

Each of the four branches now writes an explicit terminal result naming what happened, using the existing `WorkflowReasonCode` vocabulary. No new status or reason literal was introduced, and `WorkflowGuard` state-machine semantics (`finalizeTransition`/`abandonTransition`/`markUnavailable`) are unchanged — only the *evidence written to the host tool output* changed.

**Update 2:** review caught that `writeCompletionResult()`/`writeAbandonedCompletionMetadata()` replaced `output.metadata` wholesale instead of layering onto it, dropping the host's own failure sentinel on the shared `output` reference and letting a second guard instance take the success path. Fixed by spreading the host's existing metadata first everywhere.

**Update 3 (this revision):** even with that layering fix, `metadata()` itself emitted a bare, unprefixed `status` key whenever `options.config.debug` is enabled (the flattened epoch status from `source.debug.status`). Because `...metadata()` is spread *after* `...existingMetadata` (guard fields must win on genuine collisions), that bare key still overwrote the host's `status: 'error'` sentinel in debug mode — reintroducing the exact fail-open through a user-settable option (`workflow_guard.debug`, `src/lib/config-schema.ts:112`). Fixed at the source: the debug-only key is renamed to `debugEpochStatus`, so it can never collide with a host-owned `status` field, in any mode, for every consumer of `metadata()` — not just the completion paths.

## Per-branch reason codes

| Branch | Location | Trigger | Reason code | Why |
|---|---|---|---|---|
| A | `finishComplete()` (`finishMismatchedTarget`) | pending completion exists but the finalize call's target is missing/mismatched | `invalid-transition` | `workflow-guard.ts`'s own `prepareTransition`/`finalizeTransition`/`abandonTransition` return `invalid-transition` precisely when the call/transitionId or shape presented for finalization does not match what's on record for the lifecycle (:3619, :3626, :3630). Branch A is the OpenCode-level analog: the finalize call's target argument doesn't match the target that was prepared. `abandoned-transition` in the existing vocabulary specifically marks a transition that was *previously* abandoned and is now being referenced again — a replay scenario (:3650, `replayPrepare()`'s already-abandoned-lifecycle case at :2749) — not a first-time mismatch, so it was the wrong fit. |
| C | `finishComplete()` (`finishUnreplayableComplete`) | no pending transition, and `replayTerminalComplete()` found nothing replayable | `guard-unavailable` | Nothing is known about this call — no pending record, no finalized/abandoned/blocked/terminal record to replay. Same "we cannot process this" signal used elsewhere in the guard for calls it can't attribute (e.g. `takePendingOperation`'s `markUnavailable()` path). |
| E | `finishComplete()` (`finishUnavailableReadback`) | `completionReadbacks()` returned `unavailable` (observer snapshot mismatch/unavailable) | `finalization-failed` | Matches the existing internal meaning `finalization-failed` already carries in `finalizePrepared()` (:2311, :2330) — the finalize step is blocked because a required precondition could not be satisfied. |
| F1 | `finalizeComplete()` | the **host tool itself** failed (`!isSuccessfulAfter(output)`) | `failed-operation` | `attemptReason()` in `workflow-guard.ts:1233-1238` maps the `'failed'` attempt outcome to exactly this code. F1 is the host operation (the `systematic_workflow_complete` tool call itself) having failed — distinct from A's "wrong target argument". |

## Debug-metadata key rename

`metadata()` (`~:2454-2486`) flattens a debug-only block onto the returned metadata when `options.config.debug` is true: `operations`, `satisfiedCount`, `missingCount`, `family`, and (previously) a bare `status` (the epoch's `'active' | 'completed' | null` status). Only `status` is proven to collide — `parseHostOutput()` (`:449`) reads a host tool's own `output.metadata.status` to detect `'error' | 'failure' | 'cancelled'`, so a guard-owned `status` key at the same top level is a direct namespace collision. Renamed to `debugEpochStatus`.

**Every consumer checked and updated:**
- The only production assignment site is `metadata()` itself (`~:2478-2484`) — updated.
- `MarkerSource.debug.status` (the *nested*, non-flattened marker-serialization field consumed by `parseMarkerDebug()`) is a **separate, unrelated representation** — it stays nested under a `debug` key in the `<SYSTEMATIC_WORKFLOW_GUARD>` chat marker document and was never flattened there, so it needed no change.
- `src/lib/opencode-workflow-guard.ts:449` (`parseHostOutput`'s `output.metadata.status` read) is the consumer this rename *protects* — it reads the **host's** field, not the guard's, and is unaffected by the rename.
- Searched `src/`, `tests/`, `docs/`, `README.md`, `ARCHITECTURE.md`, `STRUCTURE.md` for `metadata.status`, `satisfiedCount`, `missingCount`, `metadata.family`, `metadata.operations`: no test or doc asserts on the flattened debug key names in tool-output `metadata` (the one test that exercises `debug: true`, `preserves source debug fields and uses the worst source digest in the aggregate`, only inspects the nested marker JSON's `debug !== undefined`, never the flattened tool-output field names).
- **No contract surface** (schema, docs, published fixture) names the old flattened key — it was never part of `config-schema.ts`, `docs/`, or any generated reference. Safe to rename without a deprecation path.

The other four flattened debug fields (`operations`, `satisfiedCount`, `missingCount`, `family`) were left as-is — they are lower-collision-risk (unlikely host field names) and out of the scope of the reported defect, which was specifically the `status` collision.

## The evidence-preservation rule for F1 (and the metadata-layering fix)

F1 is the one branch where the **output already holds the host's own error** (its `title`/`output` describe *why the host tool failed*). F1 only rewrites `output.metadata` — never `title`/`output`. The metadata rewrite layers onto the host's existing metadata rather than replacing it wholesale, for all four branches, matching the precedence `writeStartResult()` already used: `{...existingMetadata, ...metadata(), workflowGuard: {...}}` (host fields survive, guard's fresh top-level fields win on key collision, `workflowGuard` always wins). With the `debugEpochStatus` rename, there is no longer a genuine collision left for `...metadata()` to win on `status` in any mode.

A small shared helper pair backs all four call sites instead of four inline copies:
- `writeAbandonedCompletionResult(output, target, reasonCode)` — full terminal rewrite (A/C/E), delegates to `writeCompletionResult()`.
- `writeAbandonedCompletionMetadata(output, target, reasonCode)` — metadata-only rewrite (F1).

`finishComplete()`'s per-branch bodies are extracted into `finishMismatchedTarget()`, `finishUnreplayableComplete()`, and `finishUnavailableReadback()` to keep the outer function's cognitive complexity under the repo's linter threshold — pure extraction, no behavior change.

## Bidirectional proofs (7 total)

| Proof | Reverted → test result | Restored → test result |
|---|---|---|
| A (`invalid-transition` write) | FAIL — `not.toMatchObject({reasonCode: 'unit-ready'})` failed | PASS |
| C (`guard-unavailable` write) | FAIL — same stale-shape assertion failed | PASS |
| E (`finalization-failed` write) | FAIL — same stale-shape assertion failed | PASS |
| F1 (`failed-operation` write) | FAIL — `not.toEqual({status: 'error'})` failed (metadata untouched) | PASS |
| Non-debug metadata layering (wholesale-assign restored) | FAIL — both shared-output tests failed with `Expected: "error", Received: undefined` | PASS |
| Debug key rename (`result.status = source.debug.status` restored) | FAIL — debug shared-output test failed with `Expected: "error", Received: "active"` (the exact repro from review) | PASS |
| Non-debug shared-output test re-run during the rename revert | Unaffected — 1 pass (confirms the non-debug path was never touched by the debug-only collision) | — |

## Fail-closed tests untouched

Both existing regression tests are **absent from the diff** (verified via `git diff origin/fix/completion-records-its-own-failure`) and pass:
- `partial registration finalization fails closed and remains replay-idempotent`
- `fresh completion readback completes once and interleaving changes reject without consumption`

## Verification

- `bun run lint` — literal last line: `Found 2 infos.` (0 errors, 13 warnings — matches `main` baseline exactly)
- `bun run typecheck:all` — literal last line: `$ tsc -p tsconfig.tests.json` (clean exit)
- `bun test tests/unit` — 2272 pass, 0 fail (125 of those in `opencode-workflow-guard.test.ts`, up from 124 with 1 new debug-mode shared-output test)
- `bun scripts/content-integrity.ts` — `content-integrity: clean (125 md + 40 ts + 86 solution-md + 4 root docs scanned, 20 exempt hits, 0 warnings)`
- `bun run build` — OK, all three bundles produced
- `SYSTEMATIC_REQUIRE_OPENCODE=1 bun test tests/integration/receipt-workflow-dogfood.test.ts` — 1 pass, 0 fail
- `pgrep -fl opencode-ai` — empty after the integration run

Closes #942
