### PR TITLE
docs(architecture): record the host-contract gate and named model profiles

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -258,15 +258,20 @@ sources; bootstrap config shallow-merges.
 **Named model profiles** (`src/lib/config.ts` `resolveActiveProfile`/`resolveProfileSelector`,
 `ProfileOverlaySchema` in `src/lib/config-schema.ts`) — a top-level `profile` key selects a named
 entry from a `profiles` map (routing-only `agents`/`categories` overlays) defined in
-`$OPENCODE_CONFIG_DIR` or user config; the selected bundle merges ahead of per-target routing
-resolution. `profiles` is itself in `PROJECT_PROTECTED_FIELDS` alongside `workflow_guard`: a
-project `systematic.json` may select a profile but a `profiles` map it defines is ignored with a
+`$OPENCODE_CONFIG_DIR` or user config. The selected bundle enters the overlay merge as a fourth
+chain entry between user base and project (`user base > active profile > project > custom`), so a
+project or custom overlay still overrides a profile-supplied routing choice; every other merge in
+`loadConfigWithSources` keeps the three-source chain above. `profiles` is in
+`PROJECT_PROTECTED_FIELDS` (`src/lib/config.ts`) alongside `workflow_guard` — a distinct,
+top-level-key list from `SECURITY_OVERLAY_FIELDS` above, which strips fields *within* an overlay:
+a project `systematic.json` may select a profile but a `profiles` map it defines is ignored with a
 warning, not merged.
 
 **Host-contract gate** (`.github/workflows/main.yaml` `host-contract` job,
 `scripts/host-contract-guard.ts`, `scripts/lib/opencode-pin.ts`) — runs `tests/integration` against
 a real OpenCode host pinned to the `@opencode-ai/sdk` devDependency version
 (`SYSTEMATIC_REQUIRE_OPENCODE=1`), then guards the run's JUnit output and console log against a
