### PR TITLE
fix(workflow-guard): keep a failed completion's reason code across replay

### DIFF
--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -44,7 +44,6 @@ import {
   type EvidenceObservationResult,
   type RuntimeUnitPolicy,
   type StartUnitResult,
-  type TransitionFinalizeResult,
   type TransitionPrepareResult,
   type TransitionTarget,
   type WorkflowGuard,
@@ -338,10 +337,11 @@ interface SealedOperation {
 interface TerminalComplete {
   // Optional: some terminal outcomes (see `finishUnreplayableComplete()`)
   // are recorded without ever having observed a real target. `target` is
-  // not read back out of this record by `writeCompletionResult()` — the
-  // target actually written to the tool result always comes from that
-  // function's own `target` parameter — so leaving it unset here costs
-  // nothing and avoids a fabricated placeholder in the evidence record.
+  // not read back out of this record by `writeTerminalCompletionResult()`
+  // — the target actually written to the tool result always comes from
+  // that function's own `target` parameter — so leaving it unset here
+  // costs nothing and avoids a fabricated placeholder in the evidence
+  // record.
   target?: TransitionTarget
   status: 'rejected' | 'unavailable'
   reasonCode: WorkflowReasonCode
@@ -2573,7 +2573,7 @@ function createSessionRuntime(
     }
   }
 
-  // Only the non-success path can reach this with `target === undefined`
+  // Only the terminal writer below can ever see `target === undefined`
   // (via `finishUnreplayableComplete()`, where the target is genuinely
   // unknown). Omitted from the returned fragment rather than filled with a
   // placeholder so the written record never claims to know a target it
@@ -2584,44 +2584,52 @@ function createSessionRuntime(
     return target ? { target } : {}
   }
 
-  function writeCompletionResult(
+  // A successful completion always has a real, known target — this is the
+  // ONLY writer `finalizeComplete()`'s `completed`/`duplicate` branch calls,
+  // and that branch is only ever reached with a concrete `pending.target`.
+  // Requiring `target: TransitionTarget` here (not `| undefined`) makes
+  // that invariant a compile error to violate, instead of a comment next
+  // to a type that allowed both.
+  function writeSuccessfulCompletionResult(
     output: unknown,
-    result: TransitionFinalizeResult | TerminalComplete,
-    // `undefined` is only meaningful for the non-success branch below; the
-    // `completed`/`duplicate` branch is only ever reached from
-    // `finalizeComplete()` with a concrete `pending.target`, so it treats
-    // `target` as always present rather than adding unreachable fallback
-    // handling for a case that branch can never see.
+    target: TransitionTarget,
+  ): void {
+    if (!isRecord(output)) return
+    const existingMetadata = isRecord(output.metadata) ? output.metadata : {}
+    output.title = 'Workflow transition completed'
+    output.output = `workflow guard completed ${target}`
+    output.metadata = {
+      ...withoutStaleConditionalMetadata(existingMetadata),
+      ...metadata(),
+      workflowGuard: { status: 'completed', target },
+    }
+  }
+
+  // Every non-success completion outcome (abandoned, mismatched target,
+  // failed readback, or a finalizeTransition rejection) shares this shape.
+  // `result: TerminalComplete` — not `TransitionFinalizeResult |
+  // TerminalComplete` — means the type system, not a runtime `if`, rules
+  // out ever being called with a `completed`/`duplicate` result:
+  // `TerminalComplete.status` cannot hold those values.
+  function writeTerminalCompletionResult(
+    output: unknown,
+    result: TerminalComplete,
     target: TransitionTarget | undefined,
   ): void {
     if (!isRecord(output)) return
     const existingMetadata = isRecord(output.metadata) ? output.metadata : {}
-    if (result.status === 'completed' || result.status === 'duplicate') {
-      output.title = 'Workflow transition completed'
-      output.output = `workflow guard completed ${target}`
-      output.metadata = {
-        ...withoutStaleConditionalMetadata(existingMetadata),
-        ...metadata(),
-        workflowGuard: { status: 'completed', target },
-      }
-      return
-    }
-    const reasonCode =
-      'reasonCode' in result ? result.reasonCode : 'guard-unavailable'
-    const resultStatus =
-      result.status === 'waiting' ? 'unavailable' : result.status
     output.title = 'Workflow transition unavailable'
     output.output = JSON.stringify({
-      status: resultStatus,
-      reasonCode,
+      status: result.status,
+      reasonCode: result.reasonCode,
     })
     output.metadata = {
       ...withoutStaleConditionalMetadata(existingMetadata),
       ...metadata(),
       workflowGuard: {
-        status: resultStatus,
+        status: result.status,
         ...targetMetadataField(target),
-        reasonCode,
+        reasonCode: result.reasonCode,
       },
     }
   }
@@ -2630,14 +2638,14 @@ function createSessionRuntime(
   // target, no replayable transition, or a failed readback bundle) must not
   // leave the tool result carrying whatever pre-finalization metadata was
   // written earlier in the request. Writes a full terminal result through
-  // `writeCompletionResult()` so the shape and reason-code vocabulary match
-  // every other non-success completion outcome.
+  // `writeTerminalCompletionResult()` so the shape and reason-code
+  // vocabulary match every other non-success completion outcome.
   function writeAbandonedCompletionResult(
     output: unknown,
     target: TransitionTarget | undefined,
     reasonCode: WorkflowReasonCode,
   ): void {
-    writeCompletionResult(
+    writeTerminalCompletionResult(
       output,
       { target, status: 'unavailable', reasonCode },
       target,
@@ -3251,7 +3259,7 @@ function createSessionRuntime(
     })
     if (result.status === 'completed' || result.status === 'duplicate') {
       finalizedCompletes.set(callDigest, pending)
-      writeCompletionResult(output, result, pending.target)
+      writeSuccessfulCompletionResult(output, pending.target)
       return
     }
     markUnavailable()
@@ -3264,13 +3272,13 @@ function createSessionRuntime(
     }
     abandonedCompletes.set(callDigest, pending.target)
     terminalCompletes.set(callDigest, terminal)
-    writeCompletionResult(output, terminal, pending.target)
+    writeTerminalCompletionResult(output, terminal, pending.target)
   }
 
   // metadataOnly outcomes (see TerminalComplete) came from a branch where
   // the host's own title/output are evidence and must not be rewritten by
-  // writeCompletionResult()'s generic terminal-result shape — only the
-  // metadata is corrected, matching the first pass.
+  // writeTerminalCompletionResult()'s generic terminal-result shape — only
+  // the metadata is corrected, matching the first pass.
   function writeTerminalReplay(
     output: unknown,
     terminal: TerminalComplete,
@@ -3280,7 +3288,7 @@ function createSessionRuntime(
       writeAbandonedCompletionMetadata(output, target, terminal.reasonCode)
       return
     }
-    writeCompletionResult(output, terminal, target)
+    writeTerminalCompletionResult(output, terminal, target)
   }
 
   function replayTerminalComplete(
@@ -3509,8 +3517,8 @@ function createSessionRuntime(
     // whatever normalizeTarget() could read out of this call's own args
     // (real, when the args named a valid target) and is passed through
     // as-is. When it is also undefined the target is genuinely unknown,
-    // and writeAbandonedCompletionResult()/writeCompletionResult() omit
-    // the `target` key entirely rather than guessing one.
+    // and writeAbandonedCompletionResult()/writeTerminalCompletionResult()
+    // omit the `target` key entirely rather than guessing one.
     writeAbandonedCompletionResult(output, finalTarget, 'guard-unavailable')
   }
 

--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -2475,6 +2475,18 @@ function createSessionRuntime(
     existingMetadata: Record<string, unknown>,
   ): Record<string, unknown> {
     if (!('questionAttestation' in existingMetadata)) return existingMetadata
+    // `existingMetadata` may belong to the host tool's own raw metadata, or
+    // to ANOTHER guard instance sharing this `output` reference (see the
+    // cross-instance sharing note on writeAbandonedCompletionMetadata()) —
+    // never safe to strip from. `sourceDigest` is this instance's
+    // `ledger.metadata.registrationDigest`: fixed for the instance's
+    // lifetime, and distinct per instance (random unless
+    // `registrationIdentity` is pinned). Matching it against the existing
+    // metadata's own `sourceDigest` is how "did THIS instance write this"
+    // is verified before deleting anything from it.
+    if (existingMetadata.sourceDigest !== currentMarkerSource().source) {
+      return existingMetadata
+    }
     const { questionAttestation: _stale, ...rest } = existingMetadata
     return rest
   }
@@ -2561,37 +2573,36 @@ function createSessionRuntime(
     }
   }
 
-  // `target` is `undefined` only when `finishUnreplayableComplete()` calls
-  // through with a genuinely unknown target — every other caller passes a
-  // real `TransitionTarget`. Omitted from the returned fragment rather than
-  // filled with a placeholder so the written record never claims to know a
-  // target it does not.
+  // Only the non-success path can reach this with `target === undefined`
+  // (via `finishUnreplayableComplete()`, where the target is genuinely
+  // unknown). Omitted from the returned fragment rather than filled with a
+  // placeholder so the written record never claims to know a target it
+  // does not.
   function targetMetadataField(
     target: TransitionTarget | undefined,
   ): { target: TransitionTarget } | Record<string, never> {
     return target ? { target } : {}
   }
 
-  function completedOutputText(target: TransitionTarget | undefined): string {
-    return target
-      ? `workflow guard completed ${target}`
-      : 'workflow guard completed'
-  }
-
   function writeCompletionResult(
     output: unknown,
     result: TransitionFinalizeResult | TerminalComplete,
+    // `undefined` is only meaningful for the non-success branch below; the
+    // `completed`/`duplicate` branch is only ever reached from
+    // `finalizeComplete()` with a concrete `pending.target`, so it treats
+    // `target` as always present rather than adding unreachable fallback
+    // handling for a case that branch can never see.
     target: TransitionTarget | undefined,
   ): void {
     if (!isRecord(output)) return
     const existingMetadata = isRecord(output.metadata) ? output.metadata : {}
     if (result.status === 'completed' || result.status === 'duplicate') {
       output.title = 'Workflow transition completed'
-      output.output = completedOutputText(target)
+      output.output = `workflow guard completed ${target}`
       output.metadata = {
         ...withoutStaleConditionalMetadata(existingMetadata),
         ...metadata(),
-        workflowGuard: { status: 'completed', ...targetMetadataField(target) },
+        workflowGuard: { status: 'completed', target },
       }
       return
     }
@@ -3285,10 +3296,26 @@ function createSessionRuntime(
         return true
       }
     }
+    // A recorded TerminalComplete means THIS call digest already reached a
+    // terminal, non-success outcome (invalid-transition, failed-operation,
+    // or any other non-`completed`/`duplicate` finalizeTransition result).
+    // Unlike `replay` (a finalized success, replayed by re-driving the
+    // real transition) and `blockedTarget` (a still-live question gate),
+    // there is no live transition left here for a mismatched `finalTarget`
+    // to hijack into: writeTerminalReplay() can only ever reproduce the
+    // same non-success result, never a success one, and consumes nothing.
+    // So the target that PRODUCED this terminal (`terminal.target`) is
+    // used to replay it, without gating on whatever `finalTarget` this
+    // particular delivery happens to carry.
+    const terminal = terminalCompletes.get(callDigest)
+    if (terminal?.target) {
+      writeTerminalReplay(output, terminal, terminal.target)
+      blockedCompletes.delete(callDigest)
+      return true
+    }
     const replay = finalizedCompletes.get(callDigest)
     const abandonedTarget = abandonedCompletes.get(callDigest)
     const blockedTarget = blockedCompletes.get(callDigest)
-    const terminal = terminalCompletes.get(callDigest)
     const expectedTarget = replay?.target ?? abandonedTarget ?? blockedTarget
     if (!expectedTarget) return false
     if (finalTarget !== expectedTarget) {
@@ -3296,7 +3323,6 @@ function createSessionRuntime(
       return true
     }
     if (replay) replayComplete(callDigest)
-    if (terminal) writeTerminalReplay(output, terminal, expectedTarget)
     blockedCompletes.delete(callDigest)
     return true
   }

--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -336,9 +336,20 @@ interface SealedOperation {
 }
 
 interface TerminalComplete {
-  target: TransitionTarget
+  // Optional: some terminal outcomes (see `finishUnreplayableComplete()`)
+  // are recorded without ever having observed a real target. `target` is
+  // not read back out of this record by `writeCompletionResult()` — the
+  // target actually written to the tool result always comes from that
+  // function's own `target` parameter — so leaving it unset here costs
+  // nothing and avoids a fabricated placeholder in the evidence record.
+  target?: TransitionTarget
   status: 'rejected' | 'unavailable'
   reasonCode: WorkflowReasonCode
+  // When true, a replay of this terminal outcome must only correct the
+  // metadata (`writeAbandonedCompletionMetadata()`), never rewrite the
+  // tool result's title/output. Set for outcomes where the host tool's
+  // own title/output is evidence that must survive replay untouched.
+  metadataOnly?: boolean
 }
 
 type OperationCompletionResult =
@@ -2451,6 +2462,23 @@ function createSessionRuntime(
     return source
   }
 
+  // A conditional metadata key from an earlier `metadata()` call — notably
+  // `questionAttestation` — must not silently outlive the result that
+  // produced it: `metadata()` only adds keys when the current guard state
+  // warrants them, it never deletes stale ones, and every writer below
+  // spreads `existingMetadata` first (lowest precedence) then the current
+  // `metadata()` read. Stripping known conditional keys from the carried-
+  // over metadata before that spread lets the current metadata() call
+  // reinstate them when still valid and drop them otherwise, instead of a
+  // stale value leaking forward into a result that no longer emits it.
+  function withoutStaleConditionalMetadata(
+    existingMetadata: Record<string, unknown>,
+  ): Record<string, unknown> {
+    if (!('questionAttestation' in existingMetadata)) return existingMetadata
+    const { questionAttestation: _stale, ...rest } = existingMetadata
+    return rest
+  }
+
   function metadata(): Record<string, unknown> {
     const source = currentMarkerSource()
     const result: Record<string, unknown> = {
@@ -2510,7 +2538,7 @@ function createSessionRuntime(
       output.title = 'Workflow unit started'
       output.output = JSON.stringify({ status: 'started' })
       output.metadata = {
-        ...existingMetadata,
+        ...withoutStaleConditionalMetadata(existingMetadata),
         ...metadata(),
         workflowGuard: { status: 'started' },
       }
@@ -2524,7 +2552,7 @@ function createSessionRuntime(
       reasonCode,
     })
     output.metadata = {
-      ...existingMetadata,
+      ...withoutStaleConditionalMetadata(existingMetadata),
       ...metadata(),
       workflowGuard: {
         status: 'rejected',
@@ -2533,20 +2561,37 @@ function createSessionRuntime(
     }
   }
 
+  // `target` is `undefined` only when `finishUnreplayableComplete()` calls
+  // through with a genuinely unknown target — every other caller passes a
+  // real `TransitionTarget`. Omitted from the returned fragment rather than
+  // filled with a placeholder so the written record never claims to know a
+  // target it does not.
+  function targetMetadataField(
+    target: TransitionTarget | undefined,
+  ): { target: TransitionTarget } | Record<string, never> {
+    return target ? { target } : {}
+  }
+
+  function completedOutputText(target: TransitionTarget | undefined): string {
+    return target
+      ? `workflow guard completed ${target}`
+      : 'workflow guard completed'
+  }
+
   function writeCompletionResult(
     output: unknown,
     result: TransitionFinalizeResult | TerminalComplete,
-    target: TransitionTarget,
+    target: TransitionTarget | undefined,
   ): void {
     if (!isRecord(output)) return
     const existingMetadata = isRecord(output.metadata) ? output.metadata : {}
     if (result.status === 'completed' || result.status === 'duplicate') {
       output.title = 'Workflow transition completed'
-      output.output = `workflow guard completed ${target}`
+      output.output = completedOutputText(target)
       output.metadata = {
-        ...existingMetadata,
+        ...withoutStaleConditionalMetadata(existingMetadata),
         ...metadata(),
-        workflowGuard: { status: 'completed', target },
+        workflowGuard: { status: 'completed', ...targetMetadataField(target) },
       }
       return
     }
@@ -2560,11 +2605,11 @@ function createSessionRuntime(
       reasonCode,
     })
     output.metadata = {
-      ...existingMetadata,
+      ...withoutStaleConditionalMetadata(existingMetadata),
       ...metadata(),
       workflowGuard: {
         status: resultStatus,
-        target,
+        ...targetMetadataField(target),
         reasonCode,
       },
     }
@@ -2578,7 +2623,7 @@ function createSessionRuntime(
   // every other non-success completion outcome.
   function writeAbandonedCompletionResult(
     output: unknown,
-    target: TransitionTarget,
+    target: TransitionTarget | undefined,
     reasonCode: WorkflowReasonCode,
   ): void {
     writeCompletionResult(
@@ -2610,7 +2655,7 @@ function createSessionRuntime(
     if (!isRecord(output)) return
     const existingMetadata = isRecord(output.metadata) ? output.metadata : {}
     output.metadata = {
-      ...existingMetadata,
+      ...withoutStaleConditionalMetadata(existingMetadata),
       ...metadata(),
       workflowGuard: { status: 'unavailable', target, reasonCode },
     }
@@ -3173,6 +3218,19 @@ function createSessionRuntime(
         pending.target,
         'failed-operation',
       )
+      // Remembered so a replay of this callID reproduces the same
+      // 'failed-operation' reason code instead of falling through to
+      // finishUnreplayableComplete()'s generic 'guard-unavailable'.
+      // metadataOnly: true because the host tool's own title/output are
+      // evidence here and a replay must correct only the metadata, the
+      // same way this first pass did.
+      abandonedCompletes.set(callDigest, pending.target)
+      terminalCompletes.set(callDigest, {
+        target: pending.target,
+        status: 'unavailable',
+        reasonCode: 'failed-operation',
+        metadataOnly: true,
+      })
       return
     }
     const result = guard.finalizeTransition({
@@ -3196,6 +3254,22 @@ function createSessionRuntime(
     abandonedCompletes.set(callDigest, pending.target)
     terminalCompletes.set(callDigest, terminal)
     writeCompletionResult(output, terminal, pending.target)
+  }
+
+  // metadataOnly outcomes (see TerminalComplete) came from a branch where
+  // the host's own title/output are evidence and must not be rewritten by
+  // writeCompletionResult()'s generic terminal-result shape — only the
+  // metadata is corrected, matching the first pass.
+  function writeTerminalReplay(
+    output: unknown,
+    terminal: TerminalComplete,
+    target: TransitionTarget,
+  ): void {
+    if (terminal.metadataOnly) {
+      writeAbandonedCompletionMetadata(output, target, terminal.reasonCode)
+      return
+    }
+    writeCompletionResult(output, terminal, target)
   }
 
   function replayTerminalComplete(
@@ -3222,7 +3296,7 @@ function createSessionRuntime(
       return true
     }
     if (replay) replayComplete(callDigest)
-    if (terminal) writeCompletionResult(output, terminal, expectedTarget)
+    if (terminal) writeTerminalReplay(output, terminal, expectedTarget)
     blockedCompletes.delete(callDigest)
     return true
   }
@@ -3386,7 +3460,16 @@ function createSessionRuntime(
     pending: PendingComplete,
     output: unknown,
   ): void {
-    abandonComplete(callDigest, pending, false)
+    // remember=true (and the paired terminalCompletes entry below) so a
+    // replay of this callID reproduces 'invalid-transition' instead of
+    // falling through to finishUnreplayableComplete()'s generic
+    // 'guard-unavailable'.
+    abandonComplete(callDigest, pending, true)
+    terminalCompletes.set(callDigest, {
+      target: pending.target,
+      status: 'unavailable',
+      reasonCode: 'invalid-transition',
+    })
     markUnavailable()
     writeAbandonedCompletionResult(output, pending.target, 'invalid-transition')
   }
@@ -3396,14 +3479,13 @@ function createSessionRuntime(
     output: unknown,
   ): void {
     markUnavailable()
-    // No pending transition and nothing replayable: the target is unknown,
-    // so 'unit' is used as the required TransitionTarget field on this
-    // synthetic terminal result — display-only in this branch.
-    writeAbandonedCompletionResult(
-      output,
-      finalTarget ?? 'unit',
-      'guard-unavailable',
-    )
+    // No pending transition and nothing replayable: `finalTarget` is
+    // whatever normalizeTarget() could read out of this call's own args
+    // (real, when the args named a valid target) and is passed through
+    // as-is. When it is also undefined the target is genuinely unknown,
+    // and writeAbandonedCompletionResult()/writeCompletionResult() omit
+    // the `target` key entirely rather than guessing one.
+    writeAbandonedCompletionResult(output, finalTarget, 'guard-unavailable')
   }
 
   function finishUnavailableReadback(

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -2627,6 +2627,219 @@ describe('OpenCode workflow guard adapter', () => {
     })
   })
 
+  test('converged-recovery instances share a sourceDigest, so the questionAttestation gate does not protect them from each other (documented trade-off)', async () => {
+    // `sharedRecovery: true` pins BOTH `registrationIdentity` and
+    // `sessionSalt`, the same pinning `recoverPersistedMarkers()` uses when
+    // a second instance recovers its own prior registration from markers
+    // seeded by the first. Two instances that converge this way compute the
+    // SAME `ledger.metadata.registrationDigest` — and therefore the same
+    // `sourceDigest` — as each other, which is exactly the identifier
+    // `withoutStaleConditionalMetadata()`'s gate compares. The gate cannot
+    // tell these two apart, so it does NOT protect a converged instance's
+    // questionAttestation from being stripped by the other. This is
+    // accepted rather than fixed: `questionAttestation` in written metadata
+    // is display-only (verified: no consumer reads it back as evidence of
+    // a fresh attestation — see the sourceDigest-gate commit), so losing it
+    // here is a fidelity gap, not a security one.
+    const first = createAdapter(
+      'observe',
+      false,
+      undefined,
+      [],
+      undefined,
+      undefined,
+      true,
+    )
+    const second = createAdapter(
+      'observe',
+      false,
+      undefined,
+      [],
+      undefined,
+      undefined,
+      true,
+    )
+
+    await observeSkill(first, 'systematic_skill', 'ce:work')
+    const gateOutput = { title: 'complete', output: 'complete', metadata: {} }
+    await first.hooks['tool.execute.before'](
+      {
+        tool: 'systematic_workflow_complete',
+        sessionID: SESSION_A,
+        callID: 'converged-attest-complete',
+      },
+      { args: { target: 'unit' } },
+    )
+    await first.hooks['tool.execute.after'](
+      {
+        tool: 'systematic_workflow_complete',
+        sessionID: SESSION_A,
+        callID: 'converged-attest-complete',
+        args: { target: 'unit' },
+      },
+      gateOutput,
+    )
+    const questionOutput = { args: {} as Record<string, unknown> }
+    await first.hooks['tool.execute.before'](
+      {
+        tool: 'question',
+        sessionID: SESSION_A,
+        callID: 'converged-attest-question',
+      },
+      questionOutput,
+    )
+    await observeQuestionEvent(first, 'question.asked', {
+      id: 'converged-attest-request',
+      sessionID: SESSION_A,
+      questions: [],
+      tool: {
+        messageID: 'converged-attest-message',
+        callID: 'converged-attest-question',
+      },
+    })
+    await observeQuestionEvent(first, 'question.replied', {
+      sessionID: SESSION_A,
+      requestID: 'converged-attest-request',
+      answers: [['yes']],
+    })
+    mintReceipt(first, 'implementation')
+    mintReceipt(first, 'verification')
+
+    await first.hooks['tool.execute.before'](
+      {
+        tool: 'systematic_workflow_complete',
+        sessionID: SESSION_A,
+        callID: 'converged-first-shared-write',
+      },
+      { args: { target: 'unit' } },
+    )
+    const sharedOutput: RecordedToolOutput = {
+      title: 'stale',
+      output: 'stale',
+      metadata: {},
+    }
+    await first.hooks['tool.execute.after'](
+      {
+        tool: 'systematic_workflow_complete',
+        sessionID: SESSION_A,
+        callID: 'converged-first-shared-write',
+        args: { target: 'epoch' },
+      },
+      sharedOutput,
+    )
+    expect(sharedOutput.metadata.questionAttestation).toMatchObject({
+      status: 'attested',
+    })
+
+    // Both instances share `registrationIdentity`/`sessionSalt`, so
+    // `second`'s own `sourceDigest` equals `first`'s. The gate matches on
+    // sourceDigest equality alone and cannot tell that this write belongs
+    // to a DIFFERENT instance — it strips the attestation exactly as if
+    // `first` were correcting its own stale metadata.
+    await observeSkill(second, 'systematic_skill', 'ce:work')
+    mintReceipt(second, 'implementation')
+    mintReceipt(second, 'verification')
+    await second.hooks['tool.execute.before'](
+      {
+        tool: 'systematic_workflow_complete',
+        sessionID: SESSION_A,
+        callID: 'converged-second-shared-write',
+      },
+      { args: { target: 'unit' } },
+    )
+    await second.hooks['tool.execute.after'](
+      {
+        tool: 'systematic_workflow_complete',
+        sessionID: SESSION_A,
+        callID: 'converged-second-shared-write',
+        args: { target: 'epoch' },
+      },
+      sharedOutput,
+    )
+    expect(sharedOutput.metadata.questionAttestation).toBeUndefined()
+  })
+
+  test('branch E (a finalizeTransition rejection) replays its own recorded reason code against a fresh result object', async () => {
+    // Same partial-registration fixture as "partial registration
+    // finalization fails closed and remains replay-idempotent" — that test
+    // is left untouched; this one adds the fresh-output replay discipline
+    // the branch A regression exposed as missing last round.
+    const first = createAdapter('observe')
+    const second = createAdapter('observe')
+    await observeSkill(first, 'systematic_skill', 'ce:work')
+    await observeSkill(second, 'systematic_skill', 'ce:work')
+    mintReceipt(first, 'implementation')
+    mintReceipt(first, 'verification')
+    mintReceipt(second, 'implementation')
+    mintReceipt(second, 'verification')
+
+    const input = {
+      tool: 'systematic_workflow_complete',
+      sessionID: SESSION_A,
+      callID: 'branch-e-replay',
+    }
+    await first.hooks['tool.execute.before'](input, {
+      args: { target: 'unit' },
+    })
+    await second.hooks['tool.execute.before'](input, {
+      args: { target: 'unit' },
+    })
+
+    const secondStatus = status(second)
+    const secondReceipt = ledger(second)
+      .listReceipts()
+      .find((receipt) => receipt.canonical.operation === 'implementation')
+    if (!secondReceipt || !secondStatus.epoch || !secondStatus.unit) {
+      throw new Error('branch E fixture missing')
+    }
+    ledger(second).consumeReceipt(secondReceipt.canonical.receiptId, {
+      epochId: secondStatus.epoch.epochId,
+      unitId: secondStatus.unit.unitId,
+      workspaceIdentity: SCOPE.workspaceIdentity,
+      repositoryIdentity: SCOPE.repositoryIdentity,
+      worktreeIdentity: SCOPE.worktreeIdentity,
+      operationTargetIdentity: OPERATION_SCOPE.operationTargetIdentity,
+    })
+
+    const firstOutput = { title: 'pending', output: 'pending', metadata: {} }
+    await first.hooks['tool.execute.after'](
+      { ...input, args: { target: 'unit' } },
+      firstOutput,
+    )
+    const secondOutput: RecordedToolOutput = {
+      title: 'pending',
+      output: 'pending',
+      metadata: {},
+    }
+    await second.hooks['tool.execute.after'](
+      { ...input, args: { target: 'unit' } },
+      secondOutput,
+    )
+    expect(secondOutput.metadata.workflowGuard).toMatchObject({
+      status: 'rejected',
+      reasonCode: 'consumed-receipt',
+      target: 'unit',
+    })
+
+    // Replay against a FRESH result object, not the reused `secondOutput`:
+    // an absent write cannot pass this assertion the way a reused object
+    // could.
+    const replayOutput: RecordedToolOutput = {
+      title: 'pending',
+      output: 'pending',
+      metadata: {},
+    }
+    await second.hooks['tool.execute.after'](
+      { ...input, args: { target: 'unit' } },
+      replayOutput,
+    )
+    expect(replayOutput.metadata.workflowGuard).toMatchObject({
+      status: 'rejected',
+      reasonCode: 'consumed-receipt',
+      target: 'unit',
+    })
+  })
+
   test('a shared output across two guard instances keeps the host failure sentinel visible to the second instance', async () => {
     const first = createAdapter('protected')
     const second = createAdapter('protected')

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -2427,16 +2427,24 @@ describe('OpenCode workflow guard adapter', () => {
       reasonCode: 'invalid-transition',
       target: 'unit',
     })
-    const beforeReplay = {
-      ...(output.metadata.workflowGuard as Record<string, unknown>),
-    }
-    // Replay of the identical call (same callID, same args) must not fall
-    // through to finishUnreplayableComplete()'s generic 'guard-unavailable'.
+    // Replay against a FRESH result object (not the same shared `output`
+    // reused above): a same-object replay would pass even if the second
+    // pass writes nothing at all, since the first pass's metadata would
+    // simply still be sitting there. A fresh object can only carry
+    // 'invalid-transition' if the replay path actually wrote it.
+    const replayOutput = staleReadyOutput()
     await adapter.hooks['tool.execute.after'](
       { ...input, args: { target: 'epoch' } },
-      output,
+      replayOutput,
     )
-    expect(output.metadata.workflowGuard).toEqual(beforeReplay)
+    expect(replayOutput.metadata).not.toMatchObject({
+      reasonCode: 'unit-ready',
+    })
+    expect(replayOutput.metadata.workflowGuard).toMatchObject({
+      status: 'unavailable',
+      reasonCode: 'invalid-transition',
+      target: 'unit',
+    })
   })
 
   test('a failed host completion replayed on the same callID keeps the original reason code and does not touch title/output', async () => {
@@ -2468,6 +2476,12 @@ describe('OpenCode workflow guard adapter', () => {
       reasonCode: 'failed-operation',
       target: 'unit',
     })
+    // A host-tool failure deliberately does NOT mark the session
+    // unavailable (unlike an invalid-transition or a finalizeTransition
+    // rejection, both of which do): the guard lets the agent retry the
+    // same unit after a transient host failure. A replay of the same
+    // failed call must not change that disposition either.
+    expect(status(adapter).state).not.toBe('unavailable')
     const beforeReplay = {
       ...(output.metadata.workflowGuard as Record<string, unknown>),
     }
@@ -2483,6 +2497,7 @@ describe('OpenCode workflow guard adapter', () => {
     expect(output.output).toBe(hostErrorText)
     expect(output.metadata.status).toBe('error')
     expect(output.metadata.workflowGuard).toEqual(beforeReplay)
+    expect(status(adapter).state).not.toBe('unavailable')
   })
 
   test('a completion call with no pending transition and no target in its own args omits target rather than fabricating one', async () => {
@@ -2500,6 +2515,116 @@ describe('OpenCode workflow guard adapter', () => {
       reasonCode: 'guard-unavailable',
     })
     expect(output.metadata.workflowGuard).not.toHaveProperty('target')
+  })
+
+  test('a shared output across two guard instances does not erase questionAttestation evidence from the other instance', async () => {
+    const first = createAdapter('observe')
+    const second = createAdapter('observe')
+
+    // First instance obtains an attested question challenge for completing
+    // target 'unit' — same flow as "native question flow binds and accepts
+    // only a correlated affirmative reply" above.
+    await observeSkill(first, 'systematic_skill', 'ce:work')
+    const gateOutput = { title: 'complete', output: 'complete', metadata: {} }
+    await first.hooks['tool.execute.before'](
+      {
+        tool: 'systematic_workflow_complete',
+        sessionID: SESSION_A,
+        callID: 'attest-complete',
+      },
+      { args: { target: 'unit' } },
+    )
+    await first.hooks['tool.execute.after'](
+      {
+        tool: 'systematic_workflow_complete',
+        sessionID: SESSION_A,
+        callID: 'attest-complete',
+        args: { target: 'unit' },
+      },
+      gateOutput,
+    )
+    const questionOutput = { args: {} as Record<string, unknown> }
+    await first.hooks['tool.execute.before'](
+      { tool: 'question', sessionID: SESSION_A, callID: 'attest-question' },
+      questionOutput,
+    )
+    await observeQuestionEvent(first, 'question.asked', {
+      id: 'attest-request',
+      sessionID: SESSION_A,
+      questions: [],
+      tool: { messageID: 'attest-message', callID: 'attest-question' },
+    })
+    await observeQuestionEvent(first, 'question.replied', {
+      sessionID: SESSION_A,
+      requestID: 'attest-request',
+      answers: [['yes']],
+    })
+    // Resolve first's own missing-evidence gate (independent of the
+    // question challenge above) so its next completion attempt actually
+    // registers a pending transition instead of being rejected before
+    // reaching branch A.
+    mintReceipt(first, 'implementation')
+    mintReceipt(first, 'verification')
+
+    // First instance now writes a shared output that carries its attested
+    // questionAttestation — a mismatched-target completion (branch A) is a
+    // convenient vehicle: any of the five metadata-merge sites proves the
+    // point.
+    await first.hooks['tool.execute.before'](
+      {
+        tool: 'systematic_workflow_complete',
+        sessionID: SESSION_A,
+        callID: 'first-shared-write',
+      },
+      { args: { target: 'unit' } },
+    )
+    const sharedOutput: RecordedToolOutput = {
+      title: 'stale',
+      output: 'stale',
+      metadata: {},
+    }
+    await first.hooks['tool.execute.after'](
+      {
+        tool: 'systematic_workflow_complete',
+        sessionID: SESSION_A,
+        callID: 'first-shared-write',
+        args: { target: 'epoch' },
+      },
+      sharedOutput,
+    )
+    expect(sharedOutput.metadata.questionAttestation).toMatchObject({
+      status: 'attested',
+    })
+
+    // A second, independent guard instance (different
+    // ledger.metadata.registrationDigest, no attestation of its own) now
+    // writes into the SAME shared output for its own, unrelated
+    // mismatched-target completion. Its own metadata() call does not emit
+    // questionAttestation — the first instance's evidence must survive the
+    // strip in withoutStaleConditionalMetadata().
+    await observeSkill(second, 'systematic_skill', 'ce:work')
+    mintReceipt(second, 'implementation')
+    mintReceipt(second, 'verification')
+    await second.hooks['tool.execute.before'](
+      {
+        tool: 'systematic_workflow_complete',
+        sessionID: SESSION_A,
+        callID: 'second-shared-write',
+      },
+      { args: { target: 'unit' } },
+    )
+    await second.hooks['tool.execute.after'](
+      {
+        tool: 'systematic_workflow_complete',
+        sessionID: SESSION_A,
+        callID: 'second-shared-write',
+        args: { target: 'epoch' },
+      },
+      sharedOutput,
+    )
+    expect(sharedOutput.metadata.questionAttestation).toMatchObject({
+      status: 'attested',
+    })
   })
 
   test('a shared output across two guard instances keeps the host failure sentinel visible to the second instance', async () => {

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -2404,6 +2404,104 @@ describe('OpenCode workflow guard adapter', () => {
     })
   })
 
+  test('a mismatched completion target replayed on the same callID keeps the original reason code', async () => {
+    const adapter = createAdapter('protected')
+    await observeSkill(adapter, 'systematic_skill', 'ce:work')
+    mintReceipt(adapter, 'implementation')
+    mintReceipt(adapter, 'verification')
+    const input = {
+      tool: 'systematic_workflow_complete',
+      sessionID: SESSION_A,
+      callID: 'mismatched-target-replay',
+    }
+    await adapter.hooks['tool.execute.before'](input, {
+      args: { target: 'unit' },
+    })
+    const output = staleReadyOutput()
+    await adapter.hooks['tool.execute.after'](
+      { ...input, args: { target: 'epoch' } },
+      output,
+    )
+    expect(output.metadata.workflowGuard).toMatchObject({
+      status: 'unavailable',
+      reasonCode: 'invalid-transition',
+      target: 'unit',
+    })
+    const beforeReplay = {
+      ...(output.metadata.workflowGuard as Record<string, unknown>),
+    }
+    // Replay of the identical call (same callID, same args) must not fall
+    // through to finishUnreplayableComplete()'s generic 'guard-unavailable'.
+    await adapter.hooks['tool.execute.after'](
+      { ...input, args: { target: 'epoch' } },
+      output,
+    )
+    expect(output.metadata.workflowGuard).toEqual(beforeReplay)
+  })
+
+  test('a failed host completion replayed on the same callID keeps the original reason code and does not touch title/output', async () => {
+    const adapter = createAdapter('protected')
+    await observeSkill(adapter, 'systematic_skill', 'ce:work')
+    mintReceipt(adapter, 'implementation')
+    mintReceipt(adapter, 'verification')
+    const input = {
+      tool: 'systematic_workflow_complete',
+      sessionID: SESSION_A,
+      callID: 'host-failure-replay',
+    }
+    await adapter.hooks['tool.execute.before'](input, {
+      args: { target: 'unit' },
+    })
+    const hostErrorTitle = 'Bash command failed'
+    const hostErrorText = 'permission denied: /var/run/lock'
+    const output: RecordedToolOutput = {
+      title: hostErrorTitle,
+      output: hostErrorText,
+      metadata: { status: 'error' },
+    }
+    await adapter.hooks['tool.execute.after'](
+      { ...input, args: { target: 'unit' } },
+      output,
+    )
+    expect(output.metadata.workflowGuard).toMatchObject({
+      status: 'unavailable',
+      reasonCode: 'failed-operation',
+      target: 'unit',
+    })
+    const beforeReplay = {
+      ...(output.metadata.workflowGuard as Record<string, unknown>),
+    }
+    // Replay of the identical call (same callID, same host failure) must
+    // not fall through to finishUnreplayableComplete()'s generic
+    // 'guard-unavailable', and must not overwrite the host's own
+    // title/output with a generic terminal-result title.
+    await adapter.hooks['tool.execute.after'](
+      { ...input, args: { target: 'unit' } },
+      output,
+    )
+    expect(output.title).toBe(hostErrorTitle)
+    expect(output.output).toBe(hostErrorText)
+    expect(output.metadata.status).toBe('error')
+    expect(output.metadata.workflowGuard).toEqual(beforeReplay)
+  })
+
+  test('a completion call with no pending transition and no target in its own args omits target rather than fabricating one', async () => {
+    const adapter = createAdapter('protected')
+    const input = {
+      tool: 'systematic_workflow_complete',
+      sessionID: SESSION_A,
+      callID: 'no-pending-no-target-complete',
+    }
+    const output = staleReadyOutput()
+    await adapter.hooks['tool.execute.after']({ ...input, args: {} }, output)
+    expect(output.metadata).not.toMatchObject({ reasonCode: 'unit-ready' })
+    expect(output.metadata.workflowGuard).toMatchObject({
+      status: 'unavailable',
+      reasonCode: 'guard-unavailable',
+    })
+    expect(output.metadata.workflowGuard).not.toHaveProperty('target')
+  })
+
   test('a shared output across two guard instances keeps the host failure sentinel visible to the second instance', async () => {
     const first = createAdapter('protected')
     const second = createAdapter('protected')


### PR DESCRIPTION
## Summary

Follow-up to #945. Fixes the three evidence-fidelity gaps tracked in #946. All are safety-neutral — the host failure sentinel survives in every case, so the guard could never be tricked onto a success path — but each degraded the accuracy of the completion evidence record #942/#945 exist to protect. No fail-closed behaviour was weakened.

**Update:** this PR was revised after review to fix two blocking correctness issues found in the first pass (see "Review fixes" below). The claims in this description reflect the current, corrected state of the code.

## Item 1 — reason code survives replay for branches A and F1

**What:** Branches A (`finishMismatchedTarget`, mismatched completion target → `invalid-transition`) and F1 (`finalizeComplete`'s host-tool-failed path → `failed-operation`) now record a `TerminalComplete`, so a second `tool.execute.after` for the same `callID` replays the original reason code instead of falling through to `finishUnreplayableComplete()`'s generic `guard-unavailable`.

**F1 detail:** the recorded `TerminalComplete` carries a `metadataOnly: true` flag. On replay, `writeTerminalReplay()` checks this flag and calls `writeAbandonedCompletionMetadata()` (metadata-only correction) instead of `writeCompletionResult()` (which would overwrite `title`/`output`) — preserving #945's rule that the host's own failure title/text is evidence and must survive untouched.

**Replay path correction (see "Review fixes"):** the original implementation stored the terminal record but never actually reached it on a true replay — the pre-existing `finalTarget !== expectedTarget` mismatch check, computed from `abandonedCompletes`/`blockedCompletes`, ran *before* the terminal check and always rejected branch A's replay (since a genuine replay reproduces the same mismatched args that produced the terminal in the first place). `replayTerminalComplete()` now checks `terminalCompletes` **first**, using the target that produced the terminal record, and only falls through to the mismatch-gated `replay`/`blockedTarget` paths when no terminal record exists for this digest. See below for why bypassing the mismatch check is safe specifically for recorded terminals.

## Item 2 — decision: made `TerminalComplete.target` optional, no fabrication

**What:** `TerminalComplete.target` is optional. `writeCompletionResult()`'s third parameter is `TransitionTarget | undefined`; when undefined (only ever from `finishUnreplayableComplete()`, the genuinely-unknown-target case), the written `workflowGuard` metadata omits the `target` key entirely (via `targetMetadataField()`) instead of guessing `'unit'`. The `completed`/`duplicate` success branch treats `target` as always-present — reachable only from `finalizeComplete()` with a concrete `pending.target` — rather than adding unreachable fallback handling for a case that branch can never see (review item 4).

**Why it's safe to make optional:** `TerminalComplete.target` was never read back by `writeCompletionResult()` — the target written to the tool result always comes from that function's own `target` parameter, not `result.target`. No schema constrains the `workflowGuard` metadata shape outside this file.

## Item 3 — `questionAttestation` staleness

**Verified by reading `src/lib/question-attestation.ts` and every `questionAttestation` call site:** the attestation state machine is in-memory, keyed by `challengeId`/`requestId`/`sessionId`; consumption is tracked internally and never inferred from a tool result's `metadata.questionAttestation` field (write-only, for host/client display). No consumer reads it back. **Verdict: fidelity-only, not a fail-open.**

**Gated fix (see "Review fixes"):** `withoutStaleConditionalMetadata()` now only strips a carried-over `questionAttestation` key when `existingMetadata.sourceDigest` matches the *current* guard instance's own `sourceDigest` (`ledger.metadata.registrationDigest`, fixed per instance, distinct across instances unless `registrationIdentity` is pinned). This prevents a second guard instance sharing the same `output` reference from erasing attestation evidence a *different* instance wrote — the original unconditional strip could do exactly that.

## Review fixes (this revision)

1. **Branch A's terminal record was dead code, and its own test was vacuous.** `replayTerminalComplete()`'s mismatch check ran before the terminal lookup and always rejected branch A's genuine replay (same callID, same originally-mismatched args), so `writeTerminalReplay()` was never reached — against a *fresh* result object, replay would have produced *no* `workflowGuard` metadata at all, a net loss versus `main`'s `guard-unavailable`. Fixed by checking `terminalCompletes` first and replaying it using the target that produced it, without gating on the replay's own `finalTarget`. This is safe *specifically* for recorded terminals — never for `replay` (finalized success) or `blockedTarget` (a live question gate) — because a terminal record is already a terminal, non-success outcome: reproducing it can never take a success path and consumes nothing. The `finalTarget !== expectedTarget` check is untouched for those other two paths.
2. **F1's replay silently stopped calling `markUnavailable()`.** Judged intentional: a host-tool failure deliberately never marks the session unavailable (unlike invalid-transition or a finalizeTransition rejection, both of which do) so the agent can retry the same unit; a duplicate delivery of the same failure should not change that disposition. Pinned with an explicit `state` assertion in the F1 test (before *and* after the replay) plus a code comment recording the intent.
3. **`questionAttestation` cross-instance erasure** — described above; added a two-guard-instance regression test in the shape of the existing shared-output pattern.
4. **Dead `undefined`-target handling in the success branch** — removed; described above.

## Tests

In `tests/unit/opencode-workflow-guard.test.ts`, adjacent to the existing branch A/F1/no-pending regressions:

- `a mismatched completion target replayed on the same callID keeps the original reason code` — replays against a **fresh** result object (not the same shared one used for the first write), so an absent write cannot pass the assertion; asserts `invalid-transition`/`unit` are actually present on the fresh object.
- `a failed host completion replayed on the same callID keeps the original reason code and does not touch title/output` — asserts `title`/`output` unchanged, plus `status(adapter).state` stays non-`'unavailable'` both before and after the replay.
- `a completion call with no pending transition and no target in its own args omits target rather than fabricating one` — asserts no `target` key at all.
- `a shared output across two guard instances does not erase questionAttestation evidence from the other instance` — drives a real attest flow on one instance, writes it into a shared output, then has a second (unattested) instance write into the same shared output, and asserts the first instance's `questionAttestation` survives.

### Bidirectional proofs (each reverted → red → restored → green)

1. **Branch A fresh-output replay** — reverted the terminal-first lookup back to the original ordering. Fresh replay output retained its *stale, pre-existing* `unit-ready` metadata untouched (nothing was written at all) — exactly the "net loss of evidence" the reviewer predicted. Restored → passes.
2. **F1 reason code + title/output** (carried over from the previous revision) — reverting the terminal-recording addition made `output.title` become the generic `"Workflow transition unavailable"` instead of staying `"Bash command failed"`. Restored → passes.
3. **Item 2 target omission** (carried over) — reverting to `finalTarget ?? 'unit'` produced a fabricated `target: "unit"` where none should exist. Restored → passes.
4. **Item 3 questionAttestation gate** — reverting the `sourceDigest` gate made the second instance's write erase the first instance's `questionAttestation` entirely (`undefined`, not just downgraded). Restored → passes.

Fail-closed tests `partial registration finalization fails closed and remains replay-idempotent` and `fresh completion readback completes once and interleaving changes reject without consumption` are **untouched** (diff hunks are well outside their line ranges) and pass unmodified.

## Verification

- `bun test tests/unit/opencode-workflow-guard.test.ts`: `129 pass / 0 fail / 440 expect() calls`.
- `bun test` (full): `2474 pass / 1 skip / 0 fail`, `Ran 2475 tests across 83 files. [1318.83s]`.
- `bun run typecheck:all`: clean.
- `bun run lint`: `0 errors`, `13 warnings` — unchanged vs `main`'s 13.
- `bun scripts/content-integrity.ts`: `clean (125 md + 40 ts + 87 solution-md + 4 root docs scanned, 20 exempt hits, 0 warnings)`.
- `bun run build`: succeeds.
- `SYSTEMATIC_REQUIRE_OPENCODE=1 bun test tests/integration/receipt-workflow-dogfood.test.ts`: `1 pass / 0 fail`.
- `pgrep -fl opencode-ai` empty after every run.

Closes #946
