### PR TITLE
refactor(ci): move the host-contract guard into a tested script

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -261,147 +261,22 @@ jobs:
       # an unexpected reason while the job stays green, or a whole-file
       # collapse (a crash or an early exit) that still leaves the console
       # summary and pass floor looking plausible. The exempt set, the
-      # expected-file list, and the floor all live here, next to the guard,
-      # so widening any of them is a reviewed change.
+      # expected-file list, and the floor all live in scripts/host-contract-guard.ts,
+      # next to the guard, so widening any of them is a reviewed change.
+      #
+      # `success() || failure()` (rather than the implicit success()) makes
+      # this step run even when "Run host contract suite" fails, since that
+      # is exactly when its diagnosis is most useful -- unlike `always()`,
+      # it deliberately excludes a cancelled job (GitHub Actions treats
+      # `cancelled()` as neither success nor failure), so this does not run
+      # on cancellation. It is also gated on steps.gate.outputs.run so it
+      # still does not run on a path-gated-out pull request. This step only
+      # reports additional diagnosis: it does not (and cannot) flip the
+      # suite step's own conclusion, so a red suite still fails the job
+      # regardless of what this step finds.
       - name: Guard skipped tests and pass floor
-        if: steps.gate.outputs.run == 'true'
-        run: |
-          cat <<'EOF' > host-contract-guard.mjs
-          import { readFileSync } from 'node:fs'
-
-          // The only test allowed to skip today: the mixed-version test stays
-          // opt-in because enabling it would put a fetch of a published
-          // @fro.bot/systematic release on the path that gates publishing the
-          // next one.
-          const EXEMPT_SKIPS = [
-            {
-              classname: 'opencode mixed-version integration',
-              name: 'pinned package plus local source keep systematic_skill deterministic and converge bootstrap',
-            },
-          ]
-
-          // Every test file under tests/integration/, enumerated by hand and
-          // verified against `ls tests/integration/*.test.ts`. A file
-          // producing zero JUnit testsuite entries means bun test never
-          // actually ran it -- the exact failure mode a mass-skip or an
-          // early crash would produce while the console summary and pass
-          // floor alone could still look plausible.
-          const EXPECTED_SUITE_FILES = [
-            'tests/integration/claude-code.test.ts',
-            'tests/integration/eval-artifact.test.ts',
-            'tests/integration/eval-fixture.test.ts',
-            'tests/integration/eval-runner.test.ts',
-            'tests/integration/opencode.test.ts',
-            'tests/integration/pi.test.ts',
-            'tests/integration/question-attestation-opencode.test.ts',
-            'tests/integration/receipt-workflow-dogfood.test.ts',
-            'tests/integration/receipt-workflow-guard-real-host.test.ts',
-            'tests/integration/receipt-workflow-recovery.test.ts',
-            'tests/integration/release-notes-ci.test.ts',
-          ]
-
-          // Measured: 138 test()/it() call sites exist across the eleven
-          // integration files as of this writing. The prior floor of 50
-          // exactly equalled the host-free test count (claude-code 18 +
-          // eval-artifact 7 + eval-fixture 5 + release-notes-ci 20 = 50), so
-          // a total collapse of every host-touching file could still clear
-          // it silently. Raise this floor as the suite grows; do not lower
-          // it without a documented reason.
-          const PASS_FLOOR = 120
-
-          const [, , junitPath, logPath] = process.argv
-          const xml = readFileSync(junitPath, 'utf8')
-
-          const attrRe = /(\w+)="([^"]*)"/g
-
-          function parseAttrs(str) {
-            const attrs = {}
-            let m
-            attrRe.lastIndex = 0
-            while ((m = attrRe.exec(str))) attrs[m[1]] = m[2]
-            return attrs
-          }
-
-          // Bun emits one outer <testsuite> per test file, plus one nested
-          // <testsuite> per describe block, all sharing that file's file=
-          // attribute -- so collecting every testsuite's file attribute and
-          // taking the unique set recovers exactly the set of files bun
-          // actually loaded and ran, regardless of describe nesting.
-          // <testsuite\b never matches the closing </testsuite> tag (a /
-          // immediately follows <, not t), and never matches the plural
-          // <testsuites container (no word boundary between testsuite and
-          // the trailing s).
-          const testsuiteRe = /<testsuite\b([^>]*)>/g
-          const producedFiles = new Set()
-          let suiteMatch
-          while ((suiteMatch = testsuiteRe.exec(xml))) {
-            const attrs = parseAttrs(suiteMatch[1])
-            if (attrs.file) producedFiles.add(attrs.file)
-          }
-
-          const missingFiles = EXPECTED_SUITE_FILES.filter((f) => !producedFiles.has(f))
-
-          const testcaseRe = /<testcase\b([^>]*?)(\/>|>[\s\S]*?<\/testcase>)/g
-          const skipped = []
-          let caseMatch
-          while ((caseMatch = testcaseRe.exec(xml))) {
-            const [, attrStr, rest] = caseMatch
-            const attrs = parseAttrs(attrStr)
-            if (rest.includes('<skipped')) {
-              skipped.push({ classname: attrs.classname ?? '', name: attrs.name ?? '' })
-            }
-          }
-
-          const key = (s) => `${s.classname}::${s.name}`
-          const exemptKeys = new Set(EXEMPT_SKIPS.map(key))
-          const actualKeys = skipped.map(key)
-
-          const unexpected = actualKeys.filter((k) => !exemptKeys.has(k))
-          const missingExempt = [...exemptKeys].filter((k) => !actualKeys.includes(k))
-
-          let failed = false
-
-          if (missingFiles.length > 0) {
-            console.error('Expected integration test file(s) produced no JUnit suite (bun test never ran them):')
-            for (const f of missingFiles) console.error(`  - ${f}`)
-            failed = true
-          }
-
-          if (unexpected.length > 0) {
-            console.error('Unexpected skipped test(s) (not in the known-exempt set):')
-            for (const k of unexpected) console.error(`  - ${k}`)
-            failed = true
-          }
-
-          if (missingExempt.length > 0) {
-            console.error('Known-exempt skip(s) not found in this run (exempt set is stale):')
-            for (const k of missingExempt) console.error(`  - ${k}`)
-            failed = true
-          }
-
-          const log = readFileSync(logPath, 'utf8')
-          // Bun's default reporter prints one "<N> pass" summary line per
-          // run; take the last match rather than the first so a captured
-          // log containing more than one summary is scored on the final,
-          // authoritative count.
-          const passMatches = [...log.matchAll(/^\s*(\d+)\s+pass\s*$/gm)]
-          const lastPassMatch = passMatches.at(-1)
-          if (!lastPassMatch) {
-            console.error('Could not find a "<N> pass" summary line in the captured test output.')
-            failed = true
-          } else {
-            const passCount = Number(lastPassMatch[1])
-            console.log(`Observed pass count: ${passCount} (floor: ${PASS_FLOOR})`)
-            if (passCount < PASS_FLOOR) {
-              console.error(`Pass count ${passCount} is below the floor of ${PASS_FLOOR}.`)
-              failed = true
-            }
-          }
-
-          if (failed) process.exit(1)
-          console.log('host-contract skip/pass guard passed.')
-          EOF
-          bun host-contract-guard.mjs host-contract-junit.xml host-contract-log.txt
+        if: steps.gate.outputs.run == 'true' && (success() || failure())
+        run: bun scripts/host-contract-guard.ts host-contract-junit.xml host-contract-log.txt
 
       - name: Upload test log on failure
         if: failure() && steps.gate.outputs.run == 'true'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -265,23 +265,27 @@ jobs:
       # expected-file list, and the floor all live in scripts/host-contract-guard.ts,
       # next to the guard, so widening any of them is a reviewed change.
       #
-      # Gated on steps.suite.outcome specifically (not the job-wide success()
-      # / failure() status functions) so this step runs precisely when "Run
-      # host contract suite" itself produced a result -- whether that result
-      # was a pass or a fail, since diagnosis matters most on the fail path.
-      # If an earlier step (Install dependencies, Build) fails instead, "Run
-      # host contract suite" is skipped by its own `if:` and its outcome is
-      # 'skipped', so this step is skipped too rather than running against
-      # artifacts that were never produced. It also does not run on
-      # cancellation, since a cancelled suite step's outcome is neither
-      # 'success' nor 'failure'. It is also gated on steps.gate.outputs.run
-      # so it still does not run on a path-gated-out pull request. This step
-      # only reports additional diagnosis: it does not (and cannot) flip the
+      # `!cancelled()` is load-bearing, not decorative: an `if:` with no
+      # status check function gets an IMPLICIT `success()` ANDed in by
+      # GitHub Actions, which would make this step skip on exactly the
+      # failing suite run it exists to diagnose (success() is job-scoped and
+      # goes false the moment "Run host contract suite" fails). Any status
+      # check function in the expression overrides that implicit default;
+      # `!cancelled()` is the one that does so while staying true on both a
+      # passing AND a failing suite, and false only when the run itself was
+      # cancelled. The steps.suite.outcome check does the rest of the work:
+      # it requires "Run host contract suite" to have actually executed and
+      # concluded (excluding 'skipped', which is what its outcome is when an
+      # earlier step such as Install dependencies or Build fails first, and
+      # excluding 'cancelled', which is what its outcome is if it was
+      # cancelled mid-run). It is also gated on steps.gate.outputs.run so it
+      # still does not run on a path-gated-out pull request. This step only
+      # reports additional diagnosis: it does not (and cannot) flip the
       # suite step's own conclusion, so a red suite still fails the job
       # regardless of what this step finds.
       - name: Guard skipped tests and pass floor
         if: |
-          steps.gate.outputs.run == 'true' &&
+          steps.gate.outputs.run == 'true' && !cancelled() &&
           (steps.suite.outcome == 'success' || steps.suite.outcome == 'failure')
         run: bun scripts/host-contract-guard.ts host-contract-junit.xml host-contract-log.txt
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -246,6 +246,7 @@ jobs:
         run: bun run build
 
       - name: Run host contract suite
+        id: suite
         if: steps.gate.outputs.run == 'true'
         env:
           SYSTEMATIC_REQUIRE_OPENCODE: '1'
@@ -264,18 +265,24 @@ jobs:
       # expected-file list, and the floor all live in scripts/host-contract-guard.ts,
       # next to the guard, so widening any of them is a reviewed change.
       #
-      # `success() || failure()` (rather than the implicit success()) makes
-      # this step run even when "Run host contract suite" fails, since that
-      # is exactly when its diagnosis is most useful -- unlike `always()`,
-      # it deliberately excludes a cancelled job (GitHub Actions treats
-      # `cancelled()` as neither success nor failure), so this does not run
-      # on cancellation. It is also gated on steps.gate.outputs.run so it
-      # still does not run on a path-gated-out pull request. This step only
-      # reports additional diagnosis: it does not (and cannot) flip the
+      # Gated on steps.suite.outcome specifically (not the job-wide success()
+      # / failure() status functions) so this step runs precisely when "Run
+      # host contract suite" itself produced a result -- whether that result
+      # was a pass or a fail, since diagnosis matters most on the fail path.
+      # If an earlier step (Install dependencies, Build) fails instead, "Run
+      # host contract suite" is skipped by its own `if:` and its outcome is
+      # 'skipped', so this step is skipped too rather than running against
+      # artifacts that were never produced. It also does not run on
+      # cancellation, since a cancelled suite step's outcome is neither
+      # 'success' nor 'failure'. It is also gated on steps.gate.outputs.run
+      # so it still does not run on a path-gated-out pull request. This step
+      # only reports additional diagnosis: it does not (and cannot) flip the
       # suite step's own conclusion, so a red suite still fails the job
       # regardless of what this step finds.
       - name: Guard skipped tests and pass floor
-        if: steps.gate.outputs.run == 'true' && (success() || failure())
+        if: |
+          steps.gate.outputs.run == 'true' &&
+          (steps.suite.outcome == 'success' || steps.suite.outcome == 'failure')
         run: bun scripts/host-contract-guard.ts host-contract-junit.xml host-contract-log.txt
 
       - name: Upload test log on failure