-fixed exempt-skip list and pass floor (`scripts/host-contract-guard.ts`). `host-contract` is a
+fixed expected-suite-file list, an exempt-skip list, and a pass floor
+(`scripts/host-contract-guard.ts`). `host-contract` is a
 required predecessor of `release`; evidence gathered at one pinned OpenCode version is not evidence
 at another, so a Renovate OpenCode bump is only complete when this job is green on that bump.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -237,7 +237,8 @@ validate-review-artifact <path>` (`src/cli.ts`) validates any artifact against i
 `dist/`. `ce:review` stamps `schema_version` on the artifact it writes and runs the validator against
 it before reporting a verdict; a failing artifact is repaired and re-validated, never deleted or
 reported over. Artifacts without `schema_version` predate the contract and are excluded (exit 3,
-"legacy").
+"legacy"). By default the target must resolve inside `.context/systematic/ce-review`; pass
+`--allow-outside-artifact-root` to validate an artifact elsewhere.
 
 **Claude Code plugin build** (`scripts/build-claude-code-plugin.ts`) — generates the CC bundle from
 `skills/` and `agents/` on every CI run; the build fails on any leftover source-namespace identifier
@@ -253,3 +254,19 @@ regardless of what the user writes.
 **Config priority** — `$OPENCODE_CONFIG_DIR/systematic.json` > project `.opencode/systematic.json`
 > user `~/.config/opencode/systematic.json` > defaults. Disabled lists union-merge across all
 sources; bootstrap config shallow-merges.
+
+**Named model profiles** (`src/lib/config.ts` `resolveActiveProfile`/`resolveProfileSelector`,
+`ProfileOverlaySchema` in `src/lib/config-schema.ts`) — a top-level `profile` key selects a named
+entry from a `profiles` map (routing-only `agents`/`categories` overlays) defined in
+`$OPENCODE_CONFIG_DIR` or user config; the selected bundle merges ahead of per-target routing
+resolution. `profiles` is itself in `PROJECT_PROTECTED_FIELDS` alongside `workflow_guard`: a
+project `systematic.json` may select a profile but a `profiles` map it defines is ignored with a
+warning, not merged.
+
+**Host-contract gate** (`.github/workflows/main.yaml` `host-contract` job,
+`scripts/host-contract-guard.ts`, `scripts/lib/opencode-pin.ts`) — runs `tests/integration` against
+a real OpenCode host pinned to the `@opencode-ai/sdk` devDependency version
+(`SYSTEMATIC_REQUIRE_OPENCODE=1`), then guards the run's JUnit output and console log against a
+fixed exempt-skip list and pass floor (`scripts/host-contract-guard.ts`). `host-contract` is a
+required predecessor of `release`; evidence gathered at one pinned OpenCode version is not evidence
+at another, so a Renovate OpenCode bump is only complete when this job is green on that bump.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -259,13 +259,16 @@ sources; bootstrap config shallow-merges.
 `ProfileOverlaySchema` in `src/lib/config-schema.ts`) — a top-level `profile` key selects a named
 entry from a `profiles` map (routing-only `agents`/`categories` overlays) defined in
 `$OPENCODE_CONFIG_DIR` or user config. The selected bundle enters the overlay merge as a fourth
-chain entry between user base and project (`user base > active profile > project > custom`), so a
-project or custom overlay still overrides a profile-supplied routing choice; every other merge in
-`loadConfigWithSources` keeps the three-source chain above. `profiles` is in
-`PROJECT_PROTECTED_FIELDS` (`src/lib/config.ts`) alongside `workflow_guard` — a distinct,
-top-level-key list from `SECURITY_OVERLAY_FIELDS` above, which strips fields *within* an overlay:
-a project `systematic.json` may select a profile but a `profiles` map it defines is ignored with a
-warning, not merged.
+chain entry between user base and project (`user base → active profile → project → custom`, later
+wins); every other merge in `loadConfigWithSources` keeps the three-source chain above. Only a
+**custom** overlay can override a profile-supplied routing choice. A **project** overlay cannot:
+routing fields are exactly `SECURITY_OVERLAY_FIELDS`, which a project file may not set at all
+(`rejectProjectSecurityOverlay` fails the load rather than stripping), and which
+`preserveSecurityFields` carries over from the profile if a non-file project source supplies them.
+`profiles` is in `PROJECT_PROTECTED_FIELDS` (`src/lib/config.ts`) alongside `workflow_guard` — a
+top-level-key list distinct from the per-overlay `SECURITY_OVERLAY_FIELDS` above: a project
+`systematic.json` may select a profile, but a `profiles` map it defines is ignored with a warning,
+not merged.
 
 **Host-contract gate** (`.github/workflows/main.yaml` `host-contract` job,
 `scripts/host-contract-guard.ts`, `scripts/lib/opencode-pin.ts`) — runs `tests/integration` against

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -113,9 +113,9 @@ bundled assets before editing or building the docs site.
 **Key files:**
 - `scripts/content-integrity.ts` — CI gate: validates frontmatter contracts, catches phantom refs
 - `scripts/host-contract-guard.ts` — CI gate for the `host-contract` job: parses its JUnit XML and
-  console log, then fails on any unexpected test skip, a listed exempt skip that went missing, or a
-  pass count under `PASS_FLOOR`; invoked directly in `.github/workflows/main.yaml`, not via a
-  `bun run` script
+  console log, then fails on any unexpected test skip, a listed exempt skip that went missing, a
+  listed integration suite file that produced no results at all, or a pass count under
+  `PASS_FLOOR`; invoked directly in `.github/workflows/main.yaml`, not via a `bun run` script
 - `scripts/generate-registry.ts` — regenerates `registry/registry.jsonc` from skill/agent frontmatter
   (source of truth); pass `--check` for drift detection (`bun run registry:drift`)
 - `scripts/build-registry.ts` — builds the OCX registry output packument from `registry/registry.jsonc`;

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -112,6 +112,10 @@ bundled assets before editing or building the docs site.
 
 **Key files:**
 - `scripts/content-integrity.ts` — CI gate: validates frontmatter contracts, catches phantom refs
+- `scripts/host-contract-guard.ts` — CI gate for the `host-contract` job: parses its JUnit XML and
+  console log, then fails on any unexpected test skip, a listed exempt skip that went missing, or a
+  pass count under `PASS_FLOOR`; invoked directly in `.github/workflows/main.yaml`, not via a
+  `bun run` script
 - `scripts/generate-registry.ts` — regenerates `registry/registry.jsonc` from skill/agent frontmatter
   (source of truth); pass `--check` for drift detection (`bun run registry:drift`)
 - `scripts/build-registry.ts` — builds the OCX registry output packument from `registry/registry.jsonc`;
@@ -155,7 +159,9 @@ coverage, model inheritance) against a real OpenCode runtime, in both source and
 **Contains:**
 - `tests/unit/` — unit tests covering `src/lib/` modules, `scripts/` build/codegen scripts, and
   `docs/scripts/` generation scripts
-- `tests/integration/` — integration tests (skip automatically if deps unavailable)
+- `tests/integration/` — integration tests (skip automatically if deps unavailable locally;
+  `SYSTEMATIC_REQUIRE_OPENCODE=1` in the required `host-contract` CI job turns those skips into
+  failures against a real, pinned OpenCode host)
 
 **Pattern:** Tests use `bun:test` with `describe`/`it`. Filesystem tests use real temp directories;
 no mocking libraries.


### PR DESCRIPTION
## Summary

`ARCHITECTURE.md` and `STRUCTURE.md` had fallen behind several shipped changes. This brings them level.

**Review artifact validation** — the containment default is now stated along with the `--allow-outside-artifact-root` escape hatch, so the doc describes both halves of the behavior rather than only the restriction.

**Named model profiles** — a new cross-cutting entry covering `resolveActiveProfile` / `resolveProfileSelector`, the `profiles` map, and the trust boundary: `profiles` sits in `PROJECT_PROTECTED_FIELDS` alongside `workflow_guard`, so a project `systematic.json` may *select* a profile but a `profiles` map it defines is ignored with a warning rather than merged.

**Host-contract gate** — the `host-contract` job, `scripts/host-contract-guard.ts`, and `scripts/lib/opencode-pin.ts`, including that it is a required predecessor of `release` and that evidence gathered at one pinned OpenCode version is not evidence at another.

## Verification

Every claim was checked against the code it describes rather than read for plausibility:

| Claim | Checked |
|---|---|
| `--allow-outside-artifact-root` exists | `src/lib/review-artifact-path.ts` |
| Profile resolvers exist | `resolveActiveProfile` / `resolveProfileSelector` in `src/lib/config.ts`, `ProfileOverlaySchema` in `src/lib/config-schema.ts` |
| `profiles` is project-protected | present in `PROJECT_PROTECTED_FIELDS` |
| `release` requires `host-contract` | `.github/workflows/main.yaml:368` — `needs: [build, typecheck, lint, test, host-contract]`, under the `release:` job at line 354 |
| Guard has a pass floor | `PASS_FLOOR` in `scripts/host-contract-guard.ts` |
| Guard is invoked directly, not via a package script | no `host-contract-guard` reference in `package.json` |
| Pin helper exists | `scripts/lib/opencode-pin.ts` |

`bun scripts/content-integrity.ts` is clean.

Scoped `docs(architecture)`, which publishes nothing.
