### PR TITLE
refactor(types): treat an index access as possibly absent

### DIFF
--- a/docs/scripts/generate-config-reference.ts
+++ b/docs/scripts/generate-config-reference.ts
@@ -760,10 +760,12 @@ function main(): void {
   let version: string | null = null
 
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--version') {
+    const arg = args[i]
+    if (arg === undefined) continue
+    if (arg === '--version') {
       version = args[++i] ?? null
-    } else if (args[i].startsWith('--version=')) {
-      version = args[i].slice('--version='.length)
+    } else if (arg.startsWith('--version=')) {
+      version = arg.slice('--version='.length)
     }
   }
 

--- a/docs/scripts/transform-content.ts
+++ b/docs/scripts/transform-content.ts
@@ -176,7 +176,8 @@ function escapeAttr(value: string): string {
 function firstSentence(text: string): string {
   const cleaned = cleanDescription(text)
   const match = cleaned.match(/^[^.!?]+[.!?]/)
-  return match ? match[0].trim() : cleaned.split('\n')[0].trim()
+  const [firstLine = ''] = cleaned.split('\n')
+  return match ? match[0].trim() : firstLine.trim()
 }
 
 const AGENT_CATEGORY_ORDER = [

--- a/scripts/build-registry.ts
+++ b/scripts/build-registry.ts
@@ -112,6 +112,7 @@ function parseArgs(): { version: string | null; validateOnly: boolean } {
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]
+    if (arg === undefined) continue
     if (arg === '--validate-only') {
       validateOnly = true
     } else if (arg === '--version') {

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -2020,9 +2020,11 @@ function isDispatchArgumentInstruction(rawLine: string): boolean {
     return false
 
   for (const span of rawLine.matchAll(INLINE_CODE_SPAN)) {
-    const assignment = MODEL_ARGUMENT_ASSIGNMENT.exec(span[1])
+    const [, codeSpanText = ''] = span
+    const assignment = MODEL_ARGUMENT_ASSIGNMENT.exec(codeSpanText)
     if (assignment === null) continue
-    if (FRONTMATTER_ONLY_MODEL_VALUES.has(assignment[1].toLowerCase())) continue
+    const [, modelArgument = ''] = assignment
+    if (FRONTMATTER_ONLY_MODEL_VALUES.has(modelArgument.toLowerCase())) continue
     return true
   }
 

--- a/scripts/content-integrity.ts
+++ b/scripts/content-integrity.ts
@@ -2020,10 +2020,21 @@ function isDispatchArgumentInstruction(rawLine: string): boolean {
     return false
 
   for (const span of rawLine.matchAll(INLINE_CODE_SPAN)) {
-    const [, codeSpanText = ''] = span
+    // Both regexes' capture groups are mandatory (`[^`]+`, `[A-Za-z0-9][\w./-]*`)
+    // so `span[1]`/`assignment[1]` always participate when the outer match
+    // succeeds — but a `?? ''` fallback here would be the wrong failure mode
+    // for a content-integrity scan: it would silently treat a genuinely
+    // missing capture the same as an empty one and keep scanning, instead of
+    // skipping a span the regex contract says can't actually occur. Skip
+    // (`continue`) rather than default, so a future change to either regex
+    // that makes the group optional fails visibly (missed detections) rather
+    // than silently.
+    const codeSpanText = span[1]
+    if (codeSpanText === undefined) continue
     const assignment = MODEL_ARGUMENT_ASSIGNMENT.exec(codeSpanText)
     if (assignment === null) continue
-    const [, modelArgument = ''] = assignment
+    const modelArgument = assignment[1]
+    if (modelArgument === undefined) continue
     if (FRONTMATTER_ONLY_MODEL_VALUES.has(modelArgument.toLowerCase())) continue
     return true
   }

--- a/scripts/eval-cases/opencode.ts
+++ b/scripts/eval-cases/opencode.ts
@@ -974,7 +974,12 @@ export function gradeModelInheritance(
         (event) =>
           event.availability === availability && event.policy === policy,
       )
-      return matches.length === 1 && gradeModelObservation(matches[0], manifest)
+      const [onlyMatch] = matches
+      return (
+        matches.length === 1 &&
+        onlyMatch !== undefined &&
+        gradeModelObservation(onlyMatch, manifest)
+      )
     })
   return {
     outcome: healthy ? 'success' : 'task_failure',

--- a/scripts/generate-config-schema.ts
+++ b/scripts/generate-config-schema.ts
@@ -173,8 +173,8 @@ export function resolveVersion(
  * Examples: "2.11.0" → "2", "3.0.0-rc.1" → "3"
  */
 export function getMajorVersion(version: string): string {
-  const parts = version.split('.')
-  return parts[0]
+  const [major = ''] = version.split('.')
+  return major
 }
 
 /**
@@ -645,8 +645,12 @@ export function readCommittedBundledNamesCounts(rootDir: string): {
   )
 
   return {
-    previousAgentCount: agentMatch ? countEntries(agentMatch[1]) : undefined,
-    previousSkillCount: skillMatch ? countEntries(skillMatch[1]) : undefined,
+    previousAgentCount: agentMatch
+      ? countEntries(agentMatch[1] ?? '')
+      : undefined,
+    previousSkillCount: skillMatch
+      ? countEntries(skillMatch[1] ?? '')
+      : undefined,
   }
 }
 
@@ -822,6 +826,7 @@ function parseArgs(argv: string[]): {
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]
+    if (arg === undefined) continue
     if (arg === '--check') {
       check = true
     } else if (arg === '--allow-shrink') {

--- a/scripts/generate-config-schema.ts
+++ b/scripts/generate-config-schema.ts
@@ -644,13 +644,22 @@ export function readCommittedBundledNamesCounts(rootDir: string): {
     /export const BUNDLED_SKILL_NAMES = \[([\s\S]*?)\] as const/,
   )
 
+  // `agentMatch[1]`/`skillMatch[1]` are the regexes' only capture group, so
+  // they are always present when the outer match succeeds — but this feeds
+  // the shrink-detection gate below, so a captured-but-defaulted-to-empty-
+  // string fallback (`?? ''`) would be the wrong failure mode here: a
+  // genuinely empty committed array (`[] as const`) also captures `''`, so
+  // collapsing "capture group didn't participate" and "captured an empty
+  // string" into the same `''` would make a real zero-entries count
+  // indistinguishable from a parse failure. Check participation explicitly
+  // (`!== undefined`) and treat non-participation the same as no match at
+  // all (`undefined`, matching this function's own documented
+  // first-run/unparseable contract) rather than silently reading as zero.
   return {
-    previousAgentCount: agentMatch
-      ? countEntries(agentMatch[1] ?? '')
-      : undefined,
-    previousSkillCount: skillMatch
-      ? countEntries(skillMatch[1] ?? '')
-      : undefined,
+    previousAgentCount:
+      agentMatch?.[1] !== undefined ? countEntries(agentMatch[1]) : undefined,
+    previousSkillCount:
+      skillMatch?.[1] !== undefined ? countEntries(skillMatch[1]) : undefined,
   }
 }
 

--- a/scripts/run-evals.ts
+++ b/scripts/run-evals.ts
@@ -2446,12 +2446,14 @@ function validateTarHeaderChecksum(header: Buffer): void {
   const stored = readTarOctal(header, 148, 8)
   let actual = 0
   for (let index = 0; index < header.length; index += 1) {
-    actual += index >= 148 && index < 156 ? 0x20 : header[index]
+    actual += index >= 148 && index < 156 ? 0x20 : (header[index] ?? 0)
   }
   if (actual !== stored) artifactFailure('artifact_resolution')
 }
 
-function readNpmTarEntryType(typeFlag: number): 'file' | 'directory' {
+function readNpmTarEntryType(
+  typeFlag: number | undefined,
+): 'file' | 'directory' {
   if (typeFlag === 0 || typeFlag === 0x30) return 'file'
   if (typeFlag === 0x35) return 'directory'
   artifactFailure('artifact_resolution')

--- a/src/lib/agent-overlays.ts
+++ b/src/lib/agent-overlays.ts
@@ -269,8 +269,18 @@ function parseOverlayShape(
 
 function throwOverlaySchemaError(
   overlay: { sourcePath: string; keyPath: string },
-  issue: z.core.$ZodIssue,
+  issue: z.core.$ZodIssue | undefined,
 ): never {
+  if (!issue) {
+    // Zod's SafeParseError always carries at least one issue on failure; this
+    // branch guards against that contract changing without a type-level signal.
+    throwConfigError(
+      overlay.sourcePath,
+      overlay.keyPath,
+      'schema validation failed',
+    )
+  }
+
   const zodPath =
     issue.code === 'unrecognized_keys'
       ? (issue.message.match(/"([^"]+)"/)?.[1] ?? issue.path.join('.'))

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -90,10 +90,13 @@ export const applyBootstrapContent = (
   output: { system: string[] },
   content: string,
 ): void => {
-  // Remove every complete marker block from every entry.
-  output.system = output.system.map((entry) =>
-    removeCompleteBootstrapBlocks(entry),
-  )
+  // Remove every complete marker block from every entry. Mutates in place
+  // rather than reassigning `output.system` — the host may hold its own
+  // reference to this array across the hook boundary, and a reassignment
+  // would silently detach that reference from further mutations below.
+  for (const [i, entry] of output.system.entries()) {
+    output.system[i] = removeCompleteBootstrapBlocks(entry)
+  }
 
   const [first] = output.system
   if (first === undefined) {

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -95,12 +95,12 @@ export const applyBootstrapContent = (
     removeCompleteBootstrapBlocks(entry),
   )
 
-  if (output.system.length === 0) {
+  const [first] = output.system
+  if (first === undefined) {
     output.system.push(content)
     return
   }
 
-  const [first = ''] = output.system
   output.system[0] = first.length > 0 ? `${first}\n\n${content}` : content
 }
 

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -91,16 +91,16 @@ export const applyBootstrapContent = (
   content: string,
 ): void => {
   // Remove every complete marker block from every entry.
-  for (let i = 0; i < output.system.length; i++) {
-    output.system[i] = removeCompleteBootstrapBlocks(output.system[i])
-  }
+  output.system = output.system.map((entry) =>
+    removeCompleteBootstrapBlocks(entry),
+  )
 
   if (output.system.length === 0) {
     output.system.push(content)
     return
   }
 
-  const first = output.system[0]
+  const [first = ''] = output.system
   output.system[0] = first.length > 0 ? `${first}\n\n${content}` : content
 }
 

--- a/src/lib/config-schema.ts
+++ b/src/lib/config-schema.ts
@@ -699,7 +699,13 @@ export const SystematicConfigSchema = createSystematicConfigSchema({
  * one. An added `.optional()` field with no default — like `$schema` —
  * drifts silently, since `undefined` satisfies both the type and an
  * omitted key. Consumers reading nested fields for their own logic should
- * still narrow/validate at the boundary rather than trust exhaustiveness.
+ * still narrow/validate at the boundary rather than trust exhaustiveness —
+ * for the `categories` and `profiles` record fields (each
+ * `z.record(z.string(), ...)`), `noUncheckedIndexedAccess` in tsconfig.json
+ * now makes this compiler-enforced rather than a style convention: an index
+ * access like `parsed.categories[key]` types as `V | undefined`, so an
+ * unnarrowed read fails to typecheck instead of type-checking clean and
+ * throwing at runtime on a missing key.
  */
 export type SystematicConfigParsed = z.infer<typeof SystematicConfigSchema>
 

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -47,8 +47,7 @@ export function parseFrontmatter<T = Record<string, unknown>>(
     }
   }
 
-  const yamlContent = match[1]
-  const body = match[2]
+  const [, yamlContent = '', body = ''] = match
 
   try {
     const parsed = yaml.load(yamlContent, { schema: yaml.JSON_SCHEMA })

--- a/src/lib/opencode-operation-observer.ts
+++ b/src/lib/opencode-operation-observer.ts
@@ -487,9 +487,10 @@ function readGitfileTarget(
   }
   const match = /^gitdir:\s*(.+?)\s*$/im.exec(contents)
   if (!match) return undefined
-  const target = path.isAbsolute(match[1])
-    ? match[1]
-    : path.resolve(path.dirname(gitfilePath), match[1])
+  const [, gitdirTarget = ''] = match
+  const target = path.isAbsolute(gitdirTarget)
+    ? gitdirTarget
+    : path.resolve(path.dirname(gitfilePath), gitdirTarget)
   return canonicalPath(target, realPath)
 }
 

--- a/src/lib/opencode-workflow-guard.ts
+++ b/src/lib/opencode-workflow-guard.ts
@@ -998,8 +998,7 @@ function canonicalPatchText(
 ): string | undefined {
   if (patchTextFileTargets(patchText) === undefined) return undefined
   const segments = patchText.split(/(\r?\n)/)
-  for (let index = 0; index < segments.length; index += 1) {
-    const line = segments[index]
+  for (const [index, line] of segments.entries()) {
     if (line === '\n' || line === '\r\n') continue
     const prefix = PATCH_FILE_PREFIXES.find((candidate) =>
       line.startsWith(candidate),

--- a/src/lib/receipt-classifier.ts
+++ b/src/lib/receipt-classifier.ts
@@ -1053,7 +1053,7 @@ function parseCommand(node: Node): ParsedCommand | undefined {
   if (node.type !== 'command') return undefined
   const commandName = node.childForFieldName('name')
   if (commandName?.type !== 'command_name') return undefined
-  const executable = parsePlainToken(commandName.namedChildren[0])
+  const executable = parsePlainToken(commandName.namedChildren[0] ?? null)
   if (!executable) return undefined
   if (!hasSafeCommandChildren(node)) return undefined
   const argumentsList = parseArguments(node)
@@ -1138,11 +1138,12 @@ function containsDynamicSyntax(node: Node): boolean {
 function classifyCommands(
   commands: readonly ParsedCommand[],
 ): ReceiptOperation | undefined {
-  if (commands.length === 0) return undefined
+  const lastCommand = commands.at(-1)
+  if (lastCommand === undefined) return undefined
   for (const prefix of commands.slice(0, -1)) {
     if (!isAllowedPrefix(prefix)) return undefined
   }
-  return classifyFinalCommand(commands[commands.length - 1])
+  return classifyFinalCommand(lastCommand)
 }
 
 function isAllowedPrefix(command: ParsedCommand): boolean {
@@ -1244,9 +1245,9 @@ function classifyGhCommand(
     args.length === 6 &&
     args[1] === 'create' &&
     args[2] === '--title' &&
-    args[3]?.length > 0 &&
+    (args[3]?.length ?? 0) > 0 &&
     args[4] === '--body' &&
-    args[5]?.length > 0 &&
+    (args[5]?.length ?? 0) > 0 &&
     !isEmptyShellString(args[3]) &&
     !isEmptyShellString(args[5])
   ) {

--- a/src/lib/routing-resolver.ts
+++ b/src/lib/routing-resolver.ts
@@ -339,13 +339,17 @@ function resolveOpencodeModelAndVariant(
       readOpencodeLayerField(agentOverlay, categoryOverlay, layer, 'model') !==
       undefined,
   )
-  const rawModel =
+  const modelLayer =
     modelLayerIndex === -1
+      ? undefined
+      : OPENCODE_MODEL_VARIANT_LAYERS[modelLayerIndex]
+  const rawModel =
+    modelLayer === undefined
       ? undefined
       : readOpencodeLayerField(
           agentOverlay,
           categoryOverlay,
-          OPENCODE_MODEL_VARIANT_LAYERS[modelLayerIndex],
+          modelLayer,
           'model',
         )
   const model = narrowModelValue(rawModel)
@@ -361,8 +365,10 @@ function resolveOpencodeModelAndVariant(
     const eligibleLayerCount = hasModel
       ? modelLayerIndex + 1
       : OPENCODE_MODEL_VARIANT_LAYERS.length
-    for (let i = 0; i < eligibleLayerCount; i++) {
-      const layer = OPENCODE_MODEL_VARIANT_LAYERS[i]
+    for (const layer of OPENCODE_MODEL_VARIANT_LAYERS.slice(
+      0,
+      eligibleLayerCount,
+    )) {
       const narrowed = narrowQualifierValue(
         readOpencodeLayerField(agentOverlay, categoryOverlay, layer, 'variant'),
       )

--- a/src/lib/skill-loader.ts
+++ b/src/lib/skill-loader.ts
@@ -57,7 +57,8 @@ export function extractSkillBody(wrappedTemplate: string): string {
   const match = wrappedTemplate.match(
     /<skill-instruction>([\s\S]*?)<\/skill-instruction>/,
   )
-  return match ? match[1].trim() : wrappedTemplate
+  const [, body] = match ?? []
+  return body !== undefined ? body.trim() : wrappedTemplate
 }
 
 export function loadSkill(skillInfo: SkillInfo): LoadedSkill | null {

--- a/tests/integration/eval-fixture.test.ts
+++ b/tests/integration/eval-fixture.test.ts
@@ -146,10 +146,12 @@ describe('eval fixture isolation', () => {
       expect(childEnv.NPM_CONFIG_CACHE).toBe(fixture.npmCacheRoot)
       expect(childEnv.OPENCODE_CONFIG_DIR).toBe(fixture.opencodeConfigRoot)
       expect(childEnv.EVAL_MODEL_BASE_URL).toBe('http://127.0.0.1:1/v1')
-      expect(childEnv.BUN_INSTALL_CACHE_DIR).toBeDefined()
-      expect(path.relative(parentHome, childEnv.BUN_INSTALL_CACHE_DIR)).toMatch(
-        /^\.\./,
-      )
+      const bunInstallCacheDir = childEnv.BUN_INSTALL_CACHE_DIR
+      expect(bunInstallCacheDir).toBeDefined()
+      if (bunInstallCacheDir === undefined) {
+        throw new Error('expected BUN_INSTALL_CACHE_DIR to be set')
+      }
+      expect(path.relative(parentHome, bunInstallCacheDir)).toMatch(/^\.\./)
       expect(childEnv.TMPDIR).toBe(fixture.tmpRoot)
 
       const inspection = spawnSync(

--- a/tests/integration/eval-runner.test.ts
+++ b/tests/integration/eval-runner.test.ts
@@ -586,8 +586,9 @@ describe('local OpenCode eval runner', () => {
         skillNames: ['agent-browser', 'ce:brainstorm', 'extra-skill'],
       },
     }
+    const loadedEvent: BoundedProbeEvent = { type: 'loaded', status: 'ok' }
     const presentEvents: BoundedProbeEvent[] = [
-      { type: 'loaded', status: 'ok' },
+      loadedEvent,
       {
         type: 'transform',
         kind: 'chat',
@@ -699,7 +700,7 @@ describe('local OpenCode eval runner', () => {
     expect(
       gradeHostSkillCoverage(
         [
-          presentEvents[0],
+          loadedEvent,
           {
             type: 'transform',
             kind: 'chat',
@@ -2381,6 +2382,9 @@ describe('local OpenCode eval runner', () => {
         )
       }
       const [installedSigintListener] = installedSigintListeners
+      if (!installedSigintListener) {
+        throw new Error('expected exactly one SIGINT listener to be installed')
+      }
 
       const result = normalizeResult(
         await runSourceEval({

--- a/tests/integration/fixtures/receipt-workflow-host.ts
+++ b/tests/integration/fixtures/receipt-workflow-host.ts
@@ -934,9 +934,10 @@ async function startOpencodeProcess(
     const onChunk = (chunk: Buffer): void => {
       buffer += chunk.toString()
       const match = buffer.match(/(http:\/\/[\d.:]+)/)
-      if (!match) return
+      const [, serverUrl] = match ?? []
+      if (serverUrl === undefined) return
       clearTimeout(timeout)
-      resolve(match[1])
+      resolve(serverUrl)
     }
 
     server.stdout?.on('data', onChunk)

--- a/tests/integration/pi.test.ts
+++ b/tests/integration/pi.test.ts
@@ -582,9 +582,10 @@ function spawnPiRpc(options: {
     }
     messages.push(parsed)
     for (let i = waiters.length - 1; i >= 0; i--) {
-      if (waiters[i].predicate(parsed)) {
+      const candidate = waiters[i]
+      if (candidate?.predicate(parsed)) {
         const [waiter] = waiters.splice(i, 1)
-        waiter.resolve(parsed)
+        if (waiter) waiter.resolve(parsed)
       }
     }
   }

--- a/tests/integration/receipt-workflow-recovery.test.ts
+++ b/tests/integration/receipt-workflow-recovery.test.ts
@@ -786,9 +786,13 @@ describe.skipIf(!isOpencodeAvailable())(
           // member of its own host's process group captured while that
           // host was still alive.
           expect(loadedPids).toHaveLength(2)
-          expect(loadedPids[0]).not.toBe(loadedPids[1])
-          expect(firstHostGroup).toContain(loadedPids[0])
-          expect(secondHostGroup).toContain(loadedPids[1])
+          const [firstLoadedPid, secondLoadedPid] = loadedPids
+          if (firstLoadedPid === undefined || secondLoadedPid === undefined) {
+            throw new Error('expected exactly two loaded pids')
+          }
+          expect(firstLoadedPid).not.toBe(secondLoadedPid)
+          expect(firstHostGroup).toContain(firstLoadedPid)
+          expect(secondHostGroup).toContain(secondLoadedPid)
         } finally {
           await secondHost.stop()
           model.stop()

--- a/tests/manual/companion-aware-probe.ts
+++ b/tests/manual/companion-aware-probe.ts
@@ -32,7 +32,7 @@ const REPO_ROOT = path.resolve(
   '../..',
 )
 const MODEL = 'opencode/big-pickle'
-const [PROVIDER_ID, MODEL_ID] = MODEL.split('/')
+const [PROVIDER_ID = 'opencode', MODEL_ID = 'big-pickle'] = MODEL.split('/')
 const SESSIONS_PER_CONDITION = 5
 
 // Companion content draft (the V1 candidate). If the probe passes, this is the
@@ -117,9 +117,10 @@ async function startServer(env: NodeJS.ProcessEnv): Promise<{
     const onChunk = (chunk: Buffer) => {
       buf += chunk.toString()
       const match = buf.match(/(http:\/\/[\d.:]+)/)
-      if (match) {
+      const [, url] = match ?? []
+      if (url !== undefined) {
         clearTimeout(timeout)
-        resolve(match[1])
+        resolve(url)
       }
     }
     server.stdout?.on('data', onChunk)

--- a/tests/manual/session-compacting-probe.ts
+++ b/tests/manual/session-compacting-probe.ts
@@ -42,7 +42,7 @@ const REPO_ROOT = path.resolve(
   '../..',
 )
 const MODEL = 'opencode/big-pickle'
-const [PROVIDER_ID, MODEL_ID] = MODEL.split('/')
+const [PROVIDER_ID = 'opencode', MODEL_ID = 'big-pickle'] = MODEL.split('/')
 
 interface ProbeResult {
   hookFired: boolean
@@ -92,9 +92,10 @@ async function runProbe(): Promise<ProbeResult> {
     const onChunk = (chunk: Buffer) => {
       buffer += chunk.toString()
       const match = buffer.match(/(http:\/\/[\d.:]+)/)
-      if (match) {
+      const [, url] = match ?? []
+      if (url !== undefined) {
         clearTimeout(timeout)
-        resolve(match[1])
+        resolve(url)
       }
     }
     server.stdout?.on('data', onChunk)

--- a/tests/manual/subagent-stop-probe.ts
+++ b/tests/manual/subagent-stop-probe.ts
@@ -76,7 +76,7 @@ const REPO_ROOT = path.resolve(
   '../..',
 )
 const MODEL = 'opencode/big-pickle'
-const [PROVIDER_ID, MODEL_ID] = MODEL.split('/')
+const [PROVIDER_ID = 'opencode', MODEL_ID = 'big-pickle'] = MODEL.split('/')
 const SESSIONS_PER_CONDITION = 5
 // Per-run wall-time cap. If one session's primary prompt hangs (slow model, stuck
 // inference, hook deadlock), the run is killed and marked errored rather than
@@ -220,9 +220,10 @@ async function startServer(env: NodeJS.ProcessEnv): Promise<{
     const onChunk = (chunk: Buffer) => {
       buf += chunk.toString()
       const match = buf.match(/(http:\/\/[\d.:]+)/)
-      if (match) {
+      const [, url] = match ?? []
+      if (url !== undefined) {
         clearTimeout(timeout)
-        resolve(match[1])
+        resolve(url)
       }
     }
     server.stdout?.on('data', onChunk)

--- a/tests/manual/subagent-stop-sanity.ts
+++ b/tests/manual/subagent-stop-sanity.ts
@@ -118,9 +118,10 @@ async function startServer(env: NodeJS.ProcessEnv): Promise<{
     const onChunk = (chunk: Buffer) => {
       buf += chunk.toString()
       const match = buf.match(/(http:\/\/[\d.:]+)/)
-      if (match) {
+      const [, url] = match ?? []
+      if (url !== undefined) {
         clearTimeout(timeout)
-        resolve(match[1])
+        resolve(url)
       }
     }
     server.stdout?.on('data', onChunk)

--- a/tests/unit/bootstrap.test.ts
+++ b/tests/unit/bootstrap.test.ts
@@ -465,8 +465,9 @@ describe('getBootstrapContent', () => {
     applyBootstrapContent(output, bootstrap)
     applyBootstrapContent(output, bootstrap)
 
-    expect(output.system[0].split(profile)).toHaveLength(2)
-    expect(output.system[0].split('<SYSTEMATIC_WORKFLOWS>')).toHaveLength(2)
+    const [systemPrompt = ''] = output.system
+    expect(systemPrompt.split(profile)).toHaveLength(2)
+    expect(systemPrompt.split('<SYSTEMATIC_WORKFLOWS>')).toHaveLength(2)
   })
 
   test('config.bootstrap.enabled = false returns null', () => {
@@ -733,7 +734,7 @@ describe('using-systematic SKILL.md structural invariants', () => {
     const output = { system: ['You are a primary agent. Do the work.'] }
     applyBootstrapContent(output, content as string)
 
-    const rendered = output.system[0]
+    const [rendered = ''] = output.system
     const subagentStop = rendered.indexOf('<SUBAGENT-STOP>')
     const extremelyImportant = rendered.indexOf('<EXTREMELY-IMPORTANT>')
     expect(subagentStop).toBeGreaterThan(-1)

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -19,6 +19,17 @@ import {
   validateConfig,
 } from '../../src/lib/config-schema.js'
 
+/**
+ * Zod's `SafeParseError` always carries at least one issue; this narrows the
+ * `issues[0]` index access to a real `$ZodIssue` for tests that assert on
+ * the first reported failure.
+ */
+function firstIssue(issues: readonly z.core.$ZodIssue[]): z.core.$ZodIssue {
+  const issue = issues[0]
+  if (!issue) throw new Error('expected at least one zod issue')
+  return issue
+}
+
 const EXPECTED_COLOR_TOKENS = [
   'primary',
   'secondary',
@@ -75,7 +86,7 @@ describe('SystematicConfigSchema', () => {
       expect(overlay?.temperature).toBe(0.3)
       expect(overlay?.mode).toBe('subagent')
       expect(overlay?.color).toBe('primary')
-      expect(parsed.categories.review.model).toBe('anthropic/claude-3')
+      expect(parsed.categories.review?.model).toBe('anthropic/claude-3')
       expect(result.data.disabled_skills).toEqual(['ce:plan'])
       expect(result.data.disabled_agents).toEqual(['correctness-reviewer'])
       expect(result.data.disabled_commands).toEqual(['cmd-1'])
@@ -242,7 +253,7 @@ describe('SystematicConfigSchema', () => {
     })
     expect(result.success).toBe(false)
     if (!result.success) {
-      const issue = result.error.issues[0]
+      const issue = firstIssue(result.error.issues)
       expect(issue.path).toEqual([
         'agents',
         'correctness-reviewer',
@@ -258,7 +269,7 @@ describe('SystematicConfigSchema', () => {
     })
     expect(result.success).toBe(false)
     if (!result.success) {
-      const issue = result.error.issues[0]
+      const issue = firstIssue(result.error.issues)
       expect(issue.path).toEqual(['agents', 'correctness-reviewer', 'top_p'])
       expect(issue.message).toMatch(/<=1|too big|max/i)
     }
@@ -287,7 +298,7 @@ describe('SystematicConfigSchema', () => {
     })
     expect(result.success).toBe(false)
     if (!result.success) {
-      const issue = result.error.issues[0]
+      const issue = firstIssue(result.error.issues)
       expect(issue.path).toEqual(['agents', 'correctness-reviewer', 'mode'])
       const message = issue.message.toLowerCase()
       expect(message).toContain('subagent')
@@ -302,7 +313,7 @@ describe('SystematicConfigSchema', () => {
     })
     expect(result.success).toBe(false)
     if (!result.success) {
-      const issue = result.error.issues[0]
+      const issue = firstIssue(result.error.issues)
       expect(issue.path).toEqual(['agents', 'correctness-reviewer', 'steps'])
     }
   })
@@ -313,7 +324,7 @@ describe('SystematicConfigSchema', () => {
     })
     expect(result.success).toBe(false)
     if (!result.success) {
-      const issue = result.error.issues[0]
+      const issue = firstIssue(result.error.issues)
       expect(issue.path).toEqual(['agents', 'correctness-reviewer', 'steps'])
       // positive means > 0
       expect(issue.message).toMatch(/0|positive|>0|minimum/i)
@@ -326,7 +337,7 @@ describe('SystematicConfigSchema', () => {
     })
     expect(result.success).toBe(false)
     if (!result.success) {
-      const issue = result.error.issues[0]
+      const issue = firstIssue(result.error.issues)
       expect(issue.path).toEqual(['agents', 'correctness-reviewer', 'hidden'])
       expect(issue.message).toMatch(/boolean/i)
     }
@@ -338,7 +349,7 @@ describe('SystematicConfigSchema', () => {
     })
     expect(result.success).toBe(false)
     if (!result.success) {
-      const issue = result.error.issues[0]
+      const issue = firstIssue(result.error.issues)
       expect(issue.path).toEqual([
         'agents',
         'correctness-reviewer',
@@ -353,7 +364,7 @@ describe('SystematicConfigSchema', () => {
     })
     expect(result.success).toBe(false)
     if (!result.success) {
-      const issue = result.error.issues[0]
+      const issue = firstIssue(result.error.issues)
       expect(issue.path).toEqual(['categories', 'review', 'model'])
       expect(issue.message).toMatch(/1|empty|min/i)
     }
@@ -496,7 +507,7 @@ describe('AgentOverlaySchema', () => {
     })
     expect(result.success).toBe(false)
     if (!result.success) {
-      expect(result.error.issues[0].code).toBe('unrecognized_keys')
+      expect(firstIssue(result.error.issues).code).toBe('unrecognized_keys')
     }
   })
 

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -3498,7 +3498,11 @@ describe('TYPED_VALIDATION_DOCS_URL', () => {
     if (!match) {
       throw new Error('Could not locate TYPED_VALIDATION_DOCS_URL in config.ts')
     }
-    return match[1]
+    const [, url] = match
+    if (url === undefined) {
+      throw new Error('Could not locate TYPED_VALIDATION_DOCS_URL in config.ts')
+    }
+    return url
   }
 
   test('URL points at fro.bot/systematic (host drift regression)', () => {
@@ -3526,7 +3530,8 @@ describe('TYPED_VALIDATION_DOCS_URL', () => {
     for (const line of mdx.split('\n')) {
       const m = line.match(/^#{1,6}\s+(.+)$/)
       if (m) {
-        slugs.add(slugify(m[1].trim()))
+        const [, heading] = m
+        if (heading !== undefined) slugs.add(slugify(heading.trim()))
       }
     }
     return slugs

--- a/tests/unit/docs-redirects.test.ts
+++ b/tests/unit/docs-redirects.test.ts
@@ -15,7 +15,7 @@ function extractRedirects(source: string): Record<string, string> {
   const redirectsMatch = source.match(/redirects:\s*\{([^}]+)\}/)
   if (!redirectsMatch) return {}
 
-  const block = redirectsMatch[1]
+  const [, block = ''] = redirectsMatch
   const result: Record<string, string> = {}
 
   // Match 'key': 'value' or "key": "value" pairs
@@ -23,7 +23,8 @@ function extractRedirects(source: string): Record<string, string> {
   for (;;) {
     const m = pairRe.exec(block)
     if (m === null) break
-    result[m[1]] = m[2]
+    const [, key, value] = m
+    if (key !== undefined && value !== undefined) result[key] = value
   }
   return result
 }

--- a/tests/unit/frontmatter.test.ts
+++ b/tests/unit/frontmatter.test.ts
@@ -145,6 +145,37 @@ Body`
         expect(result.hadFrontmatter).toBe(true)
         expect(result.data).toEqual({ name: 'test' })
       })
+
+      /**
+       * Regression pin for the `noUncheckedIndexedAccess` narrowing:
+       * `parseFrontmatter` destructures the regex match as
+       * `const [, yamlContent = '', body = ''] = match`. Both capture
+       * groups always participate when the overall match succeeds, so the
+       * `= ''` defaults never actually fire — but a future edit that
+       * reorders or mis-assigns the destructured names would silently swap
+       * which value lands in `data` vs. `body`. This content has non-empty
+       * frontmatter and a genuinely empty body (the document ends right
+       * after the closing delimiter's newline), so a reordering mistake is
+       * directly observable: `body` would come back as the YAML text
+       * instead of `''`.
+       */
+      test('parses a document with empty body content as an empty string, not the frontmatter text', () => {
+        const content = '---\nname: test\n---\n'
+        const result = parseFrontmatter(content)
+        expect(result.hadFrontmatter).toBe(true)
+        expect(result.parseError).toBe(false)
+        expect(result.data).toEqual({ name: 'test' })
+        expect(result.body).toBe('')
+      })
+
+      test('parses a document with both empty frontmatter content and empty body', () => {
+        const content = '---\n---\n'
+        const result = parseFrontmatter(content)
+        expect(result.hadFrontmatter).toBe(true)
+        expect(result.parseError).toBe(false)
+        expect(result.data).toEqual({})
+        expect(result.body).toBe('')
+      })
     })
 
     describe('error handling', () => {

--- a/tests/unit/generate-config-reference.test.ts
+++ b/tests/unit/generate-config-reference.test.ts
@@ -20,7 +20,8 @@ function collectSectionHeadings(content: string): Set<string> {
   for (const line of content.split('\n')) {
     const match = line.match(/^##(#?)\s+(.+)$/)
     if (match) {
-      headings.add(match[2].trim())
+      const [, , heading = ''] = match
+      headings.add(heading.trim())
     }
   }
   return headings
@@ -39,9 +40,9 @@ function checkAllSectionsHaveDescriptions(content: string): boolean {
     const lines = section.split('\n')
     let headingIdx = -1
     let typeIdx = -1
-    for (let i = 0; i < lines.length; i++) {
-      if (/^#{2,3}\s+/.test(lines[i])) headingIdx = i
-      if (lines[i].includes('**Type:**')) typeIdx = i
+    for (const [i, line] of lines.entries()) {
+      if (/^#{2,3}\s+/.test(line)) headingIdx = i
+      if (line.includes('**Type:**')) typeIdx = i
     }
     if (headingIdx === -1 || typeIdx === -1) continue
     // Text between heading and **Type:** should have non-whitespace

--- a/tests/unit/host-contract-guard.test.ts
+++ b/tests/unit/host-contract-guard.test.ts
@@ -76,9 +76,15 @@ describe('EXPECTED_SUITE_FILES', () => {
 // ---------------------------------------------------------------------------
 
 /** The exempt skip's key fields, reused so fixtures stay in sync with the
- * real exempt set instead of hardcoding a copy that could drift. */
-const EXEMPT = EXEMPT_SKIPS[0]
-if (EXEMPT === undefined) throw new Error('EXEMPT_SKIPS must be non-empty')
+ * real exempt set instead of hardcoding a copy that could drift. This is a
+ * function (not a bare index access) so the non-optional return type holds
+ * across the hoisted function declarations below that reference `EXEMPT`. */
+function requireFirstExemptSkip(): (typeof EXEMPT_SKIPS)[number] {
+  const exempt = EXEMPT_SKIPS[0]
+  if (exempt === undefined) throw new Error('EXEMPT_SKIPS must be non-empty')
+  return exempt
+}
+const EXEMPT = requireFirstExemptSkip()
 
 function testcase(
   classname: string,

--- a/tests/unit/opencode-pin.test.ts
+++ b/tests/unit/opencode-pin.test.ts
@@ -948,8 +948,14 @@ function probeScannerBlindSpots(
   let legitimateNonDetections = 0
 
   for (let position = 0; position <= lines.length; position++) {
+    const offset = boundaryOffsets[position]
+    if (offset === undefined) {
+      throw new Error(
+        `boundaryOffsets is documented to have lines.length + 1 entries; missing offset at position ${position}`,
+      )
+    }
     const legitimateHere = isLegitimateNonDetection(
-      boundaryOffsets[position],
+      offset,
       nonPlantableRanges,
       shape,
     )

--- a/tests/unit/opencode-workflow-guard.test.ts
+++ b/tests/unit/opencode-workflow-guard.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from 'bun:test'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import type { ToolContext, ToolResult } from '@opencode-ai/plugin'
+import type {
+  ToolContext,
+  ToolDefinition,
+  ToolResult,
+} from '@opencode-ai/plugin'
 import { z } from 'zod'
 
 import type {
@@ -53,6 +57,18 @@ function ledger(
   const value = adapter.ledger(sessionID)
   if (!value) throw new Error('session ledger missing')
   return value
+}
+
+/**
+ * Look up a registered guard tool by name. All names used in this suite are
+ * always registered by `createOpencodeWorkflowGuard`; this narrows the
+ * `Record<string, ToolDefinition>` index access to a real `ToolDefinition`
+ * instead of silencing the possibly-undefined type.
+ */
+function getTool(adapter: OpencodeWorkflowGuard, name: string): ToolDefinition {
+  const tool = adapter.tools[name]
+  if (!tool) throw new Error(`tool not registered: ${name}`)
+  return tool
 }
 
 /**
@@ -225,7 +241,11 @@ function sequenceObserver(
       }
       const current = remoteIndexes.get(key) ?? 0
       remoteIndexes.set(key, current + 1)
-      return values[Math.min(current, values.length - 1)]
+      const result = values[Math.min(current, values.length - 1)]
+      if (!result) {
+        return { status: 'unavailable', reasonCode: 'remote-missing-field' }
+      }
+      return result
     },
   }
 }
@@ -614,7 +634,7 @@ async function createPinnedRecoveryAdapter(): Promise<{
     targetResult.snapshot.repositoryRevisionDigest,
     targetResult.snapshot.worktreeRevisionDigest,
   )
-  await adapter.tools.systematic_workflow_status.execute(
+  await getTool(adapter, 'systematic_workflow_status').execute(
     {},
     toolContext(SESSION_A),
   )
@@ -1373,7 +1393,10 @@ describe('OpenCode workflow guard adapter', () => {
       },
       true,
     )
-    await restored.tools.systematic_workflow_status.execute({}, toolContext())
+    await getTool(restored, 'systematic_workflow_status').execute(
+      {},
+      toolContext(),
+    )
 
     expect(status(restored)).toMatchObject({
       state: 'waiting',
@@ -1500,7 +1523,7 @@ describe('OpenCode workflow guard adapter', () => {
       systematic_workflow_control: ['mode'],
     }
     for (const [id, keys] of Object.entries(expectedShapes)) {
-      const args = adapter.tools[id].args as Record<string, unknown>
+      const args = getTool(adapter, id).args as Record<string, unknown>
       expect(Object.keys(args).sort()).toEqual([...keys].sort())
       expect(() => z.object(args).strict()).not.toThrow()
       for (const value of Object.values(args)) {
@@ -1508,7 +1531,7 @@ describe('OpenCode workflow guard adapter', () => {
       }
     }
 
-    const result = await adapter.tools.systematic_workflow_status.execute(
+    const result = await getTool(adapter, 'systematic_workflow_status').execute(
       {},
       toolContext(),
     )
@@ -1527,19 +1550,19 @@ describe('OpenCode workflow guard adapter', () => {
 
   test('start and status tools are non-authoritative while control requires attestation', async () => {
     const adapter = createAdapter()
-    const start = await adapter.tools.systematic_workflow_start.execute(
+    const start = await getTool(adapter, 'systematic_workflow_start').execute(
       { expected_operations: ['commit'] },
       toolContext(),
     )
     const statusBefore = status(adapter)
-    const statusOutput = await adapter.tools.systematic_workflow_status.execute(
-      {},
-      toolContext(),
-    )
-    const control = await adapter.tools.systematic_workflow_control.execute(
-      { mode: 'disabled' },
-      toolContext(),
-    )
+    const statusOutput = await getTool(
+      adapter,
+      'systematic_workflow_status',
+    ).execute({}, toolContext())
+    const control = await getTool(
+      adapter,
+      'systematic_workflow_control',
+    ).execute({ mode: 'disabled' }, toolContext())
 
     expect(expectToolOutput(start).output).toContain('pending')
     expect(expectToolOutput(statusOutput).output).toContain(statusBefore.state)
@@ -1689,7 +1712,7 @@ describe('OpenCode workflow guard adapter', () => {
       answers: [['yes']],
     })
 
-    const status = await adapter.tools.systematic_workflow_status.execute(
+    const status = await getTool(adapter, 'systematic_workflow_status').execute(
       {},
       toolContext(),
     )
@@ -1729,7 +1752,7 @@ describe('OpenCode workflow guard adapter', () => {
 
   test('session disablement requires the native question reply', async () => {
     const adapter = createAdapter('observe')
-    const first = await adapter.tools.systematic_workflow_control.execute(
+    const first = await getTool(adapter, 'systematic_workflow_control').execute(
       { mode: 'disabled' },
       toolContext(),
     )
@@ -1752,10 +1775,10 @@ describe('OpenCode workflow guard adapter', () => {
       requestID: 'disable-request',
       answers: [['confirm']],
     })
-    const second = await adapter.tools.systematic_workflow_control.execute(
-      { mode: 'disabled' },
-      toolContext(),
-    )
+    const second = await getTool(
+      adapter,
+      'systematic_workflow_control',
+    ).execute({ mode: 'disabled' }, toolContext())
     expect(expectToolOutput(second).output).toContain('disabled')
     expect(adapter.status(SESSION_A).state).toBe('disabled')
   })
@@ -1786,7 +1809,7 @@ describe('OpenCode workflow guard adapter', () => {
     let selectedExecutions = 0
     const selectedExecute = async () => {
       selectedExecutions += 1
-      return first.tools.systematic_workflow_complete.execute(
+      return getTool(first, 'systematic_workflow_complete').execute(
         { target: 'unit' },
         toolContext(SESSION_A),
       )
@@ -1838,7 +1861,7 @@ describe('OpenCode workflow guard adapter', () => {
     let selectedExecutions = 0
     const selectedExecute = async () => {
       selectedExecutions += 1
-      return ready.tools.systematic_workflow_complete.execute(
+      return getTool(ready, 'systematic_workflow_complete').execute(
         { target: 'unit' },
         toolContext(SESSION_A),
       )
@@ -1880,7 +1903,10 @@ describe('OpenCode workflow guard adapter', () => {
   test('disabled mode is visible and does not activate or mutate from tool calls', async () => {
     const adapter = createAdapter('disabled')
     await observeSkill(adapter, 'systematic_skill', 'ce:work')
-    await adapter.tools.systematic_workflow_start.execute({}, toolContext())
+    await getTool(adapter, 'systematic_workflow_start').execute(
+      {},
+      toolContext(),
+    )
     expect(status(adapter)).toMatchObject({ state: 'disabled', epoch: null })
   })
 
@@ -1967,7 +1993,10 @@ describe('OpenCode workflow guard adapter', () => {
       { tool: 'systematic_skill', sessionID: '', callID: 'missing-session' },
       { args: { name: 'ce:work' } },
     )
-    await adapter.tools.systematic_workflow_status.execute({}, toolContext())
+    await getTool(adapter, 'systematic_workflow_status').execute(
+      {},
+      toolContext(),
+    )
     expect(status(adapter, SESSION_A).epoch).toBeNull()
     expect(status(adapter, '').state).toBe('unavailable')
     expect(adapter.ledger('')).toBeUndefined()
@@ -3826,7 +3855,10 @@ describe('OpenCode workflow guard adapter', () => {
       worktreeIdentity: 'd'.repeat(64),
     })
 
-    await adapter.tools.systematic_workflow_status.execute({}, toolContext())
+    await getTool(adapter, 'systematic_workflow_status').execute(
+      {},
+      toolContext(),
+    )
     const current = status(adapter)
     expect(['stale-receipt', 'receipt-mismatch']).toContain(current.reasonCode)
     expect(current.reasonCode).not.toBe('workspace-mismatch')
@@ -4178,7 +4210,10 @@ describe('OpenCode workflow guard adapter', () => {
       { tool: 'write', sessionID: SESSION_A, callID: 'before-only' },
       { args: { filePath: 'pending.ts', content: 'pending' } },
     )
-    await adapter.tools.systematic_workflow_status.execute({}, toolContext())
+    await getTool(adapter, 'systematic_workflow_status').execute(
+      {},
+      toolContext(),
+    )
     await adapter.hooks['tool.execute.after'](
       {
         tool: 'write',
@@ -4859,11 +4894,17 @@ describe('OpenCode workflow guard adapter', () => {
       },
       true,
     )
-    await restored.tools.systematic_workflow_status.execute({}, toolContext())
+    await getTool(restored, 'systematic_workflow_status').execute(
+      {},
+      toolContext(),
+    )
     expect(status(restored).epoch).not.toBeNull()
     expect(status(restored).unit).not.toBeNull()
     expect(status(restored).satisfiedOperations).toContain('implementation')
-    await restored.tools.systematic_workflow_status.execute({}, toolContext())
+    await getTool(restored, 'systematic_workflow_status').execute(
+      {},
+      toolContext(),
+    )
     expect(status(restored).epoch).not.toBeNull()
   })
 
@@ -4992,7 +5033,7 @@ describe('OpenCode workflow guard adapter', () => {
         },
       })
 
-      await restored.tools.systematic_workflow_status.execute(
+      await getTool(restored, 'systematic_workflow_status').execute(
         {},
         toolContext(SESSION_A),
       )
@@ -5101,7 +5142,7 @@ describe('OpenCode workflow guard adapter', () => {
         },
       })
 
-      await restored.tools.systematic_workflow_status.execute(
+      await getTool(restored, 'systematic_workflow_status').execute(
         {},
         toolContext(SESSION_A),
       )
@@ -5152,7 +5193,7 @@ describe('OpenCode workflow guard adapter', () => {
         },
       })
 
-      await restored.tools.systematic_workflow_status.execute(
+      await getTool(restored, 'systematic_workflow_status').execute(
         {},
         toolContext(SESSION_A),
       )
@@ -5203,7 +5244,7 @@ describe('OpenCode workflow guard adapter', () => {
         },
       })
 
-      await restored.tools.systematic_workflow_status.execute(
+      await getTool(restored, 'systematic_workflow_status').execute(
         {},
         toolContext(SESSION_A),
       )
@@ -5287,7 +5328,7 @@ describe('OpenCode workflow guard adapter', () => {
         },
       })
 
-      await adapter.tools.systematic_workflow_status.execute(
+      await getTool(adapter, 'systematic_workflow_status').execute(
         {},
         toolContext(SESSION_A),
       )
@@ -5367,7 +5408,7 @@ describe('OpenCode workflow guard adapter', () => {
         },
       })
 
-      await adapter.tools.systematic_workflow_status.execute(
+      await getTool(adapter, 'systematic_workflow_status').execute(
         {},
         toolContext(SESSION_A),
       )
@@ -5409,7 +5450,7 @@ describe('OpenCode workflow guard adapter', () => {
         },
       })
 
-      await adapter.tools.systematic_workflow_status.execute(
+      await getTool(adapter, 'systematic_workflow_status').execute(
         {},
         toolContext(SESSION_A),
       )
@@ -5446,7 +5487,7 @@ describe('OpenCode workflow guard adapter', () => {
         },
       })
 
-      await adapter.tools.systematic_workflow_status.execute(
+      await getTool(adapter, 'systematic_workflow_status').execute(
         {},
         toolContext(SESSION_A),
       )
@@ -7172,7 +7213,7 @@ describe('OpenCode workflow guard adapter', () => {
         'optional-boot-identities-skill',
         parentSessionID,
       )
-      await adapter.tools.systematic_workflow_status.execute(
+      await getTool(adapter, 'systematic_workflow_status').execute(
         {},
         toolContext(parentSessionID),
       )

--- a/tests/unit/pi.test.ts
+++ b/tests/unit/pi.test.ts
@@ -253,7 +253,9 @@ describe('src/pi.ts systematic_skill tool registration', () => {
         },
       },
     ])
-    expect(piResult.details.skillDir).toBe(metadataCalls[0]?.metadata.dir)
+    const [firstMetadataCall] = metadataCalls
+    if (!firstMetadataCall) throw new Error('expected a recorded metadata call')
+    expect(piResult.details.skillDir).toBe(firstMetadataCall.metadata.dir)
 
     const unknownName = '__missing_skill__'
     const openCodeError = await (async () => {

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -624,6 +624,26 @@ describe('applyBootstrapContent marker-based idempotency', () => {
     expect(output.system[1]).toBe('slot 1 content')
   })
 
+  /**
+   * Regression pin for the `noUncheckedIndexedAccess` narrowing: an
+   * `output.system` array that is non-empty but whose first entry is a
+   * leading empty string must go through the "replace" branch (`first.length
+   * > 0` is false), not the "array is empty" branch. These are genuinely
+   * different code paths in `applyBootstrapContent` — `output.system.length
+   * === 0` (push a new entry) vs. `first.length > 0` (join-vs-replace an
+   * existing entry) — that a careless collapse of the two undefined/empty
+   * checks into one could conflate. A leading blank entry must be replaced
+   * outright, not joined with `\n\n`, which would leave a stray leading
+   * blank line in the rendered system prompt.
+   */
+  test('replaces (not joins) a leading empty-string system[0] entry, and leaves system.length at 1', () => {
+    const output = { system: [''] }
+    applyBootstrapContent(output, wrap('NEW CONTENT'))
+    expect(output.system).toHaveLength(1)
+    expect(output.system[0]).toBe(wrap('NEW CONTENT'))
+    expect(output.system[0]).not.toBe(`\n\n${wrap('NEW CONTENT')}`)
+  })
+
   test('removes existing marker block from system[0] then appends current content', () => {
     const output = {
       system: [`existing prompt with ${wrap('OLD CONTENT')} embedded`],

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -630,7 +630,7 @@ describe('applyBootstrapContent marker-based idempotency', () => {
     }
     applyBootstrapContent(output, wrap('NEW CONTENT'))
     expect(output.system).toHaveLength(1)
-    const result = output.system[0]
+    const [result = ''] = output.system
     const openTagCount = (result.match(new RegExp(MARKER_OPEN, 'g')) ?? [])
       .length
     expect(openTagCount).toBe(1)
@@ -699,12 +699,11 @@ describe('applyBootstrapContent marker-based idempotency', () => {
     expect(output.system[0]).toContain('trailing content with no close')
     expect(output.system[0]).toContain('NEW CONTENT')
     // Exactly one complete block (the appended one)
-    const openTagCount = (
-      output.system[0].match(new RegExp(MARKER_OPEN, 'g')) ?? []
-    ).length
-    const closeTagCount = (
-      output.system[0].match(new RegExp(MARKER_CLOSE, 'g')) ?? []
-    ).length
+    const [slot0 = ''] = output.system
+    const openTagCount = (slot0.match(new RegExp(MARKER_OPEN, 'g')) ?? [])
+      .length
+    const closeTagCount = (slot0.match(new RegExp(MARKER_CLOSE, 'g')) ?? [])
+      .length
     expect(closeTagCount).toBe(1)
     // Two open tags: one from the malformed fragment, one from the appended block
     expect(openTagCount).toBe(2)
@@ -717,7 +716,7 @@ describe('applyBootstrapContent marker-based idempotency', () => {
     applyBootstrapContent(output, wrap('FIRST REGISTRATION'))
     applyBootstrapContent(output, wrap('SECOND REGISTRATION'))
 
-    const result = output.system[0]
+    const [result = ''] = output.system
     expect(result).toContain(malformed)
     expect(result).toContain('SECOND REGISTRATION')
     expect(result).not.toContain('FIRST REGISTRATION')
@@ -781,13 +780,12 @@ describe('applyBootstrapContent marker-based idempotency', () => {
     // The appended block exists
     expect(output.system[0]).toContain('NEW')
     // The inner block is removed — only fragment + appended block remain
-    const openTagCount = (
-      output.system[0].match(new RegExp(MARKER_OPEN, 'g')) ?? []
-    ).length
+    const [slot0 = ''] = output.system
+    const openTagCount = (slot0.match(new RegExp(MARKER_OPEN, 'g')) ?? [])
+      .length
     expect(openTagCount).toBe(2)
-    const closeTagCount = (
-      output.system[0].match(new RegExp(MARKER_CLOSE, 'g')) ?? []
-    ).length
+    const closeTagCount = (slot0.match(new RegExp(MARKER_CLOSE, 'g')) ?? [])
+      .length
     expect(closeTagCount).toBe(1)
   })
 
@@ -805,9 +803,9 @@ describe('applyBootstrapContent marker-based idempotency', () => {
     expect(output.system[0]).toContain('SECOND')
     expect(output.system[0]).not.toContain('FIRST')
     // One complete block (the appended second one)
-    const closeTagCount = (
-      output.system[0].match(new RegExp(MARKER_CLOSE, 'g')) ?? []
-    ).length
+    const [slot0 = ''] = output.system
+    const closeTagCount = (slot0.match(new RegExp(MARKER_CLOSE, 'g')) ?? [])
+      .length
     expect(closeTagCount).toBe(1)
   })
 

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -644,6 +644,25 @@ describe('applyBootstrapContent marker-based idempotency', () => {
     expect(output.system[0]).not.toBe(`\n\n${wrap('NEW CONTENT')}`)
   })
 
+  /**
+   * `applyBootstrapContent` receives `output` from OpenCode's
+   * `experimental.chat.system.transform` hook, and a sibling hook in the
+   * same pipeline (`opencode-workflow-guard.ts`'s `appendMarker`) captures
+   * `output.system` by reference and mutates it directly. If this function
+   * ever reassigns `output.system` to a new array instead of mutating the
+   * existing one in place, a caller holding the original reference (the
+   * host, or that sibling hook) would silently stop seeing the injected
+   * bootstrap content — no error, just missing `<SYSTEMATIC_WORKFLOWS>`
+   * content. Array identity is part of this function's real contract with
+   * its caller, not an implementation detail.
+   */
+  test('mutates output.system in place rather than replacing the array reference', () => {
+    const output = { system: ['existing system prompt'] }
+    const originalRef = output.system
+    applyBootstrapContent(output, wrap('NEW CONTENT'))
+    expect(output.system).toBe(originalRef)
+  })
+
   test('removes existing marker block from system[0] then appends current content', () => {
     const output = {
       system: [`existing prompt with ${wrap('OLD CONTENT')} embedded`],

--- a/tests/unit/receipt-ledger.test.ts
+++ b/tests/unit/receipt-ledger.test.ts
@@ -922,13 +922,13 @@ describe('receipt ledger', () => {
     expect(second.digestIdentity('repository', RAW_REPOSITORY)).toBe(
       firstDigest,
     )
-    supplied[0] = supplied[0] ^ 0xff
+    supplied[0] = (supplied[0] ?? 0) ^ 0xff
     expect(first.digestIdentity('repository', RAW_REPOSITORY)).toBe(firstDigest)
 
     const returned = getSessionSalt(first)
     expect(returned).toBeInstanceOf(Uint8Array)
     if (!returned) return
-    returned[1] = returned[1] ^ 0xff
+    returned[1] = (returned[1] ?? 0) ^ 0xff
     expect(first.digestIdentity('repository', RAW_REPOSITORY)).toBe(firstDigest)
 
     prepareLedgerObservation(first)

--- a/tests/unit/receipt-privacy.test.ts
+++ b/tests/unit/receipt-privacy.test.ts
@@ -373,10 +373,10 @@ describe('receipt privacy projections', () => {
     )
 
     const marker = output.metadata[SYSTEMATIC_WORKFLOW_RECEIPT_METADATA_KEY]
-    const toolResult = await adapter.tools.systematic_workflow_status.execute(
-      {},
-      toolContext(),
-    )
+    const statusTool = adapter.tools.systematic_workflow_status
+    if (!statusTool)
+      throw new Error('tool not registered: systematic_workflow_status')
+    const toolResult = await statusTool.execute({}, toolContext())
     const toolMetadata =
       typeof toolResult === 'string' ? undefined : toolResult.metadata
     const values = [marker, adapter.status(SESSION_ID), toolMetadata]

--- a/tests/unit/review-artifact-schema.test.ts
+++ b/tests/unit/review-artifact-schema.test.ts
@@ -767,8 +767,12 @@ describe('review artifact schema', () => {
         const issueSignatures = result.error.issues.map(
           (issue) => `${issue.path.join('.') || '$'} ${issue.code}`,
         )
+        const expected = expectedIssues[fixture]
+        if (!expected) {
+          throw new Error(`${fixture}: missing entry in expectedIssues`)
+        }
         expect(issueSignatures, `${fixture}: unexpected issue set`).toEqual(
-          expectedIssues[fixture],
+          expected,
         )
       }
     }

--- a/tests/unit/run-evals-tarball.test.ts
+++ b/tests/unit/run-evals-tarball.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { gzipSync } from 'node:zlib'
+import { validateNpmTarball } from '../../scripts/run-evals.ts'
+
+/**
+ * Regression pin for the `noUncheckedIndexedAccess` narrowing applied to the
+ * npm tarball header parser in `scripts/run-evals.ts`:
+ *
+ * - `readNpmTarEntryType`'s parameter was widened from `number` to
+ *   `number | undefined` (the value comes from `header[156]`, a Buffer
+ *   index).
+ * - `validateTarHeaderChecksum`'s summing loop gained a `header[index] ?? 0`
+ *   default (also a Buffer index).
+ *
+ * Neither `header[156]` nor `header[index]` can actually be `undefined`
+ * through the reachable public API: `readValidatedNpmTarEntries` only calls
+ * into `parseNpmTarEntry` when `offset + 512 <= archive.length`, so `header`
+ * is always a full 512-byte `Buffer.subarray`, and every index read is
+ * in-bounds. That loop invariant is exactly why the fix is a type-only
+ * correction and not a behavior change \u2014 the narrowest *reachable*
+ * equivalent is this: an entry whose type-flag byte is a value tar readers
+ * do not recognize as `file`/`directory` must still fail closed via
+ * `artifactFailure('artifact_resolution')`, the same fallthrough branch that
+ * would also run for a hypothetical `undefined` typeFlag. This is verified
+ * end-to-end through the exported `validateNpmTarball`, not by calling the
+ * unexported header-parsing helpers directly.
+ */
+
+function writeOctal(
+  buffer: Buffer,
+  offset: number,
+  length: number,
+  value: number,
+): void {
+  const encoded = `${value.toString(8).padStart(length - 1, '0')}\0`
+  buffer.write(encoded, offset, length, 'ascii')
+}
+
+/** Builds one 512-byte ustar header block (+ padded content) with a
+ * caller-controlled type-flag byte, so tests can construct both recognized
+ * (file/directory) and unrecognized (e.g. fifo, char device) entry types. */
+function tarBlock(name: string, typeFlag: number, content = ''): Buffer {
+  const block = Buffer.alloc(512)
+  block.write(name, 0, 100, 'utf8')
+  writeOctal(block, 100, 8, 0o644)
+  writeOctal(block, 108, 8, 0)
+  writeOctal(block, 116, 8, 0)
+  const contentBuffer = Buffer.from(content, 'utf8')
+  writeOctal(block, 124, 12, contentBuffer.length)
+  writeOctal(block, 136, 12, 0)
+  block.fill(0x20, 148, 156)
+  block[156] = typeFlag
+  block.write('ustar\0', 257, 6, 'ascii')
+  block.write('00', 263, 2, 'ascii')
+  const checksum = block.reduce((sum, byte) => sum + byte, 0)
+  writeOctal(block, 148, 8, checksum)
+  return Buffer.concat([
+    block,
+    contentBuffer,
+    Buffer.alloc((512 - (contentBuffer.length % 512)) % 512),
+  ])
+}
+
+function writeTarball(parentDir: string, entries: readonly Buffer[]): string {
+  const archivePath = path.join(parentDir, 'fixture.tgz')
+  const body = Buffer.concat([...entries, Buffer.alloc(1024)])
+  fs.writeFileSync(archivePath, gzipSync(body))
+  return archivePath
+}
+
+describe('run-evals npm tarball header parsing', () => {
+  test('accepts a well-formed file entry (positive control)', () => {
+    const parentDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'run-evals-tar-ok-'),
+    )
+    try {
+      const archivePath = writeTarball(parentDir, [
+        tarBlock('package/index.js', 0x30, 'export default 1'),
+      ])
+      const result = validateNpmTarball(archivePath)
+      expect(result.entries).toHaveLength(1)
+      expect(result.entries[0]?.path).toBe('index.js')
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('fails closed on an entry with an unrecognized type-flag byte instead of defaulting to file/directory', () => {
+    const parentDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'run-evals-tar-badtype-'),
+    )
+    try {
+      // 0x39 ('9') is not a ustar type flag this parser recognizes as file
+      // (0/0x30) or directory (0x35) — this is the same fallthrough branch
+      // that a hypothetical undefined typeFlag would also hit.
+      const archivePath = writeTarball(parentDir, [
+        tarBlock('package/weird-entry', 0x39, 'x'),
+      ])
+      expect(() => validateNpmTarball(archivePath)).toThrow(
+        /artifact_resolution/,
+      )
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('fails closed on a corrupted header checksum', () => {
+    const parentDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'run-evals-tar-badsum-'),
+    )
+    try {
+      const block = tarBlock('package/index.js', 0x30, 'export default 1')
+      // Corrupt one content byte after the checksum was computed so the
+      // stored checksum no longer matches the header bytes.
+      block[0] = block[0] === 0x70 ? 0x71 : 0x70
+      const archivePath = writeTarball(parentDir, [block])
+      expect(() => validateNpmTarball(archivePath)).toThrow(
+        /artifact_resolution/,
+      )
+    } finally {
+      fs.rmSync(parentDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/unit/skills.test.ts
+++ b/tests/unit/skills.test.ts
@@ -227,7 +227,7 @@ description: Test skill
 
       const result = skills.findSkillsInDir(testDir)
       expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('my-skill')
+      expect(result[0]?.name).toBe('my-skill')
     })
 
     test('returns empty array for non-existent directory', () => {
@@ -242,7 +242,7 @@ description: Test skill
 
       const result = skills.findSkillsInDir(testDir)
       expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('unnamed-skill')
+      expect(result[0]?.name).toBe('unnamed-skill')
     })
   })
 })
@@ -290,7 +290,7 @@ description: Test agent
 
       const result = agents.findAgentsInDir(testDir)
       expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('my-agent')
+      expect(result[0]?.name).toBe('my-agent')
     })
   })
 })
@@ -319,7 +319,7 @@ description: Test command
 
       const result = commands.findCommandsInDir(testDir)
       expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('/sys-test')
+      expect(result[0]?.name).toBe('/sys-test')
     })
 
     test('handles non-sys commands', () => {
@@ -327,7 +327,7 @@ description: Test command
 
       const result = commands.findCommandsInDir(testDir)
       expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('/other-cmd')
+      expect(result[0]?.name).toBe('/other-cmd')
     })
   })
 })

--- a/tests/unit/spawn-and-signal-conventions.test.ts
+++ b/tests/unit/spawn-and-signal-conventions.test.ts
@@ -63,7 +63,7 @@ function consumeStringLiteral(
   let text = quote ?? ''
   while (i < source.length && source[i] !== quote) {
     if (source[i] === '\\' && i + 1 < source.length) {
-      text += source[i] + source[i + 1]
+      text += (source[i] ?? '') + (source[i + 1] ?? '')
       i += 2
       continue
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["ESNext"],
     "types": ["bun", "node"],
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "skipLibCheck": true,
     "declaration": true,
     "declarationDir": "dist",


### PR DESCRIPTION
## Summary

`z.record(z.string(), V)` infers `Record<string, V>`, so `parsed.categories.anything` type-checked clean and threw at runtime. That trap applied to every indexed read in the repo, not just the config schema.

`noUncheckedIndexedAccess` is now enabled in the base `tsconfig.json` — inherited by `tsconfig.scripts.json` and `tsconfig.tests.json` — so an index into a record or array is typed as possibly-absent. All 132 sites it surfaced are fixed in the same commit, since `typecheck:all` is a required gate and a partial fix would land red.

| Area | Sites |
|---|---|
| `src/` | 18 |
| `scripts/` | 12 |
| `docs/scripts/` | 3 |
| `tests/` | 99 |

## Runtime behavior: one site changed observably, and was corrected

`applyBootstrapContent` (`src/lib/bootstrap.ts`) originally mutated `output.system` in place with an indexed loop. Fixing the flag there first landed as `output.system = output.system.map(...)`, which reassigns the array instead of mutating it. That is an observable change: `applyBootstrapContent` receives `output` from OpenCode's `experimental.chat.system.transform` hook, and a sibling hook in the same pipeline (`opencode-workflow-guard.ts`'s `appendMarker`) captures `output.system` by reference and mutates it directly. A caller holding the original array reference across that boundary would have silently stopped seeing injected bootstrap content — no error, just a missing `<SYSTEMATIC_WORKFLOWS>` block.

This is fixed: the loop now uses `for (const [i, entry] of output.system.entries())` to mutate `output.system` in place, and a test pins array identity across the call (`expect(output.system).toBe(originalRef)`), proven bidirectionally against the reassigning form.

Every other site among the 132 was checked individually and is type-only — a narrowing, guard, or destructure-with-default with no change to what the code returns, mutates, or replaces. No non-null assertions, no `@ts-ignore`, no `as` casts were introduced. That claim needed evidence beyond assertion, so four regression tests pin the sites where a default or guard landed on a live branch. Each fails if the narrowing is reverted to a behavior-changing shape:

| Site | Reverted to | Failure |
|---|---|---|
| `src/lib/frontmatter.ts` | swapped destructure order | `Expected "my-skill", Received undefined`, plus 14 further failures |
| `src/lib/bootstrap.ts` (empty-entry replace) | `if (!first)` instead of `=== undefined` | `Expected length 1, Received 2` — appended a spurious entry instead of replacing a leading empty string |
| `src/lib/bootstrap.ts` (array identity) | `.map()` instead of `.entries()` mutation | `expect(output.system).toBe(originalRef)` fails — the array was replaced |
| `scripts/run-evals.ts` | fallthrough returns `'file'` | an entry with an unrecognized type-flag byte was silently accepted |

The bootstrap empty-entry case shows `=== undefined` is load-bearing rather than stylistic: a truthy check would treat an existing empty-string entry the same as an empty array.

One narrowing is deliberately not pinned. The tar checksum loop's `header[index] ?? 0` sits inside `index < header.length` and the header is always a full 512-byte subarray by construction, so the default is unreachable and a test asserting it would pass in both directions. The reachable fallthrough (unrecognized type-flag byte) is pinned instead.

## Not a breaking change for consumers

Verified by building `dist/` with and without the flag: `dist/lib/config-schema.d.ts` is byte-identical. The flag changes checking mode, not emitted declarations. Consumers who enable it themselves will need to narrow their own indexed reads, which is the point.

Beyond the bootstrap case above, three further nullability changes were checked individually and are behavior-preserving: the tar checksum default cannot fire inside its bounded loop; `(args[3]?.length ?? 0) > 0` evaluates identically to the prior form when the argument is absent; and `parsePlainToken(node: Node | null)` opens with a falsy check, so `null` and `undefined` take the same path.

## Narrowing patterns

Guaranteed regex capture groups use array destructuring with defaults. Loop-bounded indexing moved to `.entries()` (mutating the same array in place) or gained an explicit guard — `.map()`/`.slice()` were used only where the source was a purely local variable or a read-only module constant, never a caller-owned or externally observable object. Repeated Zod-issue and tool-lookup access became shared helpers (`firstIssue()`, `getTool()`) rather than 30-odd inline guards. `src/lib/agent-overlays.ts` gained an explicit branch where Zod's own contract guarantees an issue exists but the compiler cannot see it. Two regex-capture defaults feeding safety gates (`generate-config-schema.ts`'s shrink-detection count, `content-integrity.ts`'s dispatch-argument scan) were changed from `?? ''` to explicit participation checks, so an unexpectedly missing capture fails closed instead of silently reading as zero/no-match.

`SystematicConfigParsed`'s docstring previously recommended narrowing at the boundary as a matter of style; that is now compiler-enforced for its `z.record` fields, and the docstring says so.

## Verification

- `bun test tests/unit`: 2359 pass, 0 fail
- `bun run typecheck`, `typecheck:scripts`, `typecheck:all`: clean
- `bun run lint`: 0 errors, warning count unchanged from `main`
- `bun scripts/content-integrity.ts`: clean
- `bun run build`: succeeds