--- a/docs/solutions/workflow-issues/host-contract-evidence-is-ci-owned-2026-09-04.md
+++ b/docs/solutions/workflow-issues/host-contract-evidence-is-ci-owned-2026-09-04.md
@@ -1,6 +1,6 @@
 ---
 title: "Host-contract evidence is CI-owned: nobody re-runs the suite by hand"
-module: ".github/workflows/main.yaml host-contract job + scripts/lib/opencode-pin.ts"
+module: ".github/workflows/main.yaml host-contract job + scripts/host-contract-guard.ts + scripts/lib/opencode-pin.ts"
 date: 2026-09-04
 problem_type: workflow_issue
 component: testing_framework
@@ -50,18 +50,16 @@ memoizes. Every fixture-consuming suite wraps it in a memoizing
 `isOpencodeAvailable()` (`tests/integration/fixtures/receipt-workflow-host.ts:199`).
 
 The evidence itself is the required `host-contract` job in
-`.github/workflows/main.yaml:162-407`. It sets
-`SYSTEMATIC_REQUIRE_OPENCODE=1` (`.github/workflows/main.yaml:244`) and runs
-`bun test tests/integration` with a JUnit reporter
-(`.github/workflows/main.yaml:247-249`). `host-contract` is a required entry
-in the `release` job's `needs` (`.github/workflows/main.yaml:475`), so a red
-`host-contract` job blocks release the same way a red `test` or `typecheck`
-job does. For pull requests the job is path-gated on `src/**`, `tests/**`,
-`scripts/**`, `evals/**`, `skills/**`, `agents/**`, `registry/**`,
-`package.json`, `bun.lock`, and the workflow file itself
-(`.github/workflows/main.yaml:182-192`); on push to `main` it always runs. A
-Renovate OpenCode-group bump touches `package.json`, so it always triggers the
-job.
+`.github/workflows/main.yaml`. Its "Run host contract suite" step sets
+`SYSTEMATIC_REQUIRE_OPENCODE=1` and runs `bun test tests/integration` with a
+JUnit reporter. `host-contract` is a required entry in the `release` job's
+`needs` key, so a red `host-contract` job blocks release the same way a red
+`test` or `typecheck` job does. For pull requests the job is path-gated on
+`src/**`, `tests/**`, `scripts/**`, `evals/**`, `skills/**`, `agents/**`,
+`registry/**`, `package.json`, `bun.lock`, and the workflow file itself, via
+the job's "Detect relevant path changes" step; on push to `main` it always
+runs. A Renovate OpenCode-group bump touches `package.json`, so it always
+triggers the job.
 
 ## Guidance
 
@@ -72,13 +70,13 @@ doc, and no background process to babysit — the job already did that, against
 the exact pin the PR proposes, on a clean checkout.
 
 **Green is evidence only when the suite actually ran.** The job has no
-top-level `if:` — gating happens per step, at
-`.github/workflows/main.yaml:198-216` — so on a PR that the path filter
-excludes (a docs-only change, for example) every gated step is skipped and
-the job still reports success. A green check on an unrelated PR is not host
-evidence; it is the job correctly declining to run. This never undermines a
-Renovate OpenCode bump specifically: the filter at
-`.github/workflows/main.yaml:182-192` includes `package.json`, which a pin
+top-level `if:` — gating happens per step, in the job's "Determine whether to
+run the host contract suite" step (`id: gate`) — so on a PR that the path
+filter excludes (a docs-only change, for example) every gated step is skipped
+and the job still reports success. A green check on an unrelated PR is not
+host evidence; it is the job correctly declining to run. This never
+undermines a Renovate OpenCode bump specifically: the path filter in the
+"Detect relevant path changes" step includes `package.json`, which a pin
 bump always touches (and `bun.lock`, which it touches in practice), so that
 PR's `host-contract` green always means the suite ran. The qualifier matters for
 any other PR whose green check might be mistaken for host coverage.
@@ -105,21 +103,24 @@ consequence differs by design:
 
 That module-scope throw covers a missing or mismatched host, but not a
 narrower failure: a single `test.skipIf(...)` inside an otherwise-loaded file
-skipping for an unrelated reason while the job still reports green. The guard
-step at `.github/workflows/main.yaml:259-397` closes that gap. It parses the
-JUnit output and fails the job (`failed = true`, then `process.exit(1)`) on
-any of five independent conditions:
+skipping for an unrelated reason while the job still reports green. The
+host-contract job's "Guard skipped tests and pass floor" step closes that
+gap by running `scripts/host-contract-guard.ts`, a standalone, unit-tested
+script (extracted from an inline heredoc in #949) — not YAML. It parses the
+JUnit output (`parseJUnitXml()`) and fails the job — `evaluate()` returns one
+or more violations, and the script's CLI wrapper exits non-zero — on any of
+five independent conditions:
 
 1. `missingFiles.length > 0` — a known integration test file (the eleven
-   listed in `EXPECTED_SUITE_FILES`, `.github/workflows/main.yaml:282-294`)
+   listed in `scripts/host-contract-guard.ts`'s `EXPECTED_SUITE_FILES`)
    produced no `<testsuite>` entry at all, meaning `bun test` never actually
    ran it.
 2. `unexpected.length > 0` — a skipped test case is outside the exempt set.
 3. `missingExempt.length > 0` — a known-exempt case did **not** skip. The
-   exempt set (`.github/workflows/main.yaml:269-274`, today exactly one
-   entry: the mixed-version test, which stays opt-in because running it
-   would put a fetch of a published `@fro.bot/systematic` release on the
-   path that gates publishing the next one) is bidirectional: it both
+   exempt set (`scripts/host-contract-guard.ts`'s `EXEMPT_SKIPS`, today
+   exactly one entry: the mixed-version test, which stays opt-in because
+   running it would put a fetch of a published `@fro.bot/systematic` release
+   on the path that gates publishing the next one) is bidirectional: it both
    permits that skip and asserts it happens. A future change that enables
    the mixed-version test without pruning the exempt set trips this branch
    instead of silently passing.
@@ -127,7 +128,7 @@ any of five independent conditions:
    captured log at all. This fails independently of the floor below; a log
    with zero parseable summary lines never reaches the floor comparison.
 5. `passCount < PASS_FLOOR` — the parsed pass count is below
-   `PASS_FLOOR = 120` (`.github/workflows/main.yaml:303`).
+   `scripts/host-contract-guard.ts`'s `PASS_FLOOR = 120`.
 
 The combination — module-scope throw for "no host at all", five-way JUnit
 guard for every shape of "host present but the run didn't actually cover
@@ -136,8 +137,9 @@ reachable state for this job. The bidirectional exempt check (condition 3)
 makes that stronger than a permission list would: it is not enough for an
 unexpected skip to be absent, the one expected skip must also be present, so
 an exempt-set entry that silently stops applying is itself a red job.
-Widening the exempt set or lowering the floor means editing the guard script
-inline in the workflow, which is a reviewed diff, not a silent loosening.
+Widening the exempt set or lowering the floor means editing
+`scripts/host-contract-guard.ts`, a reviewed diff with its own unit tests
+(`tests/unit/host-contract-guard.test.ts`), not a silent loosening.
 
 ## Why This Matters
 

--- a/scripts/host-contract-guard.ts
+++ b/scripts/host-contract-guard.ts
@@ -1,0 +1,274 @@
+/**
+ * Guards the `host-contract` CI job's skip/pass floor.
+ *
+ * The module-scope throw (`SYSTEMATIC_REQUIRE_OPENCODE=1`) already covers a
+ * missing or mismatched host. This guard covers what it cannot: a per-test
+ * gate such as `test.skipIf(!DIST_LOCAL_AVAILABLE)` skipping for an
+ * unexpected reason while the job stays green, or a whole-file collapse (a
+ * crash or an early exit) that still leaves the console summary and pass
+ * floor looking plausible. The exempt set, the expected-file list, and the
+ * floor all live here, next to the guard, so widening any of them is a
+ * reviewed change.
+ *
+ * Structured as pure functions (parse JUnit XML string, parse the log's pass
+ * count, evaluate the parsed shape into violations) plus a thin CLI wrapper
+ * that performs the file I/O and exits non-zero on any violation. Splitting
+ * it this way is what makes `evaluate()` unit-testable against synthetic
+ * fixtures without touching the filesystem.
+ */
+import { readFileSync } from 'node:fs'
+
+/**
+ * The only test allowed to skip today: the mixed-version test stays opt-in
+ * because enabling it would put a fetch of a published `@fro.bot/systematic`
+ * release on the path that gates publishing the next one.
+ *
+ * This set is bidirectional: {@link evaluate} fails both when an
+ * unlisted test skips (`unexpectedSkips`) and when a listed entry is
+ * *absent* from the run (`missingExemptSkips`). A rename of the exempt
+ * test's `classname`/`name` therefore fails loudly here (the old key stops
+ * matching and shows up as missing) rather than silently accepting a
+ * differently-named skip as a match.
+ */
+export const EXEMPT_SKIPS: readonly {
+  readonly classname: string
+  readonly name: string
+}[] = [
+  {
+    classname: 'opencode mixed-version integration',
+    name: 'pinned package plus local source keep systematic_skill deterministic and converge bootstrap',
+  },
+]
+
+/**
+ * Every test file under `tests/integration/`, enumerated by hand and
+ * verified against `ls tests/integration/*.test.ts`. A file producing zero
+ * JUnit `<testsuite>` entries means `bun test` never actually ran it — the
+ * exact failure mode a mass-skip or an early crash would produce while the
+ * console summary and pass floor alone could still look plausible.
+ */
+export const EXPECTED_SUITE_FILES: readonly string[] = [
+  'tests/integration/claude-code.test.ts',
+  'tests/integration/eval-artifact.test.ts',
+  'tests/integration/eval-fixture.test.ts',
+  'tests/integration/eval-runner.test.ts',
+  'tests/integration/opencode.test.ts',
+  'tests/integration/pi.test.ts',
+  'tests/integration/question-attestation-opencode.test.ts',
+  'tests/integration/receipt-workflow-dogfood.test.ts',
+  'tests/integration/receipt-workflow-guard-real-host.test.ts',
+  'tests/integration/receipt-workflow-recovery.test.ts',
+  'tests/integration/release-notes-ci.test.ts',
+]
+
+/**
+ * Measured: 138 test()/it() call sites exist across the eleven integration
+ * files as of this writing. The prior floor of 50 exactly equalled the
+ * host-free test count (claude-code 18 + eval-artifact 7 + eval-fixture 5 +
+ * release-notes-ci 20 = 50), so a total collapse of every host-touching
+ * file could still clear it silently. Raise this floor as the suite grows;
+ * do not lower it without a documented reason.
+ */
+export const PASS_FLOOR = 120
+
+export interface SkippedTestCase {
+  readonly classname: string
+  readonly name: string
+}
+
+export interface ParsedJUnit {
+  readonly producedFiles: ReadonlySet<string>
+  readonly skipped: readonly SkippedTestCase[]
+}
+
+function parseAttrs(str: string): Record<string, string> {
+  const attrs: Record<string, string> = {}
+  const attrRe = /(\w+)="([^"]*)"/g
+  for (const m of str.matchAll(attrRe)) {
+    const [, key, value] = m
+    if (key !== undefined && value !== undefined) attrs[key] = value
+  }
+  return attrs
+}
+
+/**
+ * Parses a Bun JUnit XML report into the produced testsuite `file=`
+ * attributes and the skipped testcases.
+ *
+ * Bun emits one outer `<testsuite>` per test file, plus one nested
+ * `<testsuite>` per describe block, all sharing that file's `file=`
+ * attribute — so collecting every testsuite's file attribute and taking the
+ * unique set recovers exactly the set of files bun actually loaded and ran,
+ * regardless of describe nesting. The `<testsuite\b` pattern never matches
+ * the closing `</testsuite>` tag (a `/` immediately follows `<`, not `t`),
+ * and never matches the plural `<testsuites` container (no word boundary
+ * between `testsuite` and the trailing `s`).
+ */
+export function parseJUnitXml(xml: string): ParsedJUnit {
+  const testsuiteRe = /<testsuite\b([^>]*)>/g
+  const producedFiles = new Set<string>()
+  for (const suiteMatch of xml.matchAll(testsuiteRe)) {
+    const attrsStr = suiteMatch[1]
+    if (attrsStr === undefined) continue
+    const attrs = parseAttrs(attrsStr)
+    if (attrs.file !== undefined) producedFiles.add(attrs.file)
+  }
+
+  const testcaseRe = /<testcase\b([^>]*?)(\/>|>[\s\S]*?<\/testcase>)/g
+  const skipped: SkippedTestCase[] = []
+  for (const caseMatch of xml.matchAll(testcaseRe)) {
+    const [, attrStr, rest] = caseMatch
+    if (attrStr === undefined || rest === undefined) continue
+    const attrs = parseAttrs(attrStr)
+    if (rest.includes('<skipped')) {
+      skipped.push({ classname: attrs.classname ?? '', name: attrs.name ?? '' })
+    }
+  }
+
+  return { producedFiles, skipped }
+}
+
+/**
+ * Extracts the pass count from a captured `bun test` log.
+ *
+ * Bun's default reporter prints one "<N> pass" summary line per run; take
+ * the last match rather than the first so a captured log containing more
+ * than one summary is scored on the final, authoritative count. Returns
+ * `undefined` when no such line is found (a malformed or truncated log).
+ */
+export function parseLogPassCount(log: string): number | undefined {
+  const passMatches = [...log.matchAll(/^\s*(\d+)\s+pass\s*$/gm)]
+  const lastPassMatch = passMatches.at(-1)
+  const rawCount = lastPassMatch?.[1]
+  if (rawCount === undefined) return undefined
+  return Number(rawCount)
+}
+
+export interface GuardViolation {
+  readonly kind:
+    | 'missing-files'
+    | 'unexpected-skips'
+    | 'missing-exempt-skips'
+    | 'no-pass-line'
+    | 'below-pass-floor'
+  readonly message: string
+  readonly details: readonly string[]
+}
+
+export interface EvaluateInput {
+  readonly parsed: ParsedJUnit
+  readonly passCount: number | undefined
+}
+
+function skipKey(s: SkippedTestCase): string {
+  return `${s.classname}::${s.name}`
+}
+
+/**
+ * Evaluates a parsed JUnit report plus a parsed pass count against the
+ * five failure conditions the guard enforces. Pure: takes already-parsed
+ * data in, returns violations out, performs no I/O.
+ */
+export function evaluate(input: EvaluateInput): GuardViolation[] {
+  const { parsed, passCount } = input
+  const violations: GuardViolation[] = []
+
+  const missingFiles = EXPECTED_SUITE_FILES.filter(
+    (f) => !parsed.producedFiles.has(f),
+  )
+  if (missingFiles.length > 0) {
+    violations.push({
+      kind: 'missing-files',
+      message:
+        'Expected integration test file(s) produced no JUnit suite (bun test never ran them):',
+      details: missingFiles,
+    })
+  }
+
+  const exemptKeys = new Set(EXEMPT_SKIPS.map(skipKey))
+  const actualKeys = parsed.skipped.map(skipKey)
+
+  const unexpected = actualKeys.filter((k) => !exemptKeys.has(k))
+  if (unexpected.length > 0) {
+    violations.push({
+      kind: 'unexpected-skips',
+      message: 'Unexpected skipped test(s) (not in the known-exempt set):',
+      details: unexpected,
+    })
+  }
+
+  const missingExempt = [...exemptKeys].filter((k) => !actualKeys.includes(k))
+  if (missingExempt.length > 0) {
+    violations.push({
+      kind: 'missing-exempt-skips',
+      message:
+        'Known-exempt skip(s) not found in this run (exempt set is stale):',
+      details: missingExempt,
+    })
+  }
+
+  if (passCount === undefined) {
+    violations.push({
+      kind: 'no-pass-line',
+      message:
+        'Could not find a "<N> pass" summary line in the captured test output.',
+      details: [],
+    })
+  } else if (passCount < PASS_FLOOR) {
+    violations.push({
+      kind: 'below-pass-floor',
+      message: `Pass count ${passCount} is below the floor of ${PASS_FLOOR}.`,
+      details: [],
+    })
+  }
+
+  return violations
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error
+}
+
+function readFileOrExit(path: string): string {
+  try {
+    return readFileSync(path, 'utf8')
+  } catch (err) {
+    const message = isNodeError(err) ? err.message : String(err)
+    console.error(`Failed to read ${path}: ${message}`)
+    process.exit(1)
+  }
+}
+
+function main(): void {
+  const [, , junitPath, logPath] = process.argv
+  if (junitPath === undefined || logPath === undefined) {
+    console.error(
+      'Usage: bun scripts/host-contract-guard.ts <junit-path> <log-path>',
+    )
+    process.exit(1)
+  }
+
+  const xml = readFileOrExit(junitPath)
+  const log = readFileOrExit(logPath)
+
+  const parsed = parseJUnitXml(xml)
+  const passCount = parseLogPassCount(log)
+
+  if (passCount !== undefined) {
+    console.log(`Observed pass count: ${passCount} (floor: ${PASS_FLOOR})`)
+  }
+
+  const violations = evaluate({ parsed, passCount })
+
+  for (const violation of violations) {
+    console.error(violation.message)
+    for (const detail of violation.details) console.error(`  - ${detail}`)
+  }
+
+  if (violations.length > 0) process.exit(1)
+  console.log('host-contract skip/pass guard passed.')
+}
+
+if (import.meta.main) {
+  main()
+}

