### PR TITLE
test(evals): re-prove the fixture scanner's coverage on every run

### DIFF
--- a/docs/solutions/best-practices/measure-a-source-scanner-blind-spots-2026-09-07.md
+++ b/docs/solutions/best-practices/measure-a-source-scanner-blind-spots-2026-09-07.md
@@ -45,15 +45,18 @@ measurement found.
 
 1. **Measure a scanner's blind spots by planting a violation at every line position.** Insert the
    forbidden literal at each line of each scanned file in turn and assert the scanner reports it
-   every time. A *position* is an insertion point in the file, counted so that these four files of
-   400 / 652 / 644 / 659 lines yielded 402 / 654 / 646 / 661 positions; the exact convention lives
-   in the probe, and pinning it is part of landing that probe as a test. Reading the code found
-   none of the three holes below; this found all of them. Measured at `dbe2b12`: 0 genuine misses.
+   every time. A *position* is an insertion point in the file — before the first line, between
+   every pair of lines, and after the last. Reading the code found none of the three holes below;
+   this found all of them.
 
-   Those counts are a measurement taken at one commit, not a standing property: the files and the
-   scanner both change. The probe was run ad hoc, which is its weakness — a technique the reader
-   cannot re-run is a technique they will not use. Prefer landing the probe as a test so coverage
-   is re-proven on every change rather than asserted from a snapshot.
+   This is landed as a test, not a one-off measurement: `probeScannerBlindSpots`
+   (`tests/unit/opencode-pin.test.ts:812`) plants a realistic version literal at every position of
+   every allowlisted fixture file and re-runs the real scanner on each mutated copy, on every test
+   run. A position whose insertion point falls inside an already-open block comment is classified
+   as a legitimate non-detection rather than a miss — the scanner is supposed to ignore comment
+   text. The probe is generic over the scanner function and file contents, so a second
+   scanner-backed guard can reuse it without a rewrite. Coverage is re-proven on every change
+   instead of asserted from a snapshot that goes stale the moment the files or the scanner change.
 
 2. **Prefer a structural bound over another heuristic patch.** A `'` or `"` string cannot span a
    newline in JS/TS, so an unterminated string ends at the line break

--- a/docs/solutions/best-practices/measure-a-source-scanner-blind-spots-2026-09-07.md
+++ b/docs/solutions/best-practices/measure-a-source-scanner-blind-spots-2026-09-07.md
@@ -49,15 +49,17 @@ measurement found.
    every pair of lines, and after the last. Reading the code found none of the three holes below;
    this found all of them.
 
-   This is landed as a test, not a one-off measurement: `probeScannerBlindSpots`
-   (`tests/unit/opencode-pin.test.ts:828`) plants a realistic version literal at every position of
+   This is landed as a test, not a one-off measurement: `probeScannerBlindSpots` (in
+   `tests/unit/opencode-pin.test.ts`) plants a realistic version literal at every position of
    every allowlisted fixture file and re-runs the real scanner on each mutated copy, on every test
    run — swept across every historical injection shape the guard must detect (a plain assignment,
    an object field, a launcher template string, and a bare regex assertion), not just one, so a
    regression confined to a single shape or a single scanner code path cannot hide behind the
-   others passing. A position whose insertion point falls inside an already-open block comment is
-   classified as a legitimate non-detection rather than a miss — the scanner is supposed to ignore
-   comment text. The probe is generic over the scanner function, the file contents, and the
+   others passing. A position whose insertion point falls inside a comment, or inside a multi-line
+   template literal in a way a given shape cannot survive landing in, is classified as a legitimate
+   non-detection rather than a miss — that classification is itself derived from the scanner's own
+   tokenizer, not a second hand-written walk, so it cannot silently diverge from what the scanner
+   actually recognises. The probe is generic over the scanner function, the file contents, and the
    injection shape, so a second scanner-backed guard can reuse it without a rewrite. Coverage is
    re-proven on every change instead of asserted from a snapshot that goes stale the moment the
    files or the scanner change.
@@ -68,6 +70,16 @@ measurement found.
    none of the four allowlisted files currently contain the apostrophe-in-unrecognised-regex-position
    trigger that bound guards against. That prophylactic case is covered instead by this file's
    synthetic regression tests, which construct the trigger directly.
+
+   The probe can also produce a *false* miss, not just a false pass: a boundary is only a genuine
+   code-injection point if the planted text still parses the way the shape intends once it lands
+   there. A boundary inside an already-open multi-line template literal is string content, not
+   top-level code, so a shape whose own syntax cannot survive that (a shape that plants its own
+   backticks, or one whose literal only matches when read as a regex) will legitimately go
+   undetected there without the scanner being at fault. Before that was accounted for, sweeping a
+   file with a multi-line template reported real-looking misses for exactly this reason — a red
+   build pointing at a defect that did not exist. A probe whose whole value is that its measurement
+   can be trusted has to get this right, or a misleading red costs more than the coverage it buys.
 
 2. **Prefer a structural bound over another heuristic patch.** A `'` or `"` string cannot span a
    newline in JS/TS, so an unterminated string ends at the line break

--- a/docs/solutions/best-practices/measure-a-source-scanner-blind-spots-2026-09-07.md
+++ b/docs/solutions/best-practices/measure-a-source-scanner-blind-spots-2026-09-07.md
@@ -50,13 +50,24 @@ measurement found.
    this found all of them.
 
    This is landed as a test, not a one-off measurement: `probeScannerBlindSpots`
-   (`tests/unit/opencode-pin.test.ts:812`) plants a realistic version literal at every position of
+   (`tests/unit/opencode-pin.test.ts:828`) plants a realistic version literal at every position of
    every allowlisted fixture file and re-runs the real scanner on each mutated copy, on every test
-   run. A position whose insertion point falls inside an already-open block comment is classified
-   as a legitimate non-detection rather than a miss — the scanner is supposed to ignore comment
-   text. The probe is generic over the scanner function and file contents, so a second
-   scanner-backed guard can reuse it without a rewrite. Coverage is re-proven on every change
-   instead of asserted from a snapshot that goes stale the moment the files or the scanner change.
+   run — swept across every historical injection shape the guard must detect (a plain assignment,
+   an object field, a launcher template string, and a bare regex assertion), not just one, so a
+   regression confined to a single shape or a single scanner code path cannot hide behind the
+   others passing. A position whose insertion point falls inside an already-open block comment is
+   classified as a legitimate non-detection rather than a miss — the scanner is supposed to ignore
+   comment text. The probe is generic over the scanner function, the file contents, and the
+   injection shape, so a second scanner-backed guard can reuse it without a rewrite. Coverage is
+   re-proven on every change instead of asserted from a snapshot that goes stale the moment the
+   files or the scanner change.
+
+   The probe re-proves detection for the shapes and positions in *today's* files; it cannot prove
+   no other shape would evade the scanner, and it cannot expose a hazard whose trigger no current
+   file contains — reverting the newline bound in Guidance 2 below does not fail this sweep, because
+   none of the four allowlisted files currently contain the apostrophe-in-unrecognised-regex-position
+   trigger that bound guards against. That prophylactic case is covered instead by this file's
+   synthetic regression tests, which construct the trigger directly.
 
 2. **Prefer a structural bound over another heuristic patch.** A `'` or `"` string cannot span a
    newline in JS/TS, so an unterminated string ends at the line break

