### PR TITLE
docs(plans): mark three shipped plans as completed

### DIFF
--- a/docs/plans/2026-07-06-004-feat-discovered-skills-as-commands-plan.md
+++ b/docs/plans/2026-07-06-004-feat-discovered-skills-as-commands-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: discovered skills as commands + systematic_skill permission parity"
 type: feat
-status: active
+status: completed
 date: 2026-07-06
 origin: docs/brainstorms/2026-07-06-discovered-skills-as-commands-requirements.md
 ---
@@ -98,7 +98,7 @@ Carried from the origin brainstorm:
 
 ## Implementation Units
 
-- [ ] **Unit 1: Discovery of non-bundled skills across the six roots**
+- [x] **Unit 1: Discovery of non-bundled skills across the six roots**
 
 **Goal:** A pure function that discovers user/project skills exactly as upstream does — same roots, same order, same later-wins duplicate rule — returning name, description, frontmatter (incl. `disable-model-invocation`), and body path.
 
@@ -126,7 +126,7 @@ Carried from the origin brainstorm:
 
 **Verification:** unit tests green; discovery output for a fixture tree matches upstream's documented winner for every duplicate case.
 
-- [ ] **Unit 2: Command emission in the config hook**
+- [x] **Unit 2: Command emission in the config hook**
 
 **Goal:** Convert discovered skills into `config.command` entries — shim template for model-invocable, inline body for command-only — behind the `skills_as_commands` toggle, never clobbering existing commands.
 
@@ -155,7 +155,7 @@ Carried from the origin brainstorm:
 
 **Verification:** unit suite green; schema drift check passes; a fixture project shows `/skill-name` entries in emitted config exactly once per skill.
 
-- [ ] **Unit 3: Docs for the feature**
+- [x] **Unit 3: Docs for the feature**
 
 **Goal:** Committed docs covering discovery roots, naming, replace-by-name collision policy, the toggle, command-only semantics, and the honest upstream/trust framing.
 
@@ -172,7 +172,7 @@ Carried from the origin brainstorm:
 
 **Verification:** docs build passes; page states the trust model and upstream context plainly.
 
-- [ ] **Unit 4 (separate PR): `systematic_skill` permission parity + sampling alignment**
+- [x] **Unit 4 (separate PR): `systematic_skill` permission parity + sampling alignment**
 
 **Goal:** `systematic_skill` loads gate through `permission.skill` semantics via the bridged `ask()`; file sampling matches upstream behavior.
 

--- a/docs/plans/2026-07-11-001-refactor-v3-bundle-curation-plan.md
+++ b/docs/plans/2026-07-11-001-refactor-v3-bundle-curation-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'refactor!: v3 bundle curation — remove niche assets, consolidate overlaps'
 type: refactor
-status: active
+status: completed
 date: 2026-07-11
 origin: docs/brainstorms/2026-07-11-v3-bundle-curation-requirements.md
 ---