--- a/scripts/host-contract-guard.ts
+++ b/scripts/host-contract-guard.ts
@@ -109,7 +109,18 @@ function decodeXmlEntities(str: string): string {
           const codePoint = entity.startsWith('#x')
             ? Number.parseInt(entity.slice(2), 16)
             : Number.parseInt(entity.slice(1), 10)
-          return Number.isNaN(codePoint)
+          // `String.fromCodePoint` throws a RangeError above 0x10FFFF (the
+          // highest valid Unicode code point) instead of returning a
+          // sentinel, so an out-of-range numeric reference -- malformed
+          // input, not something Bun's own reporter would ever emit -- is
+          // left as the literal source text rather than crashing this
+          // guard. Surrogate-range code points (0xD800-0xDFFF) are
+          // deliberately NOT excluded: `String.fromCodePoint` accepts them
+          // without throwing (producing a lone surrogate in the string,
+          // unlike the stricter validation some Unicode-aware APIs apply),
+          // so there is no crash to prevent, and no test name a real `bun
+          // test` JUnit run could plausibly produce would contain one.
+          return Number.isNaN(codePoint) || codePoint > 0x10ffff
             ? match
             : String.fromCodePoint(codePoint)
         }

--- a/scripts/host-contract-guard.ts
+++ b/scripts/host-contract-guard.ts
@@ -81,12 +81,51 @@ export interface ParsedJUnit {
   readonly skipped: readonly SkippedTestCase[]
 }
 
+/**
+ * Decodes the five XML predefined entities plus numeric character
+ * references. Bun's JUnit reporter XML-escapes attribute values, so a test
+ * name containing `<`, `&`, etc. (this repo has one: the "payload &lt;=
+ * 10000 chars" test in claude-code.test.ts, confirmed by generating a real
+ * JUnit report) round-trips through `&lt;` in the report. Decoding here
+ * keeps comparisons against literal `EXEMPT_SKIPS` strings correct and
+ * keeps violation messages readable instead of printing raw entities.
+ */
+function decodeXmlEntities(str: string): string {
+  return str.replaceAll(
+    /&(amp|lt|gt|quot|apos|#x[0-9a-fA-F]+|#\d+);/g,
+    (match, entity: string) => {
+      switch (entity) {
+        case 'amp':
+          return '&'
+        case 'lt':
+          return '<'
+        case 'gt':
+          return '>'
+        case 'quot':
+          return '"'
+        case 'apos':
+          return "'"
+        default: {
+          const codePoint = entity.startsWith('#x')
+            ? Number.parseInt(entity.slice(2), 16)
+            : Number.parseInt(entity.slice(1), 10)
+          return Number.isNaN(codePoint)
+            ? match
+            : String.fromCodePoint(codePoint)
+        }
+      }
+    },
+  )
+}
+
 function parseAttrs(str: string): Record<string, string> {
   const attrs: Record<string, string> = {}
   const attrRe = /(\w+)="([^"]*)"/g
   for (const m of str.matchAll(attrRe)) {
     const [, key, value] = m
-    if (key !== undefined && value !== undefined) attrs[key] = value
+    if (key !== undefined && value !== undefined) {
+      attrs[key] = decodeXmlEntities(value)
+    }
   }
   return attrs
 }
@@ -225,17 +264,39 @@ export function evaluate(input: EvaluateInput): GuardViolation[] {
   return violations
 }
 
-function isNodeError(err: unknown): err is NodeJS.ErrnoException {
-  return err instanceof Error
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
 }
 