--- a/tests/unit/opencode-pin.test.ts
+++ b/tests/unit/opencode-pin.test.ts
@@ -666,20 +666,73 @@ describe('R2: fixture version literals stay in the unpinnable sentinel range', (
 // ---------------------------------------------------------------------------
 
 /**
- * Injection shape for the probe below: an object-literal-style
- * `opencodeVersion:` field on its own line. This is unambiguously in R2's
- * scope -- an OpenCode-shaped version key, not `packageVersion:` or another
- * versioning domain -- and, unlike a multi-line launcher template string or
- * a `.toThrow(/x\.y\.z/)` regex assertion, it is a single self-contained
- * string literal whose tokenization never depends on neighbouring lines, so
- * every planted position behaves the same way. It also matches one of R1's
- * own historical trigger shapes (`scripts/lib/opencode-pin.ts`'s
- * `pin`/`opencodeVersion` vocabulary), keeping the injected literal on R2's
- * "string" code-span path rather than its separate "regex" path.
+ * Injection shapes for the probe below, one function per historical shape
+ * the guard must detect. Guidance Example 1 in
+ * docs/solutions/best-practices/measure-a-source-scanner-blind-spots-2026-09-07.md
+ * names the four shapes a context-anchored (marker-recognising) design
+ * missed: `expectedVersion:`/`reportedVersion:`-style fields with no
+ * recognised keyword, a version inside a launcher template string, and a
+ * bare `.toThrow(/.../ )` regex assertion -- plus the `opencodeVersion:`/
+ * `pin:` shape that same design *did* recognise. Sweeping all four (not
+ * just the one recognised shape) is what makes the probe able to fail
+ * against that design; sweeping only `opencodeVersion:` cannot, since a
+ * context-anchored scanner would still catch it.
+ *
+ * Each shape is a single self-contained literal whose tokenization never
+ * depends on neighbouring lines, so every planted position behaves the
+ * same way regardless of where it lands.
  */
-function probeInjectionLine(literal: string): string {
+function injectPlainAssignment(literal: string): string {
+  // Unrecognised by any marker-anchored design: no `pin`/`opencodeVersion`
+  // keyword nearby, the exact shape a context-anchored scanner missed.
+  return `  const expectedVersion = '${literal}'`
+}
+
+function injectObjectField(literal: string): string {
+  // The one shape a context-anchored design *did* recognise -- included so
+  // the sweep still measures this shape's own coverage, not just the gaps.
   return `  opencodeVersion: '${literal}',`
 }
+
+function injectLauncherTemplate(literal: string): string {
+  // A version embedded partway through a launcher script string, in the
+  // `opencode-ai@<version>` form -- no marker keyword precedes the version
+  // itself, only free text inside a template literal.
+  return `  const launcherCmd = \`bunx opencode-ai@${literal} start\``
+}
+
+function injectRegexAssertion(literal: string): string {
+  // A version inside a `.toThrow(/.../ )` regex literal, escaped-dot form,
+  // matching VERSION_IN_REGEX_PATTERN -- the only shape that drives
+  // scanSpanForVersions's `span.kind === 'regex'` branch rather than its
+  // string-span branch. Preceded by `(`, one of REGEX_LITERAL_PRECEDING_CHARS,
+  // so precedesRegexLiteral recognises it.
+  return `  expect(() => run()).toThrow(/${literal.replaceAll('.', '\\.')}/)`
+}
+
+interface InjectionShape {
+  name: string
+  injectLine: (literal: string) => string
+}
+
+const INJECTION_SHAPES: readonly InjectionShape[] = [
+  {
+    name: 'plain assignment (expectedVersion-style, no marker keyword)',
+    injectLine: injectPlainAssignment,
+  },
+  {
+    name: 'object field (opencodeVersion:, a marker-recognised shape)',
+    injectLine: injectObjectField,
+  },
+  {
+    name: 'launcher template string (opencode-ai@<version>)',
+    injectLine: injectLauncherTemplate,
+  },
+  {
+    name: 'bare regex assertion (.toThrow(/.../ ), drives the regex-span path)',
+    injectLine: injectRegexAssertion,
+  },
+]
 
 /**
  * Byte ranges of every `/* ... *\/` block comment in `source`, found with
@@ -753,11 +806,24 @@ interface BlindSpotSummary {
  * is supposed to ignore comment text, so not reporting a violation there is
  * correct behaviour, not a blind spot.
  *
- * Generic over `scan` and the file contents (rather than closing over R2's
- * `findFixtureVersionLiteralViolations` and `ALLOWLISTED_FIXTURE_FILES`
- * directly), so a second scanner-backed guard (e.g.
+ * Generic over `scan`, the file contents, and the injection shape (rather
+ * than closing over R2's `findFixtureVersionLiteralViolations` and
+ * `ALLOWLISTED_FIXTURE_FILES` directly, or a single hardcoded shape), so a
+ * second scanner-backed guard (e.g.
  * tests/unit/spawn-and-signal-conventions.test.ts) can reuse this probe
  * later without a rewrite.
+ *
+ * What this proves and what it does not: a clean sweep re-proves that, for
+ * every shape in `INJECTION_SHAPES` and every line position in *today's*
+ * allowlisted files, the scanner detects a planted violation. It does not
+ * prove there is no injection shape outside that list the scanner would
+ * miss, and it cannot expose a hazard that depends on a trigger no current
+ * file contains (see the newline-bound regression tests below, and the
+ * bidirectional-proof note in this file's history: reverting
+ * `tryConsumeStringLiteral`'s newline bound does not fail this sweep,
+ * because none of the four allowlisted files currently contain the
+ * apostrophe-in-unrecognised-regex-position trigger that bound guards
+ * against -- only the synthetic regression tests below do).
  */
 function probeScannerBlindSpots(
   scan: (files: FixtureFileContent[]) => FixtureVersionLiteralViolation[],
@@ -809,56 +875,74 @@ function probeScannerBlindSpots(
   }
 }
 
-describe('probe: R2 catches a planted violation at every line position', () => {
+describe('probe: R2 catches a planted violation, in every historical shape, at every line position', () => {
   // Built from parts, like SYNTHETIC_REALISTIC_VERSION above, so this
   // literal never appears as a quoted string in this file's own source --
   // this file is itself on ALLOWLISTED_FIXTURE_FILES, so a literal written
   // directly here would trip R2's real scan of this file.
   const PROBE_LITERAL = ['2', '4', '17'].join('.')
 
-  test('every allowlisted file reports a violation at every planted position, except inside comments', () => {
-    const summaries: BlindSpotSummary[] = []
+  test('every allowlisted file reports a violation at every planted position, in every shape, except inside comments', () => {
     const start = performance.now()
+    const perShapeSummaries: Array<{
+      shape: string
+      summaries: BlindSpotSummary[]
+    }> = []
 
-    for (const relativePath of ALLOWLISTED_FIXTURE_FILES) {
-      const content = fs.readFileSync(
-        path.join(REPO_ROOT, relativePath),
-        'utf8',
-      )
-      summaries.push(
-        probeScannerBlindSpots(
-          findFixtureVersionLiteralViolations,
-          relativePath,
-          content,
-          PROBE_LITERAL,
-          probeInjectionLine,
-        ),
-      )
+    for (const shape of INJECTION_SHAPES) {
+      const summaries: BlindSpotSummary[] = []
+      for (const relativePath of ALLOWLISTED_FIXTURE_FILES) {
+        const content = fs.readFileSync(
+          path.join(REPO_ROOT, relativePath),
+          'utf8',
+        )
+        summaries.push(
+          probeScannerBlindSpots(
+            findFixtureVersionLiteralViolations,
+            relativePath,
+            content,
+            PROBE_LITERAL,
+            shape.injectLine,
+          ),
+        )
+      }
+      perShapeSummaries.push({ shape: shape.name, summaries })
     }
 
     const elapsedMs = performance.now() - start
-    const totalPositions = summaries.reduce(
-      (sum, s) => sum + s.totalPositions,
+    const totalPositions = perShapeSummaries.reduce(
+      (sum, s) => sum + s.summaries.reduce((n, f) => n + f.totalPositions, 0),
       0,
     )
-    const totalMisses = summaries.reduce((sum, s) => sum + s.misses.length, 0)
-
-    console.log(
-      `[blind-spot probe] ${totalPositions} positions across ${summaries.length} files in ${elapsedMs.toFixed(1)}ms (full sweep, no sampling): ` +
-        summaries
-          .map(
-            (s) =>
-              `${s.file}: ${s.detected} detected, ${s.legitimateNonDetections} legitimately not detected (inside a comment), ${s.misses.length} missed`,
-          )
-          .join('; '),
+    const totalMisses = perShapeSummaries.reduce(
+      (sum, s) => sum + s.summaries.reduce((n, f) => n + f.misses.length, 0),
+      0,
     )
 
+    console.log(
+      `[blind-spot probe] ${totalPositions} positions across ${INJECTION_SHAPES.length} shapes x ${ALLOWLISTED_FIXTURE_FILES.length} files in ${elapsedMs.toFixed(1)}ms (full sweep, no sampling):`,
+    )
+    for (const { shape, summaries } of perShapeSummaries) {
+      console.log(
+        `  [${shape}] ` +
+          summaries
+            .map(
+              (s) =>
+                `${s.file}: ${s.detected} detected, ${s.legitimateNonDetections} legitimately not detected (inside a comment), ${s.misses.length} missed`,
+            )
+            .join('; '),
+      )
+    }
+
     if (totalMisses > 0) {
-      const missReport = summaries
-        .filter((s) => s.misses.length > 0)
-        .map(
-          (s) =>
-            `${s.file}: missed line(s) ${s.misses.map((m) => m.line).join(', ')}`,
+      const missReport = perShapeSummaries
+        .flatMap(({ shape, summaries }) =>
+          summaries
+            .filter((s) => s.misses.length > 0)
+            .map(
+              (s) =>
+                `[${shape}] ${s.file}: missed line(s) ${s.misses.map((m) => m.line).join(', ')}`,
+            ),
         )
         .join('; ')
 

--- a/tests/unit/opencode-pin.test.ts
+++ b/tests/unit/opencode-pin.test.ts
@@ -304,7 +304,7 @@ const VERSION_EXEMPTIONS: VersionExemption[] = [
   },
 ]
 
-type CodeSpanKind = 'string' | 'regex'
+type CodeSpanKind = 'string' | 'regex' | 'comment'
 
 interface CodeSpan {
   kind: CodeSpanKind
@@ -416,12 +416,22 @@ function tokenizeCodeSpans(source: string): CodeSpan[] {
   while (i < n) {
     const blockCommentEnd = tryConsumeBlockComment(source, i)
     if (blockCommentEnd !== null) {
+      spans.push({
+        kind: 'comment',
+        start: i,
+        text: source.slice(i, blockCommentEnd),
+      })
       i = blockCommentEnd
       continue
     }
 
     const lineCommentEnd = tryConsumeLineComment(source, i)
     if (lineCommentEnd !== null) {
+      spans.push({
+        kind: 'comment',
+        start: i,
+        text: source.slice(i, lineCommentEnd),
+      })
       i = lineCommentEnd
       continue
     }
@@ -512,6 +522,7 @@ function findFixtureVersionLiteralViolations(
 
   for (const { file, content } of files) {
     for (const span of tokenizeCodeSpans(content)) {
+      if (span.kind === 'comment') continue
       scanSpanForVersions(file, content, span, violations)
     }
   }
@@ -713,79 +724,109 @@ function injectRegexAssertion(literal: string): string {
 interface InjectionShape {
   name: string
   injectLine: (literal: string) => string
+  /**
+   * Whether this shape is still expected to be detected when planted at a
+   * boundary that falls *inside* an already-open multi-line template
+   * literal. A boundary there is string content, not a code-injection
+   * point: the planted text becomes part of the enclosing template rather
+   * than new top-level code, so shapes that only work as top-level code
+   * cannot be expected to survive it.
+   *
+   * `injectPlainAssignment` and `injectObjectField` plant no backtick, so
+   * their text just becomes more of the enclosing template's content --
+   * and the enclosing template's *own* span still gets scanned for version
+   * digits normally (see `scanSpanForVersions`), so the literal is still
+   * detected. `injectLauncherTemplate` plants its own pair of backticks,
+   * which closes the enclosing template early and reopens a new one,
+   * stranding the version in a plain-code gap outside every span.
+   * `injectRegexAssertion` plants no backtick either, so its text also
+   * becomes template content -- but its escaped-dot literal only matches
+   * `VERSION_IN_REGEX_PATTERN`, and a boundary inside a template is always
+   * scanned as `kind: 'string'` (`VERSION_IN_STRING_PATTERN`), which never
+   * matches an escaped dot. Both failures are real, structural
+   * consequences of the shape, not scanner defects -- see
+   * `findNonPlantableRanges` below for where this is enforced.
+   */
+  plantableInsideMultilineTemplate: boolean
 }
 
 const INJECTION_SHAPES: readonly InjectionShape[] = [
   {
     name: 'plain assignment (expectedVersion-style, no marker keyword)',
     injectLine: injectPlainAssignment,
+    plantableInsideMultilineTemplate: true,
   },
   {
     name: 'object field (opencodeVersion:, a marker-recognised shape)',
     injectLine: injectObjectField,
+    plantableInsideMultilineTemplate: true,
   },
   {
     name: 'launcher template string (opencode-ai@<version>)',
     injectLine: injectLauncherTemplate,
+    plantableInsideMultilineTemplate: false,
   },
   {
     name: 'bare regex assertion (.toThrow(/.../ ), drives the regex-span path)',
     injectLine: injectRegexAssertion,
+    plantableInsideMultilineTemplate: false,
   },
 ]
 
+type NonPlantableReason = 'comment' | 'multiline-template'
+
+interface NonPlantableRange {
+  start: number
+  end: number
+  reason: NonPlantableReason
+}
+
 /**
- * Byte ranges of every `/* ... *\/` block comment in `source`, found with
- * the same left-to-right walk `tokenizeCodeSpans` uses -- reusing its
- * `tryConsume*` primitives rather than re-deriving the tokenizing rules --
- * so a `/*` inside a real string or regex is never mistaken for a comment
- * start. Used only to classify probe positions below; not part of R2
- * itself.
+ * Byte ranges of the probe below where an inserted line is not scanned as
+ * new top-level code: every comment span, and every multi-line template
+ * literal span (a backtick string whose text contains a newline). Derived
+ * directly from `tokenizeCodeSpans`'s own output -- the same function R2
+ * itself scans with -- rather than an independent walk, so a construct
+ * added to that tokenizer can never silently diverge from what this
+ * classifier knows about.
+ *
+ * Both reasons matter, and differently:
+ *
+ * - Inside a `'comment'` span, no shape is ever detected: comment text is
+ *   filtered out before `scanSpanForVersions` ever sees it (see
+ *   `findFixtureVersionLiteralViolations`), so nothing planted there can
+ *   be detected by any shape, and none should be.
+ * - Inside a `'multiline-template'` span, whether a shape is detected
+ *   depends on the shape itself -- see each `InjectionShape`'s
+ *   `plantableInsideMultilineTemplate` doc comment above for why. This is
+ *   why the reason is threaded through instead of collapsed into one
+ *   boolean: the caller decides per shape, not per range.
  */
-function findBlockCommentByteRanges(
-  source: string,
-): Array<{ start: number; end: number }> {
-  const ranges: Array<{ start: number; end: number }> = []
-  const n = source.length
-  let i = 0
+function findNonPlantableRanges(source: string): NonPlantableRange[] {
+  const ranges: NonPlantableRange[] = []
 
-  while (i < n) {
-    const blockCommentEnd = tryConsumeBlockComment(source, i)
-    if (blockCommentEnd !== null) {
-      ranges.push({ start: i, end: blockCommentEnd })
-      i = blockCommentEnd
-      continue
+  for (const span of tokenizeCodeSpans(source)) {
+    const end = span.start + span.text.length
+    if (span.kind === 'comment') {
+      ranges.push({ start: span.start, end, reason: 'comment' })
+    } else if (span.kind === 'string' && span.text.includes('\n')) {
+      ranges.push({ start: span.start, end, reason: 'multiline-template' })
     }
-
-    const lineCommentEnd = tryConsumeLineComment(source, i)
-    if (lineCommentEnd !== null) {
-      i = lineCommentEnd
-      continue
-    }
-
-    const stringEnd = tryConsumeStringLiteral(source, i)
-    if (stringEnd !== null) {
-      i = stringEnd
-      continue
-    }
-
-    const regexEnd = tryConsumeRegexLiteral(source, i)
-    if (regexEnd !== null) {
-      i = regexEnd
-      continue
-    }
-
-    i++
   }
 
   return ranges
 }
 
-function isWithinAnyRange(
+function isLegitimateNonDetection(
   offset: number,
-  ranges: readonly { start: number; end: number }[],
+  ranges: readonly NonPlantableRange[],
+  shape: InjectionShape,
 ): boolean {
-  return ranges.some((range) => offset > range.start && offset < range.end)
+  return ranges.some((range) => {
+    if (offset <= range.start || offset >= range.end) return false
+    if (range.reason === 'comment') return true
+    return !shape.plantableInsideMultilineTemplate
+  })
 }
 
 interface BlindSpotSummary {
@@ -797,14 +838,15 @@ interface BlindSpotSummary {
 }
 
 /**
- * For one file's content, inserts `literal` (via `injectLine`) as a new
- * standalone line at every line boundary -- before the first line, between
- * every pair of lines, and after the last line -- and asks `scan` whether it
- * reports a violation at that line. A boundary whose insertion point falls
- * inside an already-open block comment in the *original* content is
- * classified as a legitimate non-detection rather than a miss: the scanner
- * is supposed to ignore comment text, so not reporting a violation there is
- * correct behaviour, not a blind spot.
+ * For one file's content, inserts `literal` (via `shape.injectLine`) as a
+ * new standalone line at every line boundary -- before the first line,
+ * between every pair of lines, and after the last line -- and asks `scan`
+ * whether it reports a violation at that line. A boundary whose insertion
+ * point falls inside a comment, or inside a multi-line template literal in
+ * a way `shape` cannot survive, is classified as a legitimate
+ * non-detection rather than a miss -- see `findNonPlantableRanges` and
+ * `isLegitimateNonDetection` above for exactly which boundaries and shapes
+ * that covers, and why.
  *
  * Generic over `scan`, the file contents, and the injection shape (rather
  * than closing over R2's `findFixtureVersionLiteralViolations` and
@@ -813,40 +855,61 @@ interface BlindSpotSummary {
  * tests/unit/spawn-and-signal-conventions.test.ts) can reuse this probe
  * later without a rewrite.
  *
- * What this proves and what it does not: a clean sweep re-proves that, for
- * every shape in `INJECTION_SHAPES` and every line position in *today's*
- * allowlisted files, the scanner detects a planted violation. It does not
- * prove there is no injection shape outside that list the scanner would
- * miss, and it cannot expose a hazard that depends on a trigger no current
- * file contains (see the newline-bound regression tests below, and the
- * bidirectional-proof note in this file's history: reverting
- * `tryConsumeStringLiteral`'s newline bound does not fail this sweep,
- * because none of the four allowlisted files currently contain the
- * apostrophe-in-unrecognised-regex-position trigger that bound guards
- * against -- only the synthetic regression tests below do).
+ * What this proves, what it does not, and what it can wrongly flag:
+ *
+ * - A clean sweep re-proves that, for every shape in `INJECTION_SHAPES` and
+ *   every line position in *today's* allowlisted files, the scanner
+ *   detects a planted violation.
+ * - It does not prove there is no injection shape outside that list the
+ *   scanner would miss, and it cannot expose a hazard that depends on a
+ *   trigger no current file contains (see the newline-bound regression
+ *   tests below, and the bidirectional-proof note in this file's history:
+ *   reverting `tryConsumeStringLiteral`'s newline bound does not fail this
+ *   sweep, because none of the four allowlisted files currently contain
+ *   the apostrophe-in-unrecognised-regex-position trigger that bound
+ *   guards against -- only the synthetic regression tests below do).
+ * - It can also report a *false* miss if a boundary is not a genuine
+ *   code-injection point for a given shape and that is not accounted for
+ *   in the classifier -- e.g. a boundary inside a multi-line template
+ *   literal is string content, not top-level code, so a shape whose own
+ *   syntax cannot survive landing there (see each shape's
+ *   `plantableInsideMultilineTemplate` doc comment) will legitimately go
+ *   undetected there. Before `findNonPlantableRanges` accounted for this,
+ *   the sweep reported real-looking misses for exactly this reason,
+ *   pointing at a scanner defect that did not exist. Any future injection
+ *   shape or scanned file construct needs the same question asked of it:
+ *   does landing this text at this boundary still test what the shape
+ *   claims to test, or does it just test the probe's own insertion
+ *   mechanics?
  */
 function probeScannerBlindSpots(
-  scan: (files: FixtureFileContent[]) => FixtureVersionLiteralViolation[],
+  scan: (
+    files: readonly FixtureFileContent[],
+  ) => FixtureVersionLiteralViolation[],
   file: string,
   content: string,
   literal: string,
-  injectLine: (literal: string) => string,
+  shape: InjectionShape,
 ): BlindSpotSummary {
   const lines = content.split('\n')
-  const commentRanges = findBlockCommentByteRanges(content)
+  const nonPlantableRanges = findNonPlantableRanges(content)
   const misses: Array<{ position: number; line: number }> = []
   let detected = 0
   let legitimateNonDetections = 0
+  let boundaryOffset = 0
 
   for (let position = 0; position <= lines.length; position++) {
-    const boundaryOffset = lines
-      .slice(0, position)
-      .reduce((offset, line) => offset + line.length + 1, 0)
-    const insideComment = isWithinAnyRange(boundaryOffset, commentRanges)
+    const line = lines[position]
+    const legitimateHere = isLegitimateNonDetection(
+      boundaryOffset,
+      nonPlantableRanges,
+      shape,
+    )
+    if (line !== undefined) boundaryOffset += line.length + 1
 
     const mutatedLines = [
       ...lines.slice(0, position),
-      injectLine(literal),
+      shape.injectLine(literal),
       ...lines.slice(position),
     ]
     const mutatedContent = mutatedLines.join('\n')
@@ -859,7 +922,7 @@ function probeScannerBlindSpots(
 
     if (wasDetected) {
       detected++
-    } else if (insideComment) {
+    } else if (legitimateHere) {
       legitimateNonDetections++
     } else {
       misses.push({ position, line: injectedLine })
@@ -882,30 +945,32 @@ describe('probe: R2 catches a planted violation, in every historical shape, at e
   // directly here would trip R2's real scan of this file.
   const PROBE_LITERAL = ['2', '4', '17'].join('.')
 
-  test('every allowlisted file reports a violation at every planted position, in every shape, except inside comments', () => {
+  test('every allowlisted file reports a violation at every planted position, in every shape, except where the shape cannot survive the boundary', () => {
     const start = performance.now()
+
+    // Each file is read once, not once per shape: every shape sweeps the
+    // same on-disk content, so re-reading per shape only adds a way for a
+    // sweep to disagree with itself if the file changed mid-run.
+    const fileContents = ALLOWLISTED_FIXTURE_FILES.map((relativePath) => ({
+      relativePath,
+      content: fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf8'),
+    }))
+
     const perShapeSummaries: Array<{
       shape: string
       summaries: BlindSpotSummary[]
     }> = []
 
     for (const shape of INJECTION_SHAPES) {
-      const summaries: BlindSpotSummary[] = []
-      for (const relativePath of ALLOWLISTED_FIXTURE_FILES) {
-        const content = fs.readFileSync(
-          path.join(REPO_ROOT, relativePath),
-          'utf8',
-        )
-        summaries.push(
-          probeScannerBlindSpots(
-            findFixtureVersionLiteralViolations,
-            relativePath,
-            content,
-            PROBE_LITERAL,
-            shape.injectLine,
-          ),
-        )
-      }
+      const summaries = fileContents.map(({ relativePath, content }) =>
+        probeScannerBlindSpots(
+          findFixtureVersionLiteralViolations,
+          relativePath,
+          content,
+          PROBE_LITERAL,
+          shape,
+        ),
+      )
       perShapeSummaries.push({ shape: shape.name, summaries })
     }
 
@@ -919,22 +984,23 @@ describe('probe: R2 catches a planted violation, in every historical shape, at e
       0,
     )
 
-    console.log(
-      `[blind-spot probe] ${totalPositions} positions across ${INJECTION_SHAPES.length} shapes x ${ALLOWLISTED_FIXTURE_FILES.length} files in ${elapsedMs.toFixed(1)}ms (full sweep, no sampling):`,
-    )
-    for (const { shape, summaries } of perShapeSummaries) {
-      console.log(
-        `  [${shape}] ` +
-          summaries
-            .map(
-              (s) =>
-                `${s.file}: ${s.detected} detected, ${s.legitimateNonDetections} legitimately not detected (inside a comment), ${s.misses.length} missed`,
-            )
-            .join('; '),
-      )
-    }
-
     if (totalMisses > 0) {
+      // The per-shape breakdown is only diagnostic when something failed;
+      // logging it unconditionally would add five wide lines to every
+      // passing run, and this is the only console output under
+      // tests/unit/.
+      const breakdown = perShapeSummaries
+        .map(
+          ({ shape, summaries }) =>
+            `  [${shape}] ` +
+            summaries
+              .map(
+                (s) =>
+                  `${s.file}: ${s.detected} detected, ${s.legitimateNonDetections} legitimately not detected, ${s.misses.length} missed`,
+              )
+              .join('; '),
+        )
+        .join('\n')
       const missReport = perShapeSummaries
         .flatMap(({ shape, summaries }) =>
           summaries
@@ -947,10 +1013,104 @@ describe('probe: R2 catches a planted violation, in every historical shape, at e
         .join('; ')
 
       throw new Error(
-        `R2 failed to detect a planted "${PROBE_LITERAL}" literal at ${totalMisses} position(s) it should have caught: ${missReport}`,
+        `R2 failed to detect a planted "${PROBE_LITERAL}" literal at ${totalMisses} position(s) it should have caught (full sweep, no sampling, ${totalPositions} positions across ${INJECTION_SHAPES.length} shapes x ${ALLOWLISTED_FIXTURE_FILES.length} files in ${elapsedMs.toFixed(1)}ms):\n${breakdown}\nMisses: ${missReport}`,
       )
     }
 
     expect(totalMisses).toBe(0)
+  })
+})
+
+describe('probe classifier: a multi-line template literal is not a code-injection point for every shape', () => {
+  // A minimal reproduction of the failure mode this classifier exists to
+  // prevent: a five-line host with one multi-line template. Before
+  // `findNonPlantableRanges` accounted for multi-line templates, sweeping
+  // this host with the launcher and regex shapes reported real-looking
+  // misses at the lines inside the template -- not because the scanner has
+  // a blind spot, but because those two shapes plant syntax that cannot
+  // survive landing inside an already-open template literal (see each
+  // shape's `plantableInsideMultilineTemplate` doc comment). The
+  // plain-assignment and object-field shapes plant no backtick, so their
+  // text just becomes more of the template's own content, which is still
+  // scanned normally -- they are expected to keep being detected there.
+  const MULTILINE_TEMPLATE_HOST =
+    'const help = `\n' +
+    'first line of help text\n' +
+    'second line of help text\n' +
+    '`\n' +
+    'module.exports = help\n'
+
+  test('every shape reports zero misses against a host containing one multi-line template', () => {
+    const literal = ['6', '11', '23'].join('.')
+
+    for (const shape of INJECTION_SHAPES) {
+      const summary = probeScannerBlindSpots(
+        findFixtureVersionLiteralViolations,
+        'synthetic.test.ts',
+        MULTILINE_TEMPLATE_HOST,
+        literal,
+        shape,
+      )
+
+      expect(summary.misses).toEqual([])
+    }
+  })
+})
+
+describe('probe sensitivity: probeScannerBlindSpots can report a real miss', () => {
+  // Pins the probe's ability to FAIL without hand-reconstructing a
+  // historical design again: a deliberately crippled stub scanner,
+  // marker-anchored like the first historical design (Guidance Example 1
+  // in the blind-spots doc), recognising a version only on a line
+  // containing `opencodeVersion`. The plain-assignment shape plants no
+  // such marker, so this stub must miss it -- if `probeScannerBlindSpots`'s
+  // detection predicate ever broke such that `wasDetected` were always
+  // true, this is the test that would catch it, not a hand-run sweep.
+  function markerAnchoredStubScanner(
+    files: readonly FixtureFileContent[],
+  ): FixtureVersionLiteralViolation[] {
+    const violations: FixtureVersionLiteralViolation[] = []
+    for (const { file, content } of files) {
+      content.split('\n').forEach((line, index) => {
+        if (!line.includes('opencodeVersion')) return
+        for (const match of line.matchAll(VERSION_IN_STRING_PATTERN)) {
+          violations.push({ file, line: index + 1, literal: match[0] })
+        }
+      })
+    }
+    return violations
+  }
+
+  test('a marker-anchored stub scanner misses the plain-assignment shape', () => {
+    const plainAssignmentShape = INJECTION_SHAPES.find(
+      (shape) => shape.injectLine === injectPlainAssignment,
+    )
+    if (plainAssignmentShape === undefined) {
+      throw new Error('expected the plain-assignment shape to be registered')
+    }
+
+    const summary = probeScannerBlindSpots(
+      markerAnchoredStubScanner,
+      'synthetic.test.ts',
+      'const noop = true\n',
+      ['3', '7', '11'].join('.'),
+      plainAssignmentShape,
+    )
+
+    expect(summary.misses.length).toBeGreaterThan(0)
+  })
+})
+
+describe('findNonPlantableRanges: comment detection does not misfire inside strings or regexes', () => {
+  test('a /* inside a real string or a real regex is never mistaken for a block comment start', () => {
+    const content =
+      "const marker = '/* not a real comment */'\n" +
+      'const pattern = /a\\/\\*b/\n'
+
+    const commentRanges = findNonPlantableRanges(content).filter(
+      (range) => range.reason === 'comment',
+    )
+
+    expect(commentRanges).toEqual([])
   })
 })

--- a/tests/unit/opencode-pin.test.ts
+++ b/tests/unit/opencode-pin.test.ts
@@ -907,6 +907,30 @@ interface BlindSpotSummary {
  *   claims to test, or does it just test the probe's own insertion
  *   mechanics?
  */
+/**
+ * The byte offset of every line boundary in `lines` -- before the first
+ * line, between every pair of lines, and after the last -- as one array of
+ * `lines.length + 1` offsets, computed with a single running sum rather
+ * than a per-position `lines.slice(0, position).reduce(...)` (which would
+ * be O(n^2) in allocations across the sweep below). `boundaryOffsets[p]`
+ * is the offset for probe position `p`, for every `p` in
+ * `0..lines.length` inclusive -- a legitimately in-range index for every
+ * position the sweep visits, so the sweep never has to read `lines[p]`
+ * itself (which, at `p === lines.length`, is one past the last line and
+ * always `undefined`) just to decide whether to advance the running sum.
+ */
+function computeBoundaryOffsets(lines: readonly string[]): number[] {
+  const offsets = [0]
+  let running = 0
+
+  for (const line of lines) {
+    running += line.length + 1
+    offsets.push(running)
+  }
+
+  return offsets
+}
+
 function probeScannerBlindSpots(
   scan: (
     files: readonly FixtureFileContent[],
@@ -918,19 +942,17 @@ function probeScannerBlindSpots(
 ): BlindSpotSummary {
   const lines = content.split('\n')
   const nonPlantableRanges = findNonPlantableRanges(content)
+  const boundaryOffsets = computeBoundaryOffsets(lines)
   const misses: Array<{ position: number; line: number }> = []
   let detected = 0
   let legitimateNonDetections = 0
-  let boundaryOffset = 0
 
   for (let position = 0; position <= lines.length; position++) {
-    const line = lines[position]
     const legitimateHere = isLegitimateNonDetection(
-      boundaryOffset,
+      boundaryOffsets[position],
       nonPlantableRanges,
       shape,
     )
-    if (line !== undefined) boundaryOffset += line.length + 1
 
     const mutatedLines = [
       ...lines.slice(0, position),

--- a/tests/unit/opencode-pin.test.ts
+++ b/tests/unit/opencode-pin.test.ts
@@ -657,3 +657,216 @@ describe('R2: fixture version literals stay in the unpinnable sentinel range', (
     ])
   })
 })
+
+// ---------------------------------------------------------------------------
+// Blind-spot probe: measure R2's coverage on every run instead of asserting
+// it from a hand-run snapshot. See
+// docs/solutions/best-practices/measure-a-source-scanner-blind-spots-2026-09-07.md
+// (Guidance 1) for why a scanner's blind spots need measuring, not reviewing.
+// ---------------------------------------------------------------------------
+
+/**
+ * Injection shape for the probe below: an object-literal-style
+ * `opencodeVersion:` field on its own line. This is unambiguously in R2's
+ * scope -- an OpenCode-shaped version key, not `packageVersion:` or another
+ * versioning domain -- and, unlike a multi-line launcher template string or
+ * a `.toThrow(/x\.y\.z/)` regex assertion, it is a single self-contained
+ * string literal whose tokenization never depends on neighbouring lines, so
+ * every planted position behaves the same way. It also matches one of R1's
+ * own historical trigger shapes (`scripts/lib/opencode-pin.ts`'s
+ * `pin`/`opencodeVersion` vocabulary), keeping the injected literal on R2's
+ * "string" code-span path rather than its separate "regex" path.
+ */
+function probeInjectionLine(literal: string): string {
+  return `  opencodeVersion: '${literal}',`
+}
+
+/**
+ * Byte ranges of every `/* ... *\/` block comment in `source`, found with
+ * the same left-to-right walk `tokenizeCodeSpans` uses -- reusing its
+ * `tryConsume*` primitives rather than re-deriving the tokenizing rules --
+ * so a `/*` inside a real string or regex is never mistaken for a comment
+ * start. Used only to classify probe positions below; not part of R2
+ * itself.
+ */
+function findBlockCommentByteRanges(
+  source: string,
+): Array<{ start: number; end: number }> {
+  const ranges: Array<{ start: number; end: number }> = []
+  const n = source.length
+  let i = 0
+
+  while (i < n) {
+    const blockCommentEnd = tryConsumeBlockComment(source, i)
+    if (blockCommentEnd !== null) {
+      ranges.push({ start: i, end: blockCommentEnd })
+      i = blockCommentEnd
+      continue
+    }
+
+    const lineCommentEnd = tryConsumeLineComment(source, i)
+    if (lineCommentEnd !== null) {
+      i = lineCommentEnd
+      continue
+    }
+
+    const stringEnd = tryConsumeStringLiteral(source, i)
+    if (stringEnd !== null) {
+      i = stringEnd
+      continue
+    }
+
+    const regexEnd = tryConsumeRegexLiteral(source, i)
+    if (regexEnd !== null) {
+      i = regexEnd
+      continue
+    }
+
+    i++
+  }
+
+  return ranges
+}
+
+function isWithinAnyRange(
+  offset: number,
+  ranges: readonly { start: number; end: number }[],
+): boolean {
+  return ranges.some((range) => offset > range.start && offset < range.end)
+}
+
+interface BlindSpotSummary {
+  file: string
+  totalPositions: number
+  detected: number
+  legitimateNonDetections: number
+  misses: Array<{ position: number; line: number }>
+}
+
+/**
+ * For one file's content, inserts `literal` (via `injectLine`) as a new
+ * standalone line at every line boundary -- before the first line, between
+ * every pair of lines, and after the last line -- and asks `scan` whether it
+ * reports a violation at that line. A boundary whose insertion point falls
+ * inside an already-open block comment in the *original* content is
+ * classified as a legitimate non-detection rather than a miss: the scanner
+ * is supposed to ignore comment text, so not reporting a violation there is
+ * correct behaviour, not a blind spot.
+ *
+ * Generic over `scan` and the file contents (rather than closing over R2's
+ * `findFixtureVersionLiteralViolations` and `ALLOWLISTED_FIXTURE_FILES`
+ * directly), so a second scanner-backed guard (e.g.
+ * tests/unit/spawn-and-signal-conventions.test.ts) can reuse this probe
+ * later without a rewrite.
+ */
+function probeScannerBlindSpots(
+  scan: (files: FixtureFileContent[]) => FixtureVersionLiteralViolation[],
+  file: string,
+  content: string,
+  literal: string,
+  injectLine: (literal: string) => string,
+): BlindSpotSummary {
+  const lines = content.split('\n')
+  const commentRanges = findBlockCommentByteRanges(content)
+  const misses: Array<{ position: number; line: number }> = []
+  let detected = 0
+  let legitimateNonDetections = 0
+
+  for (let position = 0; position <= lines.length; position++) {
+    const boundaryOffset = lines
+      .slice(0, position)
+      .reduce((offset, line) => offset + line.length + 1, 0)
+    const insideComment = isWithinAnyRange(boundaryOffset, commentRanges)
+
+    const mutatedLines = [
+      ...lines.slice(0, position),
+      injectLine(literal),
+      ...lines.slice(position),
+    ]
+    const mutatedContent = mutatedLines.join('\n')
+    const injectedLine = position + 1
+
+    const wasDetected = scan([{ file, content: mutatedContent }]).some(
+      (violation) =>
+        violation.line === injectedLine && violation.literal === literal,
+    )
+
+    if (wasDetected) {
+      detected++
+    } else if (insideComment) {
+      legitimateNonDetections++
+    } else {
+      misses.push({ position, line: injectedLine })
+    }
+  }
+
+  return {
+    file,
+    totalPositions: lines.length + 1,
+    detected,
+    legitimateNonDetections,
+    misses,
+  }
+}
+
+describe('probe: R2 catches a planted violation at every line position', () => {
+  // Built from parts, like SYNTHETIC_REALISTIC_VERSION above, so this
+  // literal never appears as a quoted string in this file's own source --
+  // this file is itself on ALLOWLISTED_FIXTURE_FILES, so a literal written
+  // directly here would trip R2's real scan of this file.
+  const PROBE_LITERAL = ['2', '4', '17'].join('.')
+
+  test('every allowlisted file reports a violation at every planted position, except inside comments', () => {
+    const summaries: BlindSpotSummary[] = []
+    const start = performance.now()
+
+    for (const relativePath of ALLOWLISTED_FIXTURE_FILES) {
+      const content = fs.readFileSync(
+        path.join(REPO_ROOT, relativePath),
+        'utf8',
+      )
+      summaries.push(
+        probeScannerBlindSpots(
+          findFixtureVersionLiteralViolations,
+          relativePath,
+          content,
+          PROBE_LITERAL,
+          probeInjectionLine,
+        ),
+      )
+    }
+
+    const elapsedMs = performance.now() - start
+    const totalPositions = summaries.reduce(
+      (sum, s) => sum + s.totalPositions,
+      0,
+    )
+    const totalMisses = summaries.reduce((sum, s) => sum + s.misses.length, 0)
+
+    console.log(
+      `[blind-spot probe] ${totalPositions} positions across ${summaries.length} files in ${elapsedMs.toFixed(1)}ms (full sweep, no sampling): ` +
+        summaries
+          .map(
+            (s) =>
+              `${s.file}: ${s.detected} detected, ${s.legitimateNonDetections} legitimately not detected (inside a comment), ${s.misses.length} missed`,
+          )
+          .join('; '),
+    )
+
+    if (totalMisses > 0) {
+      const missReport = summaries
+        .filter((s) => s.misses.length > 0)
+        .map(
+          (s) =>
+            `${s.file}: missed line(s) ${s.misses.map((m) => m.line).join(', ')}`,
+        )
+        .join('; ')
+
+      throw new Error(
+        `R2 failed to detect a planted "${PROBE_LITERAL}" literal at ${totalMisses} position(s) it should have caught: ${missReport}`,
+      )
+    }
+
+    expect(totalMisses).toBe(0)
+  })
+})

--- a/tests/unit/opencode-pin.test.ts
+++ b/tests/unit/opencode-pin.test.ts
@@ -312,6 +312,31 @@ interface CodeSpan {
   text: string
 }
 
+/**
+ * The subset of `CodeSpan` that `scanSpanForVersions` is allowed to scan.
+ * Comment spans exist (`tokenizeCodeSpans` emits them so a classifier can
+ * find them; see the blind-spot probe below) but were never meant to be
+ * scanned for version literals -- comment text is exactly where false
+ * version literals live. Narrowing the parameter to this type turns
+ * passing a comment span into a compile error instead of a silent
+ * mis-scan: the call site's `if (span.kind === 'comment') continue` is
+ * what narrows `CodeSpan` down to this type, so the runtime check and the
+ * type boundary enforce the same exclusion in two different ways.
+ */
+type ScannableCodeSpan = CodeSpan & { kind: 'string' | 'regex' }
+
+/**
+ * Type guard, not a bare `span.kind !== 'comment'` check: a plain literal
+ * comparison narrows `span.kind` at the point it's read, but does not
+ * narrow the *type of `span` itself* to `ScannableCodeSpan` for a
+ * subsequent call -- `CodeSpan` is one interface with a union-typed field,
+ * not a discriminated union of variant interfaces, so TS has nothing to
+ * narrow `span`'s own type against. A named predicate does.
+ */
+function isScannableCodeSpan(span: CodeSpan): span is ScannableCodeSpan {
+  return span.kind !== 'comment'
+}
+
 const WHITESPACE_PATTERN = /\s/
 const REGEX_LITERAL_PRECEDING_CHARS = new Set(['(', ',', '=', '['])
 
@@ -475,7 +500,7 @@ function isExempt(file: string, literal: string, line: string): boolean {
 function scanSpanForVersions(
   file: string,
   content: string,
-  span: CodeSpan,
+  span: ScannableCodeSpan,
   violations: FixtureVersionLiteralViolation[],
 ): void {
   const versionPattern =
@@ -522,7 +547,7 @@ function findFixtureVersionLiteralViolations(
 
   for (const { file, content } of files) {
     for (const span of tokenizeCodeSpans(content)) {
-      if (span.kind === 'comment') continue
+      if (!isScannableCodeSpan(span)) continue
       scanSpanForVersions(file, content, span, violations)
     }
   }
@@ -1040,10 +1065,15 @@ describe('probe classifier: a multi-line template literal is not a code-injectio
     '`\n' +
     'module.exports = help\n'
 
-  test('every shape reports zero misses against a host containing one multi-line template', () => {
-    const literal = ['6', '11', '23'].join('.')
+  // A separate case per shape, not one test looping over all four: the
+  // whole point of this test is that the four shapes behave differently
+  // inside a multi-line template, so a failure needs to name which shape
+  // broke rather than report a single undifferentiated assertion.
+  test.each(INJECTION_SHAPES.map((shape) => [shape.name, shape] as const))(
+    'reports zero misses for the %s shape',
+    (_name, shape) => {
+      const literal = ['6', '11', '23'].join('.')
 
-    for (const shape of INJECTION_SHAPES) {
       const summary = probeScannerBlindSpots(
         findFixtureVersionLiteralViolations,
         'synthetic.test.ts',
@@ -1053,8 +1083,8 @@ describe('probe classifier: a multi-line template literal is not a code-injectio
       )
 
       expect(summary.misses).toEqual([])
-    }
-  })
+    },
+  )
 })
 
 describe('probe sensitivity: probeScannerBlindSpots can report a real miss', () => {


### PR DESCRIPTION
## Summary

R2 (`tests/unit/opencode-pin.test.ts`) guards against realistic-looking version literals reappearing in the allowlisted fixture files. Its own blind spots were previously measured by hand and quoted as a number at a commit — a technique nobody could re-run, so nothing re-checked it when the scanner or the files it reads changed.

This PR lands that measurement as a test: `probeScannerBlindSpots` plants a version literal at every line position of every allowlisted fixture file and asserts the scanner reports it, on every test run.

## What the sweep covers

The sweep covers every historical injection shape the guard must detect — a plain assignment with no recognised marker, an object field, a launcher template string, and a bare regex assertion — not just one, so a regression confined to a single shape or a single scanner code path (string-span vs. regex-span) can't hide behind the others passing.

A boundary is classified as a legitimate non-detection, rather than a miss, in two cases:

- It falls inside a comment. Comment text is filtered out before the scanner ever sees it, so nothing planted there can be detected by any shape.
- It falls inside an already-open multi-line template literal, for a shape whose own syntax cannot survive landing there. A boundary inside a template is string content, not a code-injection point: a shape that plants its own backticks closes the enclosing template early and reopens a new one, stranding the version in a plain-code gap outside every span; a shape whose literal only matches as a regex is scanned as string content there and never matches. Both are classified per shape, not blanket, because the plain-assignment and object-field shapes plant no backtick and are still correctly detected in that position — collapsing this to one boolean would have quietly dropped real coverage for those two shapes.

Both classifications are derived directly from the scanner's own tokenizer output, not a second hand-written walk over the source — a construct added to the tokenizer can't silently diverge from what the classifier knows about.

## Proving the probe itself

A sweep that always passes proves nothing. Three checks pin that:

- Reconstructing each of R2's three historical scanner designs (context-anchored matching, a two-pass comment stripper, no comment awareness at all) and running the sweep against it fails, naming the real positions each design would have missed. Restoring the current design passes cleanly.
- A deliberately crippled marker-anchored stub scanner, run through the sweep with the plain-assignment shape, produces a real miss — pinning that the sweep's detection predicate can fail at all, not just always report clean.
- A direct test on the comment classifier confirms a `/*` inside a real string or regex is never mistaken for a comment start, since a bug there would convert real misses into hidden "legitimate non-detections".
- A five-line host containing one multi-line template, swept with every shape, reports zero misses — pinning the template classification against the exact failure mode it exists to prevent.

## Known, stated limits

The sweep re-proves detection for the shapes and positions in today's files. It can't prove no other shape would evade the scanner, and it can't expose a hazard whose trigger no current file contains: reverting the newline bound that guards `tryConsumeStringLiteral` against unrecognised regex positions does not fail this sweep, because none of the four allowlisted files currently contain that trigger. That prophylactic case is covered by this file's existing synthetic regression tests instead, which construct the trigger directly.