@@ -86,7 +86,7 @@ The bundle grew by accretion; every asset ships to every install (including head
 
 ## Implementation Units
 
-- [ ] **Unit 1: Remove 12 peripheral/vertical skills**
+- [x] **Unit 1: Remove 12 peripheral/vertical skills**
 
 **Goal:** Delete `dspy-ruby`, `dhh-rails-style`, `andrew-kane-gem-writer`, `every-style-editor`, `rclone`, `gemini-imagegen`, `test-xcode`, `proof`, `feature-video`, `changelog`, `generate_command`, `setup`; rewire live references; extend removed-names; regenerate.
 
@@ -107,7 +107,7 @@ The bundle grew by accretion; every asset ships to every install (including head
 
 **Verification:** full unit suite, typecheck, content-integrity, schema+registry drift clean, docs build.
 
-- [ ] **Unit 2: Remove 14 agents, rewire reviewer references**
+- [x] **Unit 2: Remove 14 agents, rewire reviewer references**
 
 **Goal:** Delete the 6 stack-specific personas (`kieran-rails-reviewer`, `kieran-python-reviewer`, `dhh-rails-reviewer`, `julik-frontend-races-reviewer`, `schema-drift-detector`, `lint`), 5 duplicate standalones (`security-sentinel`, `performance-oracle`, `data-integrity-guardian`, `data-migration-expert`, `cli-agent-readiness-reviewer`), 2 Figma agents (`figma-design-sync`, `design-implementation-reviewer`), and `ankane-readme-writer`; rewire every inbound reference; populate `REMOVED_BUNDLED_AGENT_NAMES`.
 
@@ -128,7 +128,7 @@ The bundle grew by accretion; every asset ships to every install (including head
 
 **Verification:** full gates as Unit 1.
 
-- [ ] **Unit 3: Merge todo trio into `todos`**
+- [x] **Unit 3: Merge todo trio into `todos`**
 
 **Goal:** Create `skills/todos/SKILL.md` (Create/Triage/Resolve sections merging the three bodies); delete the three dirs; rewire; removed-names.
 
@@ -150,7 +150,7 @@ The bundle grew by accretion; every asset ships to every install (including head
 
 **Verification:** full gates.
 
-- [ ] **Unit 4: Fold writing-systematic-skills into writing-skills**
+- [x] **Unit 4: Fold writing-systematic-skills into writing-skills**
 
 **Goal:** Append a "Systematic bundled skills" section to `skills/writing-skills/SKILL.md` carrying the Systematic-specific contracts (frontmatter rules, content-integrity, reference-file conventions); delete `skills/writing-systematic-skills/`; update the content-integrity remediation string.
 
@@ -170,7 +170,7 @@ The bundle grew by accretion; every asset ships to every install (including head
 
 **Verification:** full gates.
 
-- [ ] **Unit 5: Docs sweep + final verification**
+- [x] **Unit 5: Docs sweep + final verification**
 
 **Goal:** Regenerate docs reference content; verify orphaned reference pages are gone (delete manually if generator is add-only); update the migration guidance started by 002 Unit 5 with the curation removals table; full-suite final verification across all gates.
 

--- a/docs/plans/2026-08-01-001-fix-worktree-targeted-receipt-observation-plan.md
+++ b/docs/plans/2026-08-01-001-fix-worktree-targeted-receipt-observation-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'fix: Observe worktree-targeted child operations in the receipt guard'
 type: fix
-status: active
+status: completed
 date: 2026-08-01
 deepened: 2026-08-01
 ---
@@ -294,7 +294,7 @@ task.after (foreground child rollup)                                  # U5
 - **`repositoryIdentity` / `worktreeIdentity`** — mutable revision digests of the
   target's HEAD/tree; staleness is skippable, target identity mismatch is not.
 
-- [ ] **Unit 1: Git-sanitized observer with worktree-structure validation**
+- [x] **Unit 1: Git-sanitized observer with worktree-structure validation**
 
 **Goal:** Give the observer a trustworthy way to validate that an arbitrary
 candidate directory is a registered worktree of the parent repository, with
@@ -348,7 +348,7 @@ shape; `createSeparatedGitFixture` for exotic git layouts.
 worktrees and rejects every spoof fixture; all git subprocesses run with `GIT_*`
 stripped.
 
-- [ ] **Unit 2: Host tool target derivation**
+- [x] **Unit 2: Host tool target derivation**
 
 **Goal:** Resolve the canonical directory a guarded tool actually operated on
 from host-observed arguments, or the parent checkout when there is no override.
@@ -400,7 +400,7 @@ closed vs fast-path fork are the core correctness surface.
 the parent for no-override cases, and fails closed for invalid explicit targets
 with no fixed-observer fallback.
 
-- [ ] **Unit 3: `operationTargetIdentity` authenticated canonical field**
+- [x] **Unit 3: `operationTargetIdentity` authenticated canonical field**
 
 **Goal:** Add a target identity to the receipt's canonical fields so it is
 covered by the salted integrity digest and survives serialize → marker →
@@ -477,7 +477,7 @@ the exact template — mirror it at every site above.
 v1 shim admits only parent-target legacy evidence, and version/closed-set checks
 reject incompatible or field-omitting envelopes.
 
-- [ ] **Unit 4: Per-operation observer wiring and unit target pinning**
+- [x] **Unit 4: Per-operation observer wiring and unit target pinning**
 
 **Goal:** Use a derived-target observer for before/after, bind
 `operationTargetIdentity` into the observation, and pin one local target per unit.
@@ -546,7 +546,7 @@ test proving the durable pin survives, before wiring worktree targets.
 **Verification:** worktree-targeted operations mint; parent-targeted operations
 are unchanged; target switches and between-hook tampering fail closed.
 
-- [ ] **Unit 5: Worktree-aware foreground child rollup**
+- [x] **Unit 5: Worktree-aware foreground child rollup**
 
 **Goal:** Roll up child receipts against each receipt's authenticated target
 instead of the fixed parent observer, preserving the fatal-vs-skippable
@@ -598,7 +598,7 @@ in the 2026-07-31 solution doc.
 shared-parent u5 is unchanged; every spoof/malformed case fails closed without
 partial mutation.
 
-- [ ] **Unit 6: Dogfood reproduction and attack-matrix consolidation**
+- [x] **Unit 6: Dogfood reproduction and attack-matrix consolidation**
 
 **Goal:** Lock in a failing-then-passing reproduction of #678 and consolidate the
 negative/attack matrix into durable regression coverage.

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -1795,8 +1795,8 @@ function collectPlanFiles(rootDir: string, plansDir: string): string[] {
     .sort()
 }
 
-const UNTICKED_UNIT_CHECKBOX_REGEX = /^\s*-\s\[ \]/m
-const TICKED_UNIT_CHECKBOX_REGEX = /^\s*-\s\[x\]/m
+const UNTICKED_UNIT_CHECKBOX_REGEX = /^\s*-\s\[ \]/im
+const TICKED_UNIT_CHECKBOX_REGEX = /^\s*-\s\[x\]/im
 
 /**
  * A plan under `docs/plans/` with frontmatter `status: active` and zero
@@ -1813,6 +1813,16 @@ const TICKED_UNIT_CHECKBOX_REGEX = /^\s*-\s\[x\]/m
  * - Any `status` other than `active` (`completed`, `superseded`, etc.) is
  *   ignored entirely; this check only targets plans currently claiming to be
  *   in progress.
+ * - Checkboxes inside fenced code blocks (documentation examples) are
+ *   stripped before counting, so an illustrative `- [x]` in a program doc's
+ *   example fence cannot trigger a flag.
+ *
+ * Deliberately NOT covered: a plan whose units are ALL unticked, however
+ * long it has sat `active`, is never flagged. Ticked-count zero is
+ * indistinguishable from "not started yet" using frontmatter and checkboxes
+ * alone — telling "shipped but nobody ticked the boxes" apart from "not
+ * started" needs verifying deliverables against the working tree, which this
+ * gate deliberately does not do.
  */
 export function checkStalePlanStatus(
   rootDir: string,
@@ -1827,8 +1837,9 @@ export function checkStalePlanStatus(
     const parsed = parseFrontmatter(content)
     if (!isRecord(parsed.data) || parsed.data.status !== 'active') continue
 
-    if (UNTICKED_UNIT_CHECKBOX_REGEX.test(parsed.body)) continue
-    if (!TICKED_UNIT_CHECKBOX_REGEX.test(parsed.body)) continue
+    const body = stripFencedCodeBlocks(parsed.body)
+    if (UNTICKED_UNIT_CHECKBOX_REGEX.test(body)) continue
+    if (!TICKED_UNIT_CHECKBOX_REGEX.test(body)) continue
 
     violations.push({
       kind: 'active-with-no-remaining-units',

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -327,6 +327,12 @@ export interface LibModuleTableCompletenessViolation {
   message: string
 }
 
+export interface StalePlanStatusViolation {
+  kind: 'active-with-no-remaining-units'
+  file: string
+  message: string
+}
+
 export interface CheckResult {
   rootDir: string
   categories: string[]
@@ -349,6 +355,7 @@ export interface CheckResult {
   hookParityViolations: HookParityViolation[]
   codemapCompletenessViolations: CodemapCompletenessViolation[]
   libModuleTableCompletenessViolations: LibModuleTableCompletenessViolation[]
+  stalePlanStatusViolations: StalePlanStatusViolation[]
   dispatchArgumentViolations: DispatchArgumentViolation[]
   exemptHits: ExemptHit[]
   scanStats: {
@@ -609,6 +616,7 @@ export const CODEMAP_DOCUMENT = 'ARCHITECTURE.md'
 export const CODEMAP_EXCLUSION_HEADING = '## Codemap exclusions'
 export const LIB_MODULE_TABLE_DOCUMENT = 'src/lib/AGENTS.md'
 export const LIB_MODULE_TABLE_EXCLUSION_HEADING = '## Module table exclusions'
+export const PLANS_DIR = 'docs/plans'
 
 const HOOK_ASSERTION_REGEX =
   /\b(?:registers?|exposes?)\b(?:[^\n]*\n){0,2}?\s*(?:these|every|all|one|two|three|four|five|six|seven|eight|nine|ten|\d+)(?:\s+(?:one|two|three|four|five|six|seven|eight|nine|ten|\d+))?\s+(?:OpenCode\s+)?hooks?\b/i
@@ -1775,6 +1783,66 @@ export function checkLibModuleTableCompleteness(
   return violations
 }
 
+function collectPlanFiles(rootDir: string, plansDir: string): string[] {
+  const absPlansDir = path.join(rootDir, plansDir)
+  if (!fs.existsSync(absPlansDir)) return []
+
+  return walkDir(absPlansDir, {
+    maxDepth: 10,
+    filter: (entry) => !entry.isDirectory && entry.name.endsWith('.md'),
+  })
+    .map((entry) => path.relative(rootDir, entry.path))
+    .sort()
+}
+
+const UNTICKED_UNIT_CHECKBOX_REGEX = /^\s*-\s\[ \]/m
+const TICKED_UNIT_CHECKBOX_REGEX = /^\s*-\s\[x\]/m
+
+/**
+ * A plan under `docs/plans/` with frontmatter `status: active` and zero
+ * remaining `- [ ]` unit checkboxes is almost certainly stale: the work
+ * shipped but nobody flipped `status` to `completed`. This is pure
+ * frontmatter + checkbox counting — it does not inspect the working tree to
+ * verify claimed deliverables actually exist.
+ *
+ * Edge cases handled deliberately:
+ * - A plan with no checkboxes at all (a program/strategy document that is
+ *   only prose) is never flagged — flagging requires at least one ticked
+ *   `- [x]` unit alongside zero unticked ones, so a plan can't be flagged
+ *   just for lacking checkbox syntax entirely.
+ * - Any `status` other than `active` (`completed`, `superseded`, etc.) is
+ *   ignored entirely; this check only targets plans currently claiming to be
+ *   in progress.
+ */
+export function checkStalePlanStatus(
+  rootDir: string,
+  plansDir = PLANS_DIR,
+): StalePlanStatusViolation[] {
+  const violations: StalePlanStatusViolation[] = []
+
+  for (const relPath of collectPlanFiles(rootDir, plansDir)) {
+    const content = readFileSafe(path.join(rootDir, relPath))
+    if (content === null) continue
+
+    const parsed = parseFrontmatter(content)
+    if (!isRecord(parsed.data) || parsed.data.status !== 'active') continue
+
+    if (UNTICKED_UNIT_CHECKBOX_REGEX.test(parsed.body)) continue
+    if (!TICKED_UNIT_CHECKBOX_REGEX.test(parsed.body)) continue
+
+    violations.push({
+      kind: 'active-with-no-remaining-units',
+      file: relPath,
+      message:
+        `${relPath} is marked \`status: active\` but has no remaining unticked ` +
+        'unit checkboxes — every `- [x]` unit is already ticked. Flip `status` ' +
+        'to `completed`, or tick the units that genuinely remain incomplete.',
+    })
+  }
+
+  return violations
+}
+
 /**
  * Strip fenced code blocks (``` or ~~~) from a markdown body string.
  * Returns the body with all fenced regions replaced by empty strings so that
@@ -2317,6 +2385,7 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
   const codemapCompletenessViolations = checkCodemapCompleteness(rootDir)
   const libModuleTableCompletenessViolations =
     checkLibModuleTableCompleteness(rootDir)
+  const stalePlanStatusViolations = checkStalePlanStatus(rootDir)
   const dispatchArgumentViolations = checkDispatchArguments(
     rootDir,
     targets.markdown,
@@ -2349,6 +2418,7 @@ export function checkContentIntegrity(rootDir: string): CheckResult {
     hookParityViolations,
     codemapCompletenessViolations,
     libModuleTableCompletenessViolations,
+    stalePlanStatusViolations,
     dispatchArgumentViolations,
     exemptHits,
     scanStats: {
@@ -2411,6 +2481,7 @@ function printResult(result: CheckResult, verbose: boolean): void {
   printLibModuleTableCompletenessViolations(
     result.libModuleTableCompletenessViolations,
   )
+  printStalePlanStatusViolations(result.stalePlanStatusViolations)
   printDispatchArgumentViolations(result.dispatchArgumentViolations)
 
   if (totalViolations(result) === 0) {
@@ -2658,6 +2729,18 @@ function printLibModuleTableCompletenessViolations(
   }
 }
 
+function printStalePlanStatusViolations(
+  violations: readonly StalePlanStatusViolation[],
+): void {
+  if (violations.length === 0) return
+  process.stderr.write(
+    `\nStale plan status violations (${violations.length}):\n`,
+  )
+  for (const violation of violations) {
+    process.stderr.write(`  [${violation.kind}] ${violation.message}\n`)
+  }
+}
+
 function totalViolations(result: CheckResult): number {
   return (
     result.phantomRefs.length +
@@ -2678,6 +2761,7 @@ function totalViolations(result: CheckResult): number {
     result.hookParityViolations.length +
     result.codemapCompletenessViolations.length +
     result.libModuleTableCompletenessViolations.length +
+    result.stalePlanStatusViolations.length +
     result.dispatchArgumentViolations.length
   )
 }

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -25,6 +25,7 @@ import {
   checkReferenceIntegrity,
   checkRemovedNamesOverlap,
   checkSkillReferenceIntegrity,
+  checkStalePlanStatus,
   checkSubfileReferences,
   collectScanTargets,
   discoverCategories,
@@ -801,6 +802,83 @@ describe('checkLibModuleTableCompleteness', () => {
       )
 
       expect(checkLibModuleTableCompleteness(root)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('checkStalePlanStatus', () => {
+  test('flags an active plan whose units are all ticked', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/plans/2026-01-01-001-feat-example-plan.md',
+        '---\ntitle: "feat: example"\nstatus: active\ndate: 2026-01-01\n---\n\n' +
+          '## Units\n\n- [x] Unit one\n- [x] Unit two\n',
+      )
+
+      const violations = checkStalePlanStatus(root)
+
+      expect(violations).toMatchObject([
+        {
+          kind: 'active-with-no-remaining-units',
+          file: 'docs/plans/2026-01-01-001-feat-example-plan.md',
+        },
+      ])
+      expect(violations[0]?.message).toContain(
+        'docs/plans/2026-01-01-001-feat-example-plan.md',
+      )
+      expect(violations[0]?.message).toContain('completed')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('leaves an active plan with at least one unticked unit clean', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/plans/2026-01-01-001-feat-example-plan.md',
+        '---\ntitle: "feat: example"\nstatus: active\ndate: 2026-01-01\n---\n\n' +
+          '## Units\n\n- [x] Unit one\n- [ ] Unit two\n',
+      )
+
+      expect(checkStalePlanStatus(root)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('leaves a completed plan with zero unticked units clean', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/plans/2026-01-01-001-feat-example-plan.md',
+        '---\ntitle: "feat: example"\nstatus: completed\ndate: 2026-01-01\n---\n\n' +
+          '## Units\n\n- [x] Unit one\n- [x] Unit two\n',
+      )
+
+      expect(checkStalePlanStatus(root)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('leaves an active plan with no checkboxes at all clean', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/plans/2026-01-01-001-refactor-program-plan.md',
+        '---\ntitle: "refactor: program"\nstatus: active\ndate: 2026-01-01\n---\n\n' +
+          '## Overview\n\nThis is a program document that delegates work to child plans.\n',
+      )
+
+      expect(checkStalePlanStatus(root)).toEqual([])
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }

--- a/tests/unit/content-integrity.test.ts
+++ b/tests/unit/content-integrity.test.ts
@@ -883,6 +883,44 @@ describe('checkStalePlanStatus', () => {
       fs.rmSync(root, { recursive: true, force: true })
     }
   })
+
+  test('leaves a program doc clean when its only ticked checkbox is an illustration inside a fence', () => {
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/plans/2026-01-01-001-refactor-program-plan.md',
+        '---\ntitle: "refactor: program"\nstatus: active\ndate: 2026-01-01\n---\n\n' +
+          '## Overview\n\nChild plans use this checkbox format:\n\n' +
+          '```md\n- [x] Unit one\n```\n\n' +
+          'This document itself has no real units.\n',
+      )
+
+      expect(checkStalePlanStatus(root)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('deliberate non-goal: an active plan whose units are ALL unticked is never flagged', () => {
+    // Pins the gate's known limitation: "shipped, nothing ticked" is
+    // indistinguishable from "not started" using frontmatter + checkboxes
+    // alone, so it is intentionally out of scope. This is not an oversight —
+    // do not tighten this check to close it without tree inspection.
+    const root = makeFixtureRepo()
+    try {
+      writeFile(
+        root,
+        'docs/plans/2026-01-01-001-feat-shipped-but-unticked-plan.md',
+        '---\ntitle: "feat: shipped but unticked"\nstatus: active\ndate: 2026-01-01\n---\n\n' +
+          '## Units\n\n- [ ] Unit one\n- [ ] Unit two\n',
+      )
+
+      expect(checkStalePlanStatus(root)).toEqual([])
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('checkContentIntegrity — library module-table completeness wiring', () => {


### PR DESCRIPTION
## Summary

Three plans in `docs/plans/` still read `status: active` with unticked units after their work had fully shipped, so the directory misrepresented what remained to be done.

Every unit was verified against the current tree rather than against the plan's own prose. Half the reported drift turned out not to be drift, so this change is narrower than the issue implies.

## Flipped to `completed`

| Plan | Evidence |
|---|---|
| `2026-07-06-004-feat-discovered-skills-as-commands` | `collectSkillsAsCommands` at `src/lib/config-handler.ts:533`, `skills_as_commands` gate at `:724`, schema field at `src/lib/config-schema.ts:661` |
| `2026-07-11-001-refactor-v3-bundle-curation` | `skills/todos/SKILL.md` present (the merged trio), `skills/writing-systematic-skills/` absent (folded as planned), `src/lib/removed-names.ts` present |
| `2026-08-01-001-fix-worktree-targeted-receipt-observation` | `operationTargetIdentity` threaded through the ledger, guard, and observer — 35 references in `src/lib/receipt-ledger.ts`, 31 in `src/lib/workflow-guard.ts`, and all five named files exist |

## Left active, and why

These three were reported as drift but are correct as they stand:

- **`2026-07-28-001-feat-pi-subagents-interop`** — Units 4 and 5 are genuinely outstanding. Unit 4's named deliverables `src/lib/pi-subagents-detect.ts` and `tests/unit/pi-subagents-detect.test.ts` do not exist, and no detection symbol is present in `src/`. Its 3-done/2-remaining checkbox state is already accurate.
- **`2026-08-13-001-refactor-bitter-lesson-harness`** — a program document, not an implementation plan. It states at line 13 that it "owns the program thesis, audit, sequencing, promotion gates, and deletion criteria" and that each architecture area "receives its own focused child plan before implementation." Its unticked boxes are Goals for future child plans, so neither `completed` nor `superseded` applies.
- **`2026-09-05-001-feat-model-id-validation-gate`** — the plan document merged two days ago and none of its three artifacts (`scripts/generate-model-ids-snapshot.ts`, `scripts/lib/model-id-extractors.ts`, `.github/workflows/refresh-model-ids.yaml`) exist yet. A recently merged plan awaiting implementation is the normal state, not drift.

## Scope

Frontmatter `status` lines and unit checkboxes only — no prose changed, confirmed by inspecting the diff for any line that is neither. `completed_at` was not added: only 11 of the 55 completed plans carry it, so it is a minority convention rather than an expectation.

`bun scripts/content-integrity.ts` is clean.

## Preventing recurrence

`content-integrity.ts` now catches one narrow shape of this drift: a plan under `docs/plans/` marked `status: active` whose units are all ticked (at least one `- [x]`, zero remaining `- [ ]`) fails the gate, naming the file and pointing at the fix — flip `status` to `completed`, or tick the units that genuinely remain incomplete. Checkboxes inside fenced code examples are stripped before counting, so a program doc illustrating checkbox syntax in a fence cannot be flagged for it.

It does not catch the drift this PR actually fixes. On the pre-fix tree, all three plans had zero ticked units and several unticked ones — work had shipped but nobody had ticked a single box. That state is indistinguishable from "not started yet" using frontmatter and checkboxes alone; telling them apart requires verifying claimed deliverables against the working tree, which this gate deliberately does not do. The gate only guards against the opposite failure mode: a plan that reports all units done but is still marked `active`.

Two cases are deliberately excluded. A plan with no checkboxes at all (a program document that is only prose) is never flagged, since it has nothing to report as "remaining." And any `status` other than `active` is ignored entirely, so `completed`, `superseded`, and other terminal states are untouched.

Checked against the current tree: the rule produces no false positives. All three plans left active above (`pi-subagents-interop`, `bitter-lesson-harness`, `model-id-validation-gate`) still have at least one unticked unit, so none of them trip the gate.

Closes #909.