-function readFileOrExit(path: string): string {
+export interface ArtifactRead {
+  /** File content, or `''` when the file could not be read. */
+  readonly content: string
+  /**
+   * Set when the file could not be read (missing, unreadable, etc). `''` is
+   * a legitimate empty-file content on success, so a separate field (rather
+   * than treating `''` as failure) is what makes an empty-but-present file
+   * distinguishable from a missing one.
+   */
+  readonly readError?: string
+}
+
+/**
+ * Reads an artifact file, converting any read failure into a `readError`
+ * instead of throwing or exiting. This is what lets a missing artifact be
+ * evaluated as the contract failure it is (via {@link evaluate}, which
+ * already treats empty JUnit/log content as `missing-files` /
+ * `missing-exempt-skips` / `no-pass-line`) rather than surfacing as an
+ * unrelated filesystem error -- the exact path the guard step's `failure()`
+ * gating newly reaches when the suite step dies before writing its output.
+ */
+export function readArtifact(path: string): ArtifactRead {
   try {
-    return readFileSync(path, 'utf8')
+    return { content: readFileSync(path, 'utf8') }
   } catch (err) {
-    const message = isNodeError(err) ? err.message : String(err)
-    console.error(`Failed to read ${path}: ${message}`)
-    process.exit(1)
+    return {
+      content: '',
+      readError: `Could not read ${path}: ${errorMessage(err)}`,
+    }
   }
 }
 
@@ -248,11 +309,24 @@ function main(): void {
     process.exit(1)
   }
 
-  const xml = readFileOrExit(junitPath)
-  const log = readFileOrExit(logPath)
+  const junit = readArtifact(junitPath)
+  const log = readArtifact(logPath)
 
-  const parsed = parseJUnitXml(xml)
-  const passCount = parseLogPassCount(log)
+  if (junit.readError !== undefined) {
+    console.error(junit.readError)
+    console.error(
+      'Treating this as the suite producing no test evidence, not as a guard pass.',
+    )
+  }
+  if (log.readError !== undefined) {
+    console.error(log.readError)
+    console.error(
+      'Treating this as the suite producing no pass-count evidence, not as a guard pass.',
+    )
+  }
+
+  const parsed = parseJUnitXml(junit.content)
+  const passCount = parseLogPassCount(log.content)
 
   if (passCount !== undefined) {
     console.log(`Observed pass count: ${passCount} (floor: ${PASS_FLOOR})`)
@@ -265,7 +339,9 @@ function main(): void {
     for (const detail of violation.details) console.error(`  - ${detail}`)
   }
 
-  if (violations.length > 0) process.exit(1)
+  const hadReadError =
+    junit.readError !== undefined || log.readError !== undefined
+  if (hadReadError || violations.length > 0) process.exit(1)
   console.log('host-contract skip/pass guard passed.')
 }
 

--- a/tests/unit/host-contract-guard.test.ts
+++ b/tests/unit/host-contract-guard.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  EXEMPT_SKIPS,
+  EXPECTED_SUITE_FILES,
+  evaluate,
+  type GuardViolation,
+  PASS_FLOOR,
+  parseJUnitXml,
+  parseLogPassCount,
+} from '../../scripts/host-contract-guard.ts'
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+/** The exempt skip's key fields, reused so fixtures stay in sync with the
+ * real exempt set instead of hardcoding a copy that could drift. */
+const EXEMPT = EXEMPT_SKIPS[0]
+if (EXEMPT === undefined) throw new Error('EXEMPT_SKIPS must be non-empty')
+
+function testcase(
+  classname: string,
+  name: string,
+  opts: { skipped?: boolean } = {},
+): string {
+  if (opts.skipped) {
+    return `<testcase classname="${classname}" name="${name}" time="0.01"><skipped/></testcase>`
+  }
+  return `<testcase classname="${classname}" name="${name}" time="0.01"/>`
+}
+
+function testsuite(file: string, cases: string): string {
+  return `<testsuite name="${file}" file="${file}" tests="1" failures="0" skipped="0">${cases}</testsuite>`
+}
+
+/** Builds a complete JUnit XML document with one <testsuite> per expected
+ * file, each containing a single non-skipped passing testcase, plus the
+ * exempt skip in its own suite. This is the "everything present and
+ * healthy" baseline every mutated fixture starts from. */
+function buildHealthyJUnit(): string {
+  const suites = EXPECTED_SUITE_FILES.map((file) =>
+    testsuite(file, testcase(`${file} suite`, 'passes')),
+  )
+  suites.push(
+    testsuite(
+      'tests/integration/opencode.test.ts',
+      testcase(EXEMPT.classname, EXEMPT.name, { skipped: true }),
+    ),
+  )
+  return `<?xml version="1.0"?><testsuites>${suites.join('')}</testsuites>`
+}
+
+function buildLog(passCount: number): string {
+  return ['bun test v1.2.3', '', `${passCount} pass`, '0 fail', ''].join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// parseJUnitXml
+// ---------------------------------------------------------------------------
+
+describe('parseJUnitXml', () => {
+  test('collects unique produced files across nested describe testsuites', () => {
+    const xml =
+      '<testsuites>' +
+      '<testsuite name="outer" file="tests/integration/opencode.test.ts">' +
+      '<testsuite name="inner describe" file="tests/integration/opencode.test.ts">' +
+      testcase('c', 'n') +
+      '</testsuite>' +
+      '</testsuite>' +
+      '</testsuites>'
+    const parsed = parseJUnitXml(xml)
+    expect([...parsed.producedFiles]).toEqual([
+      'tests/integration/opencode.test.ts',
+    ])
+  })
+
+  test('does not match the closing </testsuite> tag or the plural <testsuites>', () => {
+    const xml = buildHealthyJUnit()
+    const parsed = parseJUnitXml(xml)
+    expect(parsed.producedFiles.size).toBe(EXPECTED_SUITE_FILES.length)
+  })
+
+  test('collects skipped testcases with classname and name', () => {
+    const xml = buildHealthyJUnit()
+    const parsed = parseJUnitXml(xml)
+    expect(parsed.skipped).toEqual([
+      { classname: EXEMPT.classname, name: EXEMPT.name },
+    ])
+  })
+
+  test('ignores non-skipped testcases', () => {
+    const xml = testsuite('f', testcase('c', 'n'))
+    const parsed = parseJUnitXml(xml)
+    expect(parsed.skipped).toEqual([])
+  })
+
+  test('malformed input: empty XML produces no suites and no skips', () => {
+    const parsed = parseJUnitXml('')
+    expect(parsed.producedFiles.size).toBe(0)
+    expect(parsed.skipped).toEqual([])
+  })
+
+  test('malformed input: XML with no testsuite elements produces no suites', () => {
+    const parsed = parseJUnitXml('<testsuites></testsuites>')
+    expect(parsed.producedFiles.size).toBe(0)
+    expect(parsed.skipped).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseLogPassCount
+// ---------------------------------------------------------------------------
+
+describe('parseLogPassCount', () => {
+  test('parses a single pass summary line', () => {
+    expect(parseLogPassCount(buildLog(138))).toBe(138)
+  })
+
+  test('takes the last of multiple pass summary lines', () => {
+    const log = `${buildLog(50)}\n${buildLog(138)}`
+    expect(parseLogPassCount(log)).toBe(138)
+  })
+
+  test('malformed input: empty log returns undefined', () => {
+    expect(parseLogPassCount('')).toBeUndefined()
+  })
+
+  test('malformed input: truncated log with no pass line returns undefined', () => {
+    expect(
+      parseLogPassCount('bun test v1.2.3\n\nrunning tests...'),
+    ).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// evaluate — the five failure conditions, each proven bidirectionally
+// ---------------------------------------------------------------------------
+
+describe('evaluate', () => {
+  test('healthy fixture at the pass floor produces no violations', () => {
+    const parsed = parseJUnitXml(buildHealthyJUnit())
+    const violations = evaluate({ parsed, passCount: PASS_FLOOR })
+    expect(violations).toEqual([])
+  })
+
+  test('healthy fixture above the pass floor produces no violations', () => {
+    const parsed = parseJUnitXml(buildHealthyJUnit())
+    const violations = evaluate({ parsed, passCount: PASS_FLOOR + 18 })
+    expect(violations).toEqual([])
+  })
+
+  describe('condition 1: missingFiles', () => {
+    test('trips when an expected suite file produced no testsuite entry', () => {
+      const firstFile = EXPECTED_SUITE_FILES[0]
+      if (firstFile === undefined) throw new Error('expected at least one file')
+      const remaining = EXPECTED_SUITE_FILES.filter((f) => f !== firstFile)
+      const suites = remaining.map((file) =>
+        testsuite(file, testcase(`${file} suite`, 'passes')),
+      )
+      suites.push(
+        testsuite(
+          'tests/integration/opencode.test.ts',
+          testcase(EXEMPT.classname, EXEMPT.name, { skipped: true }),
+        ),
+      )
+      const xml = `<testsuites>${suites.join('')}</testsuites>`
+      const parsed = parseJUnitXml(xml)
+      const violations = evaluate({ parsed, passCount: PASS_FLOOR })
+      const missing = violations.find((v) => v.kind === 'missing-files')
+      expect(missing).toBeDefined()
+      expect(missing?.details).toEqual([firstFile])
+    })
+
+    test('near-miss: all expected files present does not trip', () => {
+      const parsed = parseJUnitXml(buildHealthyJUnit())
+      const violations = evaluate({ parsed, passCount: PASS_FLOOR })
+      expect(violations.some((v) => v.kind === 'missing-files')).toBe(false)
+    })
+  })
+
+  describe('condition 2: unexpected skips', () => {
+    test('trips when a skip is not in the exempt set', () => {
+      const xml = buildHealthyJUnit().replace(
+        '</testsuites>',
+        `${testsuite('tests/integration/pi.test.ts', testcase('pi suite', 'some other test', { skipped: true }))}</testsuites>`,
+      )
+      const parsed = parseJUnitXml(xml)
+      const violations = evaluate({ parsed, passCount: PASS_FLOOR })
+      const unexpected = violations.find((v) => v.kind === 'unexpected-skips')
+      expect(unexpected).toBeDefined()
+      expect(unexpected?.details).toEqual(['pi suite::some other test'])
+    })
+
+    test('near-miss: only the exempt skip present does not trip', () => {
+      const parsed = parseJUnitXml(buildHealthyJUnit())
+      const violations = evaluate({ parsed, passCount: PASS_FLOOR })
+      expect(violations.some((v) => v.kind === 'unexpected-skips')).toBe(false)
+    })
+  })
+
+  describe('condition 3: missing exempt skips (bidirectional)', () => {
+    test('trips when the known-exempt skip is absent from this run', () => {
+      const suites = EXPECTED_SUITE_FILES.map((file) =>
+        testsuite(file, testcase(`${file} suite`, 'passes')),
+      )
+      const xml = `<testsuites>${suites.join('')}</testsuites>`
+      const parsed = parseJUnitXml(xml)
+      const violations = evaluate({ parsed, passCount: PASS_FLOOR })
+      const missingExempt = violations.find(
+        (v) => v.kind === 'missing-exempt-skips',
+      )
+      expect(missingExempt).toBeDefined()
+      expect(missingExempt?.details).toEqual([
+        `${EXEMPT.classname}::${EXEMPT.name}`,
+      ])
+    })
+
+    test('near-miss: a differently-named skip does not satisfy the exempt entry (rename fails loudly)', () => {
+      const suites = EXPECTED_SUITE_FILES.map((file) =>
+        testsuite(file, testcase(`${file} suite`, 'passes')),
+      )
+      suites.push(
+        testsuite(
+          'tests/integration/opencode.test.ts',
+          testcase(EXEMPT.classname, 'a renamed version of the exempt test', {
+            skipped: true,
+          }),
+        ),
+      )
+      const xml = `<testsuites>${suites.join('')}</testsuites>`
+      const parsed = parseJUnitXml(xml)
+      const violations = evaluate({ parsed, passCount: PASS_FLOOR })
+      // The rename shows up as BOTH an unexpected skip (the new key isn't
+      // exempt) and a missing exempt skip (the old key never matched) --
+      // proving the exempt set has no rename-tolerance gap, per issue item 4.
+      expect(violations.some((v) => v.kind === 'unexpected-skips')).toBe(true)
+      expect(violations.some((v) => v.kind === 'missing-exempt-skips')).toBe(
+        true,
+      )
+    })
+
+    test('near-miss: exempt skip present does not trip', () => {
+      const parsed = parseJUnitXml(buildHealthyJUnit())
+      const violations = evaluate({ parsed, passCount: PASS_FLOOR })
+      expect(violations.some((v) => v.kind === 'missing-exempt-skips')).toBe(
+        false,
+      )
+    })
+  })
+
+  describe('condition 4: no pass line parseable', () => {
+    test('trips when passCount is undefined', () => {
+      const parsed = parseJUnitXml(buildHealthyJUnit())
+      const violations = evaluate({ parsed, passCount: undefined })
+      expect(violations.some((v) => v.kind === 'no-pass-line')).toBe(true)
+    })
+
+    test('near-miss: a parseable pass count at the floor does not trip', () => {
+      const parsed = parseJUnitXml(buildHealthyJUnit())
+      const violations = evaluate({ parsed, passCount: PASS_FLOOR })
+      expect(violations.some((v) => v.kind === 'no-pass-line')).toBe(false)
+    })
+  })
+
+  describe('condition 5: below pass floor', () => {
+    test('trips when passCount is below PASS_FLOOR', () => {
+      const parsed = parseJUnitXml(buildHealthyJUnit())
+      const violations = evaluate({ parsed, passCount: PASS_FLOOR - 1 })
+      const belowFloor = violations.find((v) => v.kind === 'below-pass-floor')
+      expect(belowFloor).toBeDefined()
+      expect(belowFloor?.message).toContain(String(PASS_FLOOR - 1))
+    })
+
+    test('near-miss: exactly at the floor does not trip', () => {
+      const parsed = parseJUnitXml(buildHealthyJUnit())
+      const violations = evaluate({ parsed, passCount: PASS_FLOOR })
+      expect(violations.some((v) => v.kind === 'below-pass-floor')).toBe(false)
+    })
+  })
+
+  test('multiple simultaneous violations are all reported', () => {
+    const parsed = parseJUnitXml('<testsuites></testsuites>')
+    const violations = evaluate({ parsed, passCount: 1 })
+    const kinds = violations.map((v) => v.kind).sort()
+    const expectedKinds: GuardViolation['kind'][] = [
+      'missing-files',
+      'missing-exempt-skips',
+      'below-pass-floor',
+    ]
+    expect(kinds).toEqual(expectedKinds.sort())
+  })
+})

--- a/tests/unit/host-contract-guard.test.ts
+++ b/tests/unit/host-contract-guard.test.ts
@@ -36,6 +36,41 @@ function makeTempDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'host-contract-guard-'))
 }
 
+const INTEGRATION_DIR = path.join(REPO_ROOT, 'tests/integration')
+
+/**
+ * Every `*.test.ts` file directly under `tests/integration/`. Deliberately
+ * non-recursive: `tests/integration/` is flat (verified -- its only
+ * subdirectory is `fixtures/`, which holds shared test scaffolding, not
+ * suite files, and a non-recursive `.test.ts` filter already excludes it
+ * since `fixtures` itself doesn't end in `.test.ts`).
+ */
+function listIntegrationSuiteFiles(): string[] {
+  return fs
+    .readdirSync(INTEGRATION_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.test.ts'))
+    .map((entry) => `tests/integration/${entry.name}`)
+    .sort()
+}
+
+// ---------------------------------------------------------------------------
+// EXPECTED_SUITE_FILES drift against the real directory
+// ---------------------------------------------------------------------------
+
+describe('EXPECTED_SUITE_FILES', () => {
+  test('matches the real contents of tests/integration/ (a new or removed suite file must update this list)', () => {
+    // EXPECTED_SUITE_FILES is deliberately hardcoded (see the module-level
+    // doc comment on it) rather than derived at guard runtime, so this
+    // test is what keeps it honest: without it, a newly added integration
+    // test file would silently escape condition 1 ("an expected suite file
+    // produced no JUnit entry") -- the guard would stay green while no
+    // longer requiring that file to have run at all, which is exactly the
+    // class of drift the guard exists to catch.
+    const actual = listIntegrationSuiteFiles()
+    expect([...EXPECTED_SUITE_FILES].sort()).toEqual(actual)
+  })
+})
+
 // ---------------------------------------------------------------------------
 // Fixture builders
 // ---------------------------------------------------------------------------

--- a/tests/unit/host-contract-guard.test.ts
+++ b/tests/unit/host-contract-guard.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import {
   EXEMPT_SKIPS,
   EXPECTED_SUITE_FILES,
@@ -7,7 +10,31 @@ import {
   PASS_FLOOR,
   parseJUnitXml,
   parseLogPassCount,
+  readArtifact,
 } from '../../scripts/host-contract-guard.ts'
+
+const REPO_ROOT = path.resolve(import.meta.dir, '../..')
+const GUARD_SCRIPT = path.join(REPO_ROOT, 'scripts/host-contract-guard.ts')
+
+function runGuard(
+  junitPath: string,
+  logPath: string,
+): { exitCode: number; stdout: string; stderr: string } {
+  const result = Bun.spawnSync(['bun', GUARD_SCRIPT, junitPath, logPath], {
+    cwd: REPO_ROOT,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  return {
+    exitCode: result.exitCode,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  }
+}
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'host-contract-guard-'))
+}
 
 // ---------------------------------------------------------------------------
 // Fixture builders
@@ -288,5 +315,210 @@ describe('evaluate', () => {
       'below-pass-floor',
     ]
     expect(kinds).toEqual(expectedKinds.sort())
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseJUnitXml — XML entity decoding
+// ---------------------------------------------------------------------------
+
+describe('parseJUnitXml entity decoding', () => {
+  test('decodes &lt; in a testcase name (the real "payload &lt;= 10000 chars" test in claude-code.test.ts produces exactly this)', () => {
+    const xml = testsuite(
+      'tests/integration/claude-code.test.ts',
+      testcase('claude-code suite', 'payload &lt;= 10000 chars', {
+        skipped: true,
+      }),
+    )
+    const parsed = parseJUnitXml(xml)
+    expect(parsed.skipped).toEqual([
+      { classname: 'claude-code suite', name: 'payload <= 10000 chars' },
+    ])
+  })
+
+  test('decodes &amp; &gt; &quot; &apos; and a numeric character reference', () => {
+    const xml = testsuite(
+      'f',
+      testcase(
+        'A &amp; B &gt; C &quot;quoted&quot; &apos;single&apos; &#65;',
+        'n',
+        { skipped: true },
+      ),
+    )
+    const parsed = parseJUnitXml(xml)
+    expect(parsed.skipped).toEqual([
+      { classname: `A & B > C "quoted" 'single' A`, name: 'n' },
+    ])
+  })
+
+  test('an entity-mismatched skip still trips both unexpected-skips and missing-exempt-skips (fails loudly, not silently)', () => {
+    // If EXEMPT_SKIPS were compared against raw, un-decoded XML text, a
+    // real skip whose name round-trips through entity-escaping would
+    // silently fail to match a correctly-written literal exempt entry.
+    // Decoding closes that gap; this proves the failure mode it prevents
+    // still fails loudly rather than passing by accident.
+    const xml = testsuite(
+      'tests/integration/opencode.test.ts',
+      testcase(EXEMPT.classname, `${EXEMPT.name} &amp; extra`, {
+        skipped: true,
+      }),
+    )
+    const parsed = parseJUnitXml(xml)
+    const violations = evaluate({ parsed, passCount: PASS_FLOOR })
+    expect(violations.some((v) => v.kind === 'unexpected-skips')).toBe(true)
+    expect(violations.some((v) => v.kind === 'missing-exempt-skips')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// readArtifact
+// ---------------------------------------------------------------------------
+
+describe('readArtifact', () => {
+  test('returns content with no readError for an existing file', () => {
+    const dir = makeTempDir()
+    const file = path.join(dir, 'present.txt')
+    fs.writeFileSync(file, 'hello', 'utf8')
+    try {
+      const result = readArtifact(file)
+      expect(result.content).toBe('hello')
+      expect(result.readError).toBeUndefined()
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns empty content and a readError naming the path for a missing file', () => {
+    const dir = makeTempDir()
+    const file = path.join(dir, 'missing.txt')
+    try {
+      const result = readArtifact(file)
+      expect(result.content).toBe('')
+      expect(result.readError).toContain(file)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('an existing but genuinely empty file has empty content and no readError', () => {
+    const dir = makeTempDir()
+    const file = path.join(dir, 'empty.txt')
+    fs.writeFileSync(file, '', 'utf8')
+    try {
+      const result = readArtifact(file)
+      expect(result.content).toBe('')
+      expect(result.readError).toBeUndefined()
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CLI wrapper (subprocess) — argv arity, exit codes, and the missing-artifact
+// path the "Guard skipped tests and pass floor" step now reaches whenever it
+// runs against a suite step that failed before producing output.
+// ---------------------------------------------------------------------------
+
+describe('CLI wrapper', () => {
+  test('exits 0 and prints the pass line for a healthy fixture pair', () => {
+    const dir = makeTempDir()
+    const junitPath = path.join(dir, 'junit.xml')
+    const logPath = path.join(dir, 'log.txt')
+    fs.writeFileSync(junitPath, buildHealthyJUnit(), 'utf8')
+    fs.writeFileSync(logPath, buildLog(PASS_FLOOR), 'utf8')
+    try {
+      const result = runGuard(junitPath, logPath)
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain(`Observed pass count: ${PASS_FLOOR}`)
+      expect(result.stdout).toContain('host-contract skip/pass guard passed.')
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('a missing JUnit path reports a contract failure, not a raw ENOENT crash, and exits 1', () => {
+    const dir = makeTempDir()
+    const junitPath = path.join(dir, 'does-not-exist.xml')
+    const logPath = path.join(dir, 'log.txt')
+    fs.writeFileSync(logPath, buildLog(PASS_FLOOR), 'utf8')
+    try {
+      const result = runGuard(junitPath, logPath)
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain(`Could not read ${junitPath}`)
+      expect(result.stderr).toContain(
+        'Treating this as the suite producing no test evidence, not as a guard pass.',
+      )
+      // The missing artifact still routes through the same evaluate() logic
+      // as any other empty JUnit content, so the reader also sees which
+      // specific expected files were never produced -- a diagnosis, not
+      // just an I/O complaint.
+      expect(result.stderr).toContain(
+        'Expected integration test file(s) produced no JUnit suite',
+      )
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('a missing log path reports a contract failure and exits 1', () => {
+    const dir = makeTempDir()
+    const junitPath = path.join(dir, 'junit.xml')
+    const logPath = path.join(dir, 'does-not-exist.txt')
+    fs.writeFileSync(junitPath, buildHealthyJUnit(), 'utf8')
+    try {
+      const result = runGuard(junitPath, logPath)
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain(`Could not read ${logPath}`)
+      expect(result.stderr).toContain(
+        'Treating this as the suite producing no pass-count evidence, not as a guard pass.',
+      )
+      expect(result.stderr).toContain(
+        'Could not find a "<N> pass" summary line',
+      )
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('both artifacts missing reports both contract failures and exits 1', () => {
+    const dir = makeTempDir()
+    const junitPath = path.join(dir, 'no-junit.xml')
+    const logPath = path.join(dir, 'no-log.txt')
+    const result = runGuard(junitPath, logPath)
+    fs.rmSync(dir, { recursive: true, force: true })
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain(`Could not read ${junitPath}`)
+    expect(result.stderr).toContain(`Could not read ${logPath}`)
+  })
+
+  test('missing CLI arguments print usage and exit 1', () => {
+    const result = Bun.spawnSync(['bun', GUARD_SCRIPT], {
+      cwd: REPO_ROOT,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr.toString()).toContain(
+      'Usage: bun scripts/host-contract-guard.ts <junit-path> <log-path>',
+    )
+  })
+
+  test('a fixture pair that trips a normal violation (below floor) exits 1 without a readError message', () => {
+    const dir = makeTempDir()
+    const junitPath = path.join(dir, 'junit.xml')
+    const logPath = path.join(dir, 'log.txt')
+    fs.writeFileSync(junitPath, buildHealthyJUnit(), 'utf8')
+    fs.writeFileSync(logPath, buildLog(PASS_FLOOR - 1), 'utf8')
+    try {
+      const result = runGuard(junitPath, logPath)
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain(
+        `Pass count ${PASS_FLOOR - 1} is below the floor`,
+      )
+      expect(result.stderr).not.toContain('Could not read')
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/tests/unit/host-contract-guard.test.ts
+++ b/tests/unit/host-contract-guard.test.ts
@@ -368,6 +368,68 @@ describe('parseJUnitXml entity decoding', () => {
     expect(violations.some((v) => v.kind === 'unexpected-skips')).toBe(true)
     expect(violations.some((v) => v.kind === 'missing-exempt-skips')).toBe(true)
   })
+
+  describe('out-of-range numeric character references (must not crash the guard)', () => {
+    // `String.fromCodePoint` throws a RangeError above 0x10FFFF (the
+    // highest valid Unicode code point) rather than returning a sentinel.
+    // These go through the real exported `parseJUnitXml` entry point, not
+    // a copy of the private `decodeXmlEntities`, so a regression that
+    // reintroduces the crash is caught exactly where a real JUnit report
+    // would trigger it.
+    test('an out-of-range hex reference (&#x110000;) is left as literal text, not thrown', () => {
+      const xml = testsuite(
+        'f',
+        testcase('c', 'broken &#x110000; reference', { skipped: true }),
+      )
+      expect(() => parseJUnitXml(xml)).not.toThrow()
+      const parsed = parseJUnitXml(xml)
+      expect(parsed.skipped).toEqual([
+        { classname: 'c', name: 'broken &#x110000; reference' },
+      ])
+    })
+
+    test('an out-of-range decimal reference (&#9999999999;) is left as literal text, not thrown', () => {
+      const xml = testsuite(
+        'f',
+        testcase('c', 'broken &#9999999999; reference', { skipped: true }),
+      )
+      expect(() => parseJUnitXml(xml)).not.toThrow()
+      const parsed = parseJUnitXml(xml)
+      expect(parsed.skipped).toEqual([
+        { classname: 'c', name: 'broken &#9999999999; reference' },
+      ])
+    })
+
+    test('a non-numeric, non-predefined reference is left as literal text, not thrown', () => {
+      // &nbsp; is a valid HTML entity but not one of the five XML
+      // predefined entities and not numeric, so the regex in
+      // decodeXmlEntities never matches it at all -- included as a
+      // baseline "not decoded, definitely not thrown" case alongside the
+      // numeric out-of-range cases above.
+      const xml = testsuite(
+        'f',
+        testcase('c', 'broken &nbsp; reference', { skipped: true }),
+      )
+      expect(() => parseJUnitXml(xml)).not.toThrow()
+      const parsed = parseJUnitXml(xml)
+      expect(parsed.skipped).toEqual([
+        { classname: 'c', name: 'broken &nbsp; reference' },
+      ])
+    })
+
+    test('valid references still decode correctly alongside the range check', () => {
+      const xml = testsuite(
+        'f',
+        testcase('c', 'valid &lt; and &#60; and &#x3C; all decode', {
+          skipped: true,
+        }),
+      )
+      const parsed = parseJUnitXml(xml)
+      expect(parsed.skipped).toEqual([
+        { classname: 'c', name: 'valid < and < and < all decode' },
+      ])
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/host-contract-workflow.test.ts
+++ b/tests/unit/host-contract-workflow.test.ts
@@ -46,6 +46,62 @@ function findStep(steps: readonly unknown[], name: string): RecordValue {
   return step
 }
 
+function normalizeCondition(condition: string): string {
+  return condition.replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * The GitHub Actions status check functions. Per GitHub's own docs: "if
+ * conditional [that doesn't contain] a status check function ... will be
+ * substituted with `success()`", i.e. an `if:` with none of these applies
+ * an IMPLICIT `success()` -- which is job-scoped and false once an earlier
+ * step in the job fails, so a condition relying only on
+ * `steps.<id>.outcome` comparisons (no status check function) would still
+ * get skipped on exactly the failing run it was written to diagnose. This
+ * is the defect that shipped twice in a row on this guard step (first a
+ * job-scoped `failure()`, then no status check function at all), which is
+ * why it is pinned here as its own mechanical check rather than trusted to
+ * manual review.
+ */
+const STATUS_CHECK_FUNCTIONS = [
+  'always()',
+  'success()',
+  'failure()',
+  'cancelled()',
+]
+
+interface GuardConditionAnalysis {
+  /** Contains at least one of the four status check functions, in any
+   * form (bare or negated) -- this is what overrides GitHub's implicit
+   * `success()` default. */
+  readonly hasStatusCheckFunction: boolean
+  /** References the given step id's `.outcome`, which is what actually
+   * excludes "an earlier step failed, so this step never ran"
+   * (`outcome == 'skipped'`) from the cases where the guard runs. */
+  readonly referencesStepOutcome: boolean
+  /** Still requires the path-gate output, so a path-gated-out pull
+   * request continues to skip this step. */
+  readonly requiresPathGate: boolean
+  /** Uses a bare (non-negated) `always()`, which would also run during
+   * job cancellation -- broader than intended. */
+  readonly usesBareAlways: boolean
+}
+
+function analyzeGuardCondition(
+  condition: string,
+  suiteStepId: string,
+): GuardConditionAnalysis {
+  const normalized = normalizeCondition(condition)
+  return {
+    hasStatusCheckFunction: STATUS_CHECK_FUNCTIONS.some((fn) =>
+      normalized.includes(fn),
+    ),
+    referencesStepOutcome: normalized.includes(`steps.${suiteStepId}.outcome`),
+    requiresPathGate: normalized.includes("steps.gate.outputs.run == 'true'"),
+    usesBareAlways: /(?<!!)\balways\(\)/.test(normalized),
+  }
+}
+
 describe('host-contract workflow structural invariants', () => {
   test('the host-contract job has no job-level `if:`', () => {
     const workflow = readWorkflow()
@@ -90,45 +146,105 @@ describe('host-contract workflow structural invariants', () => {
     expect(suiteStep.id).toBe('suite')
   })
 
-  test('the "Guard skipped tests and pass floor" step runs on both suite outcomes, gated on the suite step specifically', () => {
+  test('the "Guard skipped tests and pass floor" step condition is exactly the intended expression', () => {
     const workflow = readWorkflow()
     const jobs = asRecord(workflow.jobs, 'jobs')
     const hostContract = asRecord(jobs['host-contract'], 'host-contract job')
     const steps = asArray(hostContract.steps, 'host-contract steps')
     const guardStep = findStep(steps, 'Guard skipped tests and pass floor')
-    const condition = String(guardStep.if ?? '')
-      .replace(/\s+/g, ' ')
-      .trim()
+    const condition = normalizeCondition(String(guardStep.if ?? ''))
 
-    // Asserts the exact expression rather than substring-checking for
-    // 'failure()' alone: a lone substring check also passes for the
-    // opposite-meaning `!failure()`, which would silently reintroduce the
-    // bug this condition exists to fix (the guard step skipped exactly
-    // when the suite step fails). Also asserts the condition is scoped to
-    // steps.suite specifically (not the job-wide success()/failure()
-    // status functions), so an unrelated earlier-step failure (Install
-    // dependencies, Build) -- which leaves the suite step itself
-    // 'skipped' -- also skips this step, instead of running it against
-    // artifacts the suite step never produced.
+    // Pinned to the exact expression, not a substring, so no individual
+    // clause can quietly regress (e.g. `!failure()` instead of `failure()`,
+    // or dropping `!cancelled()` and losing the status-check-function
+    // override -- both shipped as real regressions on this same step in
+    // prior rounds). `!cancelled()` is what overrides GitHub's implicit
+    // `success()` default (see analyzeGuardCondition's doc comment) while
+    // staying true on both a passing and a failing suite; the
+    // steps.suite.outcome checks do the rest, excluding both 'skipped'
+    // (an earlier step failed first) and 'cancelled' (the suite step
+    // itself was interrupted).
     expect(condition).toBe(
-      "steps.gate.outputs.run == 'true' && (steps.suite.outcome == 'success' || steps.suite.outcome == 'failure')",
+      "steps.gate.outputs.run == 'true' && !cancelled() && (steps.suite.outcome == 'success' || steps.suite.outcome == 'failure')",
     )
   })
 
-  test('the "Guard skipped tests and pass floor" step does not run on cancellation', () => {
-    const workflow = readWorkflow()
-    const jobs = asRecord(workflow.jobs, 'jobs')
-    const hostContract = asRecord(jobs['host-contract'], 'host-contract job')
-    const steps = asArray(hostContract.steps, 'host-contract steps')
-    const guardStep = findStep(steps, 'Guard skipped tests and pass floor')
-    const condition = String(guardStep.if ?? '')
+  describe('guard condition properties (mechanically pinned, proven bidirectionally)', () => {
+    function realCondition(): string {
+      const workflow = readWorkflow()
+      const jobs = asRecord(workflow.jobs, 'jobs')
+      const hostContract = asRecord(jobs['host-contract'], 'host-contract job')
+      const steps = asArray(hostContract.steps, 'host-contract steps')
+      const guardStep = findStep(steps, 'Guard skipped tests and pass floor')
+      return normalizeCondition(String(guardStep.if ?? ''))
+    }
 
-    // `always()` would also run during a cancellation. A cancelled suite
-    // step's outcome is neither 'success' nor 'failure' either, so the
-    // steps.suite.outcome-scoped condition asserted above already excludes
-    // cancellation -- this asserts `always()` specifically isn't used, since
-    // that would be a strictly broader (and wrong) condition.
-    expect(condition).not.toContain('always()')
+    test('(a) the real condition contains a status check function', () => {
+      expect(
+        analyzeGuardCondition(realCondition(), 'suite').hasStatusCheckFunction,
+      ).toBe(true)
+    })
+
+    test('(a) bidirectional: a condition with no status check function fails this property (the exact bug that shipped)', () => {
+      // Mutates the extracted condition STRING, not the real workflow file
+      // -- this is what "an `if:` with no status check function silently
+      // gets an implicit success()" looks like once written out.
+      const mutated = realCondition().replace('!cancelled() && ', '')
+      expect(mutated).not.toContain('cancelled()')
+      expect(
+        analyzeGuardCondition(mutated, 'suite').hasStatusCheckFunction,
+      ).toBe(false)
+    })
+
+    test('(b) the real condition references steps.suite.outcome', () => {
+      expect(
+        analyzeGuardCondition(realCondition(), 'suite').referencesStepOutcome,
+      ).toBe(true)
+    })
+
+    test('(b) bidirectional: a condition referencing a different step id fails this property (the earlier-step-failure exclusion would be silently dropped)', () => {
+      const mutated = realCondition().replaceAll(
+        'steps.suite.outcome',
+        'steps.build.outcome',
+      )
+      expect(
+        analyzeGuardCondition(mutated, 'suite').referencesStepOutcome,
+      ).toBe(false)
+    })
+
+    test('(c) the real condition still requires the path gate', () => {
+      expect(
+        analyzeGuardCondition(realCondition(), 'suite').requiresPathGate,
+      ).toBe(true)
+    })
+
+    test('(c) bidirectional: a condition without the path gate fails this property (a path-gated-out pull request would no longer skip this step)', () => {
+      const mutated = realCondition().replace(
+        "steps.gate.outputs.run == 'true' && ",
+        '',
+      )
+      expect(mutated).not.toContain('steps.gate.outputs.run')
+      expect(analyzeGuardCondition(mutated, 'suite').requiresPathGate).toBe(
+        false,
+      )
+    })
+
+    test('(d) the real condition does not use a bare always()', () => {
+      expect(
+        analyzeGuardCondition(realCondition(), 'suite').usesBareAlways,
+      ).toBe(false)
+    })
+
+    test('(d) bidirectional: a condition using always() instead of !cancelled() fails this property (it would also run during cancellation)', () => {
+      const mutated = realCondition().replace('!cancelled()', 'always()')
+      expect(analyzeGuardCondition(mutated, 'suite').usesBareAlways).toBe(true)
+      // A bare always() is still a status check function, so it would
+      // pass property (a) -- proving (d) is catching something (a) alone
+      // cannot.
+      expect(
+        analyzeGuardCondition(mutated, 'suite').hasStatusCheckFunction,
+      ).toBe(true)
+    })
   })
 
   test('the guard step invokes the extracted script, not an inline heredoc', () => {

--- a/tests/unit/host-contract-workflow.test.ts
+++ b/tests/unit/host-contract-workflow.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import path from 'node:path'
+import yaml from 'js-yaml'
+
+/**
+ * Locks the structural invariants the host-contract guard
+ * (scripts/host-contract-guard.ts) depends on but cannot itself verify,
+ * since they live in the workflow YAML, not in the guard script. Kept as a
+ * sibling of host-contract-guard.test.ts (not merged into it) because these
+ * assertions are about the workflow file's shape, not the guard's parsing
+ * logic -- one file per concern keeps a workflow-YAML-format regression
+ * from being misdiagnosed as a guard-logic regression.
+ */
+
+const WORKFLOW_PATH = path.resolve(process.cwd(), '.github/workflows/main.yaml')
+
+type RecordValue = Record<string, unknown>
+
+function isRecord(value: unknown): value is RecordValue {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function asRecord(value: unknown, label: string): RecordValue {
+  if (!isRecord(value)) throw new Error(`${label} must be a mapping`)
+  return value
+}
+
+function asArray(value: unknown, label: string): readonly unknown[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be a sequence`)
+  return value
+}
+
+function readWorkflow(): RecordValue {
+  const source = fs.readFileSync(WORKFLOW_PATH, 'utf8')
+  const { JSON_SCHEMA } = yaml
+  return asRecord(yaml.load(source, { schema: JSON_SCHEMA }), 'workflow')
+}
+
+function findStep(steps: readonly unknown[], name: string): RecordValue {
+  const step = steps.find(
+    (candidate): candidate is RecordValue =>
+      isRecord(candidate) && candidate.name === name,
+  )
+  if (!step) throw new Error(`step not found: ${name}`)
+  return step
+}
+
+describe('host-contract workflow structural invariants', () => {
+  test('the host-contract job has no job-level `if:`', () => {
+    const workflow = readWorkflow()
+    const jobs = asRecord(workflow.jobs, 'jobs')
+    const hostContract = asRecord(jobs['host-contract'], 'host-contract job')
+
+    // A job-level `if:` that evaluates false would skip the job (and its
+    // `needs` dependents would treat that as satisfied), silently
+    // publishing a release without the host contract suite ever running.
+    // Path gating for this job is deliberately step-level (steps.gate)
+    // instead.
+    expect(hostContract).not.toHaveProperty('if')
+  })
+
+  test('release.needs includes host-contract', () => {
+    const workflow = readWorkflow()
+    const jobs = asRecord(workflow.jobs, 'jobs')
+    const release = asRecord(jobs.release, 'release job')
+    const needs = asArray(release.needs, 'release.needs')
+
+    expect(needs).toContain('host-contract')
+  })
+
+  test('the "Run host contract suite" step sets SYSTEMATIC_REQUIRE_OPENCODE=1', () => {
+    const workflow = readWorkflow()
+    const jobs = asRecord(workflow.jobs, 'jobs')
+    const hostContract = asRecord(jobs['host-contract'], 'host-contract job')
+    const steps = asArray(hostContract.steps, 'host-contract steps')
+    const suiteStep = findStep(steps, 'Run host contract suite')
+    const env = asRecord(suiteStep.env, 'Run host contract suite env')
+
+    expect(env.SYSTEMATIC_REQUIRE_OPENCODE).toBe('1')
+  })
+
+  test('the "Guard skipped tests and pass floor" step still runs when the suite step fails', () => {
+    const workflow = readWorkflow()
+    const jobs = asRecord(workflow.jobs, 'jobs')
+    const hostContract = asRecord(jobs['host-contract'], 'host-contract job')
+    const steps = asArray(hostContract.steps, 'host-contract steps')
+    const guardStep = findStep(steps, 'Guard skipped tests and pass floor')
+    const condition = String(guardStep.if ?? '')
+
+    // Must still be gated on the path filter (so it stays skipped on a
+    // path-gated-out pull request) ...
+    expect(condition).toContain("steps.gate.outputs.run == 'true'")
+    // ... but must NOT be limited to the implicit success()-only default,
+    // since that is exactly what previously caused this step to be skipped
+    // when the suite step failed -- the moment its diagnosis matters most.
+    expect(condition).toContain('failure()')
+  })
+
+  test('the "Guard skipped tests and pass floor" step does not run on cancellation', () => {
+    const workflow = readWorkflow()
+    const jobs = asRecord(workflow.jobs, 'jobs')
+    const hostContract = asRecord(jobs['host-contract'], 'host-contract job')
+    const steps = asArray(hostContract.steps, 'host-contract steps')
+    const guardStep = findStep(steps, 'Guard skipped tests and pass floor')
+    const condition = String(guardStep.if ?? '')
+
+    // `always()` would also run during a cancellation; this asserts the
+    // narrower `success() || failure()` form (or an equivalent that
+    // excludes cancelled()) is used instead, so a cancelled run does not
+    // spuriously report a guard failure.
+    expect(condition).not.toContain('always()')
+  })
+
+  test('the guard step invokes the extracted script, not an inline heredoc', () => {
+    const workflow = readWorkflow()
+    const jobs = asRecord(workflow.jobs, 'jobs')
+    const hostContract = asRecord(jobs['host-contract'], 'host-contract job')
+    const steps = asArray(hostContract.steps, 'host-contract steps')
+    const guardStep = findStep(steps, 'Guard skipped tests and pass floor')
+    const run = String(guardStep.run ?? '')
+
+    expect(run).toContain('bun scripts/host-contract-guard.ts')
+    expect(run).not.toContain('cat <<')
+  })
+})

--- a/tests/unit/host-contract-workflow.test.ts
+++ b/tests/unit/host-contract-workflow.test.ts
@@ -80,21 +80,39 @@ describe('host-contract workflow structural invariants', () => {
     expect(env.SYSTEMATIC_REQUIRE_OPENCODE).toBe('1')
   })
 
-  test('the "Guard skipped tests and pass floor" step still runs when the suite step fails', () => {
+  test('the "Run host contract suite" step has the id the guard step depends on', () => {
+    const workflow = readWorkflow()
+    const jobs = asRecord(workflow.jobs, 'jobs')
+    const hostContract = asRecord(jobs['host-contract'], 'host-contract job')
+    const steps = asArray(hostContract.steps, 'host-contract steps')
+    const suiteStep = findStep(steps, 'Run host contract suite')
+
+    expect(suiteStep.id).toBe('suite')
+  })
+
+  test('the "Guard skipped tests and pass floor" step runs on both suite outcomes, gated on the suite step specifically', () => {
     const workflow = readWorkflow()
     const jobs = asRecord(workflow.jobs, 'jobs')
     const hostContract = asRecord(jobs['host-contract'], 'host-contract job')
     const steps = asArray(hostContract.steps, 'host-contract steps')
     const guardStep = findStep(steps, 'Guard skipped tests and pass floor')
     const condition = String(guardStep.if ?? '')
+      .replace(/\s+/g, ' ')
+      .trim()
 
-    // Must still be gated on the path filter (so it stays skipped on a
-    // path-gated-out pull request) ...
-    expect(condition).toContain("steps.gate.outputs.run == 'true'")
-    // ... but must NOT be limited to the implicit success()-only default,
-    // since that is exactly what previously caused this step to be skipped
-    // when the suite step failed -- the moment its diagnosis matters most.
-    expect(condition).toContain('failure()')
+    // Asserts the exact expression rather than substring-checking for
+    // 'failure()' alone: a lone substring check also passes for the
+    // opposite-meaning `!failure()`, which would silently reintroduce the
+    // bug this condition exists to fix (the guard step skipped exactly
+    // when the suite step fails). Also asserts the condition is scoped to
+    // steps.suite specifically (not the job-wide success()/failure()
+    // status functions), so an unrelated earlier-step failure (Install
+    // dependencies, Build) -- which leaves the suite step itself
+    // 'skipped' -- also skips this step, instead of running it against
+    // artifacts the suite step never produced.
+    expect(condition).toBe(
+      "steps.gate.outputs.run == 'true' && (steps.suite.outcome == 'success' || steps.suite.outcome == 'failure')",
+    )
   })
 
   test('the "Guard skipped tests and pass floor" step does not run on cancellation', () => {
@@ -105,10 +123,11 @@ describe('host-contract workflow structural invariants', () => {
     const guardStep = findStep(steps, 'Guard skipped tests and pass floor')
     const condition = String(guardStep.if ?? '')
 
-    // `always()` would also run during a cancellation; this asserts the
-    // narrower `success() || failure()` form (or an equivalent that
-    // excludes cancelled()) is used instead, so a cancelled run does not
-    // spuriously report a guard failure.
+    // `always()` would also run during a cancellation. A cancelled suite
+    // step's outcome is neither 'success' nor 'failure' either, so the
+    // steps.suite.outcome-scoped condition asserted above already excludes
+    // cancellation -- this asserts `always()` specifically isn't used, since
+    // that would be a strictly broader (and wrong) condition.
     expect(condition).not.toContain('always()')
   })
 


### PR DESCRIPTION
## Summary

The `host-contract` CI job's skip/pass guard was an inline `.mjs` heredoc embedded in `.github/workflows/main.yaml` (~135 lines). It parsed JUnit XML and the `bun test` log with regexes and gated `release`, but living in YAML made it invisible to `biome check .`, `typecheck:all`, and `bun test` — an untested parser was a required release gate.

This moves the guard to `scripts/host-contract-guard.ts` (pure functions + a thin CLI wrapper), adds unit tests for all five failure conditions, locks the workflow's structural invariants in a test, and fixes a gating gap where the guard step was skipped exactly when the suite failed — the moment its diagnosis matters most.

**Update 1:** a follow-up commit addressed `@fro-bot`'s review — the guard step was scoped to the suite step's own outcome (not the job-wide status functions), and a missing/unreadable artifact reports as the contract failure it is instead of a raw `ENOENT`.

**Update 2:** that follow-up's condition (`steps.suite.outcome == 'success' || steps.suite.outcome == 'failure'`, with no status check function) contained no `always()`/`success()`/`failure()`/`cancelled()`, so GitHub Actions applied its own implicit `success()` on top — which is job-scoped and false the moment the suite step fails, silently skipping the guard step on exactly the run it exists to diagnose. Fixed with `!cancelled()`, plus a workflow test that mechanically pins "the condition contains a status check function" so this class of regression fails a test instead of shipping a third time. Details below.

Closes #935.

## The five failure conditions (preserved exactly)

All five conditions from the original heredoc are preserved with the same messages, now as `evaluate()` pure-function outputs:

1. `missingFiles.length > 0` — an expected integration suite file produced no `<testsuite>` entry
2. `unexpected.length > 0` — a skip not in the exempt set
3. `missingExempt.length > 0` — a known-exempt skip is absent (bidirectional: the exempt set asserts the mixed-version test skipped, not merely permission to skip)
4. `!lastPassMatch` — no `N pass` summary line could be parsed
5. `passCount < PASS_FLOOR` (120)

`EXEMPT_SKIPS`, `EXPECTED_SUITE_FILES`, and `PASS_FLOOR` are exported constants, unchanged from the original heredoc values (with their original explanatory comments carried over).

## Where the script lives, and why

`scripts/host-contract-guard.ts`, not `scripts/lib/`. `scripts/lib/` holds modules imported by *multiple* scripts (`opencode-pin.ts`, `opencode-availability.ts`, `process-group.ts`, `zod-internals.ts`). This guard is invoked directly as a CLI (`bun scripts/host-contract-guard.ts <junit> <log>`) and isn't shared by another script — that's exactly the shape of `content-integrity.ts`, `generate-registry.ts`, and the other top-level `scripts/*.ts` files: pure functions (`parseJUnitXml`, `parseLogPassCount`, `evaluate`) plus a thin `main()` CLI wrapper gated by `import.meta.main`, invoked directly from the workflow the same way `content-integrity.ts` and `generate-registry.ts --check` already are.

## The gating gap fix, three times over

**Round 1:** the guard step originally had only `if: steps.gate.outputs.run == 'true'`, so when "Run host contract suite" **failed**, the guard step was **skipped** — exactly when its diagnosis is most useful. Fixed with `success() || failure()`.

**Round 2:** `success()`/`failure()` are job-scoped, not step-scoped, so that condition also fired when an *unrelated earlier* step (`Install dependencies`, `Build`) failed — the guard step would run, find no artifacts, and add a second confusing red step to an already-red job. "Fixed" by giving "Run host contract suite" an explicit `id: suite` and gating the guard step on `steps.suite.outcome == 'success' || steps.suite.outcome == 'failure'`, with no status check function left in the expression at all.

**Round 3 (this update):** that round-2 condition has no `always()`/`success()`/`failure()`/`cancelled()` anywhere in it. Per GitHub's docs, an `if:` with no status check function gets GitHub's own implicit `success()` ANDed on top — and `success()` is job-scoped, so it goes false the instant the suite step fails. Row 2 of the previous matrix below ("suite failed → guard runs") was wrong: the implicit `success()` made the `steps.suite.outcome == 'failure'` branch dead code, so the guard was *still* being skipped on a failing suite, just via a different mechanism than round 1's bug. Fixed with `!cancelled()`:

```yaml
- name: Run host contract suite
  id: suite
  if: steps.gate.outputs.run == 'true'
  ...

- name: Guard skipped tests and pass floor
  if: |
    steps.gate.outputs.run == 'true' && !cancelled() &&
    (steps.suite.outcome == 'success' || steps.suite.outcome == 'failure')
  run: bun scripts/host-contract-guard.ts host-contract-junit.xml host-contract-log.txt
```

`!cancelled()` is a status check function, so it overrides the implicit `success()` default; it is `true` on both a passing and a failing suite (only `false` when the job itself was cancelled), so it doesn't reintroduce round 1's bug. `steps.suite.outcome` still does the precise gating: `'skipped'` when an earlier step (Install dependencies, Build) failed first excludes that case exactly as round 2 intended, and `'cancelled'`/never-started for the suite step itself is excluded redundantly by both the outcome check and `!cancelled()`. The guard step is purely diagnostic either way: it cannot flip the suite step's own conclusion, so a red suite still fails the job regardless of what the guard step reports.

Because this gating condition has now been *wrong twice in a row* despite two rounds of review, `tests/unit/host-contract-workflow.test.ts` now mechanically pins it rather than trusting eyeball review: four properties (has a status check function; references `steps.suite.outcome`; still requires the path gate; does not use a bare `always()`), each proven bidirectionally against string-mutated copies of the real extracted condition (see "Tests" below) — so a future edit that drops the status check function, or swaps back to job-scoped `success()`/`failure()`, fails a test instead of shipping.

### Gating condition matrix — final expression, re-derived from GitHub's documented semantics

Rule applied per row: *"if your `if:` conditional does not contain a status check function, GitHub Actions adds `success()` at the start of the expression automatically."* `!cancelled()` is present, so no implicit `success()` is added; the expression is evaluated exactly as written.

| Suite step outcome | Path-gated out | Job cancelled | Guard step runs? | Job conclusion | Rule applied |
|---|---|---|---|---|---|
| `success` | no | no | **yes** | success, unless the guard itself finds a violation | `!cancelled()` is true (not cancelled); `steps.suite.outcome == 'success'` is true |
| `failure` | no | no | **yes** — the fix | failure (from the suite step, regardless of the guard) | `!cancelled()` is true; `steps.suite.outcome == 'failure'` is true; no implicit `success()` applies because `!cancelled()` is a status check function |
| `skipped` (an earlier step — Install/Build — failed) | no | no | **no** | failure (from the earlier step) | suite step's own `if: steps.gate.outputs.run == 'true'` has no status check function, so it *does* get the implicit `success()`, and is skipped when Install/Build fails; its `outcome` becomes `'skipped'`, matching neither `'success'` nor `'failure'` |
| n/a (gate step set `run=false`) | **yes** | no | no | success (job has no failed steps) | `steps.gate.outputs.run == 'true'` is false, short-circuiting the `&&` |
| `cancelled` / never started | no | **yes** | no | cancelled | `!cancelled()` is false |

`Upload test log on failure` (`if: failure() && steps.gate.outputs.run == 'true'`) is unchanged and still uploads whenever the suite step or the guard step failed.

## A missing artifact is now a diagnosed contract failure, not an I/O crash

The `success()||failure()` gating fix newly reaches a path that previously couldn't happen: the guard step running against a suite that died before Bun's JUnit reporter flushed (e.g. the `SYSTEMATIC_REQUIRE_OPENCODE=1` module-scope throw). Previously `readFileOrExit` printed a raw `ENOENT` and exited — a filesystem complaint, not a verdict about the contract.

`readArtifact()` now converts a read failure into a `{ content: '', readError }` result instead of throwing. The CLI prints the `readError` plus an explanatory line, then feeds the empty content through the *same* `evaluate()` path a truncated/empty artifact already used — so the reader gets the full diagnosis (which specific `EXPECTED_SUITE_FILES` entries are missing, that the exempt skip wasn't found, that no pass line exists), not just "file not found." A read failure still forces a non-zero exit even in the (currently unreachable) case where `evaluate()` alone wouldn't have flagged anything.

## `isNodeError` — dropped, not fixed

The flagged predicate:
```ts
function isNodeError(err: unknown): err is NodeJS.ErrnoException {
  return err instanceof Error
}
```
claimed `err is NodeJS.ErrnoException` but only proved `err instanceof Error` — a false narrowing that happened to be harmless because only `.message` was read. Rather than widen the check to actually verify an `ErrnoException` shape (`code` as a string, etc.) for a value that's only ever used for its message, I dropped the guard entirely and inlined `err instanceof Error ? err.message : String(err)` as a plain `errorMessage()` helper — the same pattern used in `scripts/lib/opencode-pin.ts`. No guard claiming more than it establishes, and no unused machinery for a type nothing downstream inspects.

## `EXEMPT_SKIPS` rename-tolerance finding (issue item 4)

**Verdict: no change needed.** `EXEMPT_SKIPS` still hardcodes a `classname`+`name` string pair, and a rename of the exempt test would stop that pair from matching — but condition 3 (`missingExemptSkips`) already turns "the exempt entry didn't match anything in this run" into a **hard failure**, not a silent no-op. A rename produces *two* simultaneous violations: the old key shows up in `missing-exempt-skips` (nothing matched it) and the new key shows up in `unexpected-skips` (an unrecognized skip appeared) — see `'near-miss: a differently-named skip does not satisfy the exempt entry (rename fails loudly)'` in `tests/unit/host-contract-guard.test.ts`. Adding rename-tolerant matching would only make a rename *quieter*, which is the opposite of what this guard exists to do. Not adding it.

## XML entity decoding (review item 4) — fixed, with a concrete reachable example

The review flagged this as cosmetic-only speculation. It is not speculative: `parseAttrs` read raw, un-decoded attribute text, and this repository already has a test name containing `<` — `claude-code.test.ts`'s `'hooks/hooks.json is valid JSON with SessionStart/no-matcher (all sources)/type:command shape, payload <= 10000 chars'`. Generating a real JUnit report locally confirms Bun's reporter escapes it:

```
$ bun test tests/integration/claude-code.test.ts --reporter=junit --reporter-outfile=/tmp/claude-code-junit.xml
$ grep -o 'name="[^"]*10000[^"]*"' /tmp/claude-code-junit.xml
name="hooks/hooks.json is valid JSON with SessionStart/no-matcher (all sources)/type:command shape, payload &lt;= 10000 chars"
```

That test isn't currently skipped, so today's `EXEMPT_SKIPS` comparison isn't affected — but the escaping mechanism the review questioned is real and already present in this codebase's own test names, not hypothetical. Added `decodeXmlEntities()` (the five XML predefined entities plus numeric character references) and route all attribute values through it, with a test asserting a skip named with an un-decoded `&lt;` (mirroring the real test above) parses back to `<`, plus a test proving an entity-mismatched exempt name still fails loudly (`unexpected-skips` + `missing-exempt-skips`) rather than silently.

## Tests

- `tests/unit/host-contract-guard.test.ts` — synthetic JUnit/log fixtures (real strings, no mocks) covering `parseJUnitXml`, `parseLogPassCount`, and all five `evaluate()` conditions bidirectionally, plus malformed input, XML entity decoding, `readArtifact()` (present/missing/empty files), and CLI subprocess tests (`Bun.spawnSync`) covering exit codes for the healthy case, missing-JUnit, missing-log, both-missing, missing-argv, and a normal violation (to confirm the read-error message doesn't leak into an unrelated failure).
- `tests/unit/host-contract-workflow.test.ts` — parses `.github/workflows/main.yaml` with `js-yaml`'s `JSON_SCHEMA` and asserts: no job-level `if:` on `host-contract`, `release.needs` contains `host-contract`, the suite step's env sets `SYSTEMATIC_REQUIRE_OPENCODE: '1'`, the suite step has `id: suite`, the guard step's condition is *exactly* `steps.gate.outputs.run == 'true' && !cancelled() && (steps.suite.outcome == 'success' || steps.suite.outcome == 'failure')`, and it invokes the script rather than a heredoc. Because this condition has been wrong twice, it's additionally decomposed into four mechanically-pinned properties — `analyzeGuardCondition()` checks (a) the condition contains a status check function, (b) it references `steps.suite.outcome`, (c) it still requires the path gate, (d) it doesn't use a bare `always()` — each proven bidirectionally: one test confirms the real extracted condition satisfies the property, a second constructs a *string-mutated copy* of that same real condition that violates exactly that property (e.g. stripping `!cancelled() && ` reproduces round 3's actual bug) and confirms the analyzer flags it. The mutations are string operations on the extracted condition, not edits to the real workflow file.

## Real-artifact replay proof

CI only uploads `host-contract-junit.xml`/`host-contract-log.txt` on failure, so no artifact exists from a green run to download. Ran the real integration suite locally against a real OpenCode host twice — once for the original PR, once again after this follow-up commit, to reprove parity:

```
$ bun test tests/integration --reporter=junit --reporter-outfile=host-contract-junit.xml
 137 pass
 1 skip
 0 fail
Ran 138 tests across 11 files. [1234.45s]

$ bun scripts/host-contract-guard.ts host-contract-junit.xml host-contract-log.txt
Observed pass count: 137 (floor: 120)
host-contract skip/pass guard passed.
$ echo $?
0
```

Missing-artifact proof (the new behaviour this follow-up adds):
```
$ bun scripts/host-contract-guard.ts /tmp/nope-935.xml /tmp/nope-935.txt
Could not read /tmp/nope-935.xml: ENOENT: no such file or directory, open '/tmp/nope-935.xml'
Treating this as the suite producing no test evidence, not as a guard pass.
Could not read /tmp/nope-935.txt: ENOENT: no such file or directory, open '/tmp/nope-935.txt'
Treating this as the suite producing no pass-count evidence, not as a guard pass.
Expected integration test file(s) produced no JUnit suite (bun test never ran them):
  - tests/integration/claude-code.test.ts
  - tests/integration/eval-artifact.test.ts
  - tests/integration/eval-fixture.test.ts
  - tests/integration/eval-runner.test.ts
  - tests/integration/opencode.test.ts
  - tests/integration/pi.test.ts
  - tests/integration/question-attestation-opencode.test.ts
  - tests/integration/receipt-workflow-dogfood.test.ts
  - tests/integration/receipt-workflow-guard-real-host.test.ts
  - tests/integration/receipt-workflow-recovery.test.ts
  - tests/integration/release-notes-ci.test.ts
Known-exempt skip(s) not found in this run (exempt set is stale):
  - opencode mixed-version integration::pinned package plus local source keep systematic_skill deterministic and converge bootstrap
Could not find a "<N> pass" summary line in the captured test output.
$ echo $?
1
```

(The original PR's three mutation proofs — dropped suite file, pass count below floor, removed exempt skip — are unchanged by this follow-up and still hold.)

## Verification (Update 2 commit)

- `bun test tests/unit` — `2322 pass, 0 fail, 2 snapshots, 10383 expect() calls` (`host-contract-guard.test.ts` + `host-contract-workflow.test.ts`: `50 pass, 0 fail, 78 expect() calls`)
- `bun run typecheck:all` — clean (`tsc -p tsconfig.tests.json`, no output)
- `bun run lint` — 0 errors, 13 warnings — identical to the pre-existing warning set on `main`, none in the touched files
- `bun scripts/content-integrity.ts` — `content-integrity: clean (125 md + 40 ts + 86 solution-md + 4 root docs scanned, 20 exempt hits, 0 warnings)`
- `bun run build` — OK
- `bunx @action-validator/cli .github/workflows/main.yaml` — exit 0

Confirmed against the parsed YAML (Update 2 head):
```
job-level if: undefined
{ "name": "Run host contract suite", "id": "suite", "if": "steps.gate.outputs.run == 'true'" }
{ "name": "Guard skipped tests and pass floor", "if": "steps.gate.outputs.run == 'true' && !cancelled() &&\n(steps.suite.outcome == 'success' || steps.suite.outcome == 'failure')\n" }
```

